### PR TITLE
Fix provider run cleanup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3336,6 +3336,7 @@
         "@prisma/extension-read-replicas": "^0.5.0",
         "@sentry/bun": "^10.38.0",
         "@sentry/cli": "^3.2.0",
+        "@toon-format/toon": "^2.3.0",
         "@types/pg": "^8.16.0",
         "axios": "^1.13.2",
         "date-fns": "^4.1.0",

--- a/src/subspace/modules/session/src/queues/delete/providerRunCleanup.ts
+++ b/src/subspace/modules/session/src/queues/delete/providerRunCleanup.ts
@@ -1,0 +1,47 @@
+import { db } from '@metorial-subspace/db';
+
+export let deleteProviderRunsBySessionOid = async (sessionOid: bigint) => {
+  let providerRuns = await db.providerRun.findMany({
+    where: { sessionOid },
+    select: { oid: true }
+  });
+  let providerRunOids = providerRuns.map(providerRun => providerRun.oid);
+
+  if (providerRunOids.length === 0) return;
+
+  let slateSessions = await db.slateSession.findMany({
+    where: { providerRunOid: { in: providerRunOids } },
+    select: { oid: true }
+  });
+  let slateSessionOids = slateSessions.map(session => session.oid);
+
+  if (slateSessionOids.length > 0) {
+    let slateToolCalls = await db.slateToolCall.findMany({
+      where: { sessionOid: { in: slateSessionOids } },
+      select: { oid: true }
+    });
+    let slateToolCallOids = slateToolCalls.map(toolCall => toolCall.oid);
+
+    if (slateToolCallOids.length > 0) {
+      await db.slateToolCall.deleteMany({
+        where: { oid: { in: slateToolCallOids } }
+      });
+    }
+
+    await db.slateSession.deleteMany({
+      where: { oid: { in: slateSessionOids } }
+    });
+  }
+
+  await db.shuttleConnection.deleteMany({
+    where: { providerRunOid: { in: providerRunOids } }
+  });
+
+  await db.providerRunUsageRecord.deleteMany({
+    where: { providerRunOid: { in: providerRunOids } }
+  });
+
+  await db.providerRun.deleteMany({
+    where: { oid: { in: providerRunOids } }
+  });
+};

--- a/src/subspace/modules/session/src/queues/delete/session.ts
+++ b/src/subspace/modules/session/src/queues/delete/session.ts
@@ -5,6 +5,7 @@ import { getRetentionCutoffDate } from '@metorial-subspace/list-utils';
 import { env } from '../../env';
 import { sessionDeletedQueue } from '../lifecycle/session';
 import { getCutoffDate, RETENTION_BATCH_SIZE } from './_config';
+import { deleteProviderRunsBySessionOid } from './providerRunCleanup';
 
 export let sessionRetentionCleanupCron = createCron(
   {
@@ -171,12 +172,7 @@ export let sessionDeleteQueueProcessor = sessionDeleteQueue.process(async data =
   await db.sessionError.deleteMany({
     where: { sessionOid: session.oid }
   });
-  await db.providerRunUsageRecord.deleteMany({
-    where: { providerRun: { sessionOid: session.oid } }
-  });
-  await db.providerRun.deleteMany({
-    where: { sessionOid: session.oid }
-  });
+  await deleteProviderRunsBySessionOid(db, session.oid);
   await db.sessionProviderInstance.deleteMany({
     where: { sessionOid: session.oid }
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the retention deletion path for provider runs and related tables; incorrect ordering or scope could leave orphans or break cleanup jobs, but the change is intended to fix that cascade.
> 
> **Overview**
> **Fixes incomplete provider run cleanup** during archived session deletion by deleting dependent rows in FK-safe order before removing provider runs.
> 
> Session retention delete previously only removed `providerRunUsageRecord` and `providerRun` by `sessionOid`, which could leave **`slateToolCall` / `slateSession`**, **`shuttleConnection`**, and related usage rows behind or cause delete failures. That logic is moved into **`deleteProviderRunsBySessionOid`** in `providerRunCleanup.ts`, which walks provider runs for the session and deletes tool calls → slate sessions → shuttle connections → usage records → provider runs.
> 
> The session delete queue processor now calls this helper instead of the two inline `deleteMany` calls. **`@toon-format/toon`** is also added in `bun.lock` (dependency only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b4976da80694fb69a7857ef25d964325b0a10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->