### PR TITLE
Ensure unique instance names across regions

### DIFF
--- a/src/metorial/db/prisma/schema/cells/instance.prisma
+++ b/src/metorial/db/prisma/schema/cells/instance.prisma
@@ -1,0 +1,15 @@
+model CellInstance {
+  id String @id
+
+  type   InstanceType
+  status InstanceStatus
+
+  slug String
+  name String
+
+  isOwnedByDeployment Boolean
+
+  deletedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now()) @updatedAt
+}

--- a/src/metorial/modules/organization/src/services/instance.ts
+++ b/src/metorial/modules/organization/src/services/instance.ts
@@ -28,14 +28,21 @@ import { generateCode } from '@metorial/id';
 import { differenceInMinutes } from 'date-fns';
 import { syncSubspaceTenantQueue } from '../queues/syncSubspaceTenant';
 
-let getInstanceSlug = createSlugGenerator(
-  async slug =>
-    !(await db.instance.findFirst({
-      where: {
-        OR: [{ slug }, { oldSlug: slug }, { previousSlugs: { has: slug } }]
-      }
-    }))
-);
+let getInstanceSlug = createSlugGenerator(async slug => {
+  let instance = await db.instance.findFirst({
+    where: {
+      OR: [{ slug }, { oldSlug: slug }, { previousSlugs: { has: slug } }]
+    }
+  });
+  if (instance) return false;
+
+  let cellInstance = await db.cellInstance.findFirst({
+    where: { slug }
+  });
+  if (cellInstance) return false;
+
+  return true;
+});
 
 let getNextPreviousSlugs = (d: {
   previousSlugs: string[];

--- a/src/metorial/multi-region/prisma/schema/cell.prisma
+++ b/src/metorial/multi-region/prisma/schema/cell.prisma
@@ -19,4 +19,5 @@ model Cell {
   oauthTokens                       OAuthToken[]
   oauthJwks                         OAuthJwk[]
   globalLeases                      GlobalLease[]
+  instances                         Instance[]
 }

--- a/src/metorial/multi-region/prisma/schema/instance.prisma
+++ b/src/metorial/multi-region/prisma/schema/instance.prisma
@@ -1,0 +1,26 @@
+enum InstanceType {
+  development
+  production
+}
+
+enum InstanceStatus {
+  active
+  deleted
+}
+
+model Instance {
+  id String @id
+
+  type   InstanceType
+  status InstanceStatus
+
+  slug String
+  name String
+
+  ownerOid Int
+  owner    Cell @relation(fields: [ownerOid], references: [oid])
+
+  deletedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now()) @updatedAt
+}

--- a/src/metorial/multi-region/src/sync/fromDeployment/index.ts
+++ b/src/metorial/multi-region/src/sync/fromDeployment/index.ts
@@ -5,6 +5,11 @@ import {
   syncConsumerSurfacesManyQueueProcessor
 } from './consumerSurface';
 import {
+  syncInstancesCron,
+  syncInstanceSingleQueueProcessor,
+  syncInstancesManyQueueProcessor
+} from './instace';
+import {
   syncAppsCron,
   syncAppsManyQueueProcessor,
   syncOAuthAppSingleQueueProcessor
@@ -53,5 +58,9 @@ export let fromDeploymentSyncProcessors = combineQueueProcessors([
 
   syncAppsCron,
   syncAppsManyQueueProcessor,
-  syncOAuthAppSingleQueueProcessor
+  syncOAuthAppSingleQueueProcessor,
+
+  syncInstancesCron,
+  syncInstancesManyQueueProcessor,
+  syncInstanceSingleQueueProcessor
 ]);

--- a/src/metorial/multi-region/src/sync/fromDeployment/instace.ts
+++ b/src/metorial/multi-region/src/sync/fromDeployment/instace.ts
@@ -1,0 +1,74 @@
+import { createCron } from '@metorial/cron';
+import { db } from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import { createQueue } from '@metorial/queue';
+import { cell } from '../../cell';
+import { globalDB } from '../../db';
+
+export let upsertInstance = async (instanceId: string) => {
+  let instance = await db.instance.findUnique({
+    where: { id: instanceId }
+  });
+  if (!instance) return;
+
+  let inner = {
+    status: instance.status,
+    type: instance.type,
+    name: instance.name,
+    slug: instance.slug,
+    createdAt: instance.createdAt,
+    deletedAt: instance.deletedAt
+  };
+
+  await globalDB.instance.upsert({
+    where: { id: instance.id },
+    update: inner,
+    create: { id: instance.id, ...inner, ownerOid: (await cell).oid }
+  });
+};
+
+export let syncInstancesCron = createCron(
+  {
+    name: 'global/sync/from-deployment/inst',
+    cron: process.env.NODE_ENV == 'production' ? '0 * * * *' : '* * * * *'
+  },
+  async () => {
+    await syncInstancesManyQueue.add({});
+  }
+);
+
+let syncInstancesManyQueue = createQueue<{ cursor?: string }>({
+  name: 'global/sync/from-deployment/inst-many'
+});
+
+export let syncInstancesManyQueueProcessor = syncInstancesManyQueue.process(async data => {
+  let instances = await db.instance.findMany({
+    where: {
+      id: { gt: data.cursor }
+    },
+    orderBy: { id: 'asc' },
+    take: 100,
+    select: { id: true }
+  });
+  if (instances.length === 0) return;
+
+  await syncInstanceSingleQueue.addMany(instances.map(inst => ({ instanceId: inst.id })));
+
+  await syncInstancesManyQueue.add({ cursor: instances[instances.length - 1].id });
+});
+
+let syncInstanceSingleQueue = createQueue<{ instanceId: string }>({
+  name: 'global/sync/from-deployment/inst-single'
+});
+
+export let syncInstanceSingleQueueProcessor = syncInstanceSingleQueue.process(async data => {
+  await upsertInstance(data.instanceId);
+});
+
+Fabric.listen('organization.project.instance.updated:after', async event => {
+  await syncInstanceSingleQueue.add({ instanceId: event.instance.id });
+});
+
+Fabric.listen('organization.project.instance.created:after', async event => {
+  await syncInstanceSingleQueue.add({ instanceId: event.instance.id });
+});

--- a/src/metorial/multi-region/src/sync/toDeployment/index.ts
+++ b/src/metorial/multi-region/src/sync/toDeployment/index.ts
@@ -1,5 +1,6 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
 import { syncConsumerSurfaceToDeploymentQueueProcessor } from './consumerSurface';
+import { syncInstanceToDeploymentQueueProcessor } from './instance';
 import { syncOAuthAppToDeploymentQueueProcessor } from './oauth';
 import { syncOrganizationToDeploymentQueueProcessor } from './organization';
 import { syncPortalToDeploymentQueueProcessor } from './portal';
@@ -15,5 +16,6 @@ export let toDeploymentSyncProcessors = combineQueueProcessors([
   syncSkillPluginToDeploymentQueueProcessor,
   syncConsumerSurfaceToDeploymentQueueProcessor,
   syncOAuthAppToDeploymentQueueProcessor,
+  syncInstanceToDeploymentQueueProcessor,
   syncCron
 ]);

--- a/src/metorial/multi-region/src/sync/toDeployment/instance.ts
+++ b/src/metorial/multi-region/src/sync/toDeployment/instance.ts
@@ -1,0 +1,64 @@
+import { db } from '@metorial/db';
+import { generateCode } from '@metorial/id';
+import { createQueue } from '@metorial/queue';
+import { cell } from '../../cell';
+import { Instance } from '../../db';
+
+export let syncInstanceToDeploymentQueue = createQueue<{
+  instance: Instance;
+}>({
+  name: 'global/sync/to-deployment/instance'
+});
+
+export let syncInstanceToDeploymentQueueProcessor = syncInstanceToDeploymentQueue.process(
+  async data => {
+    let instance = data.instance;
+
+    let cellInstance = await db.cellInstance.upsert({
+      where: { id: instance.id },
+      update: {
+        status: instance.status,
+        type: instance.type,
+        slug: instance.slug,
+        name: instance.name,
+        isOwnedByDeployment: instance.ownerOid === (await cell).oid,
+        deletedAt: instance.deletedAt,
+        createdAt: instance.createdAt,
+        updatedAt: instance.updatedAt
+      },
+      create: {
+        id: instance.id,
+        status: instance.status,
+        type: instance.type,
+        slug: instance.slug,
+        name: instance.name,
+        isOwnedByDeployment: instance.ownerOid === (await cell).oid,
+        deletedAt: instance.deletedAt,
+        createdAt: instance.createdAt,
+        updatedAt: instance.updatedAt
+      }
+    });
+
+    if (!cellInstance.isOwnedByDeployment) {
+      let localInstanceWithSameSlug = await db.instance.findFirst({
+        where: {
+          slug: instance.slug,
+          id: { not: instance.id }
+        }
+      });
+
+      // If there are slug conflicts, whichever instance was created
+      // first will keep the slug, and the other instance will have its slug
+      // updated to a new slug with a random suffix.
+      if (
+        localInstanceWithSameSlug &&
+        localInstanceWithSameSlug.createdAt > cellInstance.createdAt
+      ) {
+        await db.instance.update({
+          where: { id: instance.id },
+          data: { slug: `${instance.slug}-${generateCode(3)}` }
+        });
+      }
+    }
+  }
+);

--- a/src/metorial/multi-region/src/sync/toDeployment/sync.ts
+++ b/src/metorial/multi-region/src/sync/toDeployment/sync.ts
@@ -3,6 +3,7 @@ import { createQueue } from '@metorial/queue';
 import { cell } from '../../cell';
 import { globalDB } from '../../db';
 import { syncConsumerSurfaceToDeploymentQueue } from './consumerSurface';
+import { syncInstanceToDeploymentQueue } from './instance';
 import { syncOAuthAppToDeploymentQueue } from './oauth';
 import { syncOrganizationToDeploymentQueue } from './organization';
 import { syncPortalToDeploymentQueue } from './portal';
@@ -58,6 +59,23 @@ export let syncToDeploymentQueueProcessor = syncToDeploymentQueue.process(async 
     );
 
     organizationCursor = organizations[organizations.length - 1].id as string;
+  }
+
+  let instanceCursor: string | undefined = undefined;
+  while (true) {
+    let instances = await globalDB.instance.findMany({
+      where: {
+        id: { gt: instanceCursor },
+        updatedAt: timeRange
+      },
+      orderBy: { id: 'asc' },
+      take: 100
+    });
+    if (instances.length === 0) break;
+
+    await syncInstanceToDeploymentQueue.addMany(instances.map(instance => ({ instance })));
+
+    instanceCursor = instances[instances.length - 1].id as string;
   }
 
   let portalCursor: string | undefined = undefined;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Sync jobs can mutate local instance slugs without going through instance service hooks, and cross-region slug rules may not apply to manual slug updates via `reclaimInstanceSlugOrThrow`.
> 
> **Overview**
> Adds **global instance replication** and **cross-region slug coordination** so instance identifiers don’t collide across cells.
> 
> A new global `Instance` model (owned by a `Cell`) is synced **from** each deployment via cron, batched queues, and Fabric create/update hooks. The periodic **to-deployment** sync now pulls updated global instances and upserts a local **`CellInstance`** mirror (including `isOwnedByDeployment`).
> 
> **Slug uniqueness:** new slug generation also rejects slugs already taken on **`CellInstance`** (instances known from other regions). When syncing a **foreign-owned** instance into a deployment, if a local `instance` already uses the same slug, the **newer** record gets a random suffix on its slug (older creation time keeps the slug).
> 
> **Note:** the new sync module is imported from `./instace` (typo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ee6ca32e32e1fb6fc7289bb9a014d3aec3963a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->