### PR TITLE
Fix instance slug deupe

### DIFF
--- a/src/metorial/multi-region/src/sync/toDeployment/instance.ts
+++ b/src/metorial/multi-region/src/sync/toDeployment/instance.ts
@@ -54,9 +54,13 @@ export let syncInstanceToDeploymentQueueProcessor = syncInstanceToDeploymentQueu
         localInstanceWithSameSlug &&
         localInstanceWithSameSlug.createdAt > cellInstance.createdAt
       ) {
+        console.log(
+          `[syncInstanceToDeploymentQueueProcessor] localInstanceWithSameSlug: ${localInstanceWithSameSlug.id} - ${localInstanceWithSameSlug.slug}`
+        );
+
         await db.instance.update({
-          where: { id: instance.id },
-          data: { slug: `${instance.slug}-${generateCode(3)}` }
+          where: { id: localInstanceWithSameSlug.id },
+          data: { slug: `${localInstanceWithSameSlug.slug}-${generateCode(3)}` }
         });
       }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which DB row gets renamed during multi-region slugging; wrong behavior could leave duplicate slugs or rename the wrong tenant instance.
> 
> **Overview**
> Fixes **instance slug deduplication** in `syncInstanceToDeploymentQueueProcessor` when a synced cell instance collides with an existing local slug.
> 
> Previously the slug suffix update targeted the **incoming synced** `instance` row. It now updates **`localInstanceWithSameSlug`**, matching the rule that the **older** instance keeps the slug and the **newer** one gets `slug-{randomCode}`. Adds a **console.log** when that rename path runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8d901c5e10763317b0a82868976f2bfcd80491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->