### PR TITLE
Add array envelopes for serialization

### DIFF
--- a/src/lowerdeck/packages/serialize/src/json.ts
+++ b/src/lowerdeck/packages/serialize/src/json.ts
@@ -3,6 +3,8 @@ import SuperJSON from 'superjson';
 
 export let serialize = {
   encode: (data: any) => {
+    if (Array.isArray(data)) data = { items: data, $$MODE$$: 'array_envelope' };
+
     let sup = SuperJSON.serialize(data);
 
     if (sup.meta?.referentialEqualities) {
@@ -26,13 +28,24 @@ export let serialize = {
 
     if (typeof data != 'object') return data;
 
-    let { $$TYPES$$, ...rest } = data;
+    let { $$TYPES$$, $$MODE$$, ...rest } = data;
 
     if (typeof $$TYPES$$ != 'object' || !$$TYPES$$.__mode) return data;
 
     let { __mode, ...meta } = $$TYPES$$;
     let json = __mode == 'value' ? rest.data : rest;
 
-    return SuperJSON.deserialize({ json, meta });
+    let res = SuperJSON.deserialize({ json, meta });
+
+    if (
+      $$MODE$$ == 'array_envelope' &&
+      typeof res == 'object' &&
+      res != null &&
+      'items' in res
+    ) {
+      return res.items;
+    }
+
+    return res;
   }
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the on-the-wire shape for encoded top-level arrays; callers relying on raw JSON layout or mixing old/new payloads need a round-trip through decode.
> 
> **Overview**
> Top-level **arrays** are no longer passed straight into SuperJSON. **`encode`** now wraps them as `{ items: data, $$MODE$$: 'array_envelope' }` so the serialized JSON matches the existing object-shaped wire format.
> 
> **`decode`** strips `$$MODE$$` from the payload and, when the mode is `array_envelope`, returns **`res.items`** instead of the wrapper object. Non-array payloads and legacy blobs without `$$MODE$$` behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835194a6cf06034872be0a60fdf19cfe88a99681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->