### PR TITLE
Harden remote server discovery

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/customProvider/utils.ts
@@ -75,6 +75,19 @@ export let getCustomProviderRedeployInput = (
     };
   }
 
+  if (customProvider.type === 'remote') {
+    let remote = customProvider.draft.remoteMcpServer;
+    if (!remote) return null;
+
+    return {
+      from: {
+        type: 'remote',
+        remoteUrl: remote.url,
+        protocol: remote.transport
+      }
+    };
+  }
+
   return null;
 };
 

--- a/src/shuttle/service/package.json
+++ b/src/shuttle/service/package.json
@@ -79,6 +79,7 @@
     "@prisma/extension-read-replicas": "^0.5.0",
     "@sentry/bun": "^10.38.0",
     "@sentry/cli": "^3.2.0",
+    "@toon-format/toon": "^2.3.0",
     "@types/pg": "^8.16.0",
     "axios": "^1.13.2",
     "date-fns": "^4.1.0",

--- a/src/shuttle/service/prisma/schema/oauthRemote.prisma
+++ b/src/shuttle/service/prisma/schema/oauthRemote.prisma
@@ -88,7 +88,7 @@ model RemoteOAuthConfig {
 
   scopes String[]
 
-  serverOid BigInt @unique
+  serverOid BigInt
   server    Server @relation(fields: [serverOid], references: [oid], name: "forRemoteOAuthConfig")
 
   oauthDiscoveryDocumentOid BigInt?

--- a/src/shuttle/service/prisma/schema/server.prisma
+++ b/src/shuttle/service/prisma/schema/server.prisma
@@ -49,7 +49,7 @@ model Server {
   serverSpecifications               ServerSpecification[]
   changeNotifications                ChangeNotification[]
   remoteOAuthConnections             RemoteOAuthConnection[]
-  remoteOAuthConfig                  RemoteOAuthConfig?                  @relation("forRemoteOAuthConfig")
+  remoteOAuthConfig                  RemoteOAuthConfig[]                 @relation("forRemoteOAuthConfig")
   delegatedOAuthConfig               DelegatedOAuthConfig?               @relation("forDelegatedOAuthConfig")
   serverAuthConfigs                  ServerAuthConfig[]
   serverOAuthCredentials             ServerOAuthCredentials[]

--- a/src/shuttle/service/src/apis/public/index.ts
+++ b/src/shuttle/service/src/apis/public/index.ts
@@ -1,5 +1,5 @@
-import { createHono } from '@lowerdeck/hono';
 import { validationError } from '@lowerdeck/error';
+import { createHono } from '@lowerdeck/hono';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
 import z from 'zod';
 import { db } from '../../db';
@@ -59,66 +59,66 @@ export let publicApp = createHono()
   })
   .get('/ping', c => c.text('OK'))
   .get('/shuttle-oauth/start', async c => {
-      let parsedQuery = parseQuery(c, shuttleOauthStartQuerySchema);
-      if (!parsedQuery.ok) return parsedQuery.response;
+    let parsedQuery = parseQuery(c, shuttleOauthStartQuerySchema);
+    if (!parsedQuery.ok) return parsedQuery.response;
 
-      let query = parsedQuery.data;
-      let setup = await serverOAuthSetupService.consumeServerOAuthSetup({
-        serverOAuthSetupId: query.setup_id
-      });
-
-      if (setup.state) {
-        setCookie(c, STATE_COOKIE_NAME, setup.state, { path: '/' });
-      }
-
-      return c.redirect(setup.url);
-    })
-  .get('/shuttle-oauth/callback', async c => {
-      let parsedQuery = parseQuery(c, shuttleOauthCallbackQuerySchema);
-      if (!parsedQuery.ok) return parsedQuery.response;
-
-      let query = { ...parsedQuery.data };
-
-      if (!query.state) {
-        let stateCookie = getCookie(c, STATE_COOKIE_NAME);
-        if (stateCookie) {
-          query.state = stateCookie;
-        }
-      }
-
-      let delegatedSetup = query.state
-        ? await db.delegatedOAuthConnectionSetup.findFirst({
-            where: { stateIdentifier: query.state }
-          })
-        : null;
-
-      let redirectUrl: string;
-
-      if (delegatedSetup) {
-        let res = await delegatedOauthAuthorizationService.completeAuthorization({
-          fullUrl: c.req.url,
-          response: {
-            code: query.code,
-            state: query.state,
-            error: query.error,
-            errorDescription: query.error_description
-          }
-        });
-        redirectUrl = res.redirectUrl;
-      } else {
-        let res = await remoteOauthAuthorizationService.completeAuthorization({
-          fullUrl: c.req.url,
-          response: {
-            code: query.code,
-            state: query.state,
-            error: query.error,
-            errorDescription: query.error_description
-          }
-        });
-        redirectUrl = res.redirectUrl;
-      }
-
-      deleteCookie(c, STATE_COOKIE_NAME, { path: '/' });
-
-      return c.redirect(redirectUrl, 302);
+    let query = parsedQuery.data;
+    let setup = await serverOAuthSetupService.consumeServerOAuthSetup({
+      serverOAuthSetupId: query.setup_id
     });
+
+    if (setup.state) {
+      setCookie(c, STATE_COOKIE_NAME, setup.state, { path: '/' });
+    }
+
+    return c.redirect(setup.url);
+  })
+  .get('/shuttle-oauth/callback', async c => {
+    let parsedQuery = parseQuery(c, shuttleOauthCallbackQuerySchema);
+    if (!parsedQuery.ok) return parsedQuery.response;
+
+    let query = { ...parsedQuery.data };
+
+    if (!query.state) {
+      let stateCookie = getCookie(c, STATE_COOKIE_NAME);
+      if (stateCookie) {
+        query.state = stateCookie;
+      }
+    }
+
+    let delegatedSetup = query.state
+      ? await db.delegatedOAuthConnectionSetup.findFirst({
+          where: { stateIdentifier: query.state }
+        })
+      : null;
+
+    let redirectUrl: string;
+
+    if (delegatedSetup) {
+      let res = await delegatedOauthAuthorizationService.completeAuthorization({
+        fullUrl: c.req.url,
+        response: {
+          code: query.code,
+          state: query.state,
+          error: query.error,
+          errorDescription: query.error_description
+        }
+      });
+      redirectUrl = res.redirectUrl;
+    } else {
+      let res = await remoteOauthAuthorizationService.completeAuthorization({
+        fullUrl: c.req.url,
+        response: {
+          code: query.code,
+          state: query.state,
+          error: query.error,
+          errorDescription: query.error_description
+        }
+      });
+      redirectUrl = res.redirectUrl;
+    }
+
+    deleteCookie(c, STATE_COOKIE_NAME, { path: '/' });
+
+    return c.redirect(redirectUrl, 302);
+  });

--- a/src/shuttle/service/src/lib/oauth/discovery.ts
+++ b/src/shuttle/service/src/lib/oauth/discovery.ts
@@ -85,7 +85,14 @@ export class OAuthDiscovery {
     for (let serverUrl of authServers) {
       try {
         let serverConfig = await this.fetchAuthorizationServerConfig(serverUrl);
-        if (serverConfig) return serverConfig;
+        if (serverConfig) {
+          return {
+            authorization_servers: authServers,
+            authorization_server: serverUrl,
+            ...config,
+            ...serverConfig
+          };
+        }
       } catch (error) {
         console.debug(`Failed to discover authorization server ${serverUrl}:`, error);
       }

--- a/src/shuttle/service/src/lib/oauth/oauthUtils.ts
+++ b/src/shuttle/service/src/lib/oauth/oauthUtils.ts
@@ -14,6 +14,7 @@ import { db } from '../../db';
 import { getId } from '../../id';
 import { getAxiosSsrfFilter } from '../http/axiosSsrf';
 import { assertUrlAllowedByEgressPolicy } from '../network/egressPolicy';
+import { normalizeAuthorizationUrl } from './normalizeAuthorizationUrl';
 import {
   type OAuthConfiguration,
   type RegistrationResponse,
@@ -21,7 +22,6 @@ import {
   type TokenResponse,
   type UserProfile
 } from './types';
-import { normalizeAuthorizationUrl } from './normalizeAuthorizationUrl';
 
 axios.defaults.headers.common['Accept-Encoding'] = 'gzip';
 
@@ -51,21 +51,21 @@ export class OAuthUtils {
   }
 
   static buildAuthorizationUrl({
-    authEndpoint,
     clientId,
     redirectUri,
     scopes,
     state,
-    codeChallenge
+    codeChallenge,
+    config
   }: {
-    authEndpoint: string;
     clientId: string;
     redirectUri: string;
     scopes: string[];
     state?: string;
     codeChallenge?: string;
+    config: OAuthConfiguration;
   }): string {
-    let url = new URL(normalizeAuthorizationUrl(authEndpoint));
+    let url = new URL(normalizeAuthorizationUrl(config.authorization_endpoint));
 
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('client_id', clientId);
@@ -82,6 +82,10 @@ export class OAuthUtils {
     if (codeChallenge) {
       url.searchParams.set('code_challenge', codeChallenge);
       url.searchParams.set('code_challenge_method', 'S256');
+    }
+
+    if (config.resource) {
+      url.searchParams.set('resource', config.resource);
     }
 
     return url.toString();
@@ -128,7 +132,12 @@ export class OAuthUtils {
     };
 
     if (clientSecret) {
-      if (config.token_endpoint_auth_methods_supported?.includes('client_secret_basic')) {
+      let hasBasic =
+        config.token_endpoint_auth_methods_supported?.includes('client_secret_basic');
+      let hasPost =
+        config.token_endpoint_auth_methods_supported?.includes('client_secret_post');
+
+      if (hasBasic && !hasPost) {
         headers.Authorization = `Basic ${btoa(`${clientId}:${clientSecret}`)}`;
       } else {
         body.set('client_id', clientId);
@@ -201,7 +210,12 @@ export class OAuthUtils {
     };
 
     if (clientSecret) {
-      if (config.token_endpoint_auth_methods_supported?.includes('client_secret_basic')) {
+      let hasBasic =
+        config.token_endpoint_auth_methods_supported?.includes('client_secret_basic');
+      let hasPost =
+        config.token_endpoint_auth_methods_supported?.includes('client_secret_post');
+
+      if (hasBasic && !hasPost) {
         headers.Authorization = `Basic ${btoa(`${clientId}:${clientSecret}`)}`;
       } else {
         body.set('client_id', clientId);

--- a/src/shuttle/service/src/lib/oauth/types.ts
+++ b/src/shuttle/service/src/lib/oauth/types.ts
@@ -15,6 +15,11 @@ export interface OAuthConfiguration {
   code_challenge_methods_supported?: string[];
   registration_endpoint?: string;
 
+  // Metorial fields
+  resource?: string;
+  authorization_servers?: string[];
+  bearer_methods_supported?: ('header' | 'body' | 'query')[];
+
   // [key: string]: any;
 }
 

--- a/src/shuttle/service/src/queues/remote/startDeployment.ts
+++ b/src/shuttle/service/src/queues/remote/startDeployment.ts
@@ -1,6 +1,7 @@
 import { delay } from '@lowerdeck/delay';
 import { isServiceError } from '@lowerdeck/error';
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { encode } from '@toon-format/toon';
 import type {
   RemoteOAuthConfig,
   RemoteOAuthDiscoveryDocument,
@@ -73,96 +74,102 @@ export let deployRemoteServerStartQueueProcessor = deployRemoteServerStartQueue.
       let oauthConfig: RemoteOAuthConfig | null = null;
       let remoteServerNeedsManualAuthentication = false;
 
-      if (server.remoteOauthConfigOid) {
-        oauthConfig = await db.remoteOAuthConfig.findUnique({
-          where: { oid: server.remoteOauthConfigOid }
-        });
-      } else {
-        let config: OAuthConfiguration | undefined = undefined;
-        let discovery: RemoteOAuthDiscoveryDocument | undefined = undefined;
+      let config: OAuthConfiguration | undefined = undefined;
+      let discovery: RemoteOAuthDiscoveryDocument | undefined = undefined;
 
-        if (data.oauthConfig) {
-          let valRes = oauthConfigValidator.validate(data.oauthConfig);
-          if (!valRes.success) {
-            deployingStep.log(`Invalid OAuth configuration provided.`);
-            valRes.errors.forEach(err => {
-              deployingStep.log(`Error: ${err}`);
-            });
-            throw new Error('Invalid OAuth configuration provided');
-          }
-
-          config = data.oauthConfig as OAuthConfiguration;
-        } else {
-          let newDiscovery =
-            await remoteOAuthDiscoveryService.discoverOauthConfigWithoutRegistrationSafe({
-              discoveryUrl: data.remoteUrl
-            });
-          if (newDiscovery) {
-            config = newDiscovery.config;
-            discovery = newDiscovery;
-          }
+      if (data.oauthConfig) {
+        let valRes = oauthConfigValidator.validate(data.oauthConfig);
+        if (!valRes.success) {
+          deployingStep.log(`Invalid OAuth configuration provided.`);
+          valRes.errors.forEach(err => {
+            deployingStep.log(`Error: ${err}`);
+          });
+          throw new Error('Invalid OAuth configuration provided');
         }
 
-        if (config) {
-          oauthConfig = await db.remoteOAuthConfig.create({
-            data: {
-              ...getId('remoteOAuthConfig'),
-              discoverStatus: 'discovering',
-              name: server.name,
-              config,
-              providerName: discovery?.providerName ?? url.hostname,
-              providerUrl: discovery?.providerUrl ?? url.origin,
-              discoveryUrl: discovery?.discoveryUrl,
-              scopes: config.scopes_supported ?? [],
-              serverOid: server.oid,
-              oauthDiscoveryDocumentOid: discovery?.oid
-            }
+        config = data.oauthConfig as OAuthConfiguration;
+      } else {
+        let newDiscovery =
+          await remoteOAuthDiscoveryService.discoverOauthConfigWithoutRegistrationSafe({
+            discoveryUrl: data.remoteUrl
           });
+        if (newDiscovery) {
+          config = newDiscovery.config;
+          discovery = newDiscovery;
+        }
+      }
 
+      if (config) {
+        oauthConfig = await db.remoteOAuthConfig.create({
+          data: {
+            ...getId('remoteOAuthConfig'),
+            discoverStatus: 'discovering',
+            name: server.name,
+            config,
+            providerName: discovery?.providerName ?? url.hostname,
+            providerUrl: discovery?.providerUrl ?? url.origin,
+            discoveryUrl: discovery?.discoveryUrl,
+            scopes: config.scopes_supported ?? [],
+            serverOid: server.oid,
+            oauthDiscoveryDocumentOid: discovery?.oid
+          }
+        });
+
+        await discoverRemoteOAuthConfigQueue.add({ oauthConfigId: oauthConfig!.id });
+
+        for (let i = 0; i < 50; i++) {
+          oauthConfig = await db.remoteOAuthConfig.findUniqueOrThrow({
+            where: { oid: oauthConfig!.oid }
+          });
+          if (oauthConfig.discoverStatus != 'discovering') break;
+          await delay(1000);
+        }
+
+        if (oauthConfig.discoverStatus == 'discovering') {
+          deployingStep.log(`OAuth configuration discovery timed out.`);
+          throw new Error('OAuth configuration discovery timed out');
+        }
+
+        if (oauthConfig.discoverStatus == 'failed') {
+          deployingStep.log(`OAuth configuration discovery failed.`);
+          deployingStep.log(`Error Code: ${oauthConfig.errorCode}`);
+          deployingStep.log(`Message: ${oauthConfig.errorMessage}`);
+        } else {
+          deployingStep.log(`OAuth configuration discovered successfully.`);
+          deployingStep.log('Provider details:');
+          deployingStep.log(`Name: ${oauthConfig.providerName}`);
+          deployingStep.log(`URL: ${oauthConfig.providerUrl}`);
+
+          // If the discovery succeeded, we can update the server to point to the new OAuth config
           await db.server.updateMany({
             where: { oid: server.oid },
             data: { remoteOauthConfigOid: oauthConfig.oid }
           });
 
-          await discoverRemoteOAuthConfigQueue.add({ oauthConfigId: oauthConfig!.id });
+          // For backwards compatibility, we need to update all existing
+          // remote connections to use the new config
+          await db.remoteOAuthConnection.updateMany({
+            where: {
+              serverOid: server.oid,
+              status: { not: 'inactive' },
+              discoveryStatus: { not: 'failed' }
+            },
+            data: { configOid: oauthConfig.oid }
+          });
 
-          for (let i = 0; i < 50; i++) {
-            oauthConfig = await db.remoteOAuthConfig.findUniqueOrThrow({
-              where: { oid: oauthConfig!.oid }
-            });
-            if (oauthConfig.discoverStatus != 'discovering') break;
-            await delay(1000);
-          }
+          deployingStep.log(encode(oauthConfig.config));
+        }
+      } else {
+        let manualAuth = await OAuthDiscovery.checkIfManualAuthIsNeeded(data.remoteUrl);
 
-          if (oauthConfig.discoverStatus == 'discovering') {
-            deployingStep.log(`OAuth configuration discovery timed out.`);
-            throw new Error('OAuth configuration discovery timed out');
-          }
-
-          if (oauthConfig.discoverStatus == 'failed') {
-            deployingStep.log(`OAuth configuration discovery failed.`);
-            deployingStep.log(`Error Code: ${oauthConfig.errorCode}`);
-            deployingStep.log(`Message: ${oauthConfig.errorMessage}`);
-          } else {
-            deployingStep.log(`OAuth configuration discovered successfully.`);
-            deployingStep.log('Provider details:');
-            deployingStep.log(`Name: ${oauthConfig.providerName}`);
-            deployingStep.log(`URL: ${oauthConfig.providerUrl}`);
-          }
+        if (manualAuth) {
+          deployingStep.log(`Server requires manual authentication. OAuth is not supported.`);
+          deployingStep.log(
+            `Follow the provider's specification for settings the required headers or query parameters. You can pass them to Metorial using the headers and query fields when creating a provider config.`
+          );
+          remoteServerNeedsManualAuthentication = true;
         } else {
-          let manualAuth = await OAuthDiscovery.checkIfManualAuthIsNeeded(data.remoteUrl);
-
-          if (manualAuth) {
-            deployingStep.log(
-              `Server requires manual authentication. OAuth is not supported.`
-            );
-            deployingStep.log(
-              `Follow the provider's specification for settings the required headers or query parameters. You can pass them to Metorial using the headers and query fields when creating a provider config.`
-            );
-            remoteServerNeedsManualAuthentication = true;
-          } else {
-            deployingStep.log(`Server does not use OAuth authentication.`);
-          }
+          deployingStep.log(`Server does not use OAuth authentication.`);
         }
       }
 

--- a/src/shuttle/service/src/services/oauth/remote/authorization.ts
+++ b/src/shuttle/service/src/services/oauth/remote/authorization.ts
@@ -109,17 +109,19 @@ class remoteOauthAuthorizationServiceImpl {
       serverOAuthSetup: d.serverOAuthSetup ?? setup.serverOAuthSetup
     });
 
+    let redirectUrl = OAuthUtils.buildAuthorizationUrl({
+      clientId: DANGEROUS_unencryptedCredentials.clientId,
+      redirectUri,
+      scopes: d.connection.config.scopes,
+      state: setup.stateIdentifier!,
+      codeChallenge,
+      config
+    });
+
     return {
       type: 'redirect' as const,
       setup,
-      redirectUrl: OAuthUtils.buildAuthorizationUrl({
-        authEndpoint: config.authorization_endpoint,
-        clientId: DANGEROUS_unencryptedCredentials.clientId,
-        redirectUri,
-        scopes: d.connection.config.scopes,
-        state: setup.stateIdentifier!,
-        codeChallenge
-      })
+      redirectUrl
     };
   }
 

--- a/src/shuttle/service/src/services/oauth/remote/discovery.ts
+++ b/src/shuttle/service/src/services/oauth/remote/discovery.ts
@@ -1,6 +1,5 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
-import { differenceInMinutes } from 'date-fns';
 import { db } from '../../../db';
 import { getId } from '../../../id';
 import { OAuthDiscovery } from '../../../lib/oauth/discovery';
@@ -9,13 +8,6 @@ import { oauthConfigValidator, type OAuthConfiguration } from '../../../lib/oaut
 
 class remoteOAuthDiscoveryServiceImpl {
   async discoverOauthConfigWithoutRegistration(d: { discoveryUrl: string }) {
-    let existingDoc = await db.remoteOAuthDiscoveryDocument.findUnique({
-      where: { discoveryUrl: d.discoveryUrl }
-    });
-    if (existingDoc && differenceInMinutes(new Date(), existingDoc.refreshedAt) < 15) {
-      return existingDoc;
-    }
-
     let doc = await OAuthDiscovery.discover(d.discoveryUrl);
     if (!doc) {
       throw new ServiceError(
@@ -37,21 +29,24 @@ class remoteOAuthDiscoveryServiceImpl {
 
     let configHash = await OAuthUtils.getConfigHash(doc, []);
 
+    let inner = {
+      config: doc as any,
+      configHash,
+      refreshedAt: new Date(),
+
+      version: 1,
+
+      providerName: OAuthUtils.getProviderName(doc),
+      providerUrl: OAuthUtils.getProviderUrl(doc),
+      discoveryUrl: d.discoveryUrl
+    };
+
     return await db.remoteOAuthDiscoveryDocument.upsert({
       where: { discoveryUrl: d.discoveryUrl },
-      update: {},
+      update: inner,
       create: {
         ...getId('remoteOAuthDiscoveryDocument'),
-
-        config: doc as any,
-        configHash,
-        refreshedAt: new Date(),
-
-        version: 1,
-
-        providerName: OAuthUtils.getProviderName(doc),
-        providerUrl: OAuthUtils.getProviderUrl(doc),
-        discoveryUrl: d.discoveryUrl
+        ...inner
       }
     });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes OAuth discovery, authorization URL construction, token client authentication, and deployment-time migration of connection configs—security-sensitive paths with data model loosening (multiple configs per server).
> 
> **Overview**
> **Remote MCP OAuth discovery and deployment** now always runs fresh discovery (or validates supplied config) on each deploy instead of reusing an existing server-linked config, then creates a new `RemoteOAuthConfig`, waits for the discovery queue, and on success points the server at it and **re-points active remote OAuth connections** to that config for backward compatibility. Deployment logs dump the resolved config via **toon** encoding.
> 
> **Discovery** merges protected-resource metadata with authorization-server documents (`authorization_servers`, `resource`, etc.), upserts discovery documents on every fetch (15-minute cache skip removed), and authorization URLs can include a **`resource`** query param. Token exchange/refresh prefers **`client_secret_post`** when both basic and post are advertised.
> 
> **Schema**: `RemoteOAuthConfig.serverOid` is no longer unique; `Server` exposes a one-to-many `remoteOAuthConfig` relation (pointer `remoteOauthConfigOid` on server unchanged).
> 
> **Dashboard**: custom provider **redeploy** for `remote` types builds version input from draft `remoteMcpServer` URL and transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936c118979fabe97fc30103c1042e7aee540a6f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->