### PR TITLE
Add instance slug override

### DIFF
--- a/src/metorial/modules/organization/src/services/instance.ts
+++ b/src/metorial/modules/organization/src/services/instance.ts
@@ -78,7 +78,11 @@ class InstanceService {
     }
   }
 
-  private async reclaimInstanceSlugOrThrow(d: { slug: string; instance?: Instance }) {
+  private async reclaimInstanceSlugOrThrow(d: {
+    slug: string;
+    instance?: Instance;
+    canOverrideSlug?: boolean;
+  }) {
     await withTransaction(
       async db => {
         let currentSlugInstance = await db.instance.findFirst({
@@ -89,11 +93,20 @@ class InstanceService {
         });
 
         if (currentSlugInstance) {
-          throw new ServiceError(
-            conflictError({
-              message: 'An instance with this slug already exists'
-            })
-          );
+          if (!d.canOverrideSlug) {
+            throw new ServiceError(
+              conflictError({
+                message: 'An instance with this slug already exists'
+              })
+            );
+          }
+
+          await db.instance.update({
+            where: { oid: currentSlugInstance.oid },
+            data: {
+              slug: `${currentSlugInstance.slug}-${generateCode(3)}`
+            }
+          });
         }
 
         let previousSlugInstances = await db.instance.findMany({
@@ -338,6 +351,7 @@ class InstanceService {
     organization: Organization;
     performedBy: OrganizationActor;
     context: Context;
+    canOverrideSlug?: boolean;
     input: {
       name?: string;
       slug?: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes slug uniqueness semantics and forcibly renames another instance’s slug, which can break existing URLs or integrations unless override is tightly gated at the API/auth layer.
> 
> **Overview**
> Instance slug updates can optionally **take over** a slug that another instance already uses instead of always returning a conflict.
> 
> `reclaimInstanceSlugOrThrow` gains a `canOverrideSlug` flag: when it is false or omitted, behavior is unchanged (conflict if the slug is in use). When true, the other instance holding that slug is renamed to `{originalSlug}-{3-char code}` so the updating instance can claim the slug. `updateInstance` accepts the same optional `canOverrideSlug` parameter for callers that need this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b42426f13df4d5c71d3aec9f2d62faa00259a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->