### PR TITLE
Fix config update error

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -73,6 +73,11 @@ type AddProviderPanelFormValues = {
 };
 
 type ToolPermissionMode = 'allow' | 'reject' | 'mixed';
+let toolPermissionModeItems: { id: ToolPermissionMode; label: string }[] = [
+  { id: 'allow', label: 'Allow' },
+  { id: 'reject', label: 'Reject' },
+  { id: 'mixed', label: 'Mixed' }
+];
 type InitialToolFilter =
   | {
       type: 'allow_all';
@@ -152,6 +157,7 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
   let selectedProviderRequiresConfig = selectedProvider.data?.type.config.status == 'enabled';
   let selectedProviderRequiresAuth = selectedProvider.data?.type.auth.status == 'enabled';
   let [step, setStep] = useState(p.hideProviderStep ? 0 : p.providerId ? 1 : 0);
+  let initialSelectionHydrationKeyRef = useRef<string | null>(null);
   let toolFilterHydrationKeyRef = useRef<string | null>(null);
   let initialSelectedToolKeys =
     p.initialToolFilter?.type === 'filter'
@@ -379,7 +385,21 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
   ]);
 
   useEffect(() => {
-    if (!p.hideProviderStep) return;
+    if (!p.hideProviderStep) {
+      initialSelectionHydrationKeyRef.current = null;
+      return;
+    }
+
+    let hydrationKey = [
+      p.sessionTemplateProviderId ?? '',
+      p.providerId ?? '',
+      p.initialDeploymentId ?? '',
+      p.initialConfigId ?? '',
+      p.initialAuthConfigId ?? '',
+      selectedProviderRequiresConfig ? 'config' : '',
+      selectedProviderRequiresAuth ? 'auth' : ''
+    ].join('::');
+    let shouldHydrateInitialSelections = initialSelectionHydrationKeyRef.current !== hydrationKey;
 
     if (p.providerId && !form.values.selectedProviderId) {
       form.setFieldValue('selectedProviderId', p.providerId);
@@ -398,6 +418,7 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
     }
 
     if (
+      shouldHydrateInitialSelections &&
       p.initialConfigId &&
       selectedProviderRequiresConfig &&
       form.values.selectedConfiguration.kind === 'none'
@@ -406,14 +427,18 @@ export let AddProviderPanelFlow = (p: AddProviderPanelFlowProps) => {
     }
 
     if (
+      shouldHydrateInitialSelections &&
       p.initialAuthConfigId &&
       selectedProviderRequiresAuth &&
       !form.values.selectedAuthConfigId
     ) {
       form.setFieldValue('selectedAuthConfigId', p.initialAuthConfigId);
     }
+
+    initialSelectionHydrationKeyRef.current = hydrationKey;
   }, [
     p.hideProviderStep,
+    p.sessionTemplateProviderId,
     p.providerId,
     p.initialDeploymentId,
     p.initialConfigId,
@@ -888,6 +913,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   let requiresAuthConfig = showAuthSection && provider.data?.type.auth.status == 'enabled';
   let pendingCreatedAuthConfigIdRef = useRef<string | null>(null);
   let previousProviderAuthMethodIdRef = useRef<string | undefined>(providerAuthMethodId);
+  let isCreatingInlineAuthConfig = !!inlineAuthMethodId;
   let selectedToolKeys = p.selectedToolKeys ?? [];
   let toolFilterMode = p.toolFilterMode ?? 'all';
   let selectedAuthConfigForMethod = useProviderAuthConfigs(
@@ -954,6 +980,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   ]);
 
   useEffect(() => {
+    if (isCreatingInlineAuthConfig) return;
     if (previousProviderAuthMethodIdRef.current === providerAuthMethodId) return;
 
     previousProviderAuthMethodIdRef.current = providerAuthMethodId;
@@ -969,6 +996,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
       p.onSelectedAuthConfigIdChange('');
     }
   }, [
+    isCreatingInlineAuthConfig,
     providerAuthMethodId,
     p.selectedAuthConfigId,
     p.onSelectedAuthConfigIdChange,
@@ -978,6 +1006,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   useEffect(() => {
     if (!requiresAuthConfig) return;
     if (!providerAuthMethodId) return;
+    if (isCreatingInlineAuthConfig) return;
     if (!p.selectedAuthConfigId) return;
     if (selectedAuthConfigForMethod.isLoading) return;
 
@@ -985,8 +1014,10 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
       config => config.id === p.selectedAuthConfigId
     );
     let createdAuthConfigSelected = createdAuthConfigSelection?.id === p.selectedAuthConfigId;
+    let pendingCreatedAuthConfigSelected =
+      pendingCreatedAuthConfigIdRef.current === p.selectedAuthConfigId;
 
-    if (!authConfigMatchesMethod && !createdAuthConfigSelected) {
+    if (!authConfigMatchesMethod && !createdAuthConfigSelected && !pendingCreatedAuthConfigSelected) {
       pendingCreatedAuthConfigIdRef.current = null;
       setCreatedAuthConfigSelection(null);
       p.onSelectedAuthConfigIdChange('');
@@ -994,6 +1025,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
   }, [
     requiresAuthConfig,
     providerAuthMethodId,
+    isCreatingInlineAuthConfig,
     p.selectedAuthConfigId,
     p.onSelectedAuthConfigIdChange,
     selectedAuthConfigForMethod.isLoading,
@@ -1393,11 +1425,7 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
                           value
                         );
                       }}
-                      items={[
-                        { id: 'allow', label: 'Allow' },
-                        { id: 'reject', label: 'Reject' },
-                        { id: 'mixed', label: 'Mixed' }
-                      ]}
+                      items={toolPermissionModeItems}
                     />
                   </div>
 

--- a/src/metorial-frontend/packages/ui/src/optionToggle/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/optionToggle/index.tsx
@@ -1,6 +1,14 @@
 import * as RadixToggleGroup from '@radix-ui/react-toggle-group';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
-import React, { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { styled } from 'styled-components';
 import { theme } from '..';
 import { ButtonSize, getButtonSize } from '../button/constants';
@@ -129,12 +137,14 @@ export let OptionToggle = ({
   let labelId = `${id}-label`;
   let rootRef = useRef<HTMLDivElement | null>(null);
   let itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  let measurementFrameRef = useRef<number | null>(null);
   let [indicator, setIndicator] = useState<{ width: number; left: number } | null>(null);
   let sizeStyles = getButtonSize(size);
   let itemBorderRadius = `calc(${sizeStyles.borderRadius} - 2px)`;
 
   let selectedItem = useMemo(() => items.find(item => item.id == value), [items, value]);
-  let updateIndicator = (nextIndicator: { width: number; left: number } | null) => {
+  let itemIds = useMemo(() => items.map(item => item.id).join('\0'), [items]);
+  let updateIndicator = useCallback((nextIndicator: { width: number; left: number } | null) => {
     setIndicator(current => {
       if (current === null && nextIndicator === null) return current;
       if (current && nextIndicator) {
@@ -145,30 +155,41 @@ export let OptionToggle = ({
 
       return nextIndicator;
     });
-  };
+  }, []);
+
+  let measureIndicator = useCallback(() => {
+    let root = rootRef.current;
+    let item = selectedItem ? itemRefs.current[selectedItem.id] : null;
+    if (!root || !item) {
+      updateIndicator(null);
+      return;
+    }
+
+    updateIndicator({
+      width: item.offsetWidth,
+      left: item.offsetLeft - 4
+    });
+  }, [selectedItem?.id, updateIndicator]);
+
+  let scheduleMeasureIndicator = useCallback(() => {
+    if (measurementFrameRef.current !== null) {
+      cancelAnimationFrame(measurementFrameRef.current);
+    }
+
+    measurementFrameRef.current = requestAnimationFrame(() => {
+      measurementFrameRef.current = null;
+      measureIndicator();
+    });
+  }, [measureIndicator]);
 
   useLayoutEffect(() => {
-    let measure = () => {
-      let root = rootRef.current;
-      let item = selectedItem ? itemRefs.current[selectedItem.id] : null;
-      if (!root || !item) {
-        updateIndicator(null);
-        return;
-      }
-
-      updateIndicator({
-        width: item.offsetWidth,
-        left: item.offsetLeft - 4
-      });
-    };
-
-    measure();
+    measureIndicator();
 
     let resizeObserver =
       typeof ResizeObserver == 'undefined'
         ? null
         : new ResizeObserver(() => {
-            measure();
+            scheduleMeasureIndicator();
           });
 
     if (rootRef.current) resizeObserver?.observe(rootRef.current);
@@ -177,27 +198,19 @@ export let OptionToggle = ({
       if (selectedNode) resizeObserver?.observe(selectedNode);
     }
 
-    return () => resizeObserver?.disconnect();
-  }, [items, selectedItem, value]);
+    return () => {
+      resizeObserver?.disconnect();
+      if (measurementFrameRef.current !== null) {
+        cancelAnimationFrame(measurementFrameRef.current);
+        measurementFrameRef.current = null;
+      }
+    };
+  }, [itemIds, measureIndicator, scheduleMeasureIndicator, selectedItem?.id, value]);
 
   useEffect(() => {
-    let handleResize = () => {
-      let root = rootRef.current;
-      let item = selectedItem ? itemRefs.current[selectedItem.id] : null;
-      if (!root || !item) {
-        updateIndicator(null);
-        return;
-      }
-
-      updateIndicator({
-        width: item.offsetWidth,
-        left: item.offsetLeft - 4
-      });
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [selectedItem]);
+    window.addEventListener('resize', scheduleMeasureIndicator);
+    return () => window.removeEventListener('resize', scheduleMeasureIndicator);
+  }, [scheduleMeasureIndicator]);
 
   return (
     <Wrapper>

--- a/src/metorial/db/prisma/schema/account/domain.prisma
+++ b/src/metorial/db/prisma/schema/account/domain.prisma
@@ -18,7 +18,7 @@ model AccountDomain {
   status             AccountDomainStatus
   verificationStatus AccountDomainVerificationStatus
 
-  isFixedToVerified Boolean
+  isFixedToVerified Boolean   @default(false)
   lastCheckedAt     DateTime?
   lastManualCheckAt DateTime?
 

--- a/src/metorial/multi-region/prisma/schema/domain.prisma
+++ b/src/metorial/multi-region/prisma/schema/domain.prisma
@@ -18,13 +18,13 @@ model AccountDomain {
   status             AccountDomainStatus
   verificationStatus AccountDomainVerificationStatus
 
-  isFixedToVerified Boolean
+  isFixedToVerified Boolean @default(false)
 
   accountId String
 
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @default(now()) @updatedAt
-  lastCheckedAt DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @default(now()) @updatedAt
+  lastCheckedAt     DateTime?
   lastManualCheckAt DateTime?
 
   verifications AccountDomainVerification[]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dashboard form/UI and schema defaults only; no auth or payment logic changes. Prisma default is backward-compatible for new rows.
> 
> **Overview**
> Fixes **session template provider edit/update** issues by controlling when initial config and auth values are re-applied from props, and by not clearing auth selection while **inline auth config** is being created or is still pending.
> 
> In **`addProviderPanelFlow`**, a hydration key (including `sessionTemplateProviderId` and initial IDs) ensures config/auth are only set from `initialConfigId` / `initialAuthConfigId` when the edit context changes—not on every effect run. Auth-related effects skip resets when `inlineAuthMethodId` is active or when the selected ID matches a pending newly created config. Tool permission toggles use a **stable** `toolPermissionModeItems` array instead of inline literals.
> 
> **`OptionToggle`** indicator sizing is refactored to use `requestAnimationFrame`, stable `useCallback` measurers, and an `itemIds` dependency so resize/remount does not thrash state (pairs with the stable items above).
> 
> **Prisma**: `AccountDomain.isFixedToVerified` gets `@default(false)` in account and multi-region domain schemas (multi-region also aligns `lastManualCheckAt` field ordering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc87f2a67f24a858bceca8031c3917db78adac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->