### PR TITLE
Fix magic mcp actors list

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/magic-mcp/server/overview.tsx
@@ -8,9 +8,9 @@ import {
   useMagicMcpTokens
 } from '@metorial/state';
 import { Attributes, Flex, RenderDate, Text } from '@metorial/ui';
-import { Box, ID } from '@metorial/ui-product';
+import { Box, ID, Table } from '@metorial/ui-product';
 import { useEffect, useRef, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { McpConnectionInstructionsScene } from '../../../scenes/mcpConnectionInstructions';
 
 export let MagicMcpServerOverviewPage = () => {
@@ -105,7 +105,6 @@ export let MagicMcpServerOverviewPage = () => {
         ) ?? createdToken;
       let activeTokenSecret = activeToken?.secret;
       let consumerOwners = server.data.consumerOwners;
-      let consumerOwner = consumerOwners[0];
 
       let fullUrl =
         streamableHttpUrl && activeTokenSecret
@@ -132,35 +131,28 @@ export let MagicMcpServerOverviewPage = () => {
             ]}
           />
 
-          {consumerOwner && (
-            <Attributes
-              itemWidth="300px"
-              attributes={[
-                {
-                  label: 'Name',
-                  content: consumerOwner.consumerProfileName || consumerOwner.consumerName
-                },
-                {
-                  label: 'Email',
-                  content: (
-                    <Link
-                      to={Paths.instance.identity.consumer(
-                        organization.data,
-                        project.data,
-                        instance.data,
-                        consumerOwner.consumerId
-                      )}
-                    >
-                      {consumerOwner.consumerProfileEmail || consumerOwner.consumerEmail}
-                    </Link>
-                  )
-                },
-                {
-                  label: 'Consumer ID',
-                  content: <ID id={consumerOwner.consumerId} />
-                }
-              ]}
-            />
+          {consumerOwners.length > 0 && (
+            <Box
+              title="User Access"
+              description="Accounts that have access this Magic MCP server."
+            >
+              <Table
+                headers={['Name', 'Email', 'Consumer ID']}
+                data={consumerOwners.map(consumerOwner => ({
+                  href: Paths.instance.identity.consumer(
+                    organization.data,
+                    project.data,
+                    instance.data,
+                    consumerOwner.consumerId
+                  ),
+                  data: [
+                    consumerOwner.consumerProfileName || consumerOwner.consumerName,
+                    consumerOwner.consumerProfileEmail || consumerOwner.consumerEmail,
+                    <ID id={consumerOwner.consumerId} />
+                  ]
+                }))}
+              />
+            </Box>
           )}
 
           {/* <Spacer height={16} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dashboard-only UI change on the Magic MCP overview page with no auth or API changes.
> 
> **Overview**
> Fixes the Magic MCP server overview so **all** consumer owners with access are shown, not only the first entry.
> 
> The single-consumer `Attributes` block (and manual `Link` to identity) is replaced by a **User Access** `Box` with a `Table` listing Name, Email, and Consumer ID for every `consumerOwners` row, with each row linking to the consumer identity page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d18fd527a67f1d1c9f585208eaa6a68db50fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->