### PR TITLE
Tool filter reset

### DIFF
--- a/src/backend/modules/magic/src/lib/backing.ts
+++ b/src/backend/modules/magic/src/lib/backing.ts
@@ -222,7 +222,7 @@ export let ensureMagicMcpServerBacking = async (d: {
     }
 
     let providers = d.providers ?? undefined;
-    let backing = await (subspaceMagicMcpBackingService.upsertServer as any)({
+    let backing = await subspaceMagicMcpBackingService.upsertServer({
       instance: d.instance,
       magicMcpServerBackingId: d.server.id,
       providerTemplateBackingId,
@@ -308,7 +308,7 @@ export let ensureMagicMcpEndpointBacking = async (d: {
     }
 
     let maxSessionDurationInMinutes = await getMagicMcpSessionDuration(d.instance);
-    let backing = await (subspaceMagicMcpBackingService.upsertEndpoint as any)({
+    let backing = await subspaceMagicMcpBackingService.upsertEndpoint({
       instance: d.instance,
       magicMcpEndpointBackingId: endpoint.id,
       name: endpoint.name,
@@ -355,7 +355,7 @@ export let waitForMagicMcpServerBackingReady = async (d: {
       latest.isSubspaceBackingReconciling
     ) {
       try {
-        let backing = await (subspaceMagicMcpBackingService.getServer as any)({
+        let backing = await subspaceMagicMcpBackingService.getServer({
           instance: d.instance,
           magicMcpServerBackingId: latest.id
         });
@@ -404,7 +404,7 @@ export let waitForMagicMcpEndpointBackingReady = async (d: {
       latest.isSubspaceBackingReconciling
     ) {
       try {
-        let backing = await (subspaceMagicMcpBackingService.getEndpoint as any)({
+        let backing = await subspaceMagicMcpBackingService.getEndpoint({
           instance: d.instance,
           magicMcpEndpointBackingId: latest.id
         });

--- a/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
+++ b/src/backend/modules/magic/src/services/magicMcpEndpoint.ts
@@ -81,6 +81,9 @@ let toNullableJson = (value: Prisma.InputJsonValue | null | undefined) => {
   return value;
 };
 
+let hasToolFiltersInput = (input: MagicMcpEndpointServerInput | undefined) =>
+  !!input && Object.prototype.hasOwnProperty.call(input, 'toolFilters');
+
 let dedupeServerInputs = (servers?: MagicMcpEndpointServerInput[]) => {
   if (!servers?.length) return [];
 
@@ -442,6 +445,11 @@ class MagicMcpEndpointImpl {
       if (servers.length) {
         await Promise.all(
           servers.map(async server => {
+            let serverInput = serverInputsById.get(server.id);
+            let toolFiltersUpdate = hasToolFiltersInput(serverInput)
+              ? { toolFilters: toNullableJson(serverInput?.toolFilters) }
+              : {};
+
             return db.magicMcpEndpointServer.upsert({
               where: {
                 magicMcpEndpointOid_magicMcpServerOid: {
@@ -453,15 +461,9 @@ class MagicMcpEndpointImpl {
                 id: await ID.generateId('magicMcpEndpoint'),
                 magicMcpEndpointOid: d.endpoint.oid,
                 magicMcpServerOid: server.oid,
-                toolFilters: toNullableJson(
-                  serverInputsById.get(server.id)?.toolFilters ?? null
-                )
+                toolFilters: toNullableJson(serverInput?.toolFilters ?? null)
               },
-              update: {
-                toolFilters: toNullableJson(
-                  serverInputsById.get(server.id)?.toolFilters ?? null
-                )
-              }
+              update: toolFiltersUpdate
             });
           })
         );

--- a/src/backend/modules/magic/test/magicMcpEndpointToolFilters.test.ts
+++ b/src/backend/modules/magic/test/magicMcpEndpointToolFilters.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { db, magicMcpEndpointUpdatedQueueAddMock } = vi.hoisted(() => {
+  let db = {
+    magicMcpServer: {
+      findMany: vi.fn()
+    },
+    magicMcpEndpointServer: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      deleteMany: vi.fn()
+    },
+    magicMcpSession: {
+      updateMany: vi.fn()
+    },
+    magicMcpEndpoint: {
+      update: vi.fn()
+    }
+  };
+
+  return {
+    db,
+    magicMcpEndpointUpdatedQueueAddMock: vi.fn()
+  };
+});
+
+vi.mock('@metorial/db', () => ({
+  db,
+  ID: {
+    generateId: vi.fn(async (prefix: string) => `${prefix}_new`)
+  },
+  Prisma: {
+    JsonNull: 'JSON_NULL'
+  },
+  withTransaction: async (cb: (db: any) => Promise<any>) => await cb(db)
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: {
+    fire: vi.fn()
+  }
+}));
+
+vi.mock('@metorial/module-access', () => ({
+  consumerMagicMcpReadRoles: ['consumer_magic_mcp_read'],
+  consumerMagicMcpWriteRoles: ['consumer_magic_mcp_write']
+}));
+
+vi.mock('../src/queues/lifecycle/magicMcpEndpoint', () => ({
+  magicMcpEndpointCreatedQueue: { add: vi.fn() },
+  magicMcpEndpointDeletedQueue: { add: vi.fn() },
+  magicMcpEndpointUpdatedQueue: { add: magicMcpEndpointUpdatedQueueAddMock }
+}));
+
+import { magicMcpEndpointService } from '../src/services/magicMcpEndpoint';
+
+let endpoint = {
+  oid: 10n,
+  id: 'mep_1',
+  instanceOid: 20n
+} as any;
+
+let server = {
+  oid: 30n,
+  id: 'mms_1',
+  status: 'active'
+};
+
+describe('magicMcpEndpointService endpoint server tool filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.magicMcpServer.findMany.mockResolvedValue([server]);
+    db.magicMcpEndpointServer.findMany.mockResolvedValue([{ magicMcpServerOid: server.oid }]);
+    db.magicMcpEndpointServer.upsert.mockResolvedValue({});
+    db.magicMcpEndpoint.update.mockResolvedValue(endpoint);
+  });
+
+  it('preserves existing endpoint server filters when toolFilters is omitted', async () => {
+    await magicMcpEndpointService.addServersToEndpoint({
+      endpoint,
+      servers: [{ magicMcpServerId: server.id }]
+    });
+
+    expect(db.magicMcpEndpointServer.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {}
+      })
+    );
+  });
+
+  it('clears endpoint server filters when toolFilters is explicitly null', async () => {
+    await magicMcpEndpointService.addServersToEndpoint({
+      endpoint,
+      servers: [{ magicMcpServerId: server.id, toolFilters: null }]
+    });
+
+    expect(db.magicMcpEndpointServer.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {
+          toolFilters: 'JSON_NULL'
+        }
+      })
+    );
+  });
+});

--- a/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
+++ b/src/frontend/apps/dashboard/src/slices/product/pages/(integrations)/integration-instance/index.tsx
@@ -170,7 +170,7 @@ let LinkedMagicMcpServersBox = (p: {
       {renderWithPagination(servers)(servers => (
         <>
           <Table
-            headers={['Name', 'Providers', 'Created']}
+            headers={['Name', 'Type', 'Created']}
             data={servers.data.items.map(server => {
               let providerManagementMode = getProviderManagementMode(
                 server.providerManagementMode

--- a/src/systems/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
@@ -4,7 +4,6 @@ import { db } from '@metorial-subspace/db';
 import { providerService } from '@metorial-subspace/module-catalog';
 import {
   adminProviderTelemetryErrorGroupService,
-  adminProviderTelemetryErrorGroupTypes,
   providerInvocationService,
   providerRunLogsService,
   sessionMessageService
@@ -752,7 +751,16 @@ export let adminProviderTelemetryController = app.controller({
       Paginator.validate(
         v.object({
           ...telemetryScopeValidator,
-          types: v.optional(v.array(v.enumOf([...adminProviderTelemetryErrorGroupTypes])))
+          types: v.optional(
+            v.array(
+              v.enumOf([
+                'message_processing_timeout',
+                'message_processing_provider_error',
+                'message_processing_system_error',
+                'provider_discovery_failed'
+              ])
+            )
+          )
         })
       )
     )

--- a/src/systems/subspace/apps/controller/src/controllers/integrationProvider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/integrationProvider.ts
@@ -136,7 +136,9 @@ export let integrationProviderController = app.controller({
           name: ctx.input.name,
           description: ctx.input.description,
           metadata: ctx.input.metadata,
-          toolFilters: normalizeToolFilters(ctx.input.toolFilters)
+          ...(ctx.input.toolFilters !== undefined
+            ? { toolFilters: normalizeToolFilters(ctx.input.toolFilters) }
+            : {})
         }
       });
 
@@ -177,7 +179,9 @@ export let integrationProviderController = app.controller({
           name: ctx.input.name,
           description: ctx.input.description,
           metadata: ctx.input.metadata,
-          toolFilters: normalizeToolFilters(ctx.input.toolFilters)
+          ...(ctx.input.toolFilters !== undefined
+            ? { toolFilters: normalizeToolFilters(ctx.input.toolFilters) }
+            : {})
         }
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerAuthConfig.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerAuthConfig.ts
@@ -284,7 +284,9 @@ export let providerAuthConfigController = app.controller({
           description: ctx.input.description,
           metadata: ctx.input.metadata,
           privateMetadata: ctx.input.privateMetadata,
-          toolFilters: normalizeToolFilters(ctx.input.toolFilters)
+          ...(ctx.input.toolFilters !== undefined
+            ? { toolFilters: normalizeToolFilters(ctx.input.toolFilters) }
+            : {})
         }
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerConfig.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerConfig.ts
@@ -285,7 +285,9 @@ export let providerConfigController = app.controller({
           description: ctx.input.description,
           metadata: ctx.input.metadata,
           privateMetadata: ctx.input.privateMetadata,
-          toolFilters: normalizeToolFilters(ctx.input.toolFilters as any)
+          ...(ctx.input.toolFilters !== undefined
+            ? { toolFilters: normalizeToolFilters(ctx.input.toolFilters as any) }
+            : {})
         }
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/providerDeployment.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/providerDeployment.ts
@@ -103,13 +103,14 @@ export let providerDeploymentController = app.controller({
       })
     )
     .do(async ctx => {
-      let providerDeployments = await providerDeploymentService.getManyProviderDeploymentsByIds({
-        tenant: ctx.tenant,
-        environment: ctx.environment,
-        solution: ctx.solution,
-        ids: ctx.input.ids,
-        allowDeleted: ctx.input.allowDeleted
-      });
+      let providerDeployments =
+        await providerDeploymentService.getManyProviderDeploymentsByIds({
+          tenant: ctx.tenant,
+          environment: ctx.environment,
+          solution: ctx.solution,
+          ids: ctx.input.ids,
+          allowDeleted: ctx.input.allowDeleted
+        });
 
       return providerDeployments.map(providerDeploymentPresenter);
     }),
@@ -222,9 +223,10 @@ export let providerDeploymentController = app.controller({
         );
       }
 
-      let lockedVersion: Awaited<
-        ReturnType<typeof providerVersionService.getProviderVersionById>
-      > | null | undefined = undefined;
+      let lockedVersion:
+        | Awaited<ReturnType<typeof providerVersionService.getProviderVersionById>>
+        | null
+        | undefined = undefined;
 
       if (ctx.input.lockedProviderVersionId !== undefined) {
         if (ctx.input.lockedProviderVersionId === null) {
@@ -260,7 +262,9 @@ export let providerDeploymentController = app.controller({
           description: ctx.input.description,
           metadata: ctx.input.metadata,
           privateMetadata: ctx.input.privateMetadata,
-          toolFilters: normalizeToolFilters(ctx.input.toolFilters as any),
+          ...(ctx.input.toolFilters !== undefined
+            ? { toolFilters: normalizeToolFilters(ctx.input.toolFilters as any) }
+            : {}),
           lockedVersion
         }
       });

--- a/src/systems/subspace/apps/controller/src/controllers/sessionProvider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/sessionProvider.ts
@@ -222,7 +222,9 @@ export let sessionProviderController = app.controller({
         solution: ctx.solution,
 
         input: {
-          toolFilters: normalizeToolFilters(ctx.input.toolFilters)
+          ...(ctx.input.toolFilters !== undefined
+            ? { toolFilters: normalizeToolFilters(ctx.input.toolFilters) }
+            : {})
         }
       });
 

--- a/src/systems/subspace/apps/controller/src/controllers/sessionTemplateProvider.ts
+++ b/src/systems/subspace/apps/controller/src/controllers/sessionTemplateProvider.ts
@@ -73,8 +73,7 @@ export let sessionTemplateProviderController = app.controller({
         integrationInstanceGroupIds: ctx.input.integrationInstanceGroupIds,
         integrationProviderIds: ctx.input.integrationProviderIds,
         integrationInstanceProviderIds: ctx.input.integrationInstanceProviderIds,
-        integrationInstanceGroupProviderIds:
-          ctx.input.integrationInstanceGroupProviderIds,
+        integrationInstanceGroupProviderIds: ctx.input.integrationInstanceGroupProviderIds,
 
         createdAt: ctx.input.createdAt,
         updatedAt: ctx.input.updatedAt
@@ -186,7 +185,9 @@ export let sessionTemplateProviderController = app.controller({
           solution: ctx.solution,
 
           input: {
-            toolFilters: normalizeToolFilters(ctx.input.toolFilters)
+            ...(ctx.input.toolFilters !== undefined
+              ? { toolFilters: normalizeToolFilters(ctx.input.toolFilters) }
+              : {})
           }
         });
 

--- a/src/systems/subspace/modules/integration/src/lib/versions.test.ts
+++ b/src/systems/subspace/modules/integration/src/lib/versions.test.ts
@@ -109,6 +109,7 @@ describe('integration version helpers', () => {
   });
 
   it('creates instance provider versions through the active transaction client', async () => {
+    tx.integrationInstanceProvider.findUnique.mockResolvedValue(null);
     tx.integrationInstanceProviderVersion.create.mockResolvedValue({
       oid: 20n
     });
@@ -124,6 +125,67 @@ describe('integration version helpers', () => {
     expect(tx.integrationInstanceProvider.updateMany).toHaveBeenCalled();
     expect(globalDb.integrationInstanceProviderVersion.create).not.toHaveBeenCalled();
     expect(globalDb.integrationInstanceProvider.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('does not create a duplicate instance provider version when current material matches', async () => {
+    let currentVersion = {
+      oid: 20n,
+      status: 'active',
+      integrationProviderVersionOid: 30n,
+      configOid: 40n,
+      authConfigOid: null,
+      toolFilter: { type: 'v1.allow_all' },
+      isOverrideToolFilter: false
+    };
+    tx.integrationInstanceProvider.findUnique.mockResolvedValue({
+      currentVersion
+    });
+
+    let version = await createIntegrationInstanceProviderVersion({
+      integrationInstanceProviderOid: 10n,
+      status: 'active',
+      integrationProviderVersionOid: 30n,
+      configOid: 40n,
+      authConfigOid: null,
+      toolFilter: { type: 'v1.allow_all' },
+      isOverrideToolFilter: false
+    });
+
+    expect(version).toBe(currentVersion);
+    expect(tx.integrationInstanceProviderVersion.create).not.toHaveBeenCalled();
+    expect(tx.integrationInstanceProvider.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('compares instance provider version tool filters canonically', async () => {
+    let currentVersion = {
+      oid: 20n,
+      status: 'active',
+      integrationProviderVersionOid: 30n,
+      configOid: null,
+      authConfigOid: null,
+      toolFilter: {
+        type: 'v1.filter',
+        filters: [{ keys: ['tool-a'], type: 'tool_keys' }]
+      },
+      isOverrideToolFilter: false
+    };
+    tx.integrationInstanceProvider.findUnique.mockResolvedValue({
+      currentVersion
+    });
+
+    let version = await createIntegrationInstanceProviderVersion({
+      integrationInstanceProviderOid: 10n,
+      status: 'active',
+      integrationProviderVersionOid: 30n,
+      toolFilter: {
+        filters: [{ type: 'tool_keys', keys: ['tool-a'] }],
+        type: 'v1.filter'
+      } as PrismaJson.ToolFilter
+    });
+
+    expect(version).toBe(currentVersion);
+    expect(tx.integrationInstanceProviderVersion.create).not.toHaveBeenCalled();
+    expect(tx.integrationInstanceProvider.updateMany).not.toHaveBeenCalled();
   });
 
   it('refreshes integration instance status through the active transaction client', async () => {

--- a/src/systems/subspace/modules/integration/src/lib/versions.ts
+++ b/src/systems/subspace/modules/integration/src/lib/versions.ts
@@ -1,4 +1,5 @@
-import { db, getId, Prisma, withTransaction } from '@metorial-subspace/db';
+import { canonicalize } from '@lowerdeck/canonicalize';
+import { getId, Prisma, withTransaction } from '@metorial-subspace/db';
 import { normalizeToolFilters } from '../../../provider-internal/src/lib/toolFilter';
 export { hasMaterialIntegrationProviderChange } from './material';
 
@@ -15,8 +16,8 @@ export let createIntegrationProviderVersion = async (d: {
   configOid?: bigint | null;
   toolFilter: PrismaJson.ToolFilter;
 }) => {
-  return await withTransaction(async tx => {
-    let integrationProvider = await tx.integrationProvider.update({
+  return await withTransaction(async db => {
+    let integrationProvider = await db.integrationProvider.update({
       where: { oid: d.integrationProviderOid },
       data: { currentVersionIndex: { increment: 1 } },
       select: {
@@ -25,7 +26,7 @@ export let createIntegrationProviderVersion = async (d: {
       }
     });
 
-    let version = await tx.integrationProviderVersion.create({
+    let version = await db.integrationProviderVersion.create({
       data: {
         ...getId('integrationProviderVersion'),
         status: d.status,
@@ -39,7 +40,7 @@ export let createIntegrationProviderVersion = async (d: {
       }
     });
 
-    await tx.integrationProvider.updateMany({
+    await db.integrationProvider.updateMany({
       where: { oid: integrationProvider.oid, currentVersionIndex: version.index },
       data: { currentVersionOid: version.oid }
     });
@@ -49,8 +50,8 @@ export let createIntegrationProviderVersion = async (d: {
 };
 
 export let createIntegrationVersion = async (d: { integrationOid: bigint }) => {
-  return await withTransaction(async tx => {
-    let integration = await tx.integration.update({
+  return await withTransaction(async db => {
+    let integration = await db.integration.update({
       where: { oid: d.integrationOid },
       data: {
         currentVersionIndex: { increment: 1 }
@@ -58,7 +59,7 @@ export let createIntegrationVersion = async (d: { integrationOid: bigint }) => {
       select: { oid: true, currentVersionIndex: true }
     });
 
-    let version = await tx.integrationVersion.create({
+    let version = await db.integrationVersion.create({
       data: {
         ...getId('integrationVersion'),
         status: 'active',
@@ -67,7 +68,7 @@ export let createIntegrationVersion = async (d: { integrationOid: bigint }) => {
       }
     });
 
-    let providers = await tx.integrationProvider.findMany({
+    let providers = await db.integrationProvider.findMany({
       where: {
         integrationOid: integration.oid,
         status: 'active',
@@ -79,7 +80,7 @@ export let createIntegrationVersion = async (d: { integrationOid: bigint }) => {
     });
 
     if (providers.length) {
-      await tx.integrationVersionProvider.createMany({
+      await db.integrationVersionProvider.createMany({
         data: providers.map((provider: { currentVersionOid: bigint | null }) => ({
           ...getId('integrationVersionProvider'),
           integrationVersionOid: version.oid,
@@ -88,7 +89,7 @@ export let createIntegrationVersion = async (d: { integrationOid: bigint }) => {
       });
     }
 
-    await tx.integration.updateMany({
+    await db.integration.updateMany({
       where: {
         oid: integration.oid,
         currentVersionIndex: version.index
@@ -109,13 +110,46 @@ export let createIntegrationInstanceProviderVersion = async (d: {
   toolFilter?: PrismaJson.ToolFilter | null;
   isOverrideToolFilter?: boolean;
 }) => {
-  return await withTransaction(async tx => {
-    let version = await tx.integrationInstanceProviderVersion.create({
+  return await withTransaction(async db => {
+    let current = await db.integrationInstanceProvider.findUnique({
+      where: { oid: d.integrationInstanceProviderOid },
+      select: {
+        currentVersion: {
+          select: {
+            oid: true,
+            status: true,
+            integrationProviderVersionOid: true,
+            configOid: true,
+            authConfigOid: true,
+            toolFilter: true,
+            isOverrideToolFilter: true
+          }
+        }
+      }
+    });
+
+    let toolFilterForStorage = d.toolFilter ?? Prisma.JsonNull;
+    let toolFilterForComparison = d.toolFilter ?? null;
+    let normalizedIsOverrideToolFilter = d.isOverrideToolFilter ?? false;
+    if (
+      current?.currentVersion?.status === d.status &&
+      current.currentVersion.integrationProviderVersionOid ===
+        d.integrationProviderVersionOid &&
+      current.currentVersion.configOid === (d.configOid ?? null) &&
+      current.currentVersion.authConfigOid === (d.authConfigOid ?? null) &&
+      canonicalize(current.currentVersion.toolFilter ?? null) ===
+        canonicalize(toolFilterForComparison) &&
+      current.currentVersion.isOverrideToolFilter === normalizedIsOverrideToolFilter
+    ) {
+      return current.currentVersion;
+    }
+
+    let version = await db.integrationInstanceProviderVersion.create({
       data: {
         ...getId('integrationInstanceProviderVersion'),
         status: d.status,
-        toolFilter: d.toolFilter ?? Prisma.JsonNull,
-        isOverrideToolFilter: d.isOverrideToolFilter ?? false,
+        toolFilter: toolFilterForStorage,
+        isOverrideToolFilter: normalizedIsOverrideToolFilter,
         integrationInstanceProviderOid: d.integrationInstanceProviderOid,
         integrationProviderVersionOid: d.integrationProviderVersionOid,
         configOid: d.configOid,
@@ -123,7 +157,7 @@ export let createIntegrationInstanceProviderVersion = async (d: {
       }
     });
 
-    await tx.integrationInstanceProvider.updateMany({
+    await db.integrationInstanceProvider.updateMany({
       where: { oid: d.integrationInstanceProviderOid },
       data: { currentVersionOid: version.oid }
     });
@@ -135,15 +169,15 @@ export let createIntegrationInstanceProviderVersion = async (d: {
 export let refreshIntegrationInstanceStatus = async (d: {
   integrationInstanceOid: bigint;
 }) => {
-  return await withTransaction(async tx => {
-    let integrationInstance = await tx.integrationInstance.findUnique({
+  return await withTransaction(async db => {
+    let integrationInstance = await db.integrationInstance.findUnique({
       where: { oid: d.integrationInstanceOid },
       select: { oid: true, integrationOid: true, status: true }
     });
     if (!integrationInstance || integrationInstance.status !== 'draft')
       return integrationInstance;
 
-    let requiredCount = await tx.integrationProvider.count({
+    let requiredCount = await db.integrationProvider.count({
       where: {
         integrationOid: integrationInstance.integrationOid,
         status: 'active'
@@ -151,7 +185,7 @@ export let refreshIntegrationInstanceStatus = async (d: {
     });
     if (requiredCount === 0) return integrationInstance;
 
-    let setCount = await tx.integrationInstanceProvider.count({
+    let setCount = await db.integrationInstanceProvider.count({
       where: {
         integrationInstanceOid: integrationInstance.oid,
         status: 'active',
@@ -162,7 +196,7 @@ export let refreshIntegrationInstanceStatus = async (d: {
     });
     if (setCount < requiredCount) return integrationInstance;
 
-    return await tx.integrationInstance.update({
+    return await db.integrationInstance.update({
       where: { oid: integrationInstance.oid },
       data: {
         status: 'active',

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/index.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/index.ts
@@ -1,16 +1,9 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
 import { archiveIntegrationInstanceQueueProcessor } from './archiveIntegrationInstance';
 import {
-  integrationInstanceGroupArchiveProvidersManyQueueProcessor,
-  integrationInstanceGroupArchivedQueueProcessor,
-  integrationInstanceGroupCreatedQueueProcessor,
-  integrationInstanceGroupUpdatedQueueProcessor
-} from './integrationInstanceGroup';
-import { integrationInstanceGroupProviderSetQueueProcessor } from './integrationInstanceGroupProvider';
-import {
-  integrationArchivedQueueProcessor,
   integrationArchiveInstancesManyQueueProcessor,
   integrationArchiveProvidersManyQueueProcessor,
+  integrationArchivedQueueProcessor,
   integrationCreatedQueueProcessor,
   integrationDeletedQueueProcessor,
   integrationUpdatedQueueProcessor
@@ -23,6 +16,13 @@ import {
   integrationInstanceUpdatedQueueProcessor
 } from './integrationInstance';
 import {
+  integrationInstanceGroupArchiveProvidersManyQueueProcessor,
+  integrationInstanceGroupArchivedQueueProcessor,
+  integrationInstanceGroupCreatedQueueProcessor,
+  integrationInstanceGroupUpdatedQueueProcessor
+} from './integrationInstanceGroup';
+import { integrationInstanceGroupProviderSetQueueProcessor } from './integrationInstanceGroupProvider';
+import {
   integrationInstanceProviderSetQueueProcessor,
   integrationInstanceProviderSyncGroupProvidersManyQueueProcessor
 } from './integrationInstanceProvider';
@@ -31,7 +31,9 @@ import {
   integrationProviderArchiveInstanceProvidersManyQueueProcessor,
   integrationProviderArchivedQueueProcessor,
   integrationProviderCreatedQueueProcessor,
-  integrationProviderUpdatedQueueProcessor
+  integrationProviderUpdatedQueueProcessor,
+  integrationProviderUpdatedSyncIntegrationInstanceGroupSessionsQueueProcessor,
+  integrationProviderUpdatedSyncIntegrationInstanceSessionsQueueProcessor
 } from './integrationProvider';
 import { magicMcpBackingReconcileQueueProcessor } from './magicMcpBackingReconcile';
 
@@ -60,5 +62,7 @@ export let lifecycleQueues = combineQueueProcessors([
   integrationProviderArchivedQueueProcessor,
   integrationProviderArchiveInstanceProvidersManyQueueProcessor,
   integrationProviderArchiveGroupProvidersManyQueueProcessor,
-  magicMcpBackingReconcileQueueProcessor
+  magicMcpBackingReconcileQueueProcessor,
+  integrationProviderUpdatedSyncIntegrationInstanceSessionsQueueProcessor,
+  integrationProviderUpdatedSyncIntegrationInstanceGroupSessionsQueueProcessor
 ]);

--- a/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
+++ b/src/systems/subspace/modules/integration/src/queues/lifecycle/integrationProvider.ts
@@ -5,25 +5,28 @@ import { enqueueSyncIntegrationInstanceGroupSessionTemplatesMany } from '@metori
 import { enqueueSyncIntegrationInstanceSessionTemplatesMany } from '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate';
 import { reconcileSkillProviderLinksForIntegrationProviderQueue } from '@metorial-subspace/module-skills/src/queues/reconciler/reconcileSkillProviderLink';
 import { env } from '../../env';
+import { integrationInstanceProviderService } from '../../services/integrationInstanceProvider';
 import { indexIntegrationQueue } from '../search/integration';
 import { indexIntegrationInstanceQueue } from '../search/integrationInstance';
 import { enqueueIntegrationInstanceProvidersSet } from './integrationInstanceProvider';
-
-let indexParentIntegration = async (integrationProviderId: string) => {
-  let integrationProvider = await db.integrationProvider.findUnique({
-    where: { id: integrationProviderId },
-    include: { integration: true }
-  });
-  if (!integrationProvider) return;
-
-  await indexIntegrationQueue.add({ integrationId: integrationProvider.integration.id });
-};
 
 let syncIntegrationInstanceSessionTemplates = async (integrationInstanceIds: string[]) => {
   if (integrationInstanceIds.length === 0) return;
 
   await enqueueSyncIntegrationInstanceSessionTemplatesMany(
     integrationInstanceIds.map(integrationInstanceId => ({ integrationInstanceId }))
+  );
+};
+
+let syncIntegrationInstanceGroupSessionTemplates = async (
+  integrationInstanceGroupIds: string[]
+) => {
+  if (integrationInstanceGroupIds.length === 0) return;
+
+  await enqueueSyncIntegrationInstanceGroupSessionTemplatesMany(
+    integrationInstanceGroupIds.map(integrationInstanceGroupId => ({
+      integrationInstanceGroupId
+    }))
   );
 };
 
@@ -40,7 +43,8 @@ export let integrationProviderCreatedQueueProcessor = integrationProviderCreated
     });
     if (!integrationProvider) throw new QueueRetryError();
 
-    await indexParentIntegration(data.integrationProviderId);
+    await indexIntegrationQueue.add({ integrationId: integrationProvider.integration.id });
+
     await reconcileSkillProviderLinksForIntegrationProviderQueue.add({
       integrationProviderId: data.integrationProviderId
     });
@@ -59,12 +63,168 @@ export let integrationProviderUpdatedQueue = createQueue<{ integrationProviderId
 
 export let integrationProviderUpdatedQueueProcessor = integrationProviderUpdatedQueue.process(
   async data => {
-    await indexParentIntegration(data.integrationProviderId);
+    let integrationProvider = await db.integrationProvider.findUnique({
+      where: { id: data.integrationProviderId },
+      include: { integration: true }
+    });
+    if (!integrationProvider) return;
+
+    await indexIntegrationQueue.add({ integrationId: integrationProvider.integration.id });
+
     await reconcileSkillProviderLinksForIntegrationProviderQueue.add({
+      integrationProviderId: data.integrationProviderId
+    });
+
+    await integrationProviderUpdatedSyncIntegrationInstanceSessionsQueue.add({
+      integrationProviderId: data.integrationProviderId
+    });
+    await integrationProviderUpdatedSyncIntegrationInstanceGroupSessionsQueue.add({
       integrationProviderId: data.integrationProviderId
     });
   }
 );
+
+export let integrationProviderUpdatedSyncIntegrationInstanceSessionsQueue = createQueue<{
+  integrationProviderId: string;
+  cursor?: string;
+}>({
+  name: 'sub/int/lc/integrationProvider/updated/instance',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let integrationProviderUpdatedSyncIntegrationInstanceSessionsQueueProcessor =
+  integrationProviderUpdatedSyncIntegrationInstanceSessionsQueue.process(async data => {
+    let integrationProvider = await db.integrationProvider.findUnique({
+      where: { id: data.integrationProviderId },
+      select: { oid: true, currentVersionOid: true }
+    });
+    if (!integrationProvider) return;
+
+    let integrationInstanceProviders = await db.integrationInstanceProvider.findMany({
+      where: {
+        integrationProviderOid: integrationProvider.oid,
+        status: 'active',
+        isParentDeleted: false,
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: 100,
+      select: {
+        integrationInstance: { select: { id: true } },
+        oid: true,
+        currentVersion: {
+          select: {
+            integrationProviderVersionOid: true,
+            configOid: true,
+            authConfigOid: true,
+            toolFilter: true,
+            isOverrideToolFilter: true
+          }
+        },
+        id: true
+      }
+    });
+    if (!integrationInstanceProviders.length) return;
+
+    await integrationInstanceProviderService.repinIntegrationInstanceProvidersToIntegrationProviderVersion(
+      {
+        integrationProviderVersionOid: integrationProvider.currentVersionOid,
+        integrationInstanceProviders
+      }
+    );
+
+    await syncIntegrationInstanceSessionTemplates(
+      Array.from(
+        new Set(integrationInstanceProviders.map(provider => provider.integrationInstance.id))
+      )
+    );
+
+    let lastIntegrationInstanceProvider =
+      integrationInstanceProviders[integrationInstanceProviders.length - 1];
+    if (!lastIntegrationInstanceProvider) return;
+
+    await integrationProviderUpdatedSyncIntegrationInstanceSessionsQueue.add({
+      integrationProviderId: data.integrationProviderId,
+      cursor: lastIntegrationInstanceProvider.id
+    });
+  });
+
+export let integrationProviderUpdatedSyncIntegrationInstanceGroupSessionsQueue = createQueue<{
+  integrationProviderId: string;
+  cursor?: string;
+}>({
+  name: 'sub/int/lc/integrationProvider/updated/group',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let integrationProviderUpdatedSyncIntegrationInstanceGroupSessionsQueueProcessor =
+  integrationProviderUpdatedSyncIntegrationInstanceGroupSessionsQueue.process(async data => {
+    let integrationProvider = await db.integrationProvider.findUnique({
+      where: { id: data.integrationProviderId },
+      select: { oid: true, currentVersionOid: true }
+    });
+    if (!integrationProvider) return;
+
+    let integrationInstanceGroupProviders = await db.integrationInstanceGroupProvider.findMany(
+      {
+        where: {
+          integrationProviderOid: integrationProvider.oid,
+          status: 'active',
+          isParentDeleted: false,
+          id: data.cursor ? { gt: data.cursor } : undefined
+        },
+        orderBy: { id: 'asc' },
+        take: 100,
+        select: {
+          integrationInstanceGroup: { select: { id: true } },
+          integrationInstanceProvider: {
+            select: {
+              oid: true,
+              currentVersion: {
+                select: {
+                  integrationProviderVersionOid: true,
+                  configOid: true,
+                  authConfigOid: true,
+                  toolFilter: true,
+                  isOverrideToolFilter: true
+                }
+              }
+            }
+          },
+          id: true
+        }
+      }
+    );
+    if (!integrationInstanceGroupProviders.length) return;
+
+    await integrationInstanceProviderService.repinIntegrationInstanceProvidersToIntegrationProviderVersion(
+      {
+        integrationProviderVersionOid: integrationProvider.currentVersionOid,
+        integrationInstanceProviders: integrationInstanceGroupProviders.map(
+          provider => provider.integrationInstanceProvider
+        )
+      }
+    );
+
+    await syncIntegrationInstanceGroupSessionTemplates(
+      Array.from(
+        new Set(
+          integrationInstanceGroupProviders.map(
+            provider => provider.integrationInstanceGroup.id
+          )
+        )
+      )
+    );
+
+    let lastProvider =
+      integrationInstanceGroupProviders[integrationInstanceGroupProviders.length - 1];
+    if (!lastProvider) return;
+
+    await integrationProviderUpdatedSyncIntegrationInstanceGroupSessionsQueue.add({
+      integrationProviderId: data.integrationProviderId,
+      cursor: lastProvider.id
+    });
+  });
 
 export let integrationProviderArchivedQueue = createQueue<{ integrationProviderId: string }>({
   name: 'sub/int/lc/integrationProvider/archived',
@@ -79,13 +239,15 @@ export let integrationProviderArchivedQueueProcessor =
     });
     if (!integrationProvider || integrationProvider.status !== 'archived') return;
 
+    await indexIntegrationQueue.add({ integrationId: integrationProvider.integration.id });
+
     await integrationProviderArchiveInstanceProvidersManyQueue.add({
       integrationProviderId: data.integrationProviderId
     });
     await integrationProviderArchiveGroupProvidersManyQueue.add({
       integrationProviderId: data.integrationProviderId
     });
-    await indexParentIntegration(data.integrationProviderId);
+
     await reconcileSkillProviderLinksForIntegrationProviderQueue.add({
       integrationProviderId: data.integrationProviderId
     });

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceGroupProvider.test.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceGroupProvider.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@metorial-subspace/db', () => ({
+  addAfterTransactionHook: vi.fn(),
+  db: {},
+  getId: (kind: string) => ({ id: `${kind}_new`, oid: 1n }),
+  Prisma: {
+    JsonNull: 'JSON_NULL'
+  },
+  withTransaction: async (cb: (db: any) => Promise<any>) => await cb({})
+}));
+
+vi.mock('@metorial-subspace/list-utils', () => ({
+  checkDeletedEdit: vi.fn(),
+  checkDeletedRelation: vi.fn(),
+  normalizeDateFilter: vi.fn(),
+  normalizeStatusForGet: vi.fn(),
+  normalizeStatusForList: vi.fn(),
+  resolveIntegrationInstanceProviders: vi.fn(),
+  resolveIntegrationInstances: vi.fn(),
+  resolveIntegrationProviders: vi.fn(),
+  resolveIntegrations: vi.fn(),
+  resolveProviderAuthConfigs: vi.fn(),
+  resolveProviderConfigs: vi.fn(),
+  resolveProviderDeployments: vi.fn(),
+  resolveProviders: vi.fn(),
+  resolveSessionTemplates: vi.fn()
+}));
+
+vi.mock('@metorial-subspace/module-provider-internal', () => ({
+  normalizeToolFilters: (input?: PrismaJson.ToolFilter | null) => {
+    if (!input) return { type: 'v1.allow_all' };
+    return input;
+  }
+}));
+
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  checkTenant: vi.fn()
+}));
+
+vi.mock('../queues/lifecycle/integrationInstanceGroupProvider', () => ({
+  enqueueIntegrationInstanceGroupProviderSet: vi.fn(),
+  enqueueIntegrationInstanceGroupProvidersSet: vi.fn()
+}));
+
+vi.mock('./integrationInstanceGroup', () => ({
+  integrationInstanceGroupProviderInclude: {}
+}));
+
+import { resolveIntegrationInstanceGroupProviderToolFilterInput } from './integrationInstanceGroupProvider';
+
+let existingFilter: PrismaJson.ToolFilter = {
+  type: 'v1.filter',
+  filters: [{ type: 'tool_keys', keys: ['old'] }]
+};
+
+let replacementFilter: PrismaJson.ToolFilter = {
+  type: 'v1.filter',
+  ignoreParentFilters: true,
+  filters: [{ type: 'tool_keys', keys: ['new'] }]
+};
+
+describe('resolveIntegrationInstanceGroupProviderToolFilterInput', () => {
+  it('preserves existing filters and override state when input omits toolFilters', () => {
+    expect(
+      resolveIntegrationInstanceGroupProviderToolFilterInput({
+        inputToolFilters: undefined,
+        existingToolFilter: existingFilter,
+        existingIsOverrideToolFilter: true
+      })
+    ).toEqual({
+      toolFilter: existingFilter,
+      isOverrideToolFilter: true
+    });
+  });
+
+  it('treats explicit null as clearing the group layer to inherit parent filters', () => {
+    expect(
+      resolveIntegrationInstanceGroupProviderToolFilterInput({
+        inputToolFilters: null,
+        existingToolFilter: existingFilter,
+        existingIsOverrideToolFilter: true
+      })
+    ).toEqual({
+      toolFilter: null,
+      isOverrideToolFilter: false
+    });
+  });
+
+  it('uses concrete filters as replacements and strips control fields from storage', () => {
+    expect(
+      resolveIntegrationInstanceGroupProviderToolFilterInput({
+        inputToolFilters: replacementFilter,
+        existingToolFilter: existingFilter,
+        existingIsOverrideToolFilter: false
+      })
+    ).toEqual({
+      toolFilter: {
+        type: 'v1.filter',
+        filters: [{ type: 'tool_keys', keys: ['new'] }]
+      },
+      isOverrideToolFilter: true
+    });
+  });
+});

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceGroupProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceGroupProvider.ts
@@ -55,6 +55,33 @@ let stripToolFilterOverrideFlag = (
   };
 };
 
+export let resolveIntegrationInstanceGroupProviderToolFilterInput = (d: {
+  inputToolFilters?: PrismaJson.ToolFilter | null;
+  existingToolFilter?: PrismaJson.ToolFilter | null;
+  existingIsOverrideToolFilter?: boolean | null;
+}) => {
+  let inputToolFilter =
+    d.inputToolFilters === undefined
+      ? undefined
+      : d.inputToolFilters === null
+        ? null
+        : normalizeToolFilters(d.inputToolFilters);
+  let isOverrideToolFilter =
+    d.inputToolFilters === null
+      ? false
+      : (inputToolFilter?.ignoreParentFilters ?? d.existingIsOverrideToolFilter ?? false);
+  let toolFilter =
+    d.inputToolFilters === undefined
+      ? d.existingToolFilter
+        ? stripToolFilterOverrideFlag(normalizeToolFilters(d.existingToolFilter))
+        : null
+      : inputToolFilter
+        ? stripToolFilterOverrideFlag(inputToolFilter)
+        : null;
+
+  return { toolFilter, isOverrideToolFilter };
+};
+
 class integrationInstanceGroupProviderServiceImpl {
   async listIntegrationInstanceGroupProviders(d: {
     tenant: Tenant;
@@ -356,20 +383,12 @@ class integrationInstanceGroupProviderServiceImpl {
 
         let input = d.input[idx]!;
         let existing = existingBySourceProviderOid.get(sourceProvider.oid);
-        let inputToolFilter =
-          input.toolFilters === undefined
-            ? undefined
-            : normalizeToolFilters(input.toolFilters);
-        let isOverrideToolFilter =
-          inputToolFilter?.ignoreParentFilters ?? existing?.isOverrideToolFilter ?? false;
-        let toolFilter =
-          input.toolFilters === undefined
-            ? existing?.toolFilter
-              ? stripToolFilterOverrideFlag(
-                  normalizeToolFilters(existing.toolFilter as PrismaJson.ToolFilter)
-                )
-              : null
-            : stripToolFilterOverrideFlag(inputToolFilter!);
+        let { toolFilter, isOverrideToolFilter } =
+          resolveIntegrationInstanceGroupProviderToolFilterInput({
+            inputToolFilters: input.toolFilters,
+            existingToolFilter: existing?.toolFilter as PrismaJson.ToolFilter | null,
+            existingIsOverrideToolFilter: existing?.isOverrideToolFilter
+          });
 
         let groupProvider = await db.integrationInstanceGroupProvider.upsert({
           where: {

--- a/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -804,6 +804,40 @@ class integrationInstanceProviderServiceImpl {
     return integrationInstanceProvider;
   }
 
+  async repinIntegrationInstanceProvidersToIntegrationProviderVersion(d: {
+    integrationProviderVersionOid: bigint | null;
+    integrationInstanceProviders: {
+      oid: bigint;
+      currentVersion?: {
+        integrationProviderVersionOid: bigint;
+        configOid?: bigint | null;
+        authConfigOid?: bigint | null;
+        toolFilter?: PrismaJson.ToolFilter | null;
+        isOverrideToolFilter?: boolean | null;
+      } | null;
+    }[];
+  }) {
+    if (!d.integrationProviderVersionOid) return;
+
+    for (let integrationInstanceProvider of d.integrationInstanceProviders) {
+      let currentVersion = integrationInstanceProvider.currentVersion;
+      if (!currentVersion) continue;
+      if (currentVersion.integrationProviderVersionOid === d.integrationProviderVersionOid) {
+        continue;
+      }
+
+      await createIntegrationInstanceProviderVersion({
+        integrationInstanceProviderOid: integrationInstanceProvider.oid,
+        status: 'active',
+        integrationProviderVersionOid: d.integrationProviderVersionOid,
+        configOid: currentVersion.configOid,
+        authConfigOid: currentVersion.authConfigOid,
+        toolFilter: currentVersion.toolFilter,
+        isOverrideToolFilter: currentVersion.isOverrideToolFilter ?? false
+      });
+    }
+  }
+
   async setMagicMcpIntegrationInstanceProviders(d: {
     tenant: Tenant;
     solution: Solution;

--- a/src/systems/subspace/modules/integration/src/services/integrationProvider.test.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationProvider.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  db,
+  tx,
+  providerDeploymentServiceMock,
+  providerServiceMock,
+  providerAuthCredentialsServiceMock,
+  createIntegrationProviderVersionMock,
+  createIntegrationVersionMock,
+  integrationProviderUpdatedQueueAddMock
+} = vi.hoisted(() => {
+  let createModel = () => ({
+    count: vi.fn(),
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn()
+  });
+
+  return {
+    db: {
+      integrationProvider: createModel()
+    },
+    tx: {
+      integrationProvider: createModel()
+    },
+    providerDeploymentServiceMock: {
+      getProviderDeploymentById: vi.fn()
+    },
+    providerServiceMock: {
+      getProviderById: vi.fn()
+    },
+    providerAuthCredentialsServiceMock: {
+      listProviderAuthCredentials: vi.fn()
+    },
+    createIntegrationProviderVersionMock: vi.fn(),
+    createIntegrationVersionMock: vi.fn(),
+    integrationProviderUpdatedQueueAddMock: vi.fn()
+  };
+});
+
+vi.mock('@metorial-subspace/db', () => ({
+  addAfterTransactionHook: async (cb: () => Promise<void>) => await cb(),
+  db,
+  getId: (kind: string) => ({ id: `${kind}_new`, oid: 100n }),
+  withTransaction: async (cb: (db: any) => Promise<any>) => await cb(tx)
+}));
+
+vi.mock('@metorial-subspace/module-catalog', () => ({
+  providerAuthMethodService: {
+    listProviderAuthMethods: vi.fn()
+  },
+  providerService: providerServiceMock
+}));
+
+vi.mock('@metorial-subspace/module-deployment', () => ({
+  providerConfigService: {},
+  providerDeploymentService: providerDeploymentServiceMock
+}));
+
+vi.mock('@metorial-subspace/module-auth', () => ({
+  providerAuthCredentialsService: providerAuthCredentialsServiceMock
+}));
+
+vi.mock('@metorial-subspace/module-provider-internal', () => ({
+  checkProviderMatch: vi.fn(),
+  providerDeploymentInternalService: {}
+}));
+
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  checkTenant: vi.fn()
+}));
+
+vi.mock('../lib/versions', () => ({
+  createIntegrationProviderVersion: createIntegrationProviderVersionMock,
+  createIntegrationVersion: createIntegrationVersionMock,
+  hasMaterialIntegrationProviderChange: (d: any) =>
+    JSON.stringify(d.currentVersion.toolFilter) !== JSON.stringify(d.input.toolFilter),
+  normalizeIntegrationProviderToolFilter: (toolFilter?: PrismaJson.ToolFilter | null) =>
+    toolFilter ?? { type: 'v1.allow_all' }
+}));
+
+vi.mock('../queues/lifecycle/integrationProvider', () => ({
+  integrationProviderArchivedQueue: { add: vi.fn() },
+  integrationProviderCreatedQueue: { add: vi.fn() },
+  integrationProviderUpdatedQueue: { add: integrationProviderUpdatedQueueAddMock }
+}));
+
+import { integrationProviderService } from './integrationProvider';
+
+let restrictiveToolFilter: PrismaJson.ToolFilter = {
+  type: 'v1.filter',
+  filters: [{ type: 'tool_keys', keys: ['allowed'] }]
+};
+
+let deployment = {
+  oid: 30n,
+  id: 'pvd_1',
+  description: 'Deployment',
+  metadata: { source: 'test' },
+  providerOid: 20n,
+  provider: {
+    oid: 20n,
+    id: 'provider_1',
+    name: 'Provider',
+    description: 'Provider',
+    type: { supportsAuth: false }
+  },
+  defaultConfigOid: 40n,
+  currentVersion: null
+} as any;
+
+let currentVersion = {
+  oid: 50n,
+  deploymentOid: deployment.oid,
+  authMethodOid: null,
+  authCredentialsOid: null,
+  configOid: deployment.defaultConfigOid,
+  toolFilter: restrictiveToolFilter
+};
+
+let existingProvider = {
+  oid: 60n,
+  id: 'ipr_existing',
+  status: 'active',
+  name: 'Provider',
+  description: 'Provider',
+  metadata: null,
+  tenantOid: 1n,
+  solutionOid: 2,
+  environmentOid: 3n,
+  currentVersion
+};
+
+let input = {
+  tenant: { oid: 1n },
+  solution: { oid: 2 },
+  environment: { oid: 3n },
+  integration: {
+    oid: 10n,
+    tenantOid: 1n,
+    solutionOid: 2,
+    environmentOid: 3n
+  },
+  input: {
+    providerDeploymentId: deployment.id
+  }
+} as any;
+
+describe('integrationProviderService.ensureIntegrationProviderForDeployment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    providerDeploymentServiceMock.getProviderDeploymentById.mockResolvedValue(deployment);
+    providerServiceMock.getProviderById.mockResolvedValue(deployment.provider);
+    tx.integrationProvider.findUnique.mockResolvedValue(existingProvider);
+    tx.integrationProvider.upsert.mockResolvedValue(existingProvider);
+    tx.integrationProvider.findUniqueOrThrow.mockResolvedValue(existingProvider);
+  });
+
+  it('preserves an existing provider tool filter when input omits toolFilters', async () => {
+    await integrationProviderService.ensureIntegrationProviderForDeployment(input);
+
+    expect(tx.integrationProvider.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          toolFilter: restrictiveToolFilter
+        })
+      })
+    );
+    expect(createIntegrationProviderVersionMock).not.toHaveBeenCalled();
+  });
+
+  it('treats explicit null toolFilters as an allow-all reset', async () => {
+    await integrationProviderService.ensureIntegrationProviderForDeployment({
+      ...input,
+      input: {
+        ...input.input,
+        toolFilters: null
+      }
+    });
+
+    let allowAllToolFilter = { type: 'v1.allow_all' };
+
+    expect(tx.integrationProvider.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          toolFilter: allowAllToolFilter
+        })
+      })
+    );
+    expect(createIntegrationProviderVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationProviderOid: existingProvider.oid,
+        toolFilter: allowAllToolFilter
+      })
+    );
+  });
+});
+
+describe('integrationProviderService.createIntegrationProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    providerDeploymentServiceMock.getProviderDeploymentById.mockResolvedValue(deployment);
+    providerServiceMock.getProviderById.mockResolvedValue(deployment.provider);
+    tx.integrationProvider.count.mockResolvedValue(0);
+    tx.integrationProvider.findUniqueOrThrow.mockResolvedValue(existingProvider);
+  });
+
+  it('preserves an archived provider tool filter when input omits toolFilters', async () => {
+    let archivedProvider = {
+      ...existingProvider,
+      status: 'archived'
+    };
+    tx.integrationProvider.findUnique.mockResolvedValue(archivedProvider);
+    tx.integrationProvider.update.mockResolvedValue({
+      ...archivedProvider,
+      status: 'active'
+    });
+
+    await integrationProviderService.createIntegrationProvider({
+      ...input,
+      input: {
+        providerId: deployment.provider.id,
+        providerDeploymentId: deployment.id
+      }
+    });
+
+    expect(tx.integrationProvider.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          toolFilter: restrictiveToolFilter
+        })
+      })
+    );
+    expect(createIntegrationProviderVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationProviderOid: archivedProvider.oid,
+        toolFilter: restrictiveToolFilter
+      })
+    );
+  });
+});

--- a/src/systems/subspace/modules/integration/src/services/integrationProvider.ts
+++ b/src/systems/subspace/modules/integration/src/services/integrationProvider.ts
@@ -43,6 +43,7 @@ import {
   providerDeploymentInternalService
 } from '@metorial-subspace/module-provider-internal';
 import { checkTenant } from '@metorial-subspace/module-tenant';
+import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
 import {
   createIntegrationProviderVersion,
   createIntegrationVersion,
@@ -54,7 +55,6 @@ import {
   integrationProviderCreatedQueue,
   integrationProviderUpdatedQueue
 } from '../queues/lifecycle/integrationProvider';
-import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
 
 export let integrationProviderInclude = {
   integration: true,
@@ -463,8 +463,6 @@ class integrationProviderServiceImpl {
       input: d.input
     });
 
-    let toolFilter = normalizeIntegrationProviderToolFilter(d.input.toolFilters);
-
     return await withTransaction(async db => {
       let existing = await db.integrationProvider.findUnique({
         where: {
@@ -484,6 +482,11 @@ class integrationProviderServiceImpl {
           })
         );
       }
+
+      let toolFilter =
+        d.input.toolFilters === undefined && existing?.currentVersion
+          ? (existing.currentVersion.toolFilter as PrismaJson.ToolFilter)
+          : normalizeIntegrationProviderToolFilter(d.input.toolFilters);
 
       let activeProviderCount = await db.integrationProvider.count({
         where: {
@@ -558,7 +561,6 @@ class integrationProviderServiceImpl {
       environment: d.environment,
       providerDeploymentId: d.input.providerDeploymentId
     });
-    let toolFilter = normalizeIntegrationProviderToolFilter(d.input.toolFilters);
     let inferredAuth = await inferReconciliationAuthMaterial({
       tenant: d.tenant,
       solution: d.solution,
@@ -576,6 +578,11 @@ class integrationProviderServiceImpl {
         },
         include: { currentVersion: true }
       });
+
+      let toolFilter =
+        d.input.toolFilters === undefined && existing?.currentVersion
+          ? (existing.currentVersion.toolFilter as PrismaJson.ToolFilter)
+          : normalizeIntegrationProviderToolFilter(d.input.toolFilters);
 
       if (existing?.status !== 'active') {
         let activeProviderCount = await db.integrationProvider.count({

--- a/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
+++ b/src/systems/subspace/modules/integration/src/services/magicMcpBacking/endpoint.ts
@@ -41,6 +41,10 @@ type UpsertMagicMcpEndpointBackingInput = {
   };
 };
 
+let hasToolFiltersInput = (
+  input: UpsertMagicMcpEndpointBackingInput['input']['servers'][number] | undefined
+) => !!input && Object.prototype.hasOwnProperty.call(input, 'toolFilters');
+
 class magicMcpEndpointBackingServiceImpl {
   async upsertMagicMcpEndpointBacking(d: UpsertMagicMcpEndpointBackingInput) {
     let actorOid = await resolveActorOid({
@@ -173,6 +177,9 @@ class magicMcpEndpointBackingServiceImpl {
           let servers = [];
           for (let serverInput of d.input.servers) {
             let serverBacking = serverBackingsById.get(serverInput.magicMcpServerBackingId)!;
+            let toolFiltersUpdate = hasToolFiltersInput(serverInput)
+              ? { toolFilters: serverInput.toolFilters ?? Prisma.JsonNull }
+              : {};
             let server = await db.magicMcpEndpointServerBacking.upsert({
               where: { id: serverInput.id },
               create: {
@@ -185,7 +192,7 @@ class magicMcpEndpointBackingServiceImpl {
               update: {
                 magicMcpEndpointBackingOid: persistedBacking.oid,
                 magicMcpServerBackingOid: serverBacking.oid,
-                toolFilters: serverInput.toolFilters ?? Prisma.JsonNull
+                ...toolFiltersUpdate
               }
             });
             servers.push({ ...server, magicMcpServerBacking: serverBacking });

--- a/src/systems/subspace/modules/integration/test/integrationProviderLifecycle.test.ts
+++ b/src/systems/subspace/modules/integration/test/integrationProviderLifecycle.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  processors,
+  db,
+  createQueueMock,
+  repinIntegrationInstanceProvidersMock,
+  enqueueSyncInstanceTemplatesMock,
+  enqueueSyncGroupTemplatesMock,
+  indexIntegrationQueueAddMock,
+  reconcileSkillProviderLinksForIntegrationProviderQueueAddMock
+} = vi.hoisted(() => {
+  let processors = new Map<string, (data: any) => Promise<void>>();
+  let db = {
+    integrationProvider: {
+      findUnique: vi.fn()
+    },
+    integrationInstanceProviderVersion: {
+      findFirst: vi.fn()
+    },
+    integrationInstanceProviderVersionConfig: {
+      createMany: vi.fn()
+    },
+    integrationInstanceProviderVersionAuthConfig: {
+      createMany: vi.fn()
+    },
+    integrationInstanceProvider: {
+      findMany: vi.fn(),
+      updateMany: vi.fn()
+    },
+    integrationInstanceGroupProvider: {
+      findMany: vi.fn(),
+      updateMany: vi.fn()
+    }
+  };
+
+  return {
+    processors,
+    db,
+    createQueueMock: vi.fn((config: { name: string }) => {
+      let queue = {
+        add: vi.fn(),
+        addMany: vi.fn(),
+        addManyWithOps: vi.fn(),
+        process: vi.fn((handler: (data: any) => Promise<void>) => {
+          processors.set(config.name, handler);
+          return { name: config.name };
+        })
+      };
+      return queue;
+    }),
+    repinIntegrationInstanceProvidersMock: vi.fn(),
+    enqueueSyncInstanceTemplatesMock: vi.fn(),
+    enqueueSyncGroupTemplatesMock: vi.fn(),
+    indexIntegrationQueueAddMock: vi.fn(),
+    reconcileSkillProviderLinksForIntegrationProviderQueueAddMock: vi.fn()
+  };
+});
+
+vi.mock('@lowerdeck/queue', () => ({
+  createQueue: createQueueMock,
+  QueueRetryError: class QueueRetryError extends Error {}
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db
+}));
+
+vi.mock('@metorial-subspace/module-identity', () => ({
+  identityInternalService: {
+    syncIntegrationInstanceProviderCredentials: vi.fn()
+  }
+}));
+
+vi.mock(
+  '@metorial-subspace/module-session/src/queues/lifecycle/linkedSessionTemplate',
+  () => ({
+    enqueueSyncIntegrationInstanceSessionTemplatesMany: enqueueSyncInstanceTemplatesMock
+  })
+);
+
+vi.mock(
+  '@metorial-subspace/module-session/src/queues/lifecycle/linkedIntegrationInstanceGroupTemplate',
+  () => ({
+    enqueueSyncIntegrationInstanceGroupSessionTemplatesMany: enqueueSyncGroupTemplatesMock
+  })
+);
+
+vi.mock(
+  '@metorial-subspace/module-skills/src/queues/reconciler/reconcileSkillProviderLink',
+  () => ({
+    reconcileSkillProviderLinksForIntegrationProviderQueue: {
+      add: reconcileSkillProviderLinksForIntegrationProviderQueueAddMock
+    }
+  })
+);
+
+vi.mock('../src/services/integrationInstanceProvider', () => ({
+  integrationInstanceProviderService: {
+    repinIntegrationInstanceProvidersToIntegrationProviderVersion:
+      repinIntegrationInstanceProvidersMock
+  }
+}));
+
+vi.mock('../src/queues/search/integration', () => ({
+  indexIntegrationQueue: {
+    add: indexIntegrationQueueAddMock
+  }
+}));
+
+vi.mock('../src/queues/search/integrationInstance', () => ({
+  indexIntegrationInstanceQueue: {
+    add: vi.fn()
+  }
+}));
+
+vi.mock('../src/queues/lifecycle/integrationInstanceProvider', () => ({
+  enqueueIntegrationInstanceProvidersSet: vi.fn()
+}));
+
+vi.mock('../src/env', () => ({
+  env: {
+    service: {
+      REDIS_URL: 'redis://test'
+    }
+  }
+}));
+
+import '../src/queues/lifecycle/integrationProvider';
+
+describe('integration provider lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('repins instance providers before syncing instance session templates', async () => {
+    let providerVersionOid = 20n;
+    let integrationInstanceProvider = {
+      id: 'iip_1',
+      oid: 30n,
+      integrationInstance: { id: 'ins_1' },
+      currentVersion: {
+        integrationProviderVersionOid: 10n,
+        configOid: 40n,
+        authConfigOid: null,
+        toolFilter: { type: 'v1.filter', filters: [] },
+        isOverrideToolFilter: false
+      }
+    };
+    db.integrationProvider.findUnique.mockResolvedValue({
+      oid: 1n,
+      currentVersionOid: providerVersionOid
+    });
+    db.integrationInstanceProvider.findMany.mockResolvedValue([integrationInstanceProvider]);
+
+    await processors.get('sub/int/lc/integrationProvider/updated/instance')!({
+      integrationProviderId: 'ipr_1'
+    });
+
+    expect(repinIntegrationInstanceProvidersMock).toHaveBeenCalledWith({
+      integrationProviderVersionOid: providerVersionOid,
+      integrationInstanceProviders: [integrationInstanceProvider]
+    });
+    expect(repinIntegrationInstanceProvidersMock.mock.invocationCallOrder[0]).toBeLessThan(
+      enqueueSyncInstanceTemplatesMock.mock.invocationCallOrder[0]
+    );
+    expect(enqueueSyncInstanceTemplatesMock).toHaveBeenCalledWith([
+      { integrationInstanceId: 'ins_1' }
+    ]);
+  });
+
+  it('repins source instance providers before syncing group session templates', async () => {
+    let providerVersionOid = 20n;
+    let integrationInstanceProvider = {
+      oid: 30n,
+      currentVersion: {
+        integrationProviderVersionOid: 10n,
+        configOid: 40n,
+        authConfigOid: null,
+        toolFilter: null,
+        isOverrideToolFilter: false
+      }
+    };
+    db.integrationProvider.findUnique.mockResolvedValue({
+      oid: 1n,
+      currentVersionOid: providerVersionOid
+    });
+    db.integrationInstanceGroupProvider.findMany.mockResolvedValue([
+      {
+        id: 'iigp_1',
+        integrationInstanceGroup: { id: 'iig_1' },
+        integrationInstanceProvider
+      }
+    ]);
+
+    await processors.get('sub/int/lc/integrationProvider/updated/group')!({
+      integrationProviderId: 'ipr_1'
+    });
+
+    expect(repinIntegrationInstanceProvidersMock).toHaveBeenCalledWith({
+      integrationProviderVersionOid: providerVersionOid,
+      integrationInstanceProviders: [integrationInstanceProvider]
+    });
+    expect(repinIntegrationInstanceProvidersMock.mock.invocationCallOrder[0]).toBeLessThan(
+      enqueueSyncGroupTemplatesMock.mock.invocationCallOrder[0]
+    );
+    expect(enqueueSyncGroupTemplatesMock).toHaveBeenCalledWith([
+      { integrationInstanceGroupId: 'iig_1' }
+    ]);
+  });
+});

--- a/src/systems/subspace/modules/provider-internal/src/lib/toolFilter.test.ts
+++ b/src/systems/subspace/modules/provider-internal/src/lib/toolFilter.test.ts
@@ -77,6 +77,40 @@ let toolKeysFilter = (keys: string[]): PrismaJson.ToolFilter => ({
 });
 
 describe('buildIntegrationProviderToolFilterChain', () => {
+  it('preserves integration provider filters when instance provider filters are inherited', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      integrationProviderToolFilter: toolKeysFilter(['add']),
+      integrationInstanceProviderToolFilter: null,
+      integrationInstanceProviderIsOverride: false
+    });
+
+    expect(checkToolAccess(addTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: true
+    });
+    expect(checkToolAccess(divideTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: false
+    });
+  });
+
+  it('does not let non-override allow-all instance filters clear parent filters', () => {
+    let addTool = createTool('add');
+    let divideTool = createTool('divide');
+    let chain = buildIntegrationProviderToolFilterChain({
+      integrationProviderToolFilter: toolKeysFilter(['add']),
+      integrationInstanceProviderToolFilter: { type: 'v1.allow_all' },
+      integrationInstanceProviderIsOverride: false
+    });
+
+    expect(checkToolAccess(addTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: true
+    });
+    expect(checkToolAccess(divideTool, [chain as PrismaJson.ToolFilter], 'list')).toEqual({
+      allowed: false
+    });
+  });
+
   it('stacks integration provider and instance provider filters as ANDed filters', () => {
     let addTool = createTool('add');
     let divideTool = createTool('divide');

--- a/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
+++ b/src/systems/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
@@ -9,9 +9,6 @@ import { sessionMessageService } from '../services/sessionMessage';
 export let PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY =
   'provider-telemetry/error-groups/failed-messages/state.json';
 
-export let PROVIDER_TELEMETRY_ERROR_GROUPS_STATE_KEY =
-  PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY;
-
 let DEFAULT_EXPORT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
 let EXPORT_PAGE_SIZE = 100;
 
@@ -72,7 +69,7 @@ let isNotFoundError = (error: unknown) =>
   'statusCode' in error &&
   (error as { statusCode?: number }).statusCode === 404;
 
-export let readProviderTelemetryErrorGroupsExportState = async (d: {
+let readProviderTelemetryErrorGroupsExportState = async (d: {
   storage: ProviderTelemetryErrorGroupsExportStorage;
   bucketName: string;
 }) => {
@@ -105,7 +102,7 @@ let getExportRange = (
   return { from, to: now };
 };
 
-export let watermarkFromProviderTelemetryFailedMessage = (
+let watermarkFromProviderTelemetryFailedMessage = (
   item: Pick<ProviderTelemetryFailedMessageExportCandidate, 'error' | 'occurredAt'>
 ): ProviderTelemetryFailedMessagesExportWatermark => ({
   occurred_at: item.occurredAt.toISOString(),
@@ -258,16 +255,12 @@ let writeJsonObject = async (d: {
   );
 };
 
-let providerTelemetryExportRedactionOptions = {
+let providerTelemetryExportRedactor = new OpenRedaction({
   deterministic: true,
   redactionMode: 'placeholder' as const,
   enableLearning: false,
   enableCache: true
-};
-
-let providerTelemetryExportRedactor = new OpenRedaction(
-  providerTelemetryExportRedactionOptions
-);
+});
 let providerTelemetryExportJsonProcessor = new JsonProcessor();
 
 let normalizeJsonValue = (value: unknown) => {

--- a/src/systems/subspace/modules/session/src/services/_shared/createSession.ts
+++ b/src/systems/subspace/modules/session/src/services/_shared/createSession.ts
@@ -1,10 +1,10 @@
 import {
   addAfterTransactionHook,
-  db,
   type Environment,
   getId,
   type Solution,
-  type Tenant
+  type Tenant,
+  withTransaction
 } from '@metorial-subspace/db';
 import { sessionCreatedQueue } from '../../queues/lifecycle/session';
 import { sessionProviderInclude } from '../sessionProvider';
@@ -23,10 +23,6 @@ export let sessionInclude = {
 };
 
 export let createSessionRecord = async (d: {
-  db: {
-    session: typeof db.session;
-    sessionTemplate: typeof db.sessionTemplate;
-  };
   tenant: Tenant;
   solution: Solution;
   environment: Environment;
@@ -42,69 +38,71 @@ export let createSessionRecord = async (d: {
   isEphemeral: boolean;
   ephemeralManagedSessionOid?: bigint | null;
 }) => {
-  let templateId = d.input.providers.find(
-    provider => provider.sessionTemplateId
-  )?.sessionTemplateId;
-  let templateIdentity =
-    d.identityActorOid === undefined && d.identityOid === undefined && templateId
-      ? await d.db.sessionTemplate.findFirst({
-          where: {
-            id: templateId,
+  return withTransaction(async db => {
+    let templateId = d.input.providers.find(
+      provider => provider.sessionTemplateId
+    )?.sessionTemplateId;
+    let templateIdentity =
+      d.identityActorOid === undefined && d.identityOid === undefined && templateId
+        ? await db.sessionTemplate.findFirst({
+            where: {
+              id: templateId,
+              tenantOid: d.tenant.oid,
+              solutionOid: d.solution.oid,
+              environmentOid: d.environment.oid,
+              status: 'active'
+            },
+            select: {
+              identityActorOid: true,
+              identityOid: true
+            }
+          })
+        : null;
+
+    let session = await db.session.create({
+      data: {
+        ...getId('session'),
+        status: 'active',
+
+        isEphemeral: d.isEphemeral,
+
+        name: d.input.name?.trim() || undefined,
+        description: d.input.description?.trim() || undefined,
+        metadata: d.input.metadata,
+        privateMetadata: d.input.privateMetadata,
+
+        tenantOid: d.tenant.oid,
+        solutionOid: d.solution.oid,
+        environmentOid: d.environment.oid,
+        identityActorOid: d.identityActorOid ?? templateIdentity?.identityActorOid ?? null,
+        identityOid: d.identityOid ?? templateIdentity?.identityOid ?? null,
+        ephemeralManagedSessionOid: d.ephemeralManagedSessionOid ?? undefined,
+
+        sessionEvents: {
+          create: {
+            ...getId('sessionEvent'),
+            type: 'session_created',
             tenantOid: d.tenant.oid,
             solutionOid: d.solution.oid,
-            environmentOid: d.environment.oid,
-            status: 'active'
-          },
-          select: {
-            identityActorOid: true,
-            identityOid: true
+            environmentOid: d.environment.oid
           }
-        })
-      : null;
-
-  let session = await d.db.session.create({
-    data: {
-      ...getId('session'),
-      status: 'active',
-
-      isEphemeral: d.isEphemeral,
-
-      name: d.input.name?.trim() || undefined,
-      description: d.input.description?.trim() || undefined,
-      metadata: d.input.metadata,
-      privateMetadata: d.input.privateMetadata,
-
-      tenantOid: d.tenant.oid,
-      solutionOid: d.solution.oid,
-      environmentOid: d.environment.oid,
-      identityActorOid: d.identityActorOid ?? templateIdentity?.identityActorOid ?? null,
-      identityOid: d.identityOid ?? templateIdentity?.identityOid ?? null,
-      ephemeralManagedSessionOid: d.ephemeralManagedSessionOid ?? undefined,
-
-      sessionEvents: {
-        create: {
-          ...getId('sessionEvent'),
-          type: 'session_created',
-          tenantOid: d.tenant.oid,
-          solutionOid: d.solution.oid,
-          environmentOid: d.environment.oid
         }
-      }
-    },
-    include: sessionInclude
+      },
+      include: sessionInclude
+    });
+
+    session.providers = await sessionProviderInputService.createSessionProvidersForInput({
+      tenant: d.tenant,
+      solution: d.solution,
+      environment: d.environment,
+      session,
+      providers: d.input.providers
+    });
+
+    await addAfterTransactionHook(async () =>
+      sessionCreatedQueue.add({ sessionId: session.id })
+    );
+
+    return session;
   });
-
-  session.providers = await sessionProviderInputService.createSessionProvidersForInput({
-    tenant: d.tenant,
-    solution: d.solution,
-    environment: d.environment,
-    session,
-    providers: d.input.providers
-  });
-
-  await addAfterTransactionHook(async () =>
-    sessionCreatedQueue.add({ sessionId: session.id })
-  );
-
-  return session;
 };

--- a/src/systems/subspace/modules/session/src/services/ephemeralManagedSession.ts
+++ b/src/systems/subspace/modules/session/src/services/ephemeralManagedSession.ts
@@ -180,7 +180,6 @@ class ephemeralManagedSessionServiceImpl {
       });
 
       let session = await createSessionRecord({
-        db: db,
         tenant: d.tenant,
         solution: d.solution,
         environment: d.environment,
@@ -389,7 +388,6 @@ class ephemeralManagedSessionServiceImpl {
 
       return await withTransaction(async db => {
         let session = await createSessionRecord({
-          db: db,
           tenant: ephemeralManagedSession.tenant,
           solution: ephemeralManagedSession.solution,
           environment: ephemeralManagedSession.environment,

--- a/src/systems/subspace/modules/session/src/services/session.ts
+++ b/src/systems/subspace/modules/session/src/services/session.ts
@@ -210,7 +210,6 @@ class sessionServiceImpl {
   }) {
     return withTransaction(async db =>
       createSessionRecord({
-        db,
         tenant: d.tenant,
         solution: d.solution,
         environment: d.environment,

--- a/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
+++ b/src/systems/subspace/modules/session/src/services/sessionTemplateProvider.ts
@@ -34,6 +34,7 @@ import {
   resolveProviders,
   resolveSessionTemplates
 } from '@metorial-subspace/list-utils';
+import { buildIntegrationProviderToolFilterChain } from '@metorial-subspace/module-provider-internal';
 import { checkTenant } from '@metorial-subspace/module-tenant';
 import {
   enqueueSessionTemplateProvidersCreated,
@@ -61,8 +62,6 @@ let include = {
   }
 };
 export let sessionTemplateProviderInclude = include;
-
-let allowAllToolFilter = (): PrismaJson.ToolFilter => ({ type: 'v1.allow_all' });
 
 let assertCanWriteSessionTemplateProvider = (
   provider: Pick<SessionTemplateProvider, 'integrationInstanceProviderOid'> & {
@@ -333,11 +332,18 @@ class sessionTemplateProviderServiceImpl {
 
         for (let provider of instanceProviders) {
           let currentVersion = provider.currentVersion!;
+          let toolFilter = buildIntegrationProviderToolFilterChain({
+            canAttachCustomToolFilters: provider.integration.canAttachCustomToolFilters,
+            canOverrideToolFilters: provider.integration.canOverrideToolFilters,
+            integrationProviderToolFilter: currentVersion.integrationProviderVersion
+              .toolFilter as PrismaJson.ToolFilter | null,
+            integrationInstanceProviderToolFilter:
+              currentVersion.toolFilter as PrismaJson.ToolFilter | null,
+            integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter
+          });
           let data = {
             status: 'active' as const,
-            toolFilter:
-              (currentVersion.toolFilter as PrismaJson.ToolFilter | null) ??
-              allowAllToolFilter(),
+            toolFilter,
             sessionTemplateOid: d.sessionTemplate.oid,
             providerOid: provider.integrationProvider.providerOid,
             deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,
@@ -409,6 +415,7 @@ class sessionTemplateProviderServiceImpl {
           },
           orderBy: { id: 'asc' },
           include: {
+            integration: true,
             integrationProvider: true,
             integrationInstanceProvider: {
               include: {
@@ -480,7 +487,7 @@ class sessionTemplateProviderServiceImpl {
           existing?: (typeof existingProviders)[number];
           data: {
             status: 'active';
-            toolFilter: PrismaJson.ToolFilter;
+            toolFilter: PrismaJson.ToolFilterChain;
             sessionTemplateOid: bigint;
             providerOid: bigint;
             deploymentOid: bigint;
@@ -528,10 +535,21 @@ class sessionTemplateProviderServiceImpl {
 
         for (let provider of groupProviders) {
           let currentVersion = provider.integrationInstanceProvider.currentVersion!;
+          let toolFilter = buildIntegrationProviderToolFilterChain({
+            canAttachCustomToolFilters: provider.integration.canAttachCustomToolFilters,
+            canOverrideToolFilters: provider.integration.canOverrideToolFilters,
+            integrationProviderToolFilter: currentVersion.integrationProviderVersion
+              .toolFilter as PrismaJson.ToolFilter | null,
+            integrationInstanceProviderToolFilter:
+              currentVersion.toolFilter as PrismaJson.ToolFilter | null,
+            integrationInstanceProviderIsOverride: currentVersion.isOverrideToolFilter,
+            integrationInstanceGroupProviderToolFilter:
+              provider.toolFilter as PrismaJson.ToolFilter | null,
+            integrationInstanceGroupProviderIsOverride: provider.isOverrideToolFilter
+          });
           let data = {
             status: 'active' as const,
-            toolFilter:
-              (provider.toolFilter as PrismaJson.ToolFilter | null) ?? allowAllToolFilter(),
+            toolFilter,
             sessionTemplateOid: d.sessionTemplate.oid,
             providerOid: provider.integrationProvider.providerOid,
             deploymentOid: currentVersion.integrationProviderVersion.deploymentOid,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect tool-access enforcement and session-template/provider versioning across integration and Magic MCP paths; incorrect optional-vs-null handling could widen or narrow tool exposure, though behavior is heavily covered by new tests.
> 
> **Overview**
> **Tool filter semantics** are tightened so **omitting `toolFilters` no longer overwrites stored filters**, while **`null` still clears or resets** (e.g. allow-all at integration-provider layers, `JsonNull` on Magic MCP endpoint-server links). Controllers for integration providers, session providers, deployments, and auth/config resources only pass `toolFilters` when the client included the field; Magic MCP `addServersToEndpoint` and subspace endpoint backing upserts apply the same **presence-based** update logic.
> 
> **Integration versioning and sync** skip creating duplicate **integration instance provider versions** when material is unchanged (canonical tool-filter comparison), add **`repinIntegrationInstanceProvidersToIntegrationProviderVersion`**, and on **integration provider update** run new paginated jobs that repin linked instance (and group) providers before enqueueing session-template sync.
> 
> **Session templates** now derive stored filters via **`buildIntegrationProviderToolFilterChain`** (integration → instance → group layers) instead of using instance filters alone. Group-provider sets use a shared **`resolveIntegrationInstanceGroupProviderToolFilterInput`** helper.
> 
> Smaller changes: typed Magic MCP backing service calls (no `as any`), integration-instance Magic MCP table column **Type** instead of Providers, and added unit/lifecycle tests for the above behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c143101db5923d346ada307baa16d33dbd3fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->