### PR TITLE
Fix message completion race

### DIFF
--- a/src/subspace/modules/connection/src/shared/completeMessage.test.ts
+++ b/src/subspace/modules/connection/src/shared/completeMessage.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  db: {
+    sessionMessage: {
+      findFirstOrThrow: vi.fn(),
+      update: vi.fn()
+    },
+    sessionEvent: {
+      updateMany: vi.fn(),
+      createMany: vi.fn()
+    },
+    $transaction: vi.fn()
+  },
+  finalizeMessageQueue: {
+    add: vi.fn()
+  },
+  createError: vi.fn(),
+  messageFailureReasonToErrorType: vi.fn(() => 'message_processing_timeout'),
+  getId: vi.fn(() => ({ id: 'sessionEvent_test', oid: 100n })),
+  getRawToolCallAttachmentsFromOutput: vi.fn(() => []),
+  presentToolCallAttachment: vi.fn((attachment: unknown) => attachment),
+  replaceToolCallAttachmentsInOutput: vi.fn((output: unknown) => output)
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: mocks.db,
+  getId: mocks.getId,
+  getRawToolCallAttachmentsFromOutput: mocks.getRawToolCallAttachmentsFromOutput,
+  presentToolCallAttachment: mocks.presentToolCallAttachment,
+  replaceToolCallAttachmentsInOutput: mocks.replaceToolCallAttachmentsInOutput
+}));
+
+vi.mock('../queues/message/finalizeMessage', () => ({
+  finalizeMessageQueue: mocks.finalizeMessageQueue
+}));
+
+vi.mock('./createError', () => ({
+  createError: mocks.createError,
+  messageFailureReasonToErrorType: mocks.messageFailureReasonToErrorType
+}));
+
+import { completeMessage } from './completeMessage';
+
+describe('completeMessage', () => {
+  beforeEach(() => {
+    mocks.db.sessionEvent.updateMany.mockResolvedValue(undefined);
+    mocks.db.sessionEvent.createMany.mockResolvedValue(undefined);
+    mocks.finalizeMessageQueue.add.mockResolvedValue(undefined);
+    mocks.createError.mockReset();
+    mocks.messageFailureReasonToErrorType.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the existing message when another worker already completed it', async () => {
+    let currentMessage = {
+      id: 'msg_current',
+      oid: 1n,
+      session: { oid: 11n },
+      connection: { oid: 12n },
+      toolCall: null
+    };
+    let completedMessage = {
+      id: 'msg_current',
+      oid: 1n,
+      status: 'failed',
+      output: {
+        type: 'error',
+        data: { code: 'timeout', message: 'The request exceeded the tenant timeout.' }
+      },
+      completedAt: new Date(),
+      providerRunOid: null,
+      connectionOid: 12n,
+      sessionOid: 11n,
+      tenantOid: 13n,
+      solutionOid: 14n,
+      environmentOid: 15n,
+      errorOid: 16n,
+      toolCall: null
+    };
+    let tx = {
+      sessionMessage: {
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        findFirstOrThrow: vi.fn().mockResolvedValue(completedMessage)
+      },
+      toolCall: {
+        updateMany: vi.fn()
+      },
+      toolCallAttachment: {
+        createMany: vi.fn()
+      }
+    };
+
+    mocks.db.sessionMessage.findFirstOrThrow.mockResolvedValue(currentMessage);
+    mocks.db.$transaction.mockImplementation(async cb => await cb(tx));
+
+    let message = await completeMessage(
+      { messageId: 'msg_current' },
+      {
+        status: 'failed',
+        failureReason: 'timeout',
+        responderParticipant: { oid: 99n },
+        completedAt: new Date(),
+        output: {
+          type: 'error',
+          data: { code: 'timeout', message: 'The conduit request timed out before the provider responded.' }
+        }
+      }
+    );
+
+    expect(message).toBe(completedMessage);
+    expect(mocks.createError).not.toHaveBeenCalled();
+    expect(mocks.db.sessionMessage.update).not.toHaveBeenCalled();
+    expect(mocks.db.sessionEvent.updateMany).not.toHaveBeenCalled();
+    expect(mocks.db.sessionEvent.createMany).not.toHaveBeenCalled();
+    expect(mocks.finalizeMessageQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('creates a session error only after winning the state transition', async () => {
+    let currentMessage = {
+      id: 'msg_transition',
+      oid: 2n,
+      session: { oid: 21n, tenantOid: 23n, solutionOid: 24n, environmentOid: 25n },
+      connection: { oid: 22n },
+      toolCall: null
+    };
+    let transitionedMessage = {
+      id: 'msg_transition',
+      oid: 2n,
+      status: 'failed',
+      output: {
+        type: 'error',
+        data: { code: 'timeout', message: 'The request exceeded the tenant timeout.' }
+      },
+      completedAt: new Date(),
+      providerRunOid: 31n,
+      connectionOid: 22n,
+      sessionOid: 21n,
+      tenantOid: 23n,
+      solutionOid: 24n,
+      environmentOid: 25n,
+      errorOid: null,
+      toolCall: null
+    };
+    let finalMessage = {
+      ...transitionedMessage,
+      errorOid: 32n
+    };
+    let tx = {
+      sessionMessage: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findFirstOrThrow: vi.fn().mockResolvedValue(transitionedMessage)
+      },
+      toolCall: {
+        updateMany: vi.fn()
+      },
+      toolCallAttachment: {
+        createMany: vi.fn()
+      }
+    };
+
+    mocks.db.sessionMessage.findFirstOrThrow.mockResolvedValue(currentMessage);
+    mocks.db.$transaction.mockImplementation(async cb => await cb(tx));
+    mocks.createError.mockResolvedValue({ oid: 32n });
+    mocks.db.sessionMessage.update.mockResolvedValue(finalMessage);
+
+    let message = await completeMessage(
+      { messageId: 'msg_transition' },
+      {
+        status: 'failed',
+        failureReason: 'timeout',
+        responderParticipant: { oid: 99n },
+        completedAt: new Date(),
+        providerRun: { oid: 31n },
+        output: {
+          type: 'error',
+          data: { code: 'timeout', message: 'The conduit request timed out before the provider responded.' }
+        }
+      }
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(message).toBe(finalMessage);
+    expect(mocks.createError).toHaveBeenCalledTimes(1);
+    expect(mocks.db.sessionMessage.update).toHaveBeenCalledWith({
+      where: { oid: 2n },
+      data: { errorOid: 32n },
+      include: {
+        toolCall: {
+          include: {
+            attachments: true
+          }
+        }
+      }
+    });
+    expect(mocks.db.sessionEvent.updateMany).toHaveBeenCalled();
+    expect(mocks.db.sessionEvent.createMany).toHaveBeenCalled();
+    expect(mocks.finalizeMessageQueue.add).toHaveBeenCalledWith({ messageId: 'msg_transition' });
+  });
+});

--- a/src/subspace/modules/connection/src/shared/completeMessage.ts
+++ b/src/subspace/modules/connection/src/shared/completeMessage.ts
@@ -53,17 +53,6 @@ export let completeMessage = async (
         })
       : undefined;
 
-  let error: SessionError | undefined;
-  if (data.status === 'failed') {
-    error = await createError({
-      type: messageFailureReasonToErrorType(data.failureReason ?? 'provider_error'),
-      session: currentMessage!.session,
-      connection: currentMessage!.connection,
-      output: data.output!,
-      providerRun: data.providerRun
-    });
-  }
-
   let toolCallAttachments =
     currentMessage?.toolCall && data.output?.type === 'tool.result'
       ? getRawToolCallAttachmentsFromOutput(data.output)
@@ -87,10 +76,20 @@ export let completeMessage = async (
     );
   }
 
+  let messageWhere = 'messageId' in filter ? { id: filter.messageId } : { oid: filter.messageOid };
+  let messageInclude = {
+    toolCall: {
+      include: {
+        attachments: true
+      }
+    }
+  };
+  let didTransition = false;
+
   let message = await db.$transaction(async tx => {
-    let message = await tx.sessionMessage.update({
+    let result = await tx.sessionMessage.updateMany({
       where: {
-        ...('messageId' in filter ? { id: filter.messageId } : { oid: filter.messageOid }),
+        ...messageWhere,
         status: 'waiting_for_response'
       },
       data: {
@@ -98,19 +97,23 @@ export let completeMessage = async (
         status: data.status,
         completedAt: data.completedAt ?? new Date(),
         failureReason: data.failureReason,
-
-        errorOid: error?.oid,
         providerRunOid: data.providerRun?.oid,
         slateToolCallOid: data.slateToolCall?.oid,
         responderParticipantOid: data.responderParticipant.oid
-      },
-      include: {
-        toolCall: {
-          include: {
-            attachments: true
-          }
-        }
       }
+    });
+    if (result.count === 0) {
+      return await tx.sessionMessage.findFirstOrThrow({
+        where: messageWhere,
+        include: messageInclude
+      });
+    }
+
+    didTransition = true;
+
+    let message = await tx.sessionMessage.findFirstOrThrow({
+      where: messageWhere,
+      include: messageInclude
     });
 
     if (message.toolCall) {
@@ -139,6 +142,25 @@ export let completeMessage = async (
 
     return message;
   });
+
+  if (!didTransition) return message;
+
+  let error: SessionError | undefined;
+  if (data.status === 'failed') {
+    error = await createError({
+      type: messageFailureReasonToErrorType(data.failureReason ?? 'provider_error'),
+      session: currentMessage!.session,
+      connection: currentMessage!.connection,
+      output: data.output!,
+      providerRun: data.providerRun
+    });
+
+    message = await db.sessionMessage.update({
+      where: { oid: message.oid },
+      data: { errorOid: error?.oid },
+      include: messageInclude
+    });
+  }
 
   (async () => {
     await db.sessionEvent.updateMany({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core session message lifecycle and failure handling; incorrect locking could leave messages stuck or skip finalize, but behavior is covered by new unit tests.
> 
> **Overview**
> Fixes a race when **multiple workers** (e.g. provider response and timeout) try to finish the same session message at once.
> 
> **`completeMessage`** now completes only messages still in `waiting_for_response` via **`updateMany`** instead of an unconditional **`update`**. If no row is updated, it returns the already-completed message and **skips** `createError`, session event updates, and **`finalizeMessageQueue`**.
> 
> Session errors are created **after** a successful transition, in a follow-up **`sessionMessage.update`** for `errorOid`, so losers do not create duplicate errors or enqueue finalize twice.
> 
> Adds **`completeMessage.test.ts`** covering the lost-race path (no side effects) and the winning path (error + events + finalize).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619dd20baca0d93eedcb4e04c69b3a2c052e05c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->