### PR TITLE
Fix provider page filters

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/provider/index.tsx
@@ -30,11 +30,13 @@ export let ProviderOverviewPage = () => {
   let provider = useProvider(instance.data?.id, providerId);
 
   let listing = useProviderListing(instance.data?.id, providerId);
-  let providerFilterQuery = providerId ? `?providerId=${encodeURIComponent(providerId)}` : '';
+  let providerFilterQuery = providerId
+    ? `?providerId=${encodeURIComponent(provider.data?.id ?? providerId)}`
+    : '';
   let integrations = useIntegrations(
     instance.data?.id && providerId ? instance.data.id : null,
     {
-      providerId,
+      providerId: provider.data?.id ?? providerId,
       status: ['active'],
       limit: 15,
       order: 'desc'
@@ -43,7 +45,7 @@ export let ProviderOverviewPage = () => {
   let magicMcpServers = useMagicMcpServers(
     instance.data?.id && providerId ? instance.data.id : null,
     {
-      providerId,
+      providerId: provider.data?.id ?? providerId,
       status: ['active'],
       limit: 15,
       order: 'desc'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small dashboard-only change to query params and list filters; no auth or backend changes.
> 
> **Overview**
> **Fixes provider overview filtering** when the URL uses a slug (or other non-canonical route param) instead of the API’s provider id.
> 
> On `ProviderOverviewPage`, integrations and Magic MCP server queries—and the **View All** query strings—now use `provider.data?.id ?? providerId` instead of the raw `useParams()` value, so list results and deep links match the loaded provider record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11de27f1eb30b980a19ec54e241934cc96d9ac04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->