### PR TITLE
Add subspace nats health logging

### DIFF
--- a/src/subspace/apps/worker/src/endpoints.ts
+++ b/src/subspace/apps/worker/src/endpoints.ts
@@ -21,11 +21,13 @@ if (process.env.NODE_ENV === 'production') {
 
           let receiver = getConnectionReceiver();
           if (receiver && receiver.isReady() && !receiver.isHealthy()) {
+            console.error('Connection receiver is unhealthy');
             return new Response('Service Unavailable', { status: 503 });
           }
 
           return new Response('OK');
         } catch (e) {
+          console.error('Health check failed:', e);
           return new Response('Service Unavailable', { status: 503 });
         }
       }),

--- a/src/subspace/modules/connection/src/controller/receiver.ts
+++ b/src/subspace/modules/connection/src/controller/receiver.ts
@@ -28,8 +28,59 @@ const NO_OUTPUT_ERROR = {
 let connectionReceiver:
   | (ReturnType<typeof conduit.createConduitReceiver> & { started: Promise<void> })
   | null = null;
+let connectionReceiverHealthInterval: Timer | null = null;
+let lastConnectionReceiverHealthState: { ready: boolean; healthy: boolean } | null = null;
 
 export let getConnectionReceiver = () => connectionReceiver;
+
+let stopConnectionReceiverHealthLogging = () => {
+  if (connectionReceiverHealthInterval) {
+    clearInterval(connectionReceiverHealthInterval);
+    connectionReceiverHealthInterval = null;
+  }
+};
+
+let startConnectionReceiverHealthLogging = (
+  receiver: ReturnType<typeof conduit.createConduitReceiver>
+) => {
+  stopConnectionReceiverHealthLogging();
+  lastConnectionReceiverHealthState = null;
+
+  connectionReceiverHealthInterval = setInterval(() => {
+    let ready = receiver.isReady();
+    let healthy = receiver.isHealthy();
+    let previous = lastConnectionReceiverHealthState;
+    lastConnectionReceiverHealthState = { ready, healthy };
+
+    if (!previous || (previous.ready === ready && previous.healthy === healthy)) {
+      return;
+    }
+
+    let stats = receiver.getStats();
+    let handledTopics = receiver.getHandledTopics();
+    let ownedTopics = receiver.getOwnedTopics();
+    let summary =
+      `receiverId=${receiver.getReceiverId()} ready=${ready} healthy=${healthy} ` +
+      `ownedTopics=${ownedTopics.length} handledTopics=${handledTopics.length} ` +
+      `inFlight=${stats.inFlight} processing=${stats.processing} ` +
+      `slotsAvail=${stats.handlerSlotsAvailable} waiting=${stats.handlerWaiting} ` +
+      `dispatched=${stats.dispatched} shed=${stats.shed} ` +
+      `ceilingAborts=${stats.ceilingAborts} dedupHits=${stats.dedupHits} ` +
+      `orphaned=${stats.orphaned} orphanedTotal=${stats.orphanedTotal} ` +
+      `sinceProgressMs=${Date.now() - stats.lastProgressAt}`;
+
+    if (previous.healthy && !healthy) {
+      console.error(
+        `CONNECTION.receiver.unhealthy ${summary} ownedTopicList=${JSON.stringify(ownedTopics)} handledTopicList=${JSON.stringify(handledTopics)}`
+      );
+      return;
+    }
+
+    if (!previous.healthy && healthy) {
+      console.warn(`CONNECTION.receiver.recovered ${summary}`);
+    }
+  }, 1000);
+};
 
 export let startReceiver = () => {
   let receiver = conduit.createConduitReceiver(async ctx => {
@@ -335,6 +386,9 @@ export let startReceiver = () => {
   let started = receiver.start();
   started.catch(err => {
     console.error('Error starting Connection Controller receiver:', err);
+  });
+  started.then(() => {
+    startConnectionReceiverHealthLogging(receiver);
   });
 
   connectionReceiver = Object.assign(receiver, { started });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and logging only; worker 503 behavior for an unhealthy ready receiver was already present.
> 
> **Overview**
> Adds **observability** around the subspace NATS/conduit connection receiver and tightens worker health reporting when probes fail.
> 
> After the conduit receiver finishes starting, a **1s interval** watches `ready`/`healthy` and only logs on **state changes**: `CONNECTION.receiver.unhealthy` (with receiver stats, topic lists) when health drops, and `CONNECTION.receiver.recovered` when it comes back.
> 
> The worker production health handler now **`console.error`s** when the connection receiver is ready but unhealthy (still **503**) and when any health check throws (DB, Redis, NATS, etc.), instead of failing silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12363b11ef9bf32d73d05c67403989b2bcc9488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->