### PR TITLE
Harden conduit message passing

### DIFF
--- a/.github/workflows/subspace.yml
+++ b/.github/workflows/subspace.yml
@@ -72,6 +72,34 @@ jobs:
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 
+  conduit-integration:
+    name: 'Conduit Integration (Redis + NATS)'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Packages
+        run: bun i --linker=hoisted
+
+      # Docker is preinstalled on ubuntu-latest. The Vitest globalSetup brings the
+      # Redis + NATS containers up (and tears them down), so no `services:` block
+      # is needed and local == CI via the same compose-driven setup.
+      - name: Run conduit integration tests
+        run: bun run test:integration
+        working-directory: src/subspace/packages/conduit
+
   test:
     name: 'Subspace Test'
     permissions:

--- a/src/subspace/apps/controller/src/endpoints.ts
+++ b/src/subspace/apps/controller/src/endpoints.ts
@@ -33,7 +33,7 @@ if (process.env.NODE_ENV === 'production') {
           await redis.ping();
 
           await checkNatsHealth();
-          await checkConduitHeartbeat();
+          await checkConduitHeartbeat({ failOnEmptyFleet: false });
 
           return new Response('OK');
         } catch (e) {

--- a/src/subspace/apps/controller/src/server.ts
+++ b/src/subspace/apps/controller/src/server.ts
@@ -33,7 +33,7 @@ if (process.env.HEARTBEAT_URL) {
         await import('@metorial-subspace/module-connection/src/health');
 
       await checkNatsHealth();
-      await checkConduitHeartbeat();
+      await checkConduitHeartbeat({ failOnEmptyFleet: true });
       await fetch(process.env.HEARTBEAT_URL!, { method: 'POST' });
     } catch (error) {
       await captureHeartbeatError(error);

--- a/src/subspace/apps/worker/src/connection.ts
+++ b/src/subspace/apps/worker/src/connection.ts
@@ -1,3 +1,36 @@
 import { startReceiver } from '@metorial-subspace/module-connection';
 
-startReceiver();
+let receiver = startReceiver();
+
+let DRAIN_TIMEOUT_MS = 25000;
+let DRAIN_POLL_MS = 250;
+
+let shuttingDown = false;
+
+let gracefulShutdown = async (signal: string) => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  console.log(`CONDUIT.worker.shutdown signal=${signal} draining in-flight messages`);
+
+  let deadline = Date.now() + DRAIN_TIMEOUT_MS;
+  try {
+    while (Date.now() < deadline) {
+      let stats = receiver.getStats();
+      if (stats.inFlight === 0) break;
+      await new Promise(resolve => setTimeout(resolve, DRAIN_POLL_MS));
+    }
+
+    let remaining = receiver.getStats().inFlight;
+    console.log(`CONDUIT.worker.shutdown.draining_done remainingInFlight=${remaining}`);
+
+    await receiver.stop();
+  } catch (err) {
+    console.error('CONDUIT.worker.shutdown.error', err);
+  } finally {
+    process.exit(0);
+  }
+};
+
+process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => void gracefulShutdown('SIGINT'));

--- a/src/subspace/apps/worker/src/endpoints.ts
+++ b/src/subspace/apps/worker/src/endpoints.ts
@@ -1,5 +1,6 @@
 import { withTracingSuppressed } from '@lowerdeck/telemetry';
 import { db } from '@metorial-subspace/db';
+import { getConnectionReceiver } from '@metorial-subspace/module-connection';
 import { checkNatsHealth } from '@metorial-subspace/module-connection/src/health';
 import { RedisClient } from 'bun';
 
@@ -17,6 +18,11 @@ if (process.env.NODE_ENV === 'production') {
           await redis.ping();
 
           await checkNatsHealth();
+
+          let receiver = getConnectionReceiver();
+          if (receiver && receiver.isReady() && !receiver.isHealthy()) {
+            return new Response('Service Unavailable', { status: 503 });
+          }
 
           return new Response('OK');
         } catch (e) {

--- a/src/subspace/apps/worker/src/server.ts
+++ b/src/subspace/apps/worker/src/server.ts
@@ -30,10 +30,11 @@ if (process.env.HEARTBEAT_URL) {
 
   let sendHeartbeat = async () => {
     try {
-      let { checkNatsHealth } =
+      let { checkNatsHealth, checkConduitSelfHealth } =
         await import('@metorial-subspace/module-connection/src/health');
 
       await checkNatsHealth();
+      await checkConduitSelfHealth();
       await fetch(process.env.HEARTBEAT_URL!, { method: 'POST' });
     } catch (error) {
       await captureHeartbeatError(error);

--- a/src/subspace/modules/connection/src/controller/receiver.ts
+++ b/src/subspace/modules/connection/src/controller/receiver.ts
@@ -25,6 +25,12 @@ const NO_OUTPUT_ERROR = {
   data: { code: 'no_result', message: 'Provided did not return a result' }
 } satisfies PrismaJson.SessionMessageOutput;
 
+let connectionReceiver:
+  | (ReturnType<typeof conduit.createConduitReceiver> & { started: Promise<void> })
+  | null = null;
+
+export let getConnectionReceiver = () => connectionReceiver;
+
 export let startReceiver = () => {
   let receiver = conduit.createConduitReceiver(async ctx => {
     ctx.extendTtl(1000 * 60);
@@ -331,5 +337,6 @@ export let startReceiver = () => {
     console.error('Error starting Connection Controller receiver:', err);
   });
 
-  return Object.assign(receiver, { started });
+  connectionReceiver = Object.assign(receiver, { started });
+  return connectionReceiver;
 };

--- a/src/subspace/modules/connection/src/health/conduitHeartbeat.test.ts
+++ b/src/subspace/modules/connection/src/health/conduitHeartbeat.test.ts
@@ -3,10 +3,18 @@ import type { ConduitHeartbeatPong } from '@metorial-subspace/connection-utils';
 import type { ConduitResponse } from '@metorial-subspace/conduit';
 import {
   checkConduitHeartbeat,
+  checkConduitHeartbeatFleet,
   ConduitHeartbeatError,
   type ConduitHeartbeatSender
 } from './conduitHeartbeat';
 import { topics } from '../lib/topic';
+
+let healthyPong = (receiverId: string): ConduitResponse => ({
+  messageId: 'message-id',
+  success: true,
+  processedAt: 1,
+  result: { type: 'conduit.health.pong', receiverId, at: 1 }
+});
 
 describe('checkConduitHeartbeat', () => {
   it('sends a health ping and returns the matching pong', async () => {
@@ -83,5 +91,132 @@ describe('checkConduitHeartbeat', () => {
     await expect(
       checkConduitHeartbeat({ sender, id: 'heartbeat-id', now: () => 123 })
     ).rejects.toBeInstanceOf(ConduitHeartbeatError);
+  });
+
+  it('tolerates an empty fleet when failOnEmptyFleet is false (no send, no churn)', async () => {
+    let sent = false;
+    let sender: ConduitHeartbeatSender = {
+      send: async () => {
+        sent = true;
+        throw new Error('No receiver available for topic v1-health-worker');
+      }
+    };
+
+    let result = await checkConduitHeartbeat({
+      sender,
+      failOnEmptyFleet: false,
+      coordination: { getActiveReceivers: async () => [] }
+    });
+
+    expect(sent).toBe(false);
+    expect(result).toEqual({ emptyFleet: true });
+  });
+});
+
+describe('checkConduitHeartbeatFleet', () => {
+  it('fails when the fleet is empty (total worker outage)', async () => {
+    await expect(
+      checkConduitHeartbeatFleet({
+        coordination: { getActiveReceivers: async () => [] },
+        pingReceiver: async () => healthyPong('unused'),
+        startupGraceMs: 0
+      })
+    ).rejects.toBeInstanceOf(ConduitHeartbeatError);
+  });
+
+  it('tolerates an empty fleet when failOnEmptyFleet is false (no churn)', async () => {
+    let result = await checkConduitHeartbeatFleet({
+      coordination: { getActiveReceivers: async () => [] },
+      pingReceiver: async () => healthyPong('unused'),
+      startupGraceMs: 0,
+      failOnEmptyFleet: false
+    });
+
+    expect(result).toEqual({ activeReceivers: 0, probed: 0, emptyFleet: true });
+  });
+
+  it('returns healthy when probed receivers pong', async () => {
+    let id = `rx-healthy-${crypto.randomUUID()}`;
+    let pinged: string[] = [];
+
+    let result = await checkConduitHeartbeatFleet({
+      coordination: { getActiveReceivers: async () => [id] },
+      pingReceiver: async receiverId => {
+        pinged.push(receiverId);
+        return healthyPong(receiverId);
+      },
+      startupGraceMs: 0
+    });
+
+    expect(pinged).toEqual([id]);
+    expect(result).toEqual({ activeReceivers: 1, probed: 1 });
+  });
+
+  it('does not count a failure toward wedged when the re-fetch also fails', async () => {
+    let id = `rx-blip-${crypto.randomUUID()}`;
+    let calls = 0;
+
+    // First call (top of fn) succeeds; the re-fetch inside the catch throws.
+    let coordination = {
+      getActiveReceivers: async () => {
+        calls++;
+        if (calls === 1) return [id];
+        throw new Error('redis blip');
+      }
+    };
+
+    // failureThreshold 1 means: if the failure were counted, it would wedge and
+    // throw. Indeterminate coordination must instead be skipped.
+    let result = await checkConduitHeartbeatFleet({
+      coordination,
+      pingReceiver: async () => {
+        throw new Error('ping failed');
+      },
+      startupGraceMs: 0,
+      failureThreshold: 1
+    });
+
+    expect(result).toEqual({ activeReceivers: 1, probed: 1 });
+  });
+
+  it('wedges a receiver after failureThreshold consecutive confirmed failures', async () => {
+    let id = `rx-wedge-${crypto.randomUUID()}`;
+    let coordination = { getActiveReceivers: async () => [id] };
+    let pingReceiver = async () => {
+      throw new Error('ping failed');
+    };
+    let opts = { coordination, pingReceiver, startupGraceMs: 0, failureThreshold: 2 };
+
+    // First failure: below threshold, still healthy.
+    let first = await checkConduitHeartbeatFleet(opts);
+    expect(first).toEqual({ activeReceivers: 1, probed: 1 });
+
+    // Second consecutive failure reaches the threshold and wedges.
+    await expect(checkConduitHeartbeatFleet(opts)).rejects.toBeInstanceOf(
+      ConduitHeartbeatError
+    );
+  });
+
+  it('discounts a receiver that has left the pool (not wedged)', async () => {
+    let id = `rx-left-${crypto.randomUUID()}`;
+    let calls = 0;
+    let coordination = {
+      getActiveReceivers: async () => {
+        calls++;
+        // Present at the top of the fn, gone on the re-fetch (graceful leave).
+        return calls === 1 ? [id] : [];
+      }
+    };
+
+    let result = await checkConduitHeartbeatFleet({
+      coordination,
+      pingReceiver: async () => {
+        throw new Error('ping failed');
+      },
+      startupGraceMs: 0,
+      failureThreshold: 1
+    });
+
+    expect(result).toEqual({ activeReceivers: 1, probed: 1 });
   });
 });

--- a/src/subspace/modules/connection/src/health/conduitHeartbeat.ts
+++ b/src/subspace/modules/connection/src/health/conduitHeartbeat.ts
@@ -1,4 +1,9 @@
-import type { ConduitResponse } from '@metorial-subspace/conduit';
+import {
+  type ConduitResponse,
+  type ICoordinationAdapter,
+  type Sender,
+  isConduitHealthPong
+} from '@metorial-subspace/conduit';
 import type {
   ConduitHeartbeatPing,
   ConduitHeartbeatPong
@@ -7,6 +12,15 @@ import { conduit } from '../lib/conduit';
 import { topics } from '../lib/topic';
 
 let HEARTBEAT_TIMEOUT_MS = 1500;
+
+let FLEET_STARTUP_GRACE_MS = 15000;
+
+let FLEET_FAILURE_THRESHOLD = 3;
+
+let isFleetHealthEnabled = () => {
+  let v = process.env.CONDUIT_FLEET_HEALTH;
+  return v === '1' || v === 'true' || v === 'yes';
+};
 
 export class ConduitHeartbeatError extends Error {
   originalError?: Error;
@@ -62,6 +76,13 @@ export let isConduitHeartbeatPong = (value: unknown): value is ConduitHeartbeatP
 };
 
 export let checkConduitHeartbeat = async (opts: CheckConduitHeartbeatOpts = {}) => {
+  if (isFleetHealthEnabled()) {
+    return checkConduitHeartbeatFleet(opts);
+  }
+  return checkConduitHeartbeatLegacy(opts);
+};
+
+let checkConduitHeartbeatLegacy = async (opts: CheckConduitHeartbeatOpts = {}) => {
   let id = opts.id ?? crypto.randomUUID();
   let sentAt = opts.now?.() ?? Date.now();
   let timeoutMs = opts.timeoutMs ?? HEARTBEAT_TIMEOUT_MS;
@@ -103,4 +124,168 @@ export let checkConduitHeartbeat = async (opts: CheckConduitHeartbeatOpts = {}) 
   }
 
   return response.result;
+};
+
+let fleetSender: Sender | null = null;
+
+let getFleetSender = (): Sender => {
+  if (!fleetSender) {
+    fleetSender = conduit.createSender({
+      defaultTimeout: HEARTBEAT_TIMEOUT_MS,
+      maxRetries: 0
+    });
+  }
+  return fleetSender;
+};
+
+// Per-receiver churn-tolerance state (controller-local). first-seen lets us
+// apply a startup grace; consecutive-failure counts avoid false alerts on a
+// transient blip.
+let receiverFirstSeenAt = new Map<string, number>();
+let receiverConsecutiveFailures = new Map<string, number>();
+
+export interface CheckConduitHeartbeatFleetOpts {
+  coordination?: Pick<ICoordinationAdapter, 'getActiveReceivers'>;
+  pingReceiver?: (receiverId: string, timeoutMs: number) => Promise<ConduitResponse>;
+  timeoutMs?: number;
+  now?: () => number;
+  startupGraceMs?: number;
+  failureThreshold?: number;
+}
+
+let isHealthyPong = (response: ConduitResponse): boolean =>
+  response.success && isConduitHealthPong(response.result);
+
+export let checkConduitHeartbeatFleet = async (opts: CheckConduitHeartbeatFleetOpts = {}) => {
+  let now = opts.now?.() ?? Date.now();
+  let timeoutMs = opts.timeoutMs ?? HEARTBEAT_TIMEOUT_MS;
+  let startupGraceMs = opts.startupGraceMs ?? FLEET_STARTUP_GRACE_MS;
+  let failureThreshold = opts.failureThreshold ?? FLEET_FAILURE_THRESHOLD;
+  let coordination = opts.coordination ?? conduit.coordination;
+  let pingReceiver =
+    opts.pingReceiver ??
+    ((receiverId: string, t: number) => getFleetSender().pingReceiver(receiverId, t));
+
+  let receivers: string[];
+  try {
+    receivers = await coordination.getActiveReceivers();
+  } catch (err) {
+    throw new ConduitHeartbeatError(
+      `Conduit heartbeat failed: could not list active receivers: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : undefined
+    );
+  }
+
+  // Maintain first-seen timestamps and prune receivers that have left.
+  let active = new Set(receivers);
+  for (let id of [...receiverFirstSeenAt.keys()]) {
+    if (!active.has(id)) {
+      receiverFirstSeenAt.delete(id);
+      receiverConsecutiveFailures.delete(id);
+    }
+  }
+  for (let id of receivers) {
+    if (!receiverFirstSeenAt.has(id)) receiverFirstSeenAt.set(id, now);
+  }
+
+  // Only probe receivers that are past the startup grace.
+  let toProbe = receivers.filter(
+    id => now - (receiverFirstSeenAt.get(id) ?? now) >= startupGraceMs
+  );
+
+  let wedged: string[] = [];
+
+  await Promise.all(
+    toProbe.map(async id => {
+      try {
+        let response = await pingReceiver(id, timeoutMs);
+        if (!isHealthyPong(response)) {
+          throw new Error(response.error ?? 'invalid health pong');
+        }
+        receiverConsecutiveFailures.set(id, 0);
+      } catch {
+        // Re-fetch the active set: if the receiver has since left the pool it is
+        // leaving (deploy / scale-in / crash-replace), not wedged - discount it.
+        let stillActive: string[] = [];
+        try {
+          stillActive = await coordination.getActiveReceivers();
+        } catch {
+          stillActive = receivers;
+        }
+        if (!stillActive.includes(id)) {
+          receiverFirstSeenAt.delete(id);
+          receiverConsecutiveFailures.delete(id);
+          return;
+        }
+
+        let failures = (receiverConsecutiveFailures.get(id) ?? 0) + 1;
+        receiverConsecutiveFailures.set(id, failures);
+        if (failures >= failureThreshold) {
+          wedged.push(id);
+        }
+      }
+    })
+  );
+
+  if (wedged.length > 0) {
+    throw new ConduitHeartbeatError(
+      `Conduit heartbeat failed: ${wedged.length} active receiver(s) wedged: ${wedged.join(', ')}`
+    );
+  }
+
+  return { activeReceivers: receivers.length, probed: toProbe.length };
+};
+
+export interface CheckConduitSelfHealthOpts {
+  receiverId?: string;
+  pingReceiver?: (receiverId: string, timeoutMs: number) => Promise<ConduitResponse>;
+  timeoutMs?: number;
+}
+
+export let checkConduitSelfHealth = async (opts: CheckConduitSelfHealthOpts = {}) => {
+  let timeoutMs = opts.timeoutMs ?? HEARTBEAT_TIMEOUT_MS;
+
+  let receiverId = opts.receiverId;
+  if (!receiverId) {
+    let { getConnectionReceiver } = await import('../controller/receiver');
+    let receiver = getConnectionReceiver();
+    if (!receiver) {
+      throw new ConduitHeartbeatError(
+        'Conduit self-health failed: no local receiver is running'
+      );
+    }
+    // During startup the receiver may not be ready yet; treat as healthy so we
+    // do not flap before the subscription is established.
+    if (!receiver.isReady()) {
+      return { receiverId: receiver.getReceiverId(), ready: false };
+    }
+    // Fast local wedge signal before paying for an end-to-end round trip.
+    if (!receiver.isHealthy()) {
+      throw new ConduitHeartbeatError(
+        `Conduit self-health failed: local receiver ${receiver.getReceiverId()} is unhealthy`
+      );
+    }
+    receiverId = receiver.getReceiverId();
+  }
+
+  let pingReceiver =
+    opts.pingReceiver ?? ((rid: string, t: number) => getFleetSender().pingReceiver(rid, t));
+
+  let response: ConduitResponse;
+  try {
+    response = await pingReceiver(receiverId, timeoutMs);
+  } catch (err) {
+    throw new ConduitHeartbeatError(
+      `Conduit self-health failed: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : undefined
+    );
+  }
+
+  if (!isHealthyPong(response)) {
+    throw new ConduitHeartbeatError(
+      `Conduit self-health failed: ${response.error ?? 'local receiver returned an invalid pong'}`
+    );
+  }
+
+  return { receiverId, ready: true };
 };

--- a/src/subspace/modules/connection/src/health/conduitHeartbeat.ts
+++ b/src/subspace/modules/connection/src/health/conduitHeartbeat.ts
@@ -41,6 +41,15 @@ export interface CheckConduitHeartbeatOpts {
   timeoutMs?: number;
   now?: () => number;
   id?: string;
+  /**
+   * Whether a totally empty fleet (no active receivers) should fail the check.
+   *
+   * Defaults to `true` so the external heartbeat (BetterUptime) still alerts on a
+   * full worker outage. ECS liveness passes `false`: replacing the controller
+   * can't bring workers back, so an empty fleet should not churn the instance.
+   */
+  failOnEmptyFleet?: boolean;
+  coordination?: Pick<ICoordinationAdapter, 'getActiveReceivers'>;
 }
 
 let heartbeatSender: ConduitHeartbeatSender | null = null;
@@ -88,6 +97,18 @@ let checkConduitHeartbeatLegacy = async (opts: CheckConduitHeartbeatOpts = {}) =
   let timeoutMs = opts.timeoutMs ?? HEARTBEAT_TIMEOUT_MS;
   let sender = opts.sender ?? (await getHeartbeatSender());
   let topic = topics.workerHeartbeat.encode();
+
+  // For callers that tolerate an empty fleet (ECS liveness), short-circuit before
+  // the send so a worker outage - which makes the send throw "No receiver
+  // available" - doesn't churn this instance. The external heartbeat keeps the
+  // default (failOnEmptyFleet) and still alerts.
+  if (opts.failOnEmptyFleet === false) {
+    let coordination = opts.coordination ?? conduit.coordination;
+    let active = await coordination.getActiveReceivers().catch(() => null);
+    if (active && active.length === 0) {
+      return { emptyFleet: true } as const;
+    }
+  }
 
   let ping = {
     type: 'health.ping',
@@ -151,6 +172,8 @@ export interface CheckConduitHeartbeatFleetOpts {
   now?: () => number;
   startupGraceMs?: number;
   failureThreshold?: number;
+  /** See {@link CheckConduitHeartbeatOpts.failOnEmptyFleet}. Defaults to `true`. */
+  failOnEmptyFleet?: boolean;
 }
 
 let isHealthyPong = (response: ConduitResponse): boolean =>
@@ -173,6 +196,19 @@ export let checkConduitHeartbeatFleet = async (opts: CheckConduitHeartbeatFleetO
     throw new ConduitHeartbeatError(
       `Conduit heartbeat failed: could not list active receivers: ${err instanceof Error ? err.message : String(err)}`,
       err instanceof Error ? err : undefined
+    );
+  }
+
+  // An empty fleet means a total worker outage. The external heartbeat fails
+  // here (so BetterUptime alerts), but ECS liveness passes `failOnEmptyFleet:
+  // false` so it doesn't churn the controller - replacing it can't bring the
+  // workers back.
+  if (receivers.length === 0) {
+    if (opts.failOnEmptyFleet === false) {
+      return { activeReceivers: 0, probed: 0, emptyFleet: true };
+    }
+    throw new ConduitHeartbeatError(
+      'Conduit heartbeat failed: no active receivers in the fleet'
     );
   }
 
@@ -206,12 +242,18 @@ export let checkConduitHeartbeatFleet = async (opts: CheckConduitHeartbeatFleetO
       } catch {
         // Re-fetch the active set: if the receiver has since left the pool it is
         // leaving (deploy / scale-in / crash-replace), not wedged - discount it.
-        let stillActive: string[] = [];
+        let stillActive: string[] | null = null;
         try {
           stillActive = await coordination.getActiveReceivers();
         } catch {
-          stillActive = receivers;
+          stillActive = null; // coordination uncertain
         }
+
+        // Can't confirm state during a coordination blip: skip this cycle so a
+        // transient error doesn't accumulate toward the wedged threshold for an
+        // otherwise-healthy receiver.
+        if (stillActive === null) return;
+
         if (!stillActive.includes(id)) {
           receiverFirstSeenAt.delete(id);
           receiverConsecutiveFailures.delete(id);

--- a/src/subspace/packages/conduit/package.json
+++ b/src/subspace/packages/conduit/package.json
@@ -10,7 +10,9 @@
     "example:topic-listener": "bun run example-topic-listener.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration:watch": "vitest --config vitest.integration.config.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/subspace/packages/conduit/src/adapters/transport/natsTransport.ts
+++ b/src/subspace/packages/conduit/src/adapters/transport/natsTransport.ts
@@ -5,10 +5,18 @@ import type { ITransportAdapter, MessageHandler } from './transportAdapter';
 
 let Sentry = getSentry();
 
+interface ActiveSubscription {
+  subject: string;
+  handler: MessageHandler;
+  sub: Subscription;
+  closed: boolean;
+}
+
 export class NatsTransport implements ITransportAdapter {
   private nc: Promise<NatsConnection>;
-  private subscriptions: Map<string, Subscription> = new Map();
+  private subscriptions: Map<string, ActiveSubscription> = new Map();
   private nextSubId = 0;
+  private resubscribeCount = 0;
 
   constructor(private config: NatsConfig) {
     console.log(
@@ -66,42 +74,99 @@ export class NatsTransport implements ITransportAdapter {
     let nc = await this.nc;
 
     let id = `sub-${this.nextSubId++}`;
-    let sub = nc.subscribe(subject);
+    let entry: ActiveSubscription = {
+      subject,
+      handler,
+      sub: nc.subscribe(subject),
+      closed: false
+    };
 
-    // Store subscription
-    this.subscriptions.set(id, sub);
+    this.subscriptions.set(id, entry);
 
-    // Process messages in background
-    (async () => {
-      try {
-        for await (let msg of sub) {
-          try {
-            await handler(msg.data);
-          } catch (err) {
-            console.error(
-              `CONDUIT.nats.message_handler_error subscriptionId=${id} subject=${subject} error=${err instanceof Error ? err.message : String(err)}`,
-              err
-            );
-          }
-        }
-      } catch (err) {
-        Sentry.captureException(err);
-        console.error(
-          `CONDUIT.nats.subscription_error subscriptionId=${id} subject=${subject} error=${err instanceof Error ? err.message : String(err)}`,
-          err
-        );
-      }
-    })();
+    // Drain messages in the background. The read loop must NEVER await the
+    // handler. One slow/never-returning handler cannot not stop us from reading
+    // later messages (the head-of-line blocking that wedged receivers). We
+    // dispatch fire-and-forget; backpressure/concurrency is enforced by the
+    // receiver. If the iterator ends or throws while the subscription is still
+    // open, we re-create it instead of dying permanently (the restart-only
+    // failure mode).
+    this.runReadLoop(id);
 
     return id;
   }
 
+  private runReadLoop(id: string): void {
+    (async () => {
+      while (true) {
+        let entry = this.subscriptions.get(id);
+        if (!entry || entry.closed) return;
+
+        try {
+          for await (let msg of entry.sub) {
+            // Fire-and-forget: do not block the read loop on handler execution.
+            Promise.resolve()
+              .then(() => entry!.handler(msg.data))
+              .catch(err => {
+                console.error(
+                  `CONDUIT.nats.message_handler_error subscriptionId=${id} subject=${entry!.subject} error=${err instanceof Error ? err.message : String(err)}`,
+                  err
+                );
+              });
+          }
+        } catch (err) {
+          Sentry.captureException(err);
+          console.error(
+            `CONDUIT.nats.subscription_error subscriptionId=${id} subject=${entry.subject} error=${err instanceof Error ? err.message : String(err)}`,
+            err
+          );
+        }
+
+        // The iterator ended. If we intentionally unsubscribed, stop.
+        let current = this.subscriptions.get(id);
+        if (!current || current.closed) return;
+
+        // Otherwise the subscription died unexpectedly while the connection is
+        // (hopefully) still up. Re-create it so the receiver keeps draining.
+        let nc: NatsConnection;
+        try {
+          nc = await this.nc;
+        } catch {
+          return;
+        }
+        if (current.closed) return;
+
+        await new Promise(resolve => setTimeout(resolve, 250));
+        if (current.closed) return;
+
+        try {
+          current.sub = nc.subscribe(current.subject);
+          this.resubscribeCount++;
+          console.log(
+            `CONDUIT.nats.resubscribe subscriptionId=${id} subject=${current.subject} totalResubscribes=${this.resubscribeCount}`
+          );
+        } catch (err) {
+          Sentry.captureException(err);
+          console.error(
+            `CONDUIT.nats.resubscribe_failed subscriptionId=${id} subject=${current.subject} error=${err instanceof Error ? err.message : String(err)}`,
+            err
+          );
+          // Back off and retry the resubscribe on the next loop iteration.
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+      }
+    })();
+  }
+
+  getResubscribeCount(): number {
+    return this.resubscribeCount;
+  }
+
   async unsubscribe(subscriptionId: string): Promise<void> {
-    let sub = this.subscriptions.get(subscriptionId);
-    if (sub) {
-      sub.unsubscribe();
+    let entry = this.subscriptions.get(subscriptionId);
+    if (entry) {
+      entry.closed = true;
+      entry.sub.unsubscribe();
       this.subscriptions.delete(subscriptionId);
-    } else {
     }
   }
 
@@ -110,9 +175,10 @@ export class NatsTransport implements ITransportAdapter {
     let nc = await this.nc;
 
     // Unsubscribe all
-    for (let [id, sub] of this.subscriptions.entries()) {
+    for (let [id, entry] of this.subscriptions.entries()) {
       console.log(`CONDUIT.nats.close.unsubscribe subscriptionId=${id}`);
-      sub.unsubscribe();
+      entry.closed = true;
+      entry.sub.unsubscribe();
     }
     this.subscriptions.clear();
 

--- a/src/subspace/packages/conduit/src/core/conduitReceiver.ts
+++ b/src/subspace/packages/conduit/src/core/conduitReceiver.ts
@@ -63,6 +63,9 @@ export class ConduitReceiver {
       messageCacheTtl: 60000,
       messageCacheSize: 10000,
       timeoutExtensionThreshold: 1000,
+      maxProcessingMs: 300000,
+      maxInFlight: 2000,
+      handlerConcurrency: 256,
       ...config.config
     };
 
@@ -349,6 +352,18 @@ export class ConduitReceiver {
 
   isRunning(): boolean {
     return this.receiver.isRunning();
+  }
+
+  isHealthy(): boolean {
+    return this.receiver.isHealthy();
+  }
+
+  isReady(): boolean {
+    return this.receiver.isReady();
+  }
+
+  getStats() {
+    return this.receiver.getStats();
   }
 
   getHandledTopics(): string[] {

--- a/src/subspace/packages/conduit/src/core/conduitReceiver.ts
+++ b/src/subspace/packages/conduit/src/core/conduitReceiver.ts
@@ -66,6 +66,7 @@ export class ConduitReceiver {
       maxProcessingMs: 300000,
       maxInFlight: 2000,
       handlerConcurrency: 256,
+      maxOrphanedHandlers: config.config?.maxOrphanedHandlers ?? config.config?.handlerConcurrency ?? 256,
       ...config.config
     };
 

--- a/src/subspace/packages/conduit/src/core/health.ts
+++ b/src/subspace/packages/conduit/src/core/health.ts
@@ -1,0 +1,13 @@
+export const CONDUIT_HEALTH_TOPIC = '__conduit_health__';
+
+export interface ConduitHealthPong {
+  type: 'conduit.health.pong';
+  receiverId: string;
+  at: number;
+}
+
+export let isConduitHealthPong = (value: unknown): value is ConduitHealthPong => {
+  if (!value || typeof value !== 'object') return false;
+  let d = value as Record<string, unknown>;
+  return d.type === 'conduit.health.pong' && typeof d.receiverId === 'string';
+};

--- a/src/subspace/packages/conduit/src/core/ownershipManager.ts
+++ b/src/subspace/packages/conduit/src/core/ownershipManager.ts
@@ -10,6 +10,7 @@ export class OwnershipManager {
   private topicTtls: Map<string, number> = new Map(); // Per-topic TTLs
   private renewalInterval: Timer | null = null;
   private ownershipLossCallbacks: OwnershipLossCallback[] = [];
+  private healthCheck: (() => boolean) | null = null;
 
   constructor(
     private receiverId: string,
@@ -17,6 +18,10 @@ export class OwnershipManager {
     private renewalIntervalMs: number,
     private ownershipTtl: number
   ) {}
+
+  setHealthCheck(healthCheck: () => boolean): void {
+    this.healthCheck = healthCheck;
+  }
 
   start(): void {
     if (this.renewalInterval) {
@@ -74,6 +79,15 @@ export class OwnershipManager {
   }
 
   private async renewOwnerships(): Promise<void> {
+    // If the receiver is unhealthy, stop renewing so ownership TTLs expire and
+    // topics get reassigned to a healthy receiver.
+    if (this.healthCheck && !this.healthCheck()) {
+      console.warn(
+        `CONDUIT.ownership.renewal_skipped_unhealthy receiverId=${this.receiverId} ownedTopics=${this.ownedTopics.size}`
+      );
+      return;
+    }
+
     let renewals = Array.from(this.ownedTopics).map(async topic => {
       try {
         // Use per-topic TTL if available, otherwise use default

--- a/src/subspace/packages/conduit/src/core/receiver.ts
+++ b/src/subspace/packages/conduit/src/core/receiver.ts
@@ -62,6 +62,12 @@ export class Receiver {
   private dedupHitCount = 0;
   private healthTick = 0;
 
+  // Handlers that breached the ceiling but are still running (JS promises can't
+  // be cancelled). Tracked for observability and as a wedge signal - we cannot
+  // stop them, so a worker accumulating too many gets recycled via isHealthy().
+  private orphanedHandlers: Set<Promise<unknown>> = new Set();
+  private orphanedCeilingTotal = 0;
+
   constructor(
     private coordination: ICoordinationAdapter,
     private transport: ITransportAdapter,
@@ -158,6 +164,7 @@ export class Receiver {
     this.processingMessages.clear();
     this.inFlightById.clear();
     this.topicChains.clear();
+    this.orphanedHandlers.clear();
     console.log(`CONDUIT.receiver.stop.done receiverId=${this.receiverId}`);
   }
 
@@ -304,6 +311,9 @@ export class Receiver {
     });
 
     let ceilingTimer: Timer | undefined;
+    // Declared out here so the catch can register a still-running handler as an
+    // orphan when the ceiling wins the race.
+    let handlerPromise: Promise<unknown> | undefined;
 
     try {
       // Race the handler against a hard ceiling so a never-returning provider
@@ -315,7 +325,8 @@ export class Receiver {
         );
       });
 
-      let result = await Promise.race([this.handler(message.topic, message.payload), ceiling]);
+      handlerPromise = this.handler(message.topic, message.payload);
+      let result = await Promise.race([handlerPromise, ceiling]);
 
       return {
         messageId: message.messageId,
@@ -326,9 +337,19 @@ export class Receiver {
     } catch (err) {
       if (err instanceof HandlerCeilingError) {
         this.ceilingAbortCount++;
+        // The handler promise is still pending and cannot be cancelled. Track it
+        // so the leaked work is observable and counts toward the wedge threshold;
+        // forget it once it eventually settles (also avoids unhandledRejection).
+        if (handlerPromise) {
+          let orphan = handlerPromise;
+          this.orphanedHandlers.add(orphan);
+          this.orphanedCeilingTotal++;
+          let forget = () => this.orphanedHandlers.delete(orphan);
+          orphan.then(forget, forget);
+        }
         Sentry.captureException(err);
         console.error(
-          `CONDUIT.receiver.processMessage.ceiling receiverId=${this.receiverId} messageId=${message.messageId} topic=${message.topic} maxProcessingMs=${this.config.maxProcessingMs} totalCeilingAborts=${this.ceilingAbortCount}`
+          `CONDUIT.receiver.processMessage.ceiling receiverId=${this.receiverId} messageId=${message.messageId} topic=${message.topic} maxProcessingMs=${this.config.maxProcessingMs} totalCeilingAborts=${this.ceilingAbortCount} orphaned=${this.orphanedHandlers.size}`
         );
         return {
           messageId: message.messageId,
@@ -542,6 +563,13 @@ export class Receiver {
     // Still starting up (subscribing): nothing to be unhealthy about yet.
     if (!this.ready) return true;
 
+    // Too many ceiling-orphaned handlers still running: we can't cancel them, so
+    // recycle this worker (stops ownership renewal + fails the ECS health check)
+    // to terminate the leaked provider work with the process.
+    if (this.orphanedHandlers.size >= this.config.maxOrphanedHandlers) {
+      return false;
+    }
+
     let now = Date.now();
     let limit = this.config.maxProcessingMs + STUCK_GRACE_MS;
     for (let processing of this.processingMessages.values()) {
@@ -567,7 +595,7 @@ export class Receiver {
     if (this.healthTick % 30 === 0 && this.inFlightById.size > 0) {
       let s = this.getStats();
       console.log(
-        `CONDUIT.receiver.stats receiverId=${this.receiverId} healthy=${healthy} inFlight=${s.inFlight} activeTopics=${s.activeTopics} processing=${s.processing} slotsAvail=${s.handlerSlotsAvailable} waiting=${s.handlerWaiting} dispatched=${s.dispatched} shed=${s.shed} ceilingAborts=${s.ceilingAborts} dedupHits=${s.dedupHits} sinceProgressMs=${Date.now() - s.lastProgressAt}`
+        `CONDUIT.receiver.stats receiverId=${this.receiverId} healthy=${healthy} inFlight=${s.inFlight} activeTopics=${s.activeTopics} processing=${s.processing} slotsAvail=${s.handlerSlotsAvailable} waiting=${s.handlerWaiting} dispatched=${s.dispatched} shed=${s.shed} ceilingAborts=${s.ceilingAborts} dedupHits=${s.dedupHits} orphaned=${s.orphaned} orphanedTotal=${s.orphanedTotal} sinceProgressMs=${Date.now() - s.lastProgressAt}`
       );
     }
   }
@@ -587,6 +615,8 @@ export class Receiver {
     shed: number;
     ceilingAborts: number;
     dedupHits: number;
+    orphaned: number;
+    orphanedTotal: number;
   } {
     return {
       inFlight: this.inFlightById.size,
@@ -598,7 +628,9 @@ export class Receiver {
       dispatched: this.dispatchedCount,
       shed: this.shedCount,
       ceilingAborts: this.ceilingAbortCount,
-      dedupHits: this.dedupHitCount
+      dedupHits: this.dedupHitCount,
+      orphaned: this.orphanedHandlers.size,
+      orphanedTotal: this.orphanedCeilingTotal
     };
   }
 

--- a/src/subspace/packages/conduit/src/core/receiver.ts
+++ b/src/subspace/packages/conduit/src/core/receiver.ts
@@ -7,12 +7,23 @@ import type { ReceiverConfig } from '../types/config';
 import type { ConduitMessage, TimeoutExtension } from '../types/message';
 import type { ConduitResponse } from '../types/response';
 import type { TopicResponseBroadcast } from '../types/topicListener';
+import { CONDUIT_HEALTH_TOPIC, type ConduitHealthPong } from './health';
 import { MessageCache } from './messageCache';
 import { OwnershipManager } from './ownershipManager';
+import { Semaphore } from './semaphore';
 
 let Sentry = getSentry();
 
 export type MessageHandler = (topic: string, payload: unknown) => Promise<unknown>;
+
+const STUCK_GRACE_MS = 30000;
+
+class HandlerCeilingError extends Error {
+  constructor(public readonly limitMs: number) {
+    super(`handler exceeded max processing time (${limitMs}ms)`);
+    this.name = 'HandlerCeilingError';
+  }
+}
 
 interface ProcessingMessage {
   message: ConduitMessage;
@@ -28,9 +39,28 @@ export class Receiver {
   private heartbeatInterval: Timer | null = null;
   private subscriptionId: string | null = null;
   private running = false;
+  private ready = false;
   private readonly conduitId: string;
   private processingMessages: Map<string, ProcessingMessage> = new Map();
   private timeoutCheckInterval: Timer | null = null;
+
+  // Per-topic FIFO chains: same-topic messages run in arrival order, different
+  // topics run concurrently. Removes cross-session head-of-line blocking while
+  // preserving per-session ordering.
+  private topicChains: Map<string, Promise<void>> = new Map();
+  // Messages currently queued/executing, keyed by messageId, for in-flight
+  // dedup (a sender retry reuses the same messageId).
+  private inFlightById: Map<string, Promise<ConduitResponse>> = new Map();
+  private handlerSemaphore: Semaphore;
+  private lastProgressAt = Date.now();
+  private lastHealthy = true;
+
+  // Observability counters.
+  private dispatchedCount = 0;
+  private shedCount = 0;
+  private ceilingAbortCount = 0;
+  private dedupHitCount = 0;
+  private healthTick = 0;
 
   constructor(
     private coordination: ICoordinationAdapter,
@@ -42,12 +72,15 @@ export class Receiver {
     this.conduitId = conduitId;
     this.receiverId = `receiver-${crypto.randomUUID()}`;
     this.messageCache = new MessageCache(config.messageCacheSize, config.messageCacheTtl);
+    this.handlerSemaphore = new Semaphore(config.handlerConcurrency);
     this.ownershipManager = new OwnershipManager(
       this.receiverId,
       coordination,
       config.ownershipRenewalInterval,
       config.topicOwnershipTtl
     );
+    // Stop renewing ownership when unhealthy so topics get reassigned.
+    this.ownershipManager.setHealthCheck(() => this.isHealthy());
   }
 
   async start(): Promise<void> {
@@ -61,7 +94,13 @@ export class Receiver {
       `CONDUIT.receiver.start receiverId=${this.receiverId} conduitId=${this.conduitId}`
     );
 
-    // Register receiver
+    // Subscribe to messages FIRST. We must be listening before we advertise
+    // ourselves as an active receiver, otherwise a freshly-started worker would
+    // be in the active pool (and pingable / assignable) while not yet draining.
+    await this.subscribe();
+    this.ready = true;
+
+    // Now register the receiver (only after we are actually listening).
     await this.coordination.registerReceiver(this.receiverId, this.config.heartbeatTtl);
     console.log(
       `CONDUIT.receiver.start.registered receiverId=${this.receiverId} heartbeatTtl=${this.config.heartbeatTtl}`
@@ -73,11 +112,9 @@ export class Receiver {
     // Start ownership renewal
     this.ownershipManager.start();
 
-    // Start shared timeout check interval
+    // Start shared timeout/health check interval
     this.startTimeoutChecker();
 
-    // Subscribe to messages
-    await this.subscribe();
     console.log(`CONDUIT.receiver.start.done receiverId=${this.receiverId}`);
   }
 
@@ -91,6 +128,7 @@ export class Receiver {
       `CONDUIT.receiver.stop receiverId=${this.receiverId} processingMessages=${this.processingMessages.size}`
     );
     this.running = false;
+    this.ready = false;
 
     // Stop heartbeat
     this.stopHeartbeat();
@@ -116,8 +154,10 @@ export class Receiver {
     // Cleanup cache
     this.messageCache.destroy();
 
-    // Clear processing messages
+    // Clear processing/in-flight state
     this.processingMessages.clear();
+    this.inFlightById.clear();
+    this.topicChains.clear();
     console.log(`CONDUIT.receiver.stop.done receiverId=${this.receiverId}`);
   }
 
@@ -131,58 +171,152 @@ export class Receiver {
   }
 
   private async handleMessage(data: Uint8Array): Promise<void> {
+    let message: ConduitMessage;
     try {
-      // Decode message
       let decoder = new TextDecoder();
       let messageStr = decoder.decode(data);
-      let message: ConduitMessage = serialize.decode(messageStr);
+      message = serialize.decode(messageStr);
+    } catch (err) {
+      Sentry.captureException(err);
+      console.error(
+        'CONDUIT.receiver.handleMessage.decode_error receiverId=' + this.receiverId,
+        err
+      );
+      // If we can't even parse/decode, we can't respond.
+      return;
+    }
 
-      // Check if we've seen this message before
+    // Dispatch happened: the read loop is alive and handed us a message.
+    this.lastProgressAt = Date.now();
+    this.dispatchedCount++;
+
+    // Reserved health topic: answer directly so a successful pong proves this
+    // receiver's read loop is draining. Bypasses the user handler and the
+    // per-topic queue so it is never blocked behind a slow topic.
+    if (message.topic === CONDUIT_HEALTH_TOPIC) {
+      await this.sendHealthPong(message).catch(err => {
+        console.error('CONDUIT.receiver.health_pong.error receiverId=' + this.receiverId, err);
+      });
+      return;
+    }
+
+    try {
+      // Already-completed response (post-completion dedup).
       let cachedResponse = this.messageCache.get(message.messageId);
       if (cachedResponse) {
-        // Return cached response
         await this.sendResponse(message, cachedResponse);
         return;
       }
 
-      // Add topic to ownership (we're processing it now)
+      // In-flight dedup: a retry of a message we are still processing must NOT
+      // run the handler twice. Attach to the existing in-flight promise and
+      // re-send its response to this retry's reply subject.
+      let inFlight = this.inFlightById.get(message.messageId);
+      if (inFlight) {
+        this.dedupHitCount++;
+        try {
+          let response = await inFlight;
+          await this.sendResponse(message, response);
+        } catch (err) {
+          Sentry.captureException(err);
+        }
+        return;
+      }
+
+      // Backpressure: shed when over the in-flight cap so memory stays bounded.
+      // Respond with failure so the sender fails/retries fast rather than hanging.
+      if (this.inFlightById.size >= this.config.maxInFlight) {
+        this.shedCount++;
+        console.warn(
+          `CONDUIT.receiver.shed receiverId=${this.receiverId} messageId=${message.messageId} topic=${message.topic} inFlight=${this.inFlightById.size} maxInFlight=${this.config.maxInFlight} totalShed=${this.shedCount}`
+        );
+        await this.sendResponse(message, {
+          messageId: message.messageId,
+          success: false,
+          error: 'receiver overloaded (in-flight cap exceeded)',
+          processedAt: Date.now()
+        }).catch(() => {});
+        return;
+      }
+
+      // Add topic to ownership (we're processing it now).
       this.ownershipManager.addTopic(message.topic);
 
-      // Process message
-      let response = await this.processMessage(message);
+      // Run on the per-topic FIFO chain (serial within topic, concurrent across
+      // topics), and register as in-flight for dedup.
+      let resultPromise = this.runOnTopic(message.topic, () => this.processMessage(message));
+      this.inFlightById.set(message.messageId, resultPromise);
 
-      // Cache the response
+      let response: ConduitResponse;
+      try {
+        response = await resultPromise;
+      } catch (err) {
+        // processMessage is designed not to throw, but guard regardless.
+        Sentry.captureException(err);
+        let error = err instanceof Error ? err : new Error(String(err));
+        response = {
+          messageId: message.messageId,
+          success: false,
+          error: error.message,
+          processedAt: Date.now()
+        };
+      } finally {
+        this.inFlightById.delete(message.messageId);
+      }
+
+      // Cache the response and reply.
       this.messageCache.set(message.messageId, response);
-
-      // Send response
       await this.sendResponse(message, response);
     } catch (err) {
       Sentry.captureException(err);
       console.error('CONDUIT.receiver.handleMessage.error receiverId=' + this.receiverId, err);
-      // If we can't even parse/decode, we can't respond
     }
   }
 
+  private runOnTopic<T>(topic: string, fn: () => Promise<T>): Promise<T> {
+    let prev = this.topicChains.get(topic) ?? Promise.resolve();
+    let result = prev.then(fn, fn);
+    let chain = result.then(
+      () => {},
+      () => {}
+    );
+    this.topicChains.set(topic, chain);
+    chain.then(() => {
+      // Clean up only if no newer work was chained after us.
+      if (this.topicChains.get(topic) === chain) {
+        this.topicChains.delete(topic);
+      }
+    });
+    return result;
+  }
+
   private async processMessage(message: ConduitMessage): Promise<ConduitResponse> {
+    // Bound the number of handlers executing concurrently (does not block the
+    // transport read loop - we are already off it here).
+    await this.handlerSemaphore.acquire();
+
+    const now = Date.now();
+    this.processingMessages.set(message.messageId, {
+      message,
+      startTime: now,
+      lastExtensionSentAt: 0,
+      currentDeadline: now + message.timeout
+    });
+
+    let ceilingTimer: Timer | undefined;
+
     try {
-      // Track message for timeout extension monitoring
-      const now = Date.now();
-      this.processingMessages.set(message.messageId, {
-        message,
-        startTime: now,
-        lastExtensionSentAt: 0, // No extension sent yet
-        currentDeadline: now + message.timeout
+      // Race the handler against a hard ceiling so a never-returning provider
+      // call cannot hold this slot forever.
+      let ceiling = new Promise<never>((_, reject) => {
+        ceilingTimer = setTimeout(
+          () => reject(new HandlerCeilingError(this.config.maxProcessingMs)),
+          this.config.maxProcessingMs
+        );
       });
 
-      // Call user handler
-      let result = await this.handler(message.topic, message.payload);
+      let result = await Promise.race([this.handler(message.topic, message.payload), ceiling]);
 
-      let elapsed = Date.now() - now;
-
-      // Remove from tracking
-      this.processingMessages.delete(message.messageId);
-
-      // Create success response
       return {
         messageId: message.messageId,
         success: true,
@@ -190,25 +324,60 @@ export class Receiver {
         processedAt: Date.now()
       };
     } catch (err) {
+      if (err instanceof HandlerCeilingError) {
+        this.ceilingAbortCount++;
+        Sentry.captureException(err);
+        console.error(
+          `CONDUIT.receiver.processMessage.ceiling receiverId=${this.receiverId} messageId=${message.messageId} topic=${message.topic} maxProcessingMs=${this.config.maxProcessingMs} totalCeilingAborts=${this.ceilingAbortCount}`
+        );
+        return {
+          messageId: message.messageId,
+          success: false,
+          error: 'handler exceeded max processing time',
+          processedAt: Date.now()
+        };
+      }
+
       Sentry.captureException(err);
-
-      // Remove from tracking
-      this.processingMessages.delete(message.messageId);
-
       let error = err instanceof Error ? err : new Error(String(err));
-
       console.error(
         `CONDUIT.receiver.processMessage.error receiverId=${this.receiverId} messageId=${message.messageId} topic=${message.topic}:`,
         error
       );
-
-      // Create error response
       return {
         messageId: message.messageId,
         success: false,
         error: error.message,
         processedAt: Date.now()
       };
+    } finally {
+      if (ceilingTimer) clearTimeout(ceilingTimer);
+      this.processingMessages.delete(message.messageId);
+      this.lastProgressAt = Date.now();
+      this.handlerSemaphore.release();
+    }
+  }
+
+  private async sendHealthPong(message: ConduitMessage): Promise<void> {
+    let pong: ConduitHealthPong = {
+      type: 'conduit.health.pong',
+      receiverId: this.receiverId,
+      at: Date.now()
+    };
+    let response: ConduitResponse = {
+      messageId: message.messageId,
+      success: true,
+      result: pong,
+      processedAt: Date.now()
+    };
+
+    let encoder = new TextEncoder();
+    let data = encoder.encode(serialize.encode(response));
+
+    if (this.isMemoryTransport()) {
+      await (this.transport as MemoryTransport).reply(message.replySubject, data);
+    } else {
+      await this.transport.publish(message.replySubject, data);
     }
   }
 
@@ -222,6 +391,7 @@ export class Receiver {
       this.checkTimeouts().catch(err => {
         console.error('Error checking timeouts:', err);
       });
+      this.evaluateHealth();
     }, 1000);
   }
 
@@ -239,10 +409,16 @@ export class Receiver {
     for (let [messageId, processing] of this.processingMessages.entries()) {
       let remaining = processing.currentDeadline - now;
 
-      // If we're getting close to deadline and haven't sent extension recently, send it
-      // Allow unlimited extensions, but rate-limit them (at least 1 second between extensions)
+      // Cap extensions at the hard processing ceiling: once a message has been
+      // running for maxProcessingMs it will be aborted by processMessage, so we
+      // stop extending its deadline instead of allowing unlimited extensions.
+      const reachedCeiling = now - processing.startTime >= this.config.maxProcessingMs;
+
+      // If we're getting close to deadline and haven't sent extension recently, send it.
+      // Rate-limit extensions (at least 1 second between them).
       const timeSinceLastExtension = now - processing.lastExtensionSentAt;
       const shouldSendExtension =
+        !reachedCeiling &&
         remaining < threshold &&
         remaining > 0 &&
         (processing.lastExtensionSentAt === 0 || timeSinceLastExtension >= 1000);
@@ -335,6 +511,16 @@ export class Receiver {
     }
 
     this.heartbeatInterval = setInterval(() => {
+      // Gate the Redis heartbeat on health: a wedged receiver stops renewing so
+      // its TTL expires and it drops out of the active pool, letting senders
+      // reassign its topics to a healthy receiver (recovery without a restart).
+      if (!this.isHealthy()) {
+        console.warn(
+          `CONDUIT.receiver.heartbeat_skipped_unhealthy receiverId=${this.receiverId}`
+        );
+        return;
+      }
+
       this.coordination
         .registerReceiver(this.receiverId, this.config.heartbeatTtl)
         .catch(err => {
@@ -349,6 +535,71 @@ export class Receiver {
       clearInterval(this.heartbeatInterval);
       this.heartbeatInterval = null;
     }
+  }
+
+  isHealthy(): boolean {
+    if (!this.running) return false;
+    // Still starting up (subscribing): nothing to be unhealthy about yet.
+    if (!this.ready) return true;
+
+    let now = Date.now();
+    let limit = this.config.maxProcessingMs + STUCK_GRACE_MS;
+    for (let processing of this.processingMessages.values()) {
+      if (now - processing.startTime > limit) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private evaluateHealth(): void {
+    let healthy = this.isHealthy();
+    if (healthy !== this.lastHealthy) {
+      this.lastHealthy = healthy;
+      console.warn(
+        `CONDUIT.receiver.health_flip receiverId=${this.receiverId} healthy=${healthy} inFlight=${this.inFlightById.size} activeTopics=${this.topicChains.size} processing=${this.processingMessages.size} sinceProgressMs=${Date.now() - this.lastProgressAt}`
+      );
+    }
+
+    // Periodic stats log (every ~30s) while there is work in flight, so the
+    // next incident is diagnosable from logs alone.
+    this.healthTick++;
+    if (this.healthTick % 30 === 0 && this.inFlightById.size > 0) {
+      let s = this.getStats();
+      console.log(
+        `CONDUIT.receiver.stats receiverId=${this.receiverId} healthy=${healthy} inFlight=${s.inFlight} activeTopics=${s.activeTopics} processing=${s.processing} slotsAvail=${s.handlerSlotsAvailable} waiting=${s.handlerWaiting} dispatched=${s.dispatched} shed=${s.shed} ceilingAborts=${s.ceilingAborts} dedupHits=${s.dedupHits} sinceProgressMs=${Date.now() - s.lastProgressAt}`
+      );
+    }
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  getStats(): {
+    inFlight: number;
+    activeTopics: number;
+    processing: number;
+    handlerSlotsAvailable: number;
+    handlerWaiting: number;
+    lastProgressAt: number;
+    dispatched: number;
+    shed: number;
+    ceilingAborts: number;
+    dedupHits: number;
+  } {
+    return {
+      inFlight: this.inFlightById.size,
+      activeTopics: this.topicChains.size,
+      processing: this.processingMessages.size,
+      handlerSlotsAvailable: this.handlerSemaphore.getAvailable(),
+      handlerWaiting: this.handlerSemaphore.getWaiting(),
+      lastProgressAt: this.lastProgressAt,
+      dispatched: this.dispatchedCount,
+      shed: this.shedCount,
+      ceilingAborts: this.ceilingAbortCount,
+      dedupHits: this.dedupHitCount
+    };
   }
 
   getReceiverId(): string {

--- a/src/subspace/packages/conduit/src/core/semaphore.ts
+++ b/src/subspace/packages/conduit/src/core/semaphore.ts
@@ -1,0 +1,37 @@
+export class Semaphore {
+  private available: number;
+  private waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    this.available = Math.max(1, Math.floor(permits));
+  }
+
+  async acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--;
+      return;
+    }
+
+    await new Promise<void>(resolve => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  release(): void {
+    let next = this.waiters.shift();
+    if (next) {
+      // Hand the permit directly to the next waiter (do not increment).
+      next();
+    } else {
+      this.available++;
+    }
+  }
+
+  getAvailable(): number {
+    return this.available;
+  }
+
+  getWaiting(): number {
+    return this.waiters.length;
+  }
+}

--- a/src/subspace/packages/conduit/src/core/sender.ts
+++ b/src/subspace/packages/conduit/src/core/sender.ts
@@ -12,6 +12,7 @@ import type {
   TopicResponseBroadcast,
   TopicSubscription
 } from '../types/topicListener';
+import { CONDUIT_HEALTH_TOPIC } from './health';
 import { RetryManager } from './retryManager';
 
 let Sentry = getSentry();
@@ -84,6 +85,93 @@ export class Sender {
 
       return await this.sendMessage(message, actualTimeout);
     }, `Send message ${messageId} to topic ${topic}`);
+  }
+
+  async pingReceiver(receiverId: string, timeoutMs?: number): Promise<ConduitResponse> {
+    let timeout = timeoutMs ?? this.config.healthPingTimeout;
+    let messageId = this.generateMessageId();
+    let subject = `conduit.${this.conduitId}.receiver.${receiverId}.${CONDUIT_HEALTH_TOPIC}`;
+    let replySubject = `_INBOX.${crypto.randomUUID()}`;
+
+    return new Promise<ConduitResponse>((resolve, reject) => {
+      let settled = false;
+      let subscriptionId: string | undefined;
+
+      let finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutHandle);
+        if (subscriptionId) {
+          this.safeUnsubscribe(subscriptionId).catch(() => {});
+        }
+        fn();
+      };
+
+      let timeoutHandle = setTimeout(() => {
+        finish(() =>
+          reject(
+            new ConduitSendError(
+              `Health ping timeout after ${timeout}ms`,
+              messageId,
+              CONDUIT_HEALTH_TOPIC,
+              0
+            )
+          )
+        );
+      }, timeout);
+
+      this.transport
+        .subscribe(replySubject, async (data: Uint8Array) => {
+          try {
+            let response = serialize.decode(new TextDecoder().decode(data)) as ConduitResponse;
+            finish(() => resolve(response));
+          } catch (err) {
+            finish(() =>
+              reject(
+                new ConduitSendError(
+                  `Health ping response parse error: ${err instanceof Error ? err.message : String(err)}`,
+                  messageId,
+                  CONDUIT_HEALTH_TOPIC,
+                  0,
+                  err instanceof Error ? err : new Error(String(err))
+                )
+              )
+            );
+          }
+        })
+        .then(subId => {
+          subscriptionId = subId;
+          if (settled) {
+            this.safeUnsubscribe(subId).catch(() => {});
+            return;
+          }
+
+          let message: ConduitMessage = {
+            messageId,
+            topic: CONDUIT_HEALTH_TOPIC,
+            payload: { type: 'conduit.health.ping' },
+            replySubject,
+            timeout,
+            sentAt: Date.now(),
+            retryCount: 0
+          };
+          let data = new TextEncoder().encode(serialize.encode(message));
+          return this.transport.publish(subject, data);
+        })
+        .catch(err => {
+          finish(() =>
+            reject(
+              new ConduitSendError(
+                `Health ping error: ${err instanceof Error ? err.message : String(err)}`,
+                messageId,
+                CONDUIT_HEALTH_TOPIC,
+                0,
+                err instanceof Error ? err : new Error(String(err))
+              )
+            )
+          );
+        });
+    });
   }
 
   async subscribeTopic(topic: string, listener: TopicListener): Promise<TopicSubscription> {

--- a/src/subspace/packages/conduit/src/index.ts
+++ b/src/subspace/packages/conduit/src/index.ts
@@ -17,6 +17,8 @@ export type {
   TopicContext,
   TopicHandler
 } from './core/conduitReceiver';
+export { CONDUIT_HEALTH_TOPIC, isConduitHealthPong } from './core/health';
+export type { ConduitHealthPong } from './core/health';
 export { MessageCache } from './core/messageCache';
 export { OwnershipManager } from './core/ownershipManager';
 export type { OwnershipLossCallback } from './core/ownershipManager';
@@ -64,6 +66,7 @@ let getSenderConfig = (config?: Partial<SenderConfig>): SenderConfig => ({
   topicOwnershipTtl: 5000,
   inFlightCacheTtl: 20000,
   maxInFlightMessages: 1000,
+  healthPingTimeout: 1500,
   ...config
 });
 
@@ -75,6 +78,9 @@ let getReceiverConfig = (config?: Partial<ReceiverConfig>): ReceiverConfig => ({
   messageCacheTtl: 60000,
   messageCacheSize: 10000,
   timeoutExtensionThreshold: 1000,
+  maxProcessingMs: 300000,
+  maxInFlight: 2000,
+  handlerConcurrency: 256,
   ...config
 });
 

--- a/src/subspace/packages/conduit/src/index.ts
+++ b/src/subspace/packages/conduit/src/index.ts
@@ -81,6 +81,7 @@ let getReceiverConfig = (config?: Partial<ReceiverConfig>): ReceiverConfig => ({
   maxProcessingMs: 300000,
   maxInFlight: 2000,
   handlerConcurrency: 256,
+  maxOrphanedHandlers: config?.handlerConcurrency ?? 256,
   ...config
 });
 

--- a/src/subspace/packages/conduit/src/types/config.ts
+++ b/src/subspace/packages/conduit/src/types/config.ts
@@ -30,6 +30,8 @@ export interface ReceiverConfig {
   maxInFlight: number;
 
   handlerConcurrency: number;
+
+  maxOrphanedHandlers: number;
 }
 
 export interface SenderConfig {
@@ -87,7 +89,8 @@ export const DEFAULT_CONFIG: ConduitConfig = {
     timeoutExtensionThreshold: 1000,
     maxProcessingMs: 300000,
     maxInFlight: 2000,
-    handlerConcurrency: 256
+    handlerConcurrency: 256,
+    maxOrphanedHandlers: 256
   },
   sender: {
     defaultTimeout: 5000,

--- a/src/subspace/packages/conduit/src/types/config.ts
+++ b/src/subspace/packages/conduit/src/types/config.ts
@@ -24,6 +24,12 @@ export interface ReceiverConfig {
   messageCacheSize: number;
 
   timeoutExtensionThreshold: number;
+
+  maxProcessingMs: number;
+
+  maxInFlight: number;
+
+  handlerConcurrency: number;
 }
 
 export interface SenderConfig {
@@ -40,6 +46,11 @@ export interface SenderConfig {
   inFlightCacheTtl: number;
 
   maxInFlightMessages: number;
+
+  /**
+   * Default timeout (ms) for a direct per-receiver health ping (`pingReceiver`).
+   */
+  healthPingTimeout: number;
 }
 
 export type CoordinationConfig = { type: 'redis'; redis: RedisConfig } | { type: 'memory' };
@@ -73,7 +84,10 @@ export const DEFAULT_CONFIG: ConduitConfig = {
     ownershipRenewalInterval: 10000, // Renew at TTL/3 for safety margin
     messageCacheTtl: 60000,
     messageCacheSize: 10000,
-    timeoutExtensionThreshold: 1000
+    timeoutExtensionThreshold: 1000,
+    maxProcessingMs: 300000,
+    maxInFlight: 2000,
+    handlerConcurrency: 256
   },
   sender: {
     defaultTimeout: 5000,
@@ -82,7 +96,8 @@ export const DEFAULT_CONFIG: ConduitConfig = {
     retryBackoffMultiplier: 1.5,
     topicOwnershipTtl: 5000,
     inFlightCacheTtl: 60000,
-    maxInFlightMessages: 1000
+    maxInFlightMessages: 1000,
+    healthPingTimeout: 1500
   },
   coordination: {
     type: 'memory'

--- a/src/subspace/packages/conduit/tests/integration-real/docker-compose.yml
+++ b/src/subspace/packages/conduit/tests/integration-real/docker-compose.yml
@@ -1,0 +1,16 @@
+# Redis + NATS for the conduit real-infra integration suite.
+# Dedicated, non-dev ports (dev compose uses 56379/56222) so this never clashes
+# with a running dev stack. Ports are overridable via env for parallel/local runs.
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '${CONDUIT_TEST_REDIS_PORT:-56390}:6379'
+    command: ['redis-server', '--save', '', '--appendonly', 'no']
+
+  nats:
+    image: nats:2-alpine
+    command: ['-js', '-m', '8222']
+    ports:
+      - '${CONDUIT_TEST_NATS_PORT:-56290}:4222'
+      - '${CONDUIT_TEST_NATS_HTTP_PORT:-56291}:8222'

--- a/src/subspace/packages/conduit/tests/integration-real/headOfLineBlocking.real.test.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/headOfLineBlocking.real.test.ts
@@ -1,0 +1,158 @@
+import { serialize } from '@lowerdeck/serialize';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ConduitMessage } from '../../src/index';
+import {
+  cleanupAll,
+  makeConduitId,
+  makeReceiverNode,
+  makeSenderNode
+} from './setup/realConduit';
+import { sleep, waitFor } from './setup/poll';
+
+describe('head-of-line blocking (Redis + NATS)', () => {
+  afterEach(cleanupAll);
+
+  it('does not let a slow topic block a fast topic', async () => {
+    let conduitId = makeConduitId();
+    await makeReceiverNode(conduitId, async topic => {
+      if (topic === 'slow') await sleep(800);
+      return { topic };
+    });
+    let { sender } = makeSenderNode(conduitId);
+
+    let start = Date.now();
+    let slowP = sender.send('slow', {});
+    let fastP = sender.send('fast', {});
+
+    let fast = await fastP;
+    let fastElapsed = Date.now() - start;
+
+    expect(fast.success).toBe(true);
+    expect(fastElapsed).toBeLessThan(600);
+
+    let slow = await slowP;
+    expect(slow.success).toBe(true);
+  });
+
+  it('processes same-topic messages serially', async () => {
+    let conduitId = makeConduitId();
+    let active = 0;
+    let maxActive = 0;
+    await makeReceiverNode(conduitId, async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await sleep(50);
+      active--;
+      return { ok: true };
+    });
+    let { sender } = makeSenderNode(conduitId);
+
+    let responses = await Promise.all(
+      Array.from({ length: 6 }, (_, i) => sender.send('same.topic', { i }))
+    );
+
+    for (let r of responses) expect(r.success).toBe(true);
+    expect(maxActive).toBe(1);
+  });
+
+  it('runs different topics concurrently', async () => {
+    let conduitId = makeConduitId();
+    let active = 0;
+    let maxActive = 0;
+    await makeReceiverNode(conduitId, async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await sleep(150);
+      active--;
+      return { ok: true };
+    });
+    let { sender } = makeSenderNode(conduitId);
+
+    let responses = await Promise.all(
+      Array.from({ length: 5 }, (_, i) => sender.send(`topic.${i}`, { i }))
+    );
+
+    for (let r of responses) expect(r.success).toBe(true);
+    expect(maxActive).toBeGreaterThan(1);
+  });
+
+  it('aborts a hung handler at the maxProcessingMs ceiling and keeps draining', async () => {
+    let conduitId = makeConduitId();
+    let node = await makeReceiverNode(
+      conduitId,
+      async topic => {
+        if (topic === 'never') await sleep(60000);
+        return { topic };
+      },
+      { maxProcessingMs: 500, timeoutExtensionThreshold: 100 }
+    );
+    let { sender } = makeSenderNode(conduitId, { defaultTimeout: 10000 });
+
+    let stuck = await sender.send('never', {});
+    expect(stuck.success).toBe(false);
+    expect(stuck.error).toBe('handler exceeded max processing time');
+
+    // Receiver is not wedged: a different topic still gets handled.
+    let ok = await sender.send('fine', {});
+    expect(ok.success).toBe(true);
+    expect(ok.result).toEqual({ topic: 'fine' });
+
+    expect(node.receiver.getStats().ceilingAborts).toBeGreaterThanOrEqual(1);
+  });
+
+  it('runs the handler once for a duplicate in-flight messageId (real NATS)', async () => {
+    let conduitId = makeConduitId();
+    let calls = 0;
+    let node = await makeReceiverNode(conduitId, async () => {
+      calls++;
+      await sleep(300);
+      return { calls };
+    });
+
+    // Publish two copies with the SAME messageId straight onto the receiver's
+    // wildcard subject so the second arrives while the first is still in-flight.
+    // This deterministically exercises in-flight dedup (the sender's own
+    // timeout-extension machinery would otherwise keep a single attempt alive).
+    let transport = node.conduit.transport;
+    let receiverId = node.receiver.getReceiverId();
+    let topic = 'dedup.topic';
+    let subject = `conduit.${conduitId}.receiver.${receiverId}.${topic}`;
+
+    let encoder = new TextEncoder();
+    let decoder = new TextDecoder();
+
+    let makeMessage = (replySubject: string): ConduitMessage => ({
+      messageId: 'dup-message-real-1',
+      topic,
+      payload: { hello: 'world' },
+      replySubject,
+      timeout: 5000,
+      sentAt: Date.now(),
+      retryCount: 0
+    });
+
+    let replies: Record<string, { success: boolean } | null> = { a: null, b: null };
+    let inboxA = `_INBOX.dedup-a-${Math.random().toString(36).slice(2)}`;
+    let inboxB = `_INBOX.dedup-b-${Math.random().toString(36).slice(2)}`;
+
+    await transport.subscribe(inboxA, async data => {
+      replies.a = serialize.decode(decoder.decode(data));
+    });
+    await transport.subscribe(inboxB, async data => {
+      replies.b = serialize.decode(decoder.decode(data));
+    });
+
+    void transport.publish(subject, encoder.encode(serialize.encode(makeMessage(inboxA))));
+    void transport.publish(subject, encoder.encode(serialize.encode(makeMessage(inboxB))));
+
+    await waitFor(() => replies.a !== null && replies.b !== null, {
+      timeout: 10000,
+      message: 'both reply subjects should receive a response'
+    });
+
+    expect(calls).toBe(1);
+    expect(replies.a?.success).toBe(true);
+    expect(replies.b?.success).toBe(true);
+    expect(node.receiver.getStats().dedupHits).toBeGreaterThanOrEqual(1);
+  }, 20000);
+});

--- a/src/subspace/packages/conduit/tests/integration-real/health.real.test.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/health.real.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isConduitHealthPong } from '../../src/index';
+import {
+  cleanupAll,
+  makeConduitId,
+  makeReceiverNode,
+  makeSenderNode
+} from './setup/realConduit';
+
+describe('health pings (Redis + NATS)', () => {
+  afterEach(cleanupAll);
+
+  it('returns a pong from a live receiver over its wildcard subscription', async () => {
+    let conduitId = makeConduitId();
+    let { receiver } = await makeReceiverNode(conduitId, async () => 'ok');
+    let { sender } = makeSenderNode(conduitId);
+
+    let response = await sender.pingReceiver(receiver.getReceiverId(), 2000);
+
+    expect(response.success).toBe(true);
+    expect(isConduitHealthPong(response.result)).toBe(true);
+    expect((response.result as { receiverId: string }).receiverId).toBe(
+      receiver.getReceiverId()
+    );
+  });
+
+  it('times out when pinging an unknown receiver', async () => {
+    let conduitId = makeConduitId();
+    await makeReceiverNode(conduitId, async () => 'ok');
+    let { sender } = makeSenderNode(conduitId);
+
+    await expect(sender.pingReceiver('receiver-does-not-exist', 500)).rejects.toThrow();
+  });
+
+  it('reports healthy under normal load and still pongs while busy on another topic', async () => {
+    let conduitId = makeConduitId();
+    let { receiver } = await makeReceiverNode(conduitId, async topic => {
+      if (topic === 'busy') await new Promise(r => setTimeout(r, 600));
+      return { topic };
+    });
+    let { sender } = makeSenderNode(conduitId);
+
+    // Kick off slow work, then ping: the health topic bypasses the per-topic
+    // queue, so the pong must come back without waiting for the busy handler.
+    let busyP = sender.send('busy', {});
+    let pong = await sender.pingReceiver(receiver.getReceiverId(), 2000);
+
+    expect(pong.success).toBe(true);
+    expect(isConduitHealthPong(pong.result)).toBe(true);
+    expect(receiver.isHealthy()).toBe(true);
+
+    let busy = await busyP;
+    expect(busy.success).toBe(true);
+  });
+});

--- a/src/subspace/packages/conduit/tests/integration-real/multiReceiver.real.test.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/multiReceiver.real.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupAll,
+  makeConduitId,
+  makeReceiverNode,
+  makeSenderNode
+} from './setup/realConduit';
+import { waitFor } from './setup/poll';
+
+describe('multi-receiver coordination (Redis + NATS)', () => {
+  afterEach(cleanupAll);
+
+  it('owns each topic on exactly one node and routes accordingly', async () => {
+    let conduitId = makeConduitId();
+    let nodeA = await makeReceiverNode(conduitId, async () => 'A');
+    let nodeB = await makeReceiverNode(conduitId, async () => 'B');
+    let { conduit: senderConduit, sender } = makeSenderNode(conduitId);
+
+    let ids = new Set([nodeA.receiver.getReceiverId(), nodeB.receiver.getReceiverId()]);
+
+    await waitFor(
+      async () => {
+        let active = await senderConduit.coordination.getActiveReceivers();
+        return active.length === 2;
+      },
+      { message: 'both receivers should register' }
+    );
+
+    let topics = Array.from({ length: 20 }, (_, i) => `topic.${i}`);
+    let handledBy = await Promise.all(topics.map(t => sender.send(t, {})));
+
+    // Each send was answered by exactly one of the two nodes.
+    for (let r of handledBy) {
+      expect(r.success).toBe(true);
+      expect(['A', 'B']).toContain(r.result);
+    }
+
+    // The recorded owner of each topic matches one of our active receivers, and
+    // the handler tag is consistent with that owner.
+    for (let [i, topic] of topics.entries()) {
+      let owner = await senderConduit.coordination.getTopicOwner(topic);
+      expect(owner).not.toBeNull();
+      expect(ids.has(owner!)).toBe(true);
+      let expectedTag = owner === nodeA.receiver.getReceiverId() ? 'A' : 'B';
+      expect(handledBy[i]!.result).toBe(expectedTag);
+    }
+
+    // With 20 topics across 2 receivers, both should have been used.
+    let tags = new Set(handledBy.map(r => r.result));
+    expect(tags).toEqual(new Set(['A', 'B']));
+  });
+
+  it('keeps a single topic pinned to one owner (NX exclusivity)', async () => {
+    let conduitId = makeConduitId();
+    await makeReceiverNode(conduitId, async () => 'A');
+    await makeReceiverNode(conduitId, async () => 'B');
+    let { conduit: senderConduit, sender } = makeSenderNode(conduitId);
+
+    await waitFor(async () => {
+      let active = await senderConduit.coordination.getActiveReceivers();
+      return active.length === 2;
+    });
+
+    let results = await Promise.all(
+      Array.from({ length: 10 }, () => sender.send('sticky.topic', {}))
+    );
+
+    let tags = new Set(results.map(r => r.result));
+    expect(tags.size).toBe(1);
+  });
+
+  it('reassigns a topic to a healthy node after the owner leaves', async () => {
+    let conduitId = makeConduitId();
+    let nodeA = await makeReceiverNode(conduitId, async () => 'A');
+    let nodeB = await makeReceiverNode(conduitId, async () => 'B');
+    let { conduit: senderConduit, sender } = makeSenderNode(conduitId);
+
+    await waitFor(async () => {
+      let active = await senderConduit.coordination.getActiveReceivers();
+      return active.length === 2;
+    });
+
+    let first = await sender.send('failover.topic', {});
+    let firstOwner = await senderConduit.coordination.getTopicOwner('failover.topic');
+    expect(firstOwner).not.toBeNull();
+
+    // Stop whichever node currently owns the topic.
+    let owningNode = firstOwner === nodeA.receiver.getReceiverId() ? nodeA : nodeB;
+    let survivingNode = owningNode === nodeA ? nodeB : nodeA;
+    let survivorTag = survivingNode === nodeA ? 'A' : 'B';
+    await owningNode.receiver.stop();
+
+    // Wait until the sender no longer sees the stopped receiver as active, so the
+    // next send is guaranteed to be (re)assigned to the survivor.
+    await waitFor(
+      async () => {
+        let active = await senderConduit.coordination.getActiveReceivers();
+        return !active.includes(owningNode.receiver.getReceiverId()) && active.length === 1;
+      },
+      { timeout: 8000, message: 'stopped receiver should drop out of active set' }
+    );
+
+    let second = await sender.send('failover.topic', {});
+    expect(second.success).toBe(true);
+    expect(second.result).toBe(survivorTag);
+
+    let newOwner = await senderConduit.coordination.getTopicOwner('failover.topic');
+    expect(newOwner).toBe(survivingNode.receiver.getReceiverId());
+    expect(first.success).toBe(true);
+  });
+});

--- a/src/subspace/packages/conduit/tests/integration-real/natsChaos.test.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/natsChaos.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupAll,
+  makeConduitId,
+  makeReceiverNode,
+  makeSenderNode
+} from './setup/realConduit';
+import { composeRestart, composeStart, composeStop } from './setup/dockerControl';
+import { sleep, waitFor } from './setup/poll';
+
+let trySend = async (
+  sender: { send: (topic: string, payload: unknown) => Promise<{ success: boolean }> },
+  topic: string
+) => {
+  try {
+    let r = await sender.send(topic, {});
+    return r.success;
+  } catch {
+    return false;
+  }
+};
+
+describe('NATS chaos (restart / outage)', () => {
+  afterEach(cleanupAll);
+
+  it('keeps draining new messages after the NATS server is restarted', async () => {
+    let conduitId = makeConduitId();
+    let node = await makeReceiverNode(conduitId, async topic => ({ topic }));
+    let { sender } = makeSenderNode(conduitId, { defaultTimeout: 3000, maxRetries: 1 });
+
+    // Baseline: messages flow.
+    expect((await sender.send('before.restart', {})).success).toBe(true);
+
+    // Bounce NATS. The client auto-reconnects; the receiver's read loop must
+    // resume draining (either via the client's transparent resubscribe or our
+    // resubscribe-on-iterator-death fallback).
+    composeRestart('nats');
+
+    await waitFor(() => trySend(sender, 'after.restart'), {
+      timeout: 40000,
+      interval: 500,
+      message: 'sends should succeed again after NATS recovers'
+    });
+
+    expect(node.receiver.isHealthy()).toBe(true);
+
+    let transport = node.conduit.transport as { getResubscribeCount?: () => number };
+    console.log(
+      `[natsChaos] resubscribeCount=${transport.getResubscribeCount?.() ?? 'n/a'} (informational; may be 0 if the client resubscribed transparently)`
+    );
+  }, 60000);
+
+  it('eventually delivers a send issued during a brief NATS outage', async () => {
+    let conduitId = makeConduitId();
+    await makeReceiverNode(conduitId, async () => 'ok');
+    // Generous timeout + retries so the request survives the outage window.
+    let { sender } = makeSenderNode(conduitId, {
+      defaultTimeout: 10000,
+      maxRetries: 5,
+      retryBackoffMs: 500
+    });
+
+    expect((await sender.send('warmup', {})).success).toBe(true);
+
+    composeStop('nats');
+    // Issue the send while NATS is down, then bring it back shortly after.
+    let inflight = sender.send('during.outage', {});
+    await sleep(1500);
+    composeStart('nats');
+
+    let result = await inflight;
+    expect(result.success).toBe(true);
+  }, 60000);
+});

--- a/src/subspace/packages/conduit/tests/integration-real/realFlow.test.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/realFlow.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupAll,
+  makeConduitId,
+  makeReceiverNode,
+  makeSenderNode
+} from './setup/realConduit';
+import { waitFor } from './setup/poll';
+
+describe('real flow (Redis + NATS)', () => {
+  afterEach(cleanupAll);
+
+  it('round-trips a request/response over real infrastructure', async () => {
+    let conduitId = makeConduitId();
+    let { receiver } = await makeReceiverNode(conduitId, async (topic, payload) => {
+      return { echoedTopic: topic, doubled: (payload as { n: number }).n * 2 };
+    });
+    let { sender } = makeSenderNode(conduitId);
+
+    let response = await sender.send('math.double', { n: 21 });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({ echoedTopic: 'math.double', doubled: 42 });
+    expect(receiver.getReceiverId()).toBeTruthy();
+  });
+
+  it('records topic ownership in Redis after the first send', async () => {
+    let conduitId = makeConduitId();
+    let { conduit, receiver } = await makeReceiverNode(conduitId, async () => 'ok');
+    let { sender } = makeSenderNode(conduitId);
+
+    await sender.send('topic.alpha', {});
+
+    let owner = await waitFor(() => conduit.coordination.getTopicOwner('topic.alpha'), {
+      message: 'topic owner should be recorded in Redis'
+    });
+    expect(owner).toBe(receiver.getReceiverId());
+  });
+
+  it('routes multiple distinct topics to the same single receiver', async () => {
+    let conduitId = makeConduitId();
+    let seen: string[] = [];
+    await makeReceiverNode(conduitId, async topic => {
+      seen.push(topic);
+      return topic;
+    });
+    let { sender } = makeSenderNode(conduitId);
+
+    let topics = ['t.one', 't.two', 't.three'];
+    let results = await Promise.all(topics.map(t => sender.send(t, {})));
+
+    expect(results.map(r => r.success)).toEqual([true, true, true]);
+    expect(results.map(r => r.result)).toEqual(topics);
+    expect(new Set(seen)).toEqual(new Set(topics));
+  });
+});

--- a/src/subspace/packages/conduit/tests/integration-real/redisChaos.test.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/redisChaos.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupAll,
+  makeConduitId,
+  makeReceiverNode,
+  makeSenderNode
+} from './setup/realConduit';
+import { composeRestart } from './setup/dockerControl';
+import { waitFor } from './setup/poll';
+
+let trySend = async (
+  sender: { send: (topic: string, payload: unknown) => Promise<{ success: boolean }> },
+  topic: string
+) => {
+  try {
+    let r = await sender.send(topic, {});
+    return r.success;
+  } catch {
+    return false;
+  }
+};
+
+describe('Redis chaos (restart)', () => {
+  afterEach(cleanupAll);
+
+  it('recovers coordination after Redis is restarted (re-registers + resumes routing)', async () => {
+    let conduitId = makeConduitId();
+    let node = await makeReceiverNode(conduitId, async topic => ({ topic }), {
+      // Re-register quickly after the wipe so failover/recovery is fast.
+      heartbeatInterval: 500,
+      heartbeatTtl: 2000
+    });
+    let { conduit: senderConduit, sender } = makeSenderNode(conduitId);
+
+    expect((await sender.send('before.redis.restart', {})).success).toBe(true);
+
+    // Restart Redis. Persistence is disabled, so registration + ownership are
+    // wiped; ioredis reconnects and the receiver's heartbeat re-registers it.
+    composeRestart('redis');
+
+    // Receiver should re-appear in the active set after reconnect + heartbeat.
+    await waitFor(
+      async () => {
+        let active = await senderConduit.coordination.getActiveReceivers();
+        return active.includes(node.receiver.getReceiverId());
+      },
+      { timeout: 30000, interval: 500, message: 'receiver should re-register after Redis restart' }
+    );
+
+    // And routing/sends resume (ownership re-claimed against fresh Redis state).
+    await waitFor(() => trySend(sender, 'after.redis.restart'), {
+      timeout: 30000,
+      interval: 500,
+      message: 'sends should resume after Redis recovers'
+    });
+  }, 60000);
+});

--- a/src/subspace/packages/conduit/tests/integration-real/redisCoordination.real.test.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/redisCoordination.real.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanupAll, makeConduit, makeConduitId } from './setup/realConduit';
+import { sleep, waitFor } from './setup/poll';
+
+describe('Redis coordination adapter (real Redis)', () => {
+  afterEach(cleanupAll);
+
+  it('drops a receiver from the active set once its registration TTL expires', async () => {
+    let conduit = makeConduit();
+    let coord = conduit.coordination;
+
+    await coord.registerReceiver('rx-temp', 1500);
+    expect(await coord.getActiveReceivers()).toContain('rx-temp');
+
+    await waitFor(
+      async () => {
+        let active = await coord.getActiveReceivers();
+        return !active.includes('rx-temp');
+      },
+      { timeout: 5000, message: 'receiver should expire from active set' }
+    );
+  });
+
+  it('enforces mutually-exclusive topic ownership across nodes (NX)', async () => {
+    let conduitId = makeConduitId();
+    let nodeA = makeConduit(conduitId);
+    let nodeB = makeConduit(conduitId);
+
+    let claimedA = await nodeA.coordination.claimTopicOwnership('excl.topic', 'r-a', 5000);
+    let claimedB = await nodeB.coordination.claimTopicOwnership('excl.topic', 'r-b', 5000);
+
+    expect(claimedA).toBe(true);
+    expect(claimedB).toBe(false);
+    expect(await nodeB.coordination.getTopicOwner('excl.topic')).toBe('r-a');
+  });
+
+  it('extends ownership via renew so it outlives the original TTL', async () => {
+    let conduit = makeConduit();
+    let coord = conduit.coordination;
+
+    expect(await coord.claimTopicOwnership('renew.topic', 'r-1', 1000)).toBe(true);
+
+    // Renew well before the 1s lease lapses, extending it to 5s.
+    await sleep(400);
+    expect(await coord.renewTopicOwnership('renew.topic', 'r-1', 5000)).toBe(true);
+
+    // Past the original 1s TTL, the renewed lease keeps us as owner.
+    await sleep(1200);
+    expect(await coord.getTopicOwner('renew.topic')).toBe('r-1');
+  });
+
+  it('frees ownership on release so another node can claim', async () => {
+    let conduitId = makeConduitId();
+    let nodeA = makeConduit(conduitId);
+    let nodeB = makeConduit(conduitId);
+
+    expect(await nodeA.coordination.claimTopicOwnership('rel.topic', 'r-a', 5000)).toBe(true);
+
+    // A non-owner cannot release it.
+    await nodeB.coordination.releaseTopicOwnership('rel.topic', 'r-b');
+    expect(await nodeA.coordination.getTopicOwner('rel.topic')).toBe('r-a');
+
+    // The owner releasing it frees the lease for someone else.
+    await nodeA.coordination.releaseTopicOwnership('rel.topic', 'r-a');
+    expect(await nodeA.coordination.getTopicOwner('rel.topic')).toBeNull();
+    expect(await nodeB.coordination.claimTopicOwnership('rel.topic', 'r-b', 5000)).toBe(true);
+  });
+
+  it('lets a receiver renew its registration to stay active', async () => {
+    let conduit = makeConduit();
+    let coord = conduit.coordination;
+
+    await coord.registerReceiver('rx-keep', 1500);
+    await sleep(700);
+    await coord.registerReceiver('rx-keep', 1500);
+    await sleep(900);
+
+    // Total elapsed > original 1.5s TTL, but the renewal kept it alive.
+    expect(await coord.getActiveReceivers()).toContain('rx-keep');
+  });
+});

--- a/src/subspace/packages/conduit/tests/integration-real/setup/connection.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/setup/connection.ts
@@ -1,0 +1,29 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface TestConnection {
+  redis: { host: string; port: number };
+  natsUrl: string;
+  natsHttpPort: number;
+}
+
+export let getTestConnection = (): TestConnection => {
+  let host = process.env.CONDUIT_TEST_REDIS_HOST ?? '127.0.0.1';
+  let redisPort = Number(process.env.CONDUIT_TEST_REDIS_PORT ?? 56390);
+  let natsPort = Number(process.env.CONDUIT_TEST_NATS_PORT ?? 56290);
+  let natsHttpPort = Number(process.env.CONDUIT_TEST_NATS_HTTP_PORT ?? 56291);
+  let natsUrl = process.env.CONDUIT_TEST_NATS_URL ?? `nats://${host}:${natsPort}`;
+
+  return {
+    redis: { host, port: redisPort },
+    natsUrl,
+    natsHttpPort
+  };
+};
+
+let here = dirname(fileURLToPath(import.meta.url));
+
+export let COMPOSE_PROJECT = 'conduit-it';
+export let COMPOSE_FILE = join(here, '..', 'docker-compose.yml');
+
+export let isNoDocker = () => process.env.CONDUIT_TEST_NO_DOCKER === '1';

--- a/src/subspace/packages/conduit/tests/integration-real/setup/dockerControl.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/setup/dockerControl.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process';
+import { COMPOSE_FILE, COMPOSE_PROJECT, isNoDocker } from './connection';
+
+type Stdio = 'inherit' | 'pipe' | 'ignore';
+
+let compose = (args: string[], stdio: Stdio = 'pipe') => {
+  execFileSync('docker', ['compose', '-p', COMPOSE_PROJECT, '-f', COMPOSE_FILE, ...args], {
+    stdio
+  });
+};
+
+export let composeUp = () => compose(['up', '-d'], 'inherit');
+export let composeDown = () => compose(['down', '-v', '--remove-orphans'], 'inherit');
+
+export let composeDownQuiet = () => {
+  try {
+    compose(['down', '-v', '--remove-orphans'], 'ignore');
+  } catch {
+    // ignore - nothing to clean or docker not ready yet
+  }
+};
+
+export let composeRestart = (service: string) => {
+  if (isNoDocker()) return;
+  compose(['restart', service]);
+};
+
+export let composeStop = (service: string) => {
+  if (isNoDocker()) return;
+  compose(['stop', service]);
+};
+
+export let composeStart = (service: string) => {
+  if (isNoDocker()) return;
+  compose(['start', service]);
+};

--- a/src/subspace/packages/conduit/tests/integration-real/setup/globalSetup.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/setup/globalSetup.ts
@@ -1,0 +1,79 @@
+import Redis from 'ioredis';
+import { connect } from 'nats';
+import { composeDownQuiet, composeUp, composeDown } from './dockerControl';
+import { getTestConnection, isNoDocker } from './connection';
+import { sleep } from './poll';
+
+let pingRedis = async (host: string, port: number) => {
+  let client = new Redis({
+    host,
+    port,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    retryStrategy: () => null,
+    reconnectOnError: () => false
+  });
+  try {
+    await client.connect();
+    let pong = await client.ping();
+    return pong === 'PONG';
+  } finally {
+    client.disconnect();
+  }
+};
+
+let pingNats = async (url: string) => {
+  let nc = await connect({ servers: [url], timeout: 1000, reconnect: false });
+  await nc.flush();
+  await nc.close();
+  return true;
+};
+
+let waitForReady = async () => {
+  let conn = getTestConnection();
+  let deadline = Date.now() + 60000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      let [redisOk] = await Promise.all([
+        pingRedis(conn.redis.host, conn.redis.port),
+        pingNats(conn.natsUrl)
+      ]);
+      if (redisOk) return;
+    } catch (err) {
+      lastError = err;
+    }
+    await sleep(250);
+  }
+
+  throw new Error(
+    `Redis/NATS not ready within 60s${
+      lastError instanceof Error ? `: ${lastError.message}` : ''
+    }`
+  );
+};
+
+export default async function setup() {
+  let noDocker = isNoDocker();
+
+  if (!noDocker) {
+    // Best-effort clean of any leftovers from a previously aborted run (a stale
+    // half-up project can hold the host ports and break `up`).
+    composeDownQuiet();
+    console.log('[conduit-it] starting Redis + NATS containers...');
+    composeUp();
+  } else {
+    console.log('[conduit-it] CONDUIT_TEST_NO_DOCKER=1, using already-running containers');
+  }
+
+  await waitForReady();
+  console.log('[conduit-it] Redis + NATS ready');
+
+  return async () => {
+    if (!noDocker) {
+      console.log('[conduit-it] tearing down containers...');
+      composeDown();
+    }
+  };
+}

--- a/src/subspace/packages/conduit/tests/integration-real/setup/poll.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/setup/poll.ts
@@ -1,0 +1,33 @@
+export let sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+export interface WaitForOptions {
+  timeout?: number;
+  interval?: number;
+  message?: string;
+}
+
+export let waitFor = async <T>(
+  fn: () => Promise<T> | T,
+  opts: WaitForOptions = {}
+): Promise<T> => {
+  let timeout = opts.timeout ?? 10000;
+  let interval = opts.interval ?? 100;
+  let deadline = Date.now() + timeout;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      let result = await fn();
+      if (result) return result;
+    } catch (err) {
+      lastError = err;
+    }
+    await sleep(interval);
+  }
+
+  let suffix = opts.message ? `: ${opts.message}` : '';
+  let errInfo = lastError
+    ? ` (last error: ${lastError instanceof Error ? lastError.message : String(lastError)})`
+    : '';
+  throw new Error(`waitFor timed out after ${timeout}ms${suffix}${errInfo}`);
+};

--- a/src/subspace/packages/conduit/tests/integration-real/setup/realConduit.ts
+++ b/src/subspace/packages/conduit/tests/integration-real/setup/realConduit.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from 'node:crypto';
+import type { TopicHandler } from '../../../src/core/conduitReceiver';
+import type { MessageHandler } from '../../../src/core/receiver';
+import {
+  createConduit,
+  createRedisNatsConduit,
+  type Receiver,
+  type ReceiverConfig,
+  type Sender,
+  type SenderConfig
+} from '../../../src/index';
+import { getTestConnection } from './connection';
+
+type Conduit = ReturnType<typeof createConduit> & { conduitId: string };
+
+interface Stoppable {
+  stop: () => Promise<void>;
+}
+
+interface Tracked {
+  receivers: Stoppable[];
+  senders: Sender[];
+  conduits: Conduit[];
+}
+
+let tracked: Tracked = { receivers: [], senders: [], conduits: [] };
+
+export let makeConduitId = () => `it-${randomUUID()}`;
+
+export let makeConduit = (conduitId: string = makeConduitId()): Conduit => {
+  let conn = getTestConnection();
+  let base = createConduit(
+    createRedisNatsConduit({
+      conduitId,
+      redisConfig: { host: conn.redis.host, port: conn.redis.port },
+      natsConfig: { servers: [conn.natsUrl] }
+    })
+  );
+
+  let conduit = Object.assign(base, { conduitId });
+  tracked.conduits.push(conduit);
+  return conduit;
+};
+
+export let trackReceiver = (receiver: Receiver): Receiver => {
+  tracked.receivers.push(receiver);
+  return receiver;
+};
+
+export let trackSender = (sender: Sender): Sender => {
+  tracked.senders.push(sender);
+  return sender;
+};
+
+/** Convenience: a conduit with a single started receiver. */
+export let makeReceiverNode = async (
+  conduitId: string,
+  handler: MessageHandler,
+  config?: Partial<ReceiverConfig>
+) => {
+  let conduit = makeConduit(conduitId);
+  let receiver = trackReceiver(conduit.createReceiver(handler, config));
+  await receiver.start();
+  return { conduit, receiver };
+};
+
+/** Convenience: a conduit with a single started topic-based receiver. */
+export let makeTopicReceiverNode = async (
+  conduitId: string,
+  handleTopic: TopicHandler,
+  config?: Partial<ReceiverConfig>
+) => {
+  let conduit = makeConduit(conduitId);
+  let receiver = conduit.createConduitReceiver(handleTopic, config);
+  tracked.receivers.push(receiver);
+  await receiver.start();
+  return { conduit, receiver };
+};
+
+/** Convenience: a conduit with a sender (separate process from receivers). */
+export let makeSenderNode = (conduitId: string, config?: Partial<SenderConfig>) => {
+  let conduit = makeConduit(conduitId);
+  let sender = trackSender(conduit.createSender(config));
+  return { conduit, sender };
+};
+
+/**
+ * Tear down everything created during a test, in dependency order: stop
+ * receivers (clears intervals + unsubscribes + drops Redis registration),
+ * close senders (clears intervals + unsubscribes), then close conduits
+ * (closes the underlying NATS connection + Redis client). Errors are swallowed
+ * so one wedged resource cannot block cleanup of the rest.
+ */
+export let cleanupAll = async () => {
+  let { receivers, senders, conduits } = tracked;
+  tracked = { receivers: [], senders: [], conduits: [] };
+
+  await Promise.allSettled(receivers.map(r => r.stop()));
+  await Promise.allSettled(senders.map(s => s.close()));
+  await Promise.allSettled(conduits.map(c => c.close()));
+};

--- a/src/subspace/packages/conduit/tests/integration/headOfLineBlocking.test.ts
+++ b/src/subspace/packages/conduit/tests/integration/headOfLineBlocking.test.ts
@@ -1,0 +1,191 @@
+import { serialize } from '@lowerdeck/serialize';
+import { describe, expect, test } from 'vitest';
+import type { ConduitMessage } from '../../src/index';
+import { createConduit } from '../../src/index';
+
+let sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('Head-of-line blocking', () => {
+  test('a slow message on topic A does not delay topic B', async () => {
+    let conduit = createConduit();
+
+    let receiver = conduit.createReceiver(async (topic, _payload) => {
+      if (topic === 'slow') await sleep(800);
+      return { topic, at: Date.now() };
+    });
+    await receiver.start();
+
+    let sender = conduit.createSender({ defaultTimeout: 5000 });
+
+    let start = Date.now();
+    // Fire the slow message first, then the fast one. The fast one must not be
+    // stuck behind the slow one (different topics run concurrently).
+    let slowP = sender.send('slow', {});
+    let fastP = sender.send('fast', {});
+
+    let fast = await fastP;
+    let fastElapsed = Date.now() - start;
+
+    expect(fast.success).toBe(true);
+    // Fast should come back well before the slow handler's 800ms.
+    expect(fastElapsed).toBeLessThan(500);
+
+    let slow = await slowP;
+    expect(slow.success).toBe(true);
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+
+  test('messages on the same topic are processed serially', async () => {
+    let conduit = createConduit();
+
+    let active = 0;
+    let maxActive = 0;
+    let receiver = conduit.createReceiver(async (_topic, _payload) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await sleep(50);
+      active--;
+      return { ok: true };
+    });
+    await receiver.start();
+
+    let sender = conduit.createSender({ defaultTimeout: 5000 });
+
+    let responses = await Promise.all(
+      Array.from({ length: 6 }, (_, i) => sender.send('same-topic', { i }))
+    );
+
+    for (let r of responses) expect(r.success).toBe(true);
+    // Same topic must never run two handlers concurrently.
+    expect(maxActive).toBe(1);
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+
+  test('different topics run concurrently', async () => {
+    let conduit = createConduit();
+
+    let active = 0;
+    let maxActive = 0;
+    let receiver = conduit.createReceiver(async (_topic, _payload) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await sleep(100);
+      active--;
+      return { ok: true };
+    });
+    await receiver.start();
+
+    let sender = conduit.createSender({ defaultTimeout: 5000 });
+
+    let start = Date.now();
+    let responses = await Promise.all(
+      Array.from({ length: 5 }, (_, i) => sender.send(`topic-${i}`, { i }))
+    );
+    let elapsed = Date.now() - start;
+
+    for (let r of responses) expect(r.success).toBe(true);
+    // Concurrent across topics: should be far less than 5 * 100ms.
+    expect(maxActive).toBeGreaterThan(1);
+    expect(elapsed).toBeLessThan(400);
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+
+  test('handler ceiling fails one message and frees the loop', async () => {
+    let conduit = createConduit();
+
+    let receiver = conduit.createReceiver(
+      async (topic, _payload) => {
+        if (topic === 'never') {
+          // Never returns within the ceiling.
+          await sleep(60000);
+        }
+        return { topic };
+      },
+      { maxProcessingMs: 500, timeoutExtensionThreshold: 100 }
+    );
+    await receiver.start();
+
+    let sender = conduit.createSender({ defaultTimeout: 10000 });
+
+    let stuck = await sender.send('never', {});
+    expect(stuck.success).toBe(false);
+    expect(stuck.error).toBe('handler exceeded max processing time');
+
+    // The receiver is not wedged: another topic still processes.
+    let ok = await sender.send('fine', {});
+    expect(ok.success).toBe(true);
+    expect(ok.result).toEqual({ topic: 'fine' });
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+
+  test('in-flight dedup: a retry of an in-flight messageId runs the handler once', async () => {
+    let conduit = createConduit();
+
+    let calls = 0;
+    let receiver = conduit.createReceiver(async (_topic, _payload) => {
+      calls++;
+      await sleep(300);
+      return { calls };
+    });
+    await receiver.start();
+
+    let transport = conduit.transport; // MemoryTransport
+    let receiverId = receiver.getReceiverId();
+    let topic = 'dedup-topic';
+    let subject = `conduit.default.receiver.${receiverId}.${topic}`;
+
+    let encoder = new TextEncoder();
+    let decoder = new TextDecoder();
+
+    let makeMessage = (replySubject: string): ConduitMessage => ({
+      messageId: 'dup-message-1',
+      topic,
+      payload: { hello: 'world' },
+      replySubject,
+      timeout: 5000,
+      sentAt: Date.now(),
+      retryCount: 0
+    });
+
+    let reply1: any = null;
+    let reply2: any = null;
+    let r1 = new Promise<void>(resolve => {
+      transport.subscribe('_INBOX.dup-1', async data => {
+        reply1 = serialize.decode(decoder.decode(data));
+        resolve();
+      });
+    });
+    let r2 = new Promise<void>(resolve => {
+      transport.subscribe('_INBOX.dup-2', async data => {
+        reply2 = serialize.decode(decoder.decode(data));
+        resolve();
+      });
+    });
+
+    // Publish two copies with the SAME messageId in the same tick: the second
+    // arrives while the first is still in-flight.
+    void transport.publish(subject, encoder.encode(serialize.encode(makeMessage('_INBOX.dup-1'))));
+    void transport.publish(subject, encoder.encode(serialize.encode(makeMessage('_INBOX.dup-2'))));
+
+    await Promise.all([r1, r2]);
+
+    expect(calls).toBe(1);
+    expect(reply1.success).toBe(true);
+    expect(reply2.success).toBe(true);
+
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+});

--- a/src/subspace/packages/conduit/tests/integration/healthPing.test.ts
+++ b/src/subspace/packages/conduit/tests/integration/healthPing.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+import { createConduit, isConduitHealthPong } from '../../src/index';
+
+describe('Direct per-receiver health ping', () => {
+  test('a running receiver answers a health ping with a pong', async () => {
+    let conduit = createConduit();
+
+    let receiver = conduit.createReceiver(async (_topic, payload) => ({ echo: payload }));
+    await receiver.start();
+
+    let sender = conduit.createSender();
+
+    let response = await sender.pingReceiver(receiver.getReceiverId(), 2000);
+
+    expect(response.success).toBe(true);
+    expect(isConduitHealthPong(response.result)).toBe(true);
+    if (isConduitHealthPong(response.result)) {
+      expect(response.result.receiverId).toBe(receiver.getReceiverId());
+    }
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+
+  test('the health ping bypasses the user handler', async () => {
+    let conduit = createConduit();
+
+    let handlerCalls = 0;
+    let receiver = conduit.createReceiver(async () => {
+      handlerCalls++;
+      return {};
+    });
+    await receiver.start();
+
+    let sender = conduit.createSender();
+    await sender.pingReceiver(receiver.getReceiverId(), 2000);
+
+    expect(handlerCalls).toBe(0);
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+
+  test('pinging an unknown receiver times out', async () => {
+    let conduit = createConduit();
+
+    let sender = conduit.createSender();
+
+    await expect(sender.pingReceiver('receiver-does-not-exist', 300)).rejects.toThrow();
+
+    await sender.close();
+    await conduit.close();
+  }, 15000);
+});

--- a/src/subspace/packages/conduit/tests/integration/orphanedHandlers.test.ts
+++ b/src/subspace/packages/conduit/tests/integration/orphanedHandlers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+import { createConduit } from '../../src/index';
+
+let tick = () => new Promise<void>(resolve => setImmediate(resolve));
+
+describe('Ceiling-orphaned handlers', () => {
+  test('orphaned handlers are tracked, recycle the receiver, then drain on settle', async () => {
+    let conduit = createConduit();
+
+    // Handlers block until the test releases them, so a ceiling abort leaves a
+    // still-running ("orphaned") handler we can observe.
+    let release: Array<() => void> = [];
+    let receiver = conduit.createReceiver(
+      async () => {
+        await new Promise<void>(resolve => release.push(resolve));
+        return { done: true };
+      },
+      { maxProcessingMs: 100, maxOrphanedHandlers: 2, timeoutExtensionThreshold: 50 }
+    );
+    await receiver.start();
+
+    let sender = conduit.createSender({ defaultTimeout: 5000 });
+
+    // Distinct topics so the handlers run concurrently (different topic chains).
+    let first = await sender.send('topic-a', {});
+    expect(first.success).toBe(false);
+    expect(first.error).toBe('handler exceeded max processing time');
+    expect(receiver.getStats().orphaned).toBe(1);
+    expect(receiver.getStats().orphanedTotal).toBe(1);
+    // One orphan is below the recycle threshold (2).
+    expect(receiver.isHealthy()).toBe(true);
+
+    let second = await sender.send('topic-b', {});
+    expect(second.success).toBe(false);
+    expect(receiver.getStats().orphaned).toBe(2);
+
+    // At the threshold the receiver reports unhealthy so it gets recycled (which
+    // would terminate the orphaned provider work with the process).
+    expect(receiver.isHealthy()).toBe(false);
+
+    // Once the orphaned handlers finally settle, they stop counting and health
+    // recovers.
+    for (let resolve of release) resolve();
+    await tick();
+    await tick();
+
+    expect(receiver.getStats().orphaned).toBe(0);
+    expect(receiver.getStats().orphanedTotal).toBe(2);
+    expect(receiver.isHealthy()).toBe(true);
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 15000);
+});

--- a/src/subspace/packages/conduit/tests/integration/unlimitedTimeoutExtensions.test.ts
+++ b/src/subspace/packages/conduit/tests/integration/unlimitedTimeoutExtensions.test.ts
@@ -155,12 +155,13 @@ describe('Unlimited Timeout Extensions', () => {
       defaultTimeout: 3000
     });
 
-    // Send mix of fast and slow messages concurrently
+    // Send mix of fast and slow messages to DIFFERENT topics so they run
+    // concurrently (same topic is serialized).
     const promises = [
-      sender.send('concurrent-ext-topic', { id: 1, slow: false }),
-      sender.send('concurrent-ext-topic', { id: 2, slow: true }),
-      sender.send('concurrent-ext-topic', { id: 3, slow: false }),
-      sender.send('concurrent-ext-topic', { id: 4, slow: true })
+      sender.send('concurrent-ext-1', { id: 1, slow: false }),
+      sender.send('concurrent-ext-2', { id: 2, slow: true }),
+      sender.send('concurrent-ext-3', { id: 3, slow: false }),
+      sender.send('concurrent-ext-4', { id: 4, slow: true })
     ];
 
     const responses = await Promise.all(promises);
@@ -174,4 +175,38 @@ describe('Unlimited Timeout Extensions', () => {
     await receiver.stop();
     await conduit.close();
   }, 25000);
+
+  test('extensions are capped at maxProcessingMs (handler is aborted)', async () => {
+    const conduit = createConduit();
+
+    // A handler that would run far longer than the ceiling. Extensions must NOT
+    // keep it alive indefinitely - it is aborted once maxProcessingMs elapses.
+    const receiver = conduit.createReceiver(
+      async (_topic, _payload) => {
+        await new Promise(resolve => setTimeout(resolve, 30000));
+        return { processed: true };
+      },
+      {
+        timeoutExtensionThreshold: 500,
+        maxProcessingMs: 1500
+      }
+    );
+
+    await receiver.start();
+
+    const sender = conduit.createSender({ defaultTimeout: 1000 });
+
+    const start = Date.now();
+    const response = await sender.send('capped-topic', { data: 'test' });
+    const elapsed = Date.now() - start;
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe('handler exceeded max processing time');
+    // Aborted near the ceiling, not after the full 30s handler.
+    expect(elapsed).toBeLessThan(6000);
+
+    await sender.close();
+    await receiver.stop();
+    await conduit.close();
+  }, 20000);
 });

--- a/src/subspace/packages/conduit/tests/unit/semaphore.test.ts
+++ b/src/subspace/packages/conduit/tests/unit/semaphore.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { Semaphore } from '../../src/core/semaphore';
+
+describe('Semaphore', () => {
+  test('allows up to N concurrent holders', async () => {
+    let sem = new Semaphore(2);
+
+    await sem.acquire();
+    await sem.acquire();
+
+    expect(sem.getAvailable()).toBe(0);
+
+    let acquired3 = false;
+    let p = sem.acquire().then(() => {
+      acquired3 = true;
+    });
+
+    // The third acquire must wait.
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(acquired3).toBe(false);
+    expect(sem.getWaiting()).toBe(1);
+
+    // Releasing hands the permit to the waiter.
+    sem.release();
+    await p;
+    expect(acquired3).toBe(true);
+    expect(sem.getWaiting()).toBe(0);
+  });
+
+  test('serializes work to at most N concurrent', async () => {
+    let sem = new Semaphore(3);
+    let active = 0;
+    let maxActive = 0;
+
+    let task = async () => {
+      await sem.acquire();
+      try {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise(resolve => setTimeout(resolve, 20));
+      } finally {
+        active--;
+        sem.release();
+      }
+    };
+
+    await Promise.all(Array.from({ length: 12 }, () => task()));
+
+    expect(maxActive).toBeLessThanOrEqual(3);
+    expect(active).toBe(0);
+  });
+});

--- a/src/subspace/packages/conduit/vitest.config.ts
+++ b/src/subspace/packages/conduit/vitest.config.ts
@@ -1,10 +1,13 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
+// Default suite: the fast, in-memory tests. Explicitly excludes the docker-backed
+// real-infra suite so `bun run test` stays dockerless and unchanged.
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    exclude: [...configDefaults.exclude, 'tests/integration-real/**'],
     testTimeout: 30000,
     hookTimeout: 30000
   }

--- a/src/subspace/packages/conduit/vitest.integration.config.ts
+++ b/src/subspace/packages/conduit/vitest.integration.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+// Real-infra suite: runs only the docker-backed tests under tests/integration-real.
+// globalSetup brings Redis + NATS up before the suite and tears them down after.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration-real/**/*.test.ts'],
+    globalSetup: ['tests/integration-real/setup/globalSetup.ts'],
+    testTimeout: 30000,
+    hookTimeout: 60000,
+    // Chaos tests restart the shared containers, so files must not run in
+    // parallel against each other.
+    pool: 'forks',
+    fileParallelism: false
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core message dispatch, ownership renewal, and health semantics for controller/worker production paths; mis-tuned limits or fleet health could cause false 503s, missed alerts, or topic reassignment during deploys.
> 
> **Overview**
> Hardens **Conduit** (Redis coordination + NATS transport) so wedged or slow handlers cannot block the whole worker, and adds fleet-level health probing plus deploy-friendly shutdown.
> 
> **Receiver / transport:** NATS subscriptions dispatch handlers fire-and-forget and **resubscribe** when the read loop dies. Messages run on **per-topic FIFO chains** (serial per topic, concurrent across topics), with a **handler concurrency semaphore**, **in-flight caps** (shed overload), **in-flight dedup** by `messageId`, and a **`maxProcessingMs` ceiling** that stops unlimited timeout extensions. A reserved **`__conduit_health__`** path answers pings without touching user handlers. Receivers **subscribe before** registering in Redis; unhealthy workers **stop renewing** heartbeats and topic ownership. **`isHealthy` / `isReady` / `getStats`** expose wedge signals (including ceiling-orphaned handlers).
> 
> **Health & ops:** Optional **`CONDUIT_FLEET_HEALTH`** switches controller checks to **per-receiver `pingReceiver` probes** with startup grace and wedged thresholds. **`failOnEmptyFleet`** separates ECS liveness (tolerate empty workers) from external heartbeats (alert on total outage). Workers use **`checkConduitSelfHealth`**, fail liveness when the local receiver is unhealthy, and **drain in-flight work** on SIGTERM/SIGINT before stop.
> 
> **CI:** New **`conduit-integration`** workflow job runs docker-backed Redis+NATS Vitest suite (`test:integration`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aec02d31118bc9f2782a0c72d1e10be497c1a7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->