### PR TITLE
Omit http errors

### DIFF
--- a/src/lowerdeck/packages/sentry/src/index.test.ts
+++ b/src/lowerdeck/packages/sentry/src/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getSentryHttpErrorDetails, shouldIgnoreSentryHttpError } from './index';
+
+describe('@lowerdeck/sentry filters', () => {
+  it('extracts client error details from wrapped lowerdeck errors', () => {
+    let hint = {
+      originalException: new Error(
+        '[@lowerdeck/error]: You are not authorized to access this resource. ({"status":401,"code":"unauthorized","message":"You are not authorized to access this resource."})'
+      )
+    };
+
+    expect(getSentryHttpErrorDetails(hint)).toEqual({
+      status: 401,
+      code: 'unauthorized'
+    });
+    expect(shouldIgnoreSentryHttpError(hint)).toBe(true);
+  });
+
+  it('ignores nested client response errors', () => {
+    expect(
+      shouldIgnoreSentryHttpError({
+        object: 'ServiceError',
+        response: {
+          status: 404
+        }
+      })
+    ).toBe(true);
+  });
+
+  it('keeps upstream http errors reportable when they are not lowerdeck errors', () => {
+    expect(
+      shouldIgnoreSentryHttpError({
+        response: {
+          status: 404
+        }
+      })
+    ).toBe(false);
+  });
+
+  it('keeps server-side failures reportable', () => {
+    expect(
+      shouldIgnoreSentryHttpError({
+        originalException: {
+          response: {
+            status: 500
+          },
+          code: 'internal_error'
+        }
+      })
+    ).toBe(false);
+  });
+});

--- a/src/lowerdeck/packages/sentry/src/index.ts
+++ b/src/lowerdeck/packages/sentry/src/index.ts
@@ -2,8 +2,137 @@ import * as SentryBase from '@sentry/core';
 
 let sentryRef = { current: SentryBase };
 
+let ignoredSentryHttpErrorCodes = new Set([
+  'bad_request',
+  'forbidden',
+  'invalid_data',
+  'not_found',
+  'unauthorized'
+]);
+
+let lowerdeckErrorPrefix = '[@lowerdeck/error]:';
+
+let isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+let toStatusCode = (value: unknown): number | null => {
+  let parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+};
+
+let toErrorCode = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null;
+
+let getMessagePayload = (message: string): Record<string, unknown> | null => {
+  let start = message.indexOf('{');
+  let end = message.lastIndexOf('}');
+  if (start === -1 || end <= start) return null;
+
+  try {
+    let payload = JSON.parse(message.slice(start, end + 1));
+    return isRecord(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+};
+
+let isLowerdeckErrorValue = (value: unknown): boolean => {
+  let visited = new Set<unknown>();
+
+  let visit = (current: unknown): boolean => {
+    if (typeof current === 'string') {
+      return current.includes(lowerdeckErrorPrefix);
+    }
+
+    if (!isRecord(current)) return false;
+    if (visited.has(current)) return false;
+    visited.add(current);
+
+    if (current.object === 'ServiceError' || current.object === 'ErrorRecord') return true;
+
+    for (let candidate of [
+      current.originalException,
+      current.response,
+      current.data,
+      current.cause,
+      current.error,
+      current.message
+    ]) {
+      if (visit(candidate)) return true;
+    }
+
+    return false;
+  };
+
+  return visit(value);
+};
+
+export let getSentryHttpErrorDetails = (
+  value: unknown
+): { status: number | null; code: string | null } | null => {
+  let visited = new Set<unknown>();
+
+  let visit = (current: unknown): { status: number | null; code: string | null } | null => {
+    if (typeof current === 'string') {
+      let payload = getMessagePayload(current);
+      if (payload) return visit(payload);
+
+      let code = current.match(
+        /\b(unauthorized|forbidden|not_found|bad_request|invalid_data)\b/i
+      )?.[1];
+      if (code) return { status: null, code: code.toLowerCase() };
+
+      return null;
+    }
+
+    if (!isRecord(current)) return null;
+    if (visited.has(current)) return null;
+    visited.add(current);
+
+    let status =
+      toStatusCode(current.status) ??
+      toStatusCode(current.statusCode) ??
+      toStatusCode(current.httpStatus);
+    let code = toErrorCode(current.code)?.toLowerCase() ?? null;
+
+    for (let candidate of [
+      current.originalException,
+      current.response,
+      current.data,
+      current.cause,
+      current.error,
+      current.message
+    ]) {
+      let nested = visit(candidate);
+      if (!nested) continue;
+
+      status ??= nested.status;
+      code ??= nested.code;
+
+      if (status !== null && code) break;
+    }
+
+    return status !== null || code ? { status, code } : null;
+  };
+
+  return visit(value);
+};
+
 export let setSentry = (sentry: typeof SentryBase) => {
   sentryRef.current = sentry;
 };
 
 export let getSentry = (): typeof SentryBase => sentryRef.current;
+
+export let shouldIgnoreSentryHttpError = (value: unknown): boolean => {
+  if (!isLowerdeckErrorValue(value)) return false;
+
+  let details = getSentryHttpErrorDetails(value);
+  if (!details) return false;
+
+  if (details.status !== null && details.status >= 400 && details.status < 500) {
+    return true;
+  }
+
+  return details.code ? ignoredSentryHttpErrorCodes.has(details.code) : false;
+};

--- a/src/metorial-frontend/packages/state/src/user/auth/withAuth.ts
+++ b/src/metorial-frontend/packages/state/src/user/auth/withAuth.ts
@@ -1,13 +1,11 @@
 import { delay } from '@lowerdeck/delay';
 import { isServiceError } from '@lowerdeck/error';
 import { ProgrammablePromise } from '@lowerdeck/programmable-promise';
-import { getSentry } from '@lowerdeck/sentry';
+import { getSentry, shouldIgnoreSentryHttpError } from '@lowerdeck/sentry';
 import { MetorialDashboardSDK, MetorialUser } from '@metorial/dashboard-sdk';
 import { isMetorialSDKError } from '@metorial/util-endpoint';
 import { withDashboardSDK } from '../../sdk';
 import { redirectToAuth } from './redirect';
-
-let Sentry = getSentry();
 
 let authRequiredRef = { current: true };
 export let setAuthRequired = (required: boolean) => {
@@ -55,13 +53,9 @@ export let redirectToAuthIfNotAuthenticated = async <R>(fn: () => Promise<R>) =>
       }
     }
 
-    if (
-      err.code != 'unauthorized' &&
-      err.code != 'not_found' &&
-      err.code != 'bad_request' &&
-      err.code != 'invalid_data'
-    )
-      Sentry.captureException(err);
+    if (!shouldIgnoreSentryHttpError(err)) {
+      getSentry().captureException(err);
+    }
 
     throw err;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only which client-side auth errors reach Sentry; server errors and non-lowerdeck HTTP failures remain reportable, with tests locking in the rules.
> 
> **Overview**
> Adds shared Sentry filtering in `@lowerdeck/sentry` so expected **lowerdeck** client HTTP failures are not reported, while non-lowerdeck 404s and 5xx errors still are.
> 
> **`getSentryHttpErrorDetails`** and **`shouldIgnoreSentryHttpError`** walk nested error shapes (wrapped messages, `ServiceError` / `ErrorRecord`, `response`, etc.), parse status/code from JSON in `[@lowerdeck/error]:` messages, and treat 4xx or known codes (`unauthorized`, `forbidden`, `not_found`, `bad_request`, `invalid_data`) as ignorable only when the value is identified as a lowerdeck error.
> 
> **`withAuth`** replaces a hardcoded allowlist of error codes with **`shouldIgnoreSentryHttpError`** and calls **`getSentry()`** when capturing, so filtering stays in one place and **`forbidden`** is covered. Vitest cases document the intended behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb43d9b9e271666aaaf74c0369f9a54013dee7c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->