### PR TITLE
Omit invalid errors

### DIFF
--- a/src/metorial/apis/connection/src/hono.ts
+++ b/src/metorial/apis/connection/src/hono.ts
@@ -19,6 +19,32 @@ let normalizeErrorForSentry = (error: unknown) => {
   return normalized;
 };
 
+let getErrorCandidates = (error: unknown): unknown[] => {
+  let candidates = [error];
+  let cause =
+    error && typeof error == 'object' && 'cause' in error ? (error as { cause?: unknown }).cause : null;
+
+  if (cause !== undefined && cause !== null && cause !== error) {
+    candidates.push(cause);
+  }
+
+  return candidates;
+};
+
+let isExpectedConnectionAbortError = (error: unknown) => {
+  return getErrorCandidates(error).some(candidate => {
+    if (!candidate || typeof candidate != 'object') return false;
+
+    let name = 'name' in candidate ? (candidate as { name?: unknown }).name : undefined;
+    let message = 'message' in candidate ? (candidate as { message?: unknown }).message : undefined;
+
+    return (
+      name === 'AbortError' &&
+      (message === 'The connection was closed.' || message === 'This operation was aborted')
+    );
+  });
+};
+
 let getRequestContext = (c?: Context) => {
   if (!c) return undefined;
 
@@ -37,6 +63,7 @@ export let reportConnectionError = (
   }
 ) => {
   if (isServiceError(error) && error.data.status < 500) return;
+  if (isExpectedConnectionAbortError(error)) return;
 
   Sentry.captureException(normalizeErrorForSentry(error), {
     extra: {

--- a/src/metorial/apis/connection/test/hono.test.ts
+++ b/src/metorial/apis/connection/test/hono.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { captureException } = vi.hoisted(() => ({
+  captureException: vi.fn()
+}));
+
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({
+    captureException
+  })
+}));
+
+import { reportConnectionError } from '../src/hono';
+
+let createAbortError = (message = 'The connection was closed.') => {
+  let error = new Error(message);
+  error.name = 'AbortError';
+  return error;
+};
+
+describe('reportConnectionError', () => {
+  beforeEach(() => {
+    captureException.mockClear();
+  });
+
+  it('does not report expected connection abort errors', () => {
+    reportConnectionError(createAbortError());
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('does not report wrapped connection abort errors', () => {
+    let error = new Error('Proxy request failed');
+    (error as Error & { cause?: unknown }).cause = createAbortError();
+
+    reportConnectionError(error);
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('still reports non-abort errors', () => {
+    let error = new Error('boom');
+
+    reportConnectionError(error);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        extra: expect.objectContaining({
+          source: undefined,
+          thrownType: 'object'
+        })
+      })
+    );
+  });
+
+  it('still reports abort errors with unexpected messages', () => {
+    reportConnectionError(createAbortError('Request timed out'));
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change that suppresses a narrow class of abort errors; real failures still report to Sentry.
> 
> **Overview**
> **`reportConnectionError`** no longer sends routine client disconnects to Sentry by treating certain **`AbortError`** cases as expected noise.
> 
> It walks the error and its **`cause`**, and returns early when **`name`** is **`AbortError`** and the message is **`The connection was closed.`** or **`This operation was aborted`**. Other errors—and aborts with different messages—still go to Sentry.
> 
> New **`hono.test.ts`** covers direct aborts, wrapped aborts, normal errors, and unexpected abort messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64537b07725019be8baee70f03bd3f5aa7eaaacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->