### PR TITLE
Fix provider version fetching

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/provider/_layout.tsx
@@ -16,7 +16,7 @@ import {
 } from '@metorial/state';
 import { Avatar, Callout, Flex, LinkTabs, Spacer } from '@metorial/ui';
 import { useEffect, useMemo, useState } from 'react';
-import { Link, Outlet, useLocation, useParams, useNavigate } from 'react-router-dom';
+import { Link, Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { OpenExplorerButton } from '../../components/openExplorer';
 import { UseProviderButton } from '../../scenes/providers/useProviderButton';
 import {
@@ -49,7 +49,7 @@ export let ProviderLayout = () => {
     }
   }, [providerId, provider.data]);
 
-  let versions = useProviderVersions(instance.data?.id, providerId);
+  let versions = useProviderVersions(instance.data?.id, provider.data?.id);
   let allVersions: ProviderVersion[] = versions.data?.items ?? [];
   let currentVersionId = providerData?.currentVersion?.id;
   let sortedVersions = useMemo(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-parameter fix in provider layout; no auth or data-model changes, only corrects which identifier is sent to the versions API.
> 
> **Overview**
> **Provider version lists** on the provider detail layout were loaded with the route param (`providerId`), which is the provider **slug**, while `useProviderVersions` expects the provider’s internal **id**.
> 
> The layout now passes `provider.data?.id` from the already-resolved `useProvider` result, so version fetching aligns with other call sites (e.g. deployment settings) and works after slug-based navigation/redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e513b2b6544d5610a8a72df027a234afd77af671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->