### PR TITLE
Add smarter integration deletion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@metorial/oss",

--- a/src/metorial/modules/consumer/src/index.ts
+++ b/src/metorial/modules/consumer/src/index.ts
@@ -24,6 +24,7 @@ export * from './lib/magicMcpServerAccess';
 export * from './lib/magicMcpTokenAccess';
 export * from './lib/oauth';
 export * from './portalUrlTemplate';
+export * from './queues/lifecycle';
 export * from './queues/materializeMagicMcpSessionOwnership';
 export * from './services';
 

--- a/src/metorial/modules/consumer/src/queues/lifecycle/consumerAccessCleanup.ts
+++ b/src/metorial/modules/consumer/src/queues/lifecycle/consumerAccessCleanup.ts
@@ -1,0 +1,220 @@
+import { db, type Prisma } from '@metorial/db';
+import { createQueue } from '@metorial/queue';
+import { consumerAccessService } from '../../services/consumerAccess/consumerAccess';
+import { consumerAccessListingService } from '../../services/consumerAccess/consumerAccessListing';
+
+let consumerAccessInclude = {
+  consumerGroup: true,
+  providerTemplate: true,
+  magicMcpServer: true,
+  skill: true,
+  skillTemplate: true,
+  skillGroup: true,
+  skillMarketplace: true,
+  listing: true
+} satisfies Prisma.ConsumerAccessInclude;
+
+let consumerAccessListingInclude = {
+  providerTemplate: true,
+  magicMcpServer: true,
+  skill: true,
+  skillTemplate: true,
+  skillGroup: true,
+  skillMarketplace: true,
+  consumerSurfaceProviderGroups: {
+    include: {
+      consumerSurfaceProviderGroup: true
+    }
+  }
+} satisfies Prisma.ConsumerAccessListingInclude;
+
+let queueJobId = (...parts: (string | null | undefined)[]) =>
+  parts.filter(Boolean).join('-').replaceAll(':', '-');
+
+type ConsumerTargetAccessCleanupManyInput = {
+  organizationId: string;
+  providerTemplateId?: string | null;
+  magicMcpServerId?: string | null;
+  listingCursor?: string | null;
+  accessCursor?: string | null;
+};
+
+let resolveTarget = async (d: ConsumerTargetAccessCleanupManyInput) => {
+  let organization = await db.organization.findUnique({
+    where: { id: d.organizationId }
+  });
+  if (!organization) return null;
+
+  if (d.providerTemplateId) {
+    let providerTemplate = await db.providerTemplate.findUnique({
+      where: { id: d.providerTemplateId },
+      select: { oid: true }
+    });
+    if (!providerTemplate) return null;
+
+    return {
+      organization,
+      listingWhere: { providerTemplateOid: providerTemplate.oid },
+      accessWhere: { providerTemplateOid: providerTemplate.oid }
+    } satisfies {
+      organization: typeof organization;
+      listingWhere: Prisma.ConsumerAccessListingWhereInput;
+      accessWhere: Prisma.ConsumerAccessWhereInput;
+    };
+  }
+
+  if (d.magicMcpServerId) {
+    let magicMcpServer = await db.magicMcpServer.findUnique({
+      where: { id: d.magicMcpServerId },
+      select: { oid: true }
+    });
+    if (!magicMcpServer) return null;
+
+    return {
+      organization,
+      listingWhere: { magicMcpServerOid: magicMcpServer.oid },
+      accessWhere: { magicMcpServerOid: magicMcpServer.oid }
+    } satisfies {
+      organization: typeof organization;
+      listingWhere: Prisma.ConsumerAccessListingWhereInput;
+      accessWhere: Prisma.ConsumerAccessWhereInput;
+    };
+  }
+
+  return null;
+};
+
+export let consumerTargetAccessCleanupManyQueue =
+  createQueue<ConsumerTargetAccessCleanupManyInput>({
+    name: 'cons/lc/access/cleanupTargetMany'
+  });
+
+export let enqueueConsumerTargetAccessCleanup = async (
+  d: Omit<ConsumerTargetAccessCleanupManyInput, 'listingCursor' | 'accessCursor'>
+) => {
+  if (!d.providerTemplateId && !d.magicMcpServerId) return;
+  await consumerTargetAccessCleanupManyQueue.add(d);
+};
+
+export let consumerAccessListingDeleteQueue = createQueue<{
+  organizationId: string;
+  consumerAccessListingId: string;
+}>({
+  name: 'cons/lc/access/deleteListing'
+});
+
+export let consumerAccessDeleteQueue = createQueue<{
+  organizationId: string;
+  consumerAccessId: string;
+}>({
+  name: 'cons/lc/access/deleteAccess'
+});
+
+export let consumerTargetAccessCleanupManyQueueProcessor =
+  consumerTargetAccessCleanupManyQueue.process(async data => {
+    let target = await resolveTarget(data);
+    if (!target) return;
+
+    if (!data.accessCursor) {
+      let listings = await db.consumerAccessListing.findMany({
+        where: {
+          ...target.listingWhere,
+          id: data.listingCursor ? { gt: data.listingCursor } : undefined
+        },
+        orderBy: { id: 'asc' },
+        take: 100,
+        select: { id: true }
+      });
+
+      if (listings.length) {
+        await consumerAccessListingDeleteQueue.addManyWithOps(
+          listings.map(listing => ({
+            data: {
+              organizationId: data.organizationId,
+              consumerAccessListingId: listing.id
+            },
+            opts: {
+              id: queueJobId('delete-listing', data.organizationId, listing.id)
+            }
+          }))
+        );
+      }
+
+      let lastListing = listings[listings.length - 1];
+      if (lastListing) {
+        await consumerTargetAccessCleanupManyQueue.add({
+          ...data,
+          listingCursor: lastListing.id
+        });
+        return;
+      }
+    }
+
+    let accesses = await db.consumerAccess.findMany({
+      where: {
+        ...target.accessWhere,
+        listingOid: null,
+        id: data.accessCursor ? { gt: data.accessCursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: 100,
+      select: { id: true }
+    });
+
+    if (accesses.length) {
+      await consumerAccessDeleteQueue.addManyWithOps(
+        accesses.map(access => ({
+          data: {
+            organizationId: data.organizationId,
+            consumerAccessId: access.id
+          },
+          opts: {
+            id: queueJobId('delete-access', data.organizationId, access.id)
+          }
+        }))
+      );
+    }
+
+    let lastAccess = accesses[accesses.length - 1];
+    if (!lastAccess) return;
+
+    await consumerTargetAccessCleanupManyQueue.add({
+      ...data,
+      accessCursor: lastAccess.id
+    });
+  });
+
+export let consumerAccessListingDeleteQueueProcessor =
+  consumerAccessListingDeleteQueue.process(async data => {
+    let [organization, consumerAccessListing] = await Promise.all([
+      db.organization.findUnique({ where: { id: data.organizationId } }),
+      db.consumerAccessListing.findUnique({
+        where: { id: data.consumerAccessListingId },
+        include: consumerAccessListingInclude
+      })
+    ]);
+    if (!organization || !consumerAccessListing) return;
+
+    await consumerAccessListingService.delete({
+      organization,
+      consumerAccessListing
+    });
+  });
+
+export let consumerAccessDeleteQueueProcessor = consumerAccessDeleteQueue.process(
+  async data => {
+    let [organization, consumerAccess] = await Promise.all([
+      db.organization.findUnique({ where: { id: data.organizationId } }),
+      db.consumerAccess.findUnique({
+        where: { id: data.consumerAccessId },
+        include: consumerAccessInclude
+      })
+    ]);
+    if (!organization || !consumerAccess) return;
+
+    await consumerAccessService.deleteConsumerAccess({
+      organization,
+      consumerAccess
+    });
+  }
+);

--- a/src/metorial/modules/consumer/src/queues/lifecycle/consumerGroup.ts
+++ b/src/metorial/modules/consumer/src/queues/lifecycle/consumerGroup.ts
@@ -59,6 +59,7 @@ export let consumerGroupArchivedQueueProcessor = consumerGroupArchivedQueue.proc
         skill: true,
         skillTemplate: true,
         skillGroup: true,
+        skillMarketplace: true,
         listing: true,
         surface: { include: { organization: true } }
       }

--- a/src/metorial/modules/consumer/src/queues/lifecycle/index.ts
+++ b/src/metorial/modules/consumer/src/queues/lifecycle/index.ts
@@ -1,6 +1,11 @@
 import { combineQueueProcessors } from '@metorial/queue';
 import { consumerCreatedQueueProcessor, consumerUpdatedQueueProcessor } from './consumer';
 import {
+  consumerAccessDeleteQueueProcessor,
+  consumerAccessListingDeleteQueueProcessor,
+  consumerTargetAccessCleanupManyQueueProcessor
+} from './consumerAccessCleanup';
+import {
   consumerAccessRequestCreatedQueueProcessor,
   consumerAccessRequestUpdatedQueueProcessor
 } from './consumerAccessRequest';
@@ -25,6 +30,7 @@ import {
 } from './consumerSurface';
 
 export * from './consumer';
+export * from './consumerAccessCleanup';
 export * from './consumerAccessRequest';
 export * from './consumerGroup';
 export * from './consumerInvite';
@@ -41,6 +47,9 @@ export let consumerLifecycleQueueProcessor = combineQueueProcessors([
   consumerGroupCreatedQueueProcessor,
   consumerGroupUpdatedQueueProcessor,
   consumerGroupArchivedQueueProcessor,
+  consumerTargetAccessCleanupManyQueueProcessor,
+  consumerAccessListingDeleteQueueProcessor,
+  consumerAccessDeleteQueueProcessor,
   consumerAccessRequestCreatedQueueProcessor,
   consumerAccessRequestUpdatedQueueProcessor,
   consumerSurfaceCreatedQueueProcessor,

--- a/src/metorial/modules/consumer/src/services/consumerAccess/consumerAccess.ts
+++ b/src/metorial/modules/consumer/src/services/consumerAccess/consumerAccess.ts
@@ -11,6 +11,7 @@ import {
   ID,
   MagicMcpServer,
   Organization,
+  Prisma,
   ProviderTemplate,
   Skill,
   SkillGroup,
@@ -65,7 +66,7 @@ type ConsumerAccessWithRelations = ConsumerAccess & {
   skill: Skill | null;
   skillTemplate: SkillTemplate | null;
   skillGroup: SkillGroup | null;
-  skillMarketplace?: SkillMarketplace | null;
+  skillMarketplace: SkillMarketplace | null;
   listing: ConsumerAccessListing | null;
 };
 
@@ -881,12 +882,21 @@ class ConsumerAccessServiceImpl {
     consumerAccess: ConsumerAccessWithRelations;
   }) {
     return await withTransaction(async tx => {
-      let consumerAccess = await tx.consumerAccess.delete({
-        where: {
-          oid: d.consumerAccess.oid
-        },
-        include
-      });
+      let consumerAccess: ConsumerAccessWithRelations;
+      try {
+        consumerAccess = await tx.consumerAccess.delete({
+          where: {
+            oid: d.consumerAccess.oid
+          },
+          include
+        });
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+          return d.consumerAccess;
+        }
+
+        throw error;
+      }
 
       if (consumerAccess.type != 'skill_marketplace') {
         await consumerAccessPolicyService.revokeAccessForConsumerAccess({

--- a/src/metorial/modules/consumer/src/services/consumerAccess/consumerAccess.ts
+++ b/src/metorial/modules/consumer/src/services/consumerAccess/consumerAccess.ts
@@ -892,6 +892,13 @@ class ConsumerAccessServiceImpl {
         });
       } catch (error) {
         if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+          if (d.consumerAccess.type != 'skill_marketplace') {
+            await consumerAccessPolicyService.revokeAccessForConsumerAccess({
+              organization: d.organization,
+              consumerAccess: d.consumerAccess
+            });
+          }
+
           return d.consumerAccess;
         }
 

--- a/src/metorial/modules/consumer/src/services/consumerAccess/consumerAccessListing.ts
+++ b/src/metorial/modules/consumer/src/services/consumerAccess/consumerAccessListing.ts
@@ -698,6 +698,7 @@ class ConsumerAccessListingServiceImpl {
         skill: true,
         skillTemplate: true,
         skillGroup: true,
+        skillMarketplace: true,
         listing: true
       }
     });
@@ -721,10 +722,18 @@ class ConsumerAccessListingServiceImpl {
 
       if (!existing) return d.consumerAccessListing;
 
-      return await db.consumerAccessListing.delete({
-        where: { oid: d.consumerAccessListing.oid },
-        include
-      });
+      try {
+        return await db.consumerAccessListing.delete({
+          where: { oid: d.consumerAccessListing.oid },
+          include
+        });
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+          return d.consumerAccessListing;
+        }
+
+        throw error;
+      }
     });
   }
 

--- a/src/metorial/modules/consumer/test/consumerAccessCleanupQueue.test.ts
+++ b/src/metorial/modules/consumer/test/consumerAccessCleanupQueue.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { db, processors, createQueueMock, listingDeleteMock, accessDeleteMock } = vi.hoisted(
+  () => {
+    let processors = new Map<string, (data: any) => Promise<void>>();
+    let db = {
+      organization: {
+        findUnique: vi.fn()
+      },
+      providerTemplate: {
+        findUnique: vi.fn()
+      },
+      magicMcpServer: {
+        findUnique: vi.fn()
+      },
+      consumerAccessListing: {
+        findMany: vi.fn(),
+        findUnique: vi.fn()
+      },
+      consumerAccess: {
+        findMany: vi.fn(),
+        findUnique: vi.fn()
+      }
+    };
+
+    return {
+      db,
+      processors,
+      createQueueMock: vi.fn((config: { name: string }) => ({
+        add: vi.fn(),
+        addMany: vi.fn(),
+        addManyWithOps: vi.fn(),
+        process: vi.fn((handler: (data: any) => Promise<void>) => {
+          processors.set(config.name, handler);
+          return { name: config.name, handler };
+        })
+      })),
+      listingDeleteMock: vi.fn(),
+      accessDeleteMock: vi.fn()
+    };
+  }
+);
+
+vi.mock('@metorial/queue', () => ({
+  createQueue: createQueueMock
+}));
+
+vi.mock('@metorial/db', () => ({
+  db
+}));
+
+vi.mock('../src/services/consumerAccess/consumerAccessListing', () => ({
+  consumerAccessListingService: {
+    delete: listingDeleteMock
+  }
+}));
+
+vi.mock('../src/services/consumerAccess/consumerAccess', () => ({
+  consumerAccessService: {
+    deleteConsumerAccess: accessDeleteMock
+  }
+}));
+
+import {
+  consumerAccessDeleteQueue,
+  consumerAccessListingDeleteQueue,
+  consumerTargetAccessCleanupManyQueue
+} from '../src/queues/lifecycle/consumerAccessCleanup';
+
+describe('consumer access cleanup queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fans target cleanup into listing and access single-delete jobs', async () => {
+    db.organization.findUnique.mockResolvedValue({ id: 'org-1' });
+    db.providerTemplate.findUnique.mockResolvedValue({ oid: 10n });
+    db.consumerAccessListing.findMany.mockResolvedValue([{ id: 'listing-1' }]);
+
+    await processors.get('cons/lc/access/cleanupTargetMany')!({
+      organizationId: 'org-1',
+      providerTemplateId: 'provider-template-1'
+    });
+
+    expect(consumerAccessListingDeleteQueue.addManyWithOps).toHaveBeenCalledWith([
+      {
+        data: { organizationId: 'org-1', consumerAccessListingId: 'listing-1' },
+        opts: { id: 'delete-listing-org-1-listing-1' }
+      }
+    ]);
+    expect(consumerTargetAccessCleanupManyQueue.add).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      providerTemplateId: 'provider-template-1',
+      listingCursor: 'listing-1'
+    });
+    expect(consumerAccessDeleteQueue.addManyWithOps).not.toHaveBeenCalled();
+  });
+
+  it('only separately deletes unlisted accesses after listings are exhausted', async () => {
+    db.organization.findUnique.mockResolvedValue({ id: 'org-1' });
+    db.providerTemplate.findUnique.mockResolvedValue({ oid: 10n });
+    db.consumerAccessListing.findMany.mockResolvedValue([]);
+    db.consumerAccess.findMany.mockResolvedValue([{ id: 'access-1' }]);
+
+    await processors.get('cons/lc/access/cleanupTargetMany')!({
+      organizationId: 'org-1',
+      providerTemplateId: 'provider-template-1'
+    });
+
+    expect(db.consumerAccess.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          providerTemplateOid: 10n,
+          listingOid: null
+        })
+      })
+    );
+    expect(consumerAccessDeleteQueue.addManyWithOps).toHaveBeenCalledWith([
+      {
+        data: { organizationId: 'org-1', consumerAccessId: 'access-1' },
+        opts: { id: 'delete-access-org-1-access-1' }
+      }
+    ]);
+  });
+
+  it('deletes one listing through the listing service', async () => {
+    let organization = { id: 'org-1' };
+    let listing = { id: 'listing-1' };
+    db.organization.findUnique.mockResolvedValue(organization);
+    db.consumerAccessListing.findUnique.mockResolvedValue(listing);
+
+    await processors.get('cons/lc/access/deleteListing')!({
+      organizationId: 'org-1',
+      consumerAccessListingId: 'listing-1'
+    });
+
+    expect(listingDeleteMock).toHaveBeenCalledWith({
+      organization,
+      consumerAccessListing: listing
+    });
+  });
+
+  it('deletes one access through the access service', async () => {
+    let organization = { id: 'org-1' };
+    let access = { id: 'access-1' };
+    db.organization.findUnique.mockResolvedValue(organization);
+    db.consumerAccess.findUnique.mockResolvedValue(access);
+
+    await processors.get('cons/lc/access/deleteAccess')!({
+      organizationId: 'org-1',
+      consumerAccessId: 'access-1'
+    });
+
+    expect(accessDeleteMock).toHaveBeenCalledWith({
+      organization,
+      consumerAccess: access
+    });
+  });
+});

--- a/src/metorial/modules/consumer/test/consumerAccessService.test.ts
+++ b/src/metorial/modules/consumer/test/consumerAccessService.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { tx, revokeAccessForConsumerAccessMock, PrismaClientKnownRequestError } = vi.hoisted(
+  () => {
+    class PrismaClientKnownRequestError extends Error {
+      code: string;
+
+      constructor(code: string) {
+        super(code);
+        this.code = code;
+      }
+    }
+
+    return {
+      tx: {
+        consumerAccess: {
+          delete: vi.fn()
+        }
+      },
+      revokeAccessForConsumerAccessMock: vi.fn(),
+      PrismaClientKnownRequestError
+    };
+  }
+);
+
+vi.mock('@metorial/db', () => ({
+  db: {},
+  ID: {
+    generateId: vi.fn()
+  },
+  Prisma: {
+    PrismaClientKnownRequestError
+  },
+  withTransaction: vi.fn(async (fn: any) => await fn(tx))
+}));
+
+vi.mock('../src/services/consumerAccess/accessPolicy', () => ({
+  consumerAccessPolicyService: {
+    grantAccess: vi.fn(),
+    revokeAccessForConsumerAccess: revokeAccessForConsumerAccessMock
+  }
+}));
+
+import { consumerAccessService } from '../src/services/consumerAccess/consumerAccess';
+
+describe('consumer access service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('revokes policies when delete is retried after the row is already gone', async () => {
+    let organization = { id: 'org-1' };
+    let consumerAccess = {
+      id: 'access-1',
+      oid: 1n,
+      type: 'provider_template',
+      consumerGroup: { accessTagOid: 2n },
+      providerTemplate: { oid: 3n },
+      magicMcpServer: null,
+      skill: null,
+      skillTemplate: null,
+      skillGroup: null,
+      skillMarketplace: null,
+      listing: null
+    };
+
+    tx.consumerAccess.delete.mockRejectedValue(new PrismaClientKnownRequestError('P2025'));
+
+    await consumerAccessService.deleteConsumerAccess({
+      organization: organization as any,
+      consumerAccess: consumerAccess as any
+    });
+
+    expect(revokeAccessForConsumerAccessMock).toHaveBeenCalledWith({
+      organization,
+      consumerAccess
+    });
+  });
+});

--- a/src/metorial/modules/magic/src/queues/lifecycle/index.ts
+++ b/src/metorial/modules/magic/src/queues/lifecycle/index.ts
@@ -14,7 +14,14 @@ import {
   magicMcpServerDeletedQueueProcessor,
   magicMcpServerUpdatedQueueProcessor
 } from './magicMcpServer';
-import { magicMcpBackingCleanupQueueProcessor } from './magicMcpBackingCleanup';
+import {
+  magicMcpBackingCleanupBackingsManyQueueProcessor,
+  magicMcpBackingCleanupIntegrationInstancesManyQueueProcessor,
+  magicMcpBackingCleanupManyQueueProcessor,
+  magicMcpBackingCleanupProviderTemplateQueueProcessor,
+  magicMcpBackingCleanupProviderTemplatesManyQueueProcessor,
+  magicMcpBackingCleanupServerQueueProcessor
+} from './magicMcpBackingCleanup';
 import {
   providerTemplateArchivedQueueProcessor,
   providerTemplateCreatedQueueProcessor,
@@ -37,7 +44,12 @@ export let magicLifecycleQueueProcessor = combineQueueProcessors([
   magicMcpServerCreatedQueueProcessor,
   magicMcpServerUpdatedQueueProcessor,
   magicMcpServerDeletedQueueProcessor,
-  magicMcpBackingCleanupQueueProcessor,
+  magicMcpBackingCleanupManyQueueProcessor,
+  magicMcpBackingCleanupBackingsManyQueueProcessor,
+  magicMcpBackingCleanupIntegrationInstancesManyQueueProcessor,
+  magicMcpBackingCleanupServerQueueProcessor,
+  magicMcpBackingCleanupProviderTemplatesManyQueueProcessor,
+  magicMcpBackingCleanupProviderTemplateQueueProcessor,
   providerTemplateCreatedQueueProcessor,
   providerTemplateUpdatedQueueProcessor,
   providerTemplateArchivedQueueProcessor

--- a/src/metorial/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
+++ b/src/metorial/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
@@ -148,6 +148,18 @@ export let magicMcpBackingCleanupProviderTemplatesManyQueueProcessor =
       }))
     );
 
+    await magicMcpBackingCleanupManyQueue.addManyWithOps(
+      providerTemplates.map(providerTemplate => ({
+        data: {
+          instanceId: data.instanceId,
+          providerTemplateId: providerTemplate.id
+        },
+        opts: {
+          id: queueJobId('provider-template-servers', data.instanceId, providerTemplate.id)
+        }
+      }))
+    );
+
     let lastProviderTemplate = providerTemplates[providerTemplates.length - 1];
     if (!lastProviderTemplate) return;
 

--- a/src/metorial/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
+++ b/src/metorial/modules/magic/src/queues/lifecycle/magicMcpBackingCleanup.ts
@@ -1,21 +1,175 @@
 import { db, type Prisma, withTransaction } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
+import { enqueueConsumerTargetAccessCleanup } from '@metorial/module-consumer';
 import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
 import { createQueue } from '@metorial/queue';
 import { magicMcpServerDeletedQueue } from './magicMcpServer';
+import { providerTemplateArchivedQueue } from './providerTemplate';
 
 type MagicMcpBackingCleanupQueueInput = {
   instanceId: string;
   integrationId?: string | null;
   integrationInstanceId?: string | null;
+  providerTemplateId?: string | null;
+  serverCursor?: string;
 };
 
-let archiveLinkedMagicMcpServer = async (d: { magicMcpServerId: string }) => {
+type MagicMcpBackingCleanupBackingsManyInput = {
+  instanceId: string;
+  integrationId?: string | null;
+  integrationInstanceId?: string | null;
+  backingCursor?: string | null;
+  serverCursor?: string;
+};
+
+type MagicMcpBackingCleanupIntegrationInstancesManyInput = {
+  instanceId: string;
+  integrationId?: string | null;
+  integrationInstanceId?: string | null;
+  integrationInstanceCursor?: string | null;
+  serverCursor?: string;
+};
+
+type ProviderTemplateCleanupManyInput = {
+  instanceId: string;
+  integrationId?: string | null;
+  providerTemplateId?: string | null;
+  cursor?: string | null;
+};
+
+type ProviderTemplateCleanupSingleInput = {
+  instanceId: string;
+  providerTemplateId: string;
+};
+
+type ServerCleanupSingleInput = {
+  instanceId: string;
+  magicMcpServerId: string;
+};
+
+let PAGE_SIZE = 100;
+
+let queueJobId = (...parts: (string | null | undefined)[]) =>
+  parts.filter(Boolean).join('-').replaceAll(':', '-');
+
+let archiveProviderTemplate = async (d: ProviderTemplateCleanupSingleInput) => {
+  let providerTemplate = await db.providerTemplate.findFirst({
+    where: {
+      id: d.providerTemplateId,
+      instance: {
+        id: d.instanceId
+      }
+    },
+    include: {
+      instance: {
+        include: {
+          organization: true
+        }
+      }
+    }
+  });
+  if (!providerTemplate) return;
+
+  if (providerTemplate.status === 'active') {
+    let archived = await db.providerTemplate.update({
+      where: { oid: providerTemplate.oid },
+      data: {
+        status: 'archived',
+        archivedAt: new Date()
+      }
+    });
+
+    await providerTemplateArchivedQueue.addManyWithOps([
+      {
+        data: { providerTemplateId: archived.id },
+        opts: { id: queueJobId('provider-template-archived', archived.id) }
+      }
+    ]);
+  }
+
+  await enqueueConsumerTargetAccessCleanup({
+    organizationId: providerTemplate.instance.organization.id,
+    providerTemplateId: providerTemplate.id
+  });
+};
+
+export let magicMcpBackingCleanupProviderTemplatesManyQueue =
+  createQueue<ProviderTemplateCleanupManyInput>({
+    name: 'mgc/lc/magicMcpBacking/cleanupProviderTemplatesMany'
+  });
+
+export let magicMcpBackingCleanupProviderTemplateQueue =
+  createQueue<ProviderTemplateCleanupSingleInput>({
+    name: 'mgc/lc/magicMcpBacking/cleanupProviderTemplate'
+  });
+
+export let magicMcpBackingCleanupProviderTemplatesManyQueueProcessor =
+  magicMcpBackingCleanupProviderTemplatesManyQueue.process(async data => {
+    if (!data.integrationId && !data.providerTemplateId) return;
+
+    if (data.providerTemplateId) {
+      await magicMcpBackingCleanupProviderTemplateQueue.addManyWithOps([
+        {
+          data: {
+            instanceId: data.instanceId,
+            providerTemplateId: data.providerTemplateId
+          },
+          opts: {
+            id: queueJobId('provider-template', data.instanceId, data.providerTemplateId)
+          }
+        }
+      ]);
+      return;
+    }
+
+    let providerTemplates = await db.providerTemplate.findMany({
+      where: {
+        instance: {
+          id: data.instanceId
+        },
+        id: data.cursor ? { gt: data.cursor } : undefined,
+        subspaceIntegrationId: data.integrationId ?? undefined,
+        status: { not: 'deleted' }
+      },
+      orderBy: { id: 'asc' },
+      take: PAGE_SIZE,
+      select: { id: true }
+    });
+
+    await magicMcpBackingCleanupProviderTemplateQueue.addManyWithOps(
+      providerTemplates.map(providerTemplate => ({
+        data: {
+          instanceId: data.instanceId,
+          providerTemplateId: providerTemplate.id
+        },
+        opts: {
+          id: queueJobId('provider-template', data.instanceId, providerTemplate.id)
+        }
+      }))
+    );
+
+    let lastProviderTemplate = providerTemplates[providerTemplates.length - 1];
+    if (!lastProviderTemplate) return;
+
+    await magicMcpBackingCleanupProviderTemplatesManyQueue.add({
+      ...data,
+      cursor: lastProviderTemplate.id
+    });
+  });
+
+export let magicMcpBackingCleanupProviderTemplateQueueProcessor =
+  magicMcpBackingCleanupProviderTemplateQueue.process(async data => {
+    await archiveProviderTemplate(data);
+  });
+
+let archiveLinkedMagicMcpServer = async (d: ServerCleanupSingleInput) => {
   let magicMcpServer = await db.magicMcpServer.findFirst({
     where: {
       id: d.magicMcpServerId,
-      ownerType: { in: ['integration', 'server_owned'] },
-      status: 'active'
+      status: 'active',
+      instance: {
+        id: d.instanceId
+      }
     },
     include: {
       instance: {
@@ -28,11 +182,33 @@ let archiveLinkedMagicMcpServer = async (d: { magicMcpServerId: string }) => {
   if (!magicMcpServer) return;
 
   let archived = await withTransaction(async db => {
+    let endpointLinks = await db.magicMcpEndpointServer.findMany({
+      where: {
+        magicMcpServerOid: magicMcpServer.oid
+      },
+      select: {
+        magicMcpEndpointOid: true
+      }
+    });
+
     await db.magicMcpEndpointServer.deleteMany({
       where: {
         magicMcpServerOid: magicMcpServer.oid
       }
     });
+
+    if (endpointLinks.length) {
+      await db.magicMcpSession.updateMany({
+        where: {
+          magicMcpEndpointOid: {
+            in: endpointLinks.map(link => link.magicMcpEndpointOid)
+          }
+        },
+        data: {
+          isConsumerReconciled: false
+        }
+      });
+    }
 
     return await db.magicMcpServer.update({
       where: { oid: magicMcpServer.oid },
@@ -43,7 +219,12 @@ let archiveLinkedMagicMcpServer = async (d: { magicMcpServerId: string }) => {
     });
   });
 
-  await magicMcpServerDeletedQueue.add({ magicMcpServerId: archived.id });
+  await magicMcpServerDeletedQueue.addManyWithOps([
+    {
+      data: { magicMcpServerId: archived.id },
+      opts: { id: queueJobId('server-deleted', archived.id) }
+    }
+  ]);
   await Fabric.fire('magic_mcp.server.archived:after', {
     organization: magicMcpServer.instance.organization,
     instance: magicMcpServer.instance,
@@ -51,62 +232,252 @@ let archiveLinkedMagicMcpServer = async (d: { magicMcpServerId: string }) => {
   });
 };
 
-export let magicMcpBackingCleanupQueue = createQueue<MagicMcpBackingCleanupQueueInput>({
-  name: 'mgc/lc/magicMcpBacking/cleanup'
+export let magicMcpBackingCleanupManyQueue = createQueue<MagicMcpBackingCleanupQueueInput>({
+  name: 'mgc/lc/magicMcpBacking/cleanupMany'
+});
+
+export let magicMcpBackingCleanupBackingsManyQueue =
+  createQueue<MagicMcpBackingCleanupBackingsManyInput>({
+    name: 'mgc/lc/magicMcpBacking/cleanupBackingsMany'
+  });
+
+export let magicMcpBackingCleanupIntegrationInstancesManyQueue =
+  createQueue<MagicMcpBackingCleanupIntegrationInstancesManyInput>({
+    name: 'mgc/lc/magicMcpBacking/cleanupInstancesMany'
+  });
+
+export let magicMcpBackingCleanupServerQueue = createQueue<ServerCleanupSingleInput>({
+  name: 'mgc/lc/magicMcpBacking/cleanupServer'
 });
 
 export let enqueueMagicMcpBackingCleanup = async (d: MagicMcpBackingCleanupQueueInput) => {
   if (!d.integrationId && !d.integrationInstanceId) return;
 
-  await magicMcpBackingCleanupQueue.add(d);
+  await magicMcpBackingCleanupBackingsManyQueue.add(d);
+  await magicMcpBackingCleanupIntegrationInstancesManyQueue.add(d);
+  if (d.integrationId) {
+    await magicMcpBackingCleanupProviderTemplatesManyQueue.add({
+      instanceId: d.instanceId,
+      integrationId: d.integrationId
+    });
+  }
 };
 
-export let magicMcpBackingCleanupQueueProcessor = magicMcpBackingCleanupQueue.process(
+export let enqueueProviderTemplateBackingCleanup = async (d: {
+  instanceId: string;
+  integrationId?: string | null;
+  providerTemplateId: string;
+}) => {
+  await magicMcpBackingCleanupManyQueue.add({
+    instanceId: d.instanceId,
+    providerTemplateId: d.providerTemplateId
+  });
+  await magicMcpBackingCleanupProviderTemplatesManyQueue.add({
+    instanceId: d.instanceId,
+    integrationId: d.integrationId,
+    providerTemplateId: d.providerTemplateId
+  });
+};
+
+export let magicMcpBackingCleanupManyQueueProcessor = magicMcpBackingCleanupManyQueue.process(
   async data => {
     let instance = await db.instance.findUnique({
       where: { id: data.instanceId }
     });
     if (!instance) return;
 
-    let { magicMcpServerBackingIds } =
-      await subspaceMagicMcpBackingService.resolveServerBackingIdsByIntegrationResource({
-        instance,
-        integrationId: data.integrationId,
-        integrationInstanceId: data.integrationInstanceId
-      });
-    let linkedServerFilters: Prisma.MagicMcpServerWhereInput[] = [];
-
-    if (magicMcpServerBackingIds.length) {
-      linkedServerFilters.push({
-        id: { in: magicMcpServerBackingIds }
-      });
-    }
-
-    if (data.integrationInstanceId) {
-      linkedServerFilters.push({
-        subspaceIntegrationInstanceId: data.integrationInstanceId
-      });
-    }
-
-    if (!linkedServerFilters.length) return;
+    if (!data.providerTemplateId) return;
 
     let linkedServers = await db.magicMcpServer.findMany({
       where: {
         instanceOid: instance.oid,
-        ownerType: { in: ['integration', 'server_owned'] },
         status: 'active',
-        OR: linkedServerFilters
+        id: data.serverCursor ? { gt: data.serverCursor } : undefined,
+        providerTemplateId: data.providerTemplateId
       },
+      orderBy: { id: 'asc' },
+      take: PAGE_SIZE,
       select: {
         id: true
       }
     });
 
-    for (let server of linkedServers) {
-      await archiveLinkedMagicMcpServer({ magicMcpServerId: server.id });
-    }
+    await magicMcpBackingCleanupServerQueue.addManyWithOps(
+      linkedServers.map(server => ({
+        data: {
+          instanceId: data.instanceId,
+          magicMcpServerId: server.id
+        },
+        opts: {
+          id: queueJobId('server', data.instanceId, server.id)
+        }
+      }))
+    );
+
+    let lastServer = linkedServers[linkedServers.length - 1];
+    if (!lastServer) return;
+
+    await magicMcpBackingCleanupManyQueue.add({
+      ...data,
+      serverCursor: lastServer.id
+    });
   }
 );
+
+export let magicMcpBackingCleanupBackingsManyQueueProcessor =
+  magicMcpBackingCleanupBackingsManyQueue.process(async data => {
+    let instance = await db.instance.findUnique({
+      where: { id: data.instanceId }
+    });
+    if (!instance) return;
+
+    let { magicMcpServerBackingIds, nextBackingCursor } =
+      await subspaceMagicMcpBackingService.resolveIntegrationResourceLinks({
+        instance,
+        integrationId: data.integrationId,
+        integrationInstanceId: data.integrationInstanceId,
+        backingCursor: data.backingCursor,
+        limit: PAGE_SIZE,
+        includeBackings: true,
+        includeIntegrationInstances: false
+      });
+
+    if (!magicMcpServerBackingIds.length) {
+      if (nextBackingCursor) {
+        await magicMcpBackingCleanupBackingsManyQueue.add({
+          ...data,
+          backingCursor: nextBackingCursor,
+          serverCursor: undefined
+        });
+      }
+      return;
+    }
+
+    let linkedServers = await db.magicMcpServer.findMany({
+      where: {
+        instanceOid: instance.oid,
+        status: 'active',
+        id: {
+          ...(data.serverCursor ? { gt: data.serverCursor } : {}),
+          in: magicMcpServerBackingIds
+        }
+      },
+      orderBy: { id: 'asc' },
+      take: PAGE_SIZE,
+      select: {
+        id: true
+      }
+    });
+
+    await magicMcpBackingCleanupServerQueue.addManyWithOps(
+      linkedServers.map(server => ({
+        data: {
+          instanceId: data.instanceId,
+          magicMcpServerId: server.id
+        },
+        opts: {
+          id: queueJobId('server', data.instanceId, server.id)
+        }
+      }))
+    );
+
+    let lastServer = linkedServers[linkedServers.length - 1];
+
+    if (lastServer) {
+      await magicMcpBackingCleanupBackingsManyQueue.add({
+        ...data,
+        serverCursor: lastServer.id
+      });
+      return;
+    }
+
+    if (!nextBackingCursor) return;
+
+    await magicMcpBackingCleanupBackingsManyQueue.add({
+      ...data,
+      backingCursor: nextBackingCursor,
+      serverCursor: undefined
+    });
+  });
+
+export let magicMcpBackingCleanupIntegrationInstancesManyQueueProcessor =
+  magicMcpBackingCleanupIntegrationInstancesManyQueue.process(async data => {
+    let instance = await db.instance.findUnique({
+      where: { id: data.instanceId }
+    });
+    if (!instance) return;
+
+    let { integrationInstanceIds, nextIntegrationInstanceCursor } =
+      await subspaceMagicMcpBackingService.resolveIntegrationResourceLinks({
+        instance,
+        integrationId: data.integrationId,
+        integrationInstanceId: data.integrationInstanceId,
+        integrationInstanceCursor: data.integrationInstanceCursor,
+        limit: PAGE_SIZE,
+        includeBackings: false,
+        includeIntegrationInstances: true
+      });
+
+    if (!integrationInstanceIds.length) {
+      if (nextIntegrationInstanceCursor) {
+        await magicMcpBackingCleanupIntegrationInstancesManyQueue.add({
+          ...data,
+          integrationInstanceCursor: nextIntegrationInstanceCursor,
+          serverCursor: undefined
+        });
+      }
+      return;
+    }
+
+    let linkedServers = await db.magicMcpServer.findMany({
+      where: {
+        instanceOid: instance.oid,
+        status: 'active',
+        id: data.serverCursor ? { gt: data.serverCursor } : undefined,
+        subspaceIntegrationInstanceId: { in: integrationInstanceIds }
+      },
+      orderBy: { id: 'asc' },
+      take: PAGE_SIZE,
+      select: {
+        id: true
+      }
+    });
+
+    await magicMcpBackingCleanupServerQueue.addManyWithOps(
+      linkedServers.map(server => ({
+        data: {
+          instanceId: data.instanceId,
+          magicMcpServerId: server.id
+        },
+        opts: {
+          id: queueJobId('server', data.instanceId, server.id)
+        }
+      }))
+    );
+
+    let lastServer = linkedServers[linkedServers.length - 1];
+
+    if (lastServer) {
+      await magicMcpBackingCleanupIntegrationInstancesManyQueue.add({
+        ...data,
+        serverCursor: lastServer.id
+      });
+      return;
+    }
+
+    if (!nextIntegrationInstanceCursor) return;
+
+    await magicMcpBackingCleanupIntegrationInstancesManyQueue.add({
+      ...data,
+      integrationInstanceCursor: nextIntegrationInstanceCursor,
+      serverCursor: undefined
+    });
+  });
+
+export let magicMcpBackingCleanupServerQueueProcessor =
+  magicMcpBackingCleanupServerQueue.process(async data => {
+    await archiveLinkedMagicMcpServer(data);
+  });
 
 Fabric.listen('provider.integration.deleted:after', async event => {
   await enqueueMagicMcpBackingCleanup({

--- a/src/metorial/modules/magic/src/queues/lifecycle/magicMcpServer.ts
+++ b/src/metorial/modules/magic/src/queues/lifecycle/magicMcpServer.ts
@@ -1,4 +1,5 @@
 import { db } from '@metorial/db';
+import { enqueueConsumerTargetAccessCleanup } from '@metorial/module-consumer';
 import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
 import { createQueue } from '@metorial/queue';
 import {
@@ -11,6 +12,31 @@ import { indexMagicMcpServerSearchQueue } from '../search/magicMcpServer';
 
 let queueMagicMcpServerIndex = async (magicMcpServerId: string) => {
   await indexMagicMcpServerSearchQueue.add({ magicMcpServerId });
+};
+
+let cleanupMagicMcpServerConsumerRecords = async (d: { magicMcpServerId: string }) => {
+  let magicMcpServer = await db.magicMcpServer.findUnique({
+    where: { id: d.magicMcpServerId },
+    include: {
+      instance: {
+        include: {
+          organization: true
+        }
+      }
+    }
+  });
+  if (!magicMcpServer) return;
+
+  await db.consumerIntegration.deleteMany({
+    where: {
+      magicMcpServerOid: magicMcpServer.oid
+    }
+  });
+
+  await enqueueConsumerTargetAccessCleanup({
+    organizationId: magicMcpServer.instance.organization.id,
+    magicMcpServerId: magicMcpServer.id
+  });
 };
 
 type MagicMcpServerLifecycleQueueInput = {
@@ -90,6 +116,9 @@ export let magicMcpServerDeletedQueueProcessor = magicMcpServerDeletedQueue.proc
     if (!magicMcpServer) return;
 
     await queueMagicMcpServerIndex(data.magicMcpServerId);
+    await cleanupMagicMcpServerConsumerRecords({
+      magicMcpServerId: data.magicMcpServerId
+    });
 
     if (magicMcpServer.hasSubspaceBacking) {
       await subspaceMagicMcpBackingService.archiveServer({

--- a/src/metorial/modules/magic/src/services/providerTemplate.ts
+++ b/src/metorial/modules/magic/src/services/providerTemplate.ts
@@ -23,6 +23,7 @@ import {
   providerTemplateCreatedQueue,
   providerTemplateUpdatedQueue
 } from '../queues/lifecycle/providerTemplate';
+import { enqueueProviderTemplateBackingCleanup } from '../queues/lifecycle/magicMcpBackingCleanup';
 
 export type EnrichedProviderTemplate = ProviderTemplate & {
   subspaceIntegrationId: string | null;
@@ -59,6 +60,37 @@ class ProviderTemplateServiceImpl {
         subspaceIntegrationId: d.integrationId
       }
     });
+  }
+
+  private async resurrectProviderTemplate(d: {
+    providerTemplate: ProviderTemplate;
+    organization: Organization;
+    instance: Instance;
+    input: ProviderTemplateCreateInput;
+    integrationId: string;
+  }) {
+    let providerTemplate = await withTransaction(async db => {
+      return await db.providerTemplate.update({
+        where: {
+          oid: d.providerTemplate.oid
+        },
+        data: {
+          status: 'active',
+          archivedAt: null,
+          deletedAt: null,
+          name: d.input.name,
+          description: d.input.description,
+          metadata: d.input.metadata ?? {},
+          organizationOid: d.organization.oid,
+          instanceOid: d.instance.oid,
+          hasSubspaceBacking: true,
+          subspaceIntegrationId: d.integrationId
+        }
+      });
+    });
+
+    await providerTemplateCreatedQueue.add({ providerTemplateId: providerTemplate.id });
+    return providerTemplate;
   }
 
   async getProviderTemplateById(d: {
@@ -111,6 +143,20 @@ class ProviderTemplateServiceImpl {
     });
     if (existing) return existing;
 
+    let inactive = await this.getProviderTemplateByIntegrationId({
+      instance: d.instance,
+      integrationId: backing.integrationId
+    });
+    if (inactive && inactive.status !== 'deleted') {
+      return await this.resurrectProviderTemplate({
+        providerTemplate: inactive,
+        organization: d.organization,
+        instance: d.instance,
+        input: d.input,
+        integrationId: backing.integrationId
+      });
+    }
+
     try {
       let providerTemplate = await withTransaction(async db => {
         return await db.providerTemplate.create({
@@ -136,7 +182,15 @@ class ProviderTemplateServiceImpl {
           instance: d.instance,
           integrationId: backing.integrationId
         });
-        if (providerTemplate) return providerTemplate;
+        if (providerTemplate && providerTemplate.status !== 'deleted') {
+          return await this.resurrectProviderTemplate({
+            providerTemplate,
+            organization: d.organization,
+            instance: d.instance,
+            input: d.input,
+            integrationId: backing.integrationId
+          });
+        }
       }
 
       throw error;
@@ -211,14 +265,12 @@ class ProviderTemplateServiceImpl {
       });
     });
 
-    if (providerTemplate.hasSubspaceBacking) {
-      await subspaceMagicMcpBackingService.archiveProviderTemplate({
-        instance: d.instance,
-        providerTemplateBackingId: providerTemplate.id
-      });
-    }
-
     await providerTemplateArchivedQueue.add({ providerTemplateId: providerTemplate.id });
+    await enqueueProviderTemplateBackingCleanup({
+      instanceId: d.instance.id,
+      integrationId: providerTemplate.subspaceIntegrationId,
+      providerTemplateId: providerTemplate.id
+    });
 
     return providerTemplate;
   }

--- a/src/metorial/modules/magic/test/magicLifecycleDeleteFanout.test.ts
+++ b/src/metorial/modules/magic/test/magicLifecycleDeleteFanout.test.ts
@@ -325,6 +325,12 @@ describe('magic MCP lifecycle delete fanout', () => {
         opts: { id: 'provider-template-instance-1-provider-template-1' }
       }
     ]);
+    expect(magicMcpBackingCleanupManyQueue.addManyWithOps).toHaveBeenCalledWith([
+      {
+        data: { instanceId: 'instance-1', providerTemplateId: 'provider-template-1' },
+        opts: { id: 'provider-template-servers-instance-1-provider-template-1' }
+      }
+    ]);
   });
 
   it('cleans access for already archived provider templates', async () => {

--- a/src/metorial/modules/magic/test/magicLifecycleDeleteFanout.test.ts
+++ b/src/metorial/modules/magic/test/magicLifecycleDeleteFanout.test.ts
@@ -5,6 +5,7 @@ vi.mock('@metorial/queue', () => ({
     name: config.name,
     add: vi.fn(),
     addMany: vi.fn(),
+    addManyWithOps: vi.fn(),
     process: vi.fn(handler => ({
       handler
     }))
@@ -12,21 +13,65 @@ vi.mock('@metorial/queue', () => ({
   combineQueueProcessors: vi.fn(processors => processors)
 }));
 
-vi.mock('@metorial/db', () => ({
-  db: {
+vi.mock('@metorial/db', () => {
+  let db = {
     magicMcpServer: {
-      findUnique: vi.fn()
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn()
     },
     magicMcpEndpoint: {
       findUnique: vi.fn()
+    },
+    magicMcpEndpointServer: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn()
+    },
+    magicMcpSession: {
+      updateMany: vi.fn()
+    },
+    instance: {
+      findUnique: vi.fn()
+    },
+    providerTemplate: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn()
+    },
+    consumerIntegration: {
+      deleteMany: vi.fn()
+    },
+    consumerAccessListing: {
+      findMany: vi.fn()
+    },
+    consumerAccess: {
+      findMany: vi.fn()
     }
-  }
-}));
+  };
+
+  return {
+    db,
+    withTransaction: vi.fn(async callback => await callback(db))
+  };
+});
 
 vi.mock('@metorial/module-subspace', () => ({
   subspaceMagicMcpBackingService: {
     archiveServer: vi.fn(),
-    archiveEndpoint: vi.fn()
+    archiveEndpoint: vi.fn(),
+    resolveIntegrationResourceLinks: vi.fn()
+  }
+}));
+
+vi.mock('@metorial/module-consumer', () => ({
+  enqueueConsumerTargetAccessCleanup: vi.fn()
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: {
+    listen: vi.fn(),
+    fire: vi.fn()
   }
 }));
 
@@ -36,19 +81,43 @@ vi.mock('../src/queues/search/magicMcpServer', () => ({
   }
 }));
 
+vi.mock('../src/queues/lifecycle/providerTemplate', () => ({
+  providerTemplateArchivedQueue: {
+    add: vi.fn(),
+    addManyWithOps: vi.fn()
+  }
+}));
+
 import { db } from '@metorial/db';
+import { enqueueConsumerTargetAccessCleanup } from '@metorial/module-consumer';
 import { subspaceMagicMcpBackingService } from '@metorial/module-subspace';
 import { magicMcpEndpointDeletedQueueProcessor } from '../src/queues/lifecycle/magicMcpEndpoint';
+import {
+  magicMcpBackingCleanupBackingsManyQueueProcessor,
+  magicMcpBackingCleanupIntegrationInstancesManyQueueProcessor,
+  magicMcpBackingCleanupManyQueue,
+  magicMcpBackingCleanupManyQueueProcessor,
+  magicMcpBackingCleanupProviderTemplateQueue,
+  magicMcpBackingCleanupProviderTemplateQueueProcessor,
+  magicMcpBackingCleanupProviderTemplatesManyQueue,
+  magicMcpBackingCleanupProviderTemplatesManyQueueProcessor,
+  magicMcpBackingCleanupServerQueue,
+  magicMcpBackingCleanupServerQueueProcessor
+} from '../src/queues/lifecycle/magicMcpBackingCleanup';
 import { magicMcpServerDeletedQueueProcessor } from '../src/queues/lifecycle/magicMcpServer';
 import { indexMagicMcpServerSearchQueue } from '../src/queues/search/magicMcpServer';
 
 describe('magic MCP lifecycle delete fanout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(db.consumerAccessListing.findMany).mockResolvedValue([]);
+    vi.mocked(db.consumerAccess.findMany).mockResolvedValue([]);
+    vi.mocked(db.providerTemplate.findMany).mockResolvedValue([]);
+    vi.mocked(db.magicMcpEndpointServer.findMany).mockResolvedValue([]);
   });
 
   it('archives a server backing without deleting legacy session templates', async () => {
-    let instance = { id: 'instance-1' };
+    let instance = { id: 'instance-1', organization: { id: 'org-1' } };
     vi.mocked(db.magicMcpServer.findUnique).mockResolvedValue({
       oid: 10n,
       id: 'server-1',
@@ -66,6 +135,217 @@ describe('magic MCP lifecycle delete fanout', () => {
     expect(subspaceMagicMcpBackingService.archiveServer).toHaveBeenCalledWith({
       instance,
       magicMcpServerBackingId: 'server-1'
+    });
+    expect(db.consumerIntegration.deleteMany).toHaveBeenCalledWith({
+      where: { magicMcpServerOid: 10n }
+    });
+    expect(enqueueConsumerTargetAccessCleanup).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      magicMcpServerId: 'server-1'
+    });
+  });
+
+  it('enqueues single server cleanup jobs from one backing link page', async () => {
+    let instance = { id: 'instance-1', oid: 1n };
+    vi.mocked(db.instance.findUnique).mockResolvedValue(instance as any);
+    vi.mocked(
+      subspaceMagicMcpBackingService.resolveIntegrationResourceLinks
+    ).mockResolvedValue({
+      magicMcpServerBackingIds: ['backing-server-1'],
+      integrationInstanceIds: [],
+      nextBackingCursor: 'backing-server-1',
+      nextIntegrationInstanceCursor: null
+    });
+    vi.mocked(db.magicMcpServer.findMany).mockResolvedValue([
+      { id: 'server-1' },
+      { id: 'server-2' }
+    ] as any);
+
+    await (magicMcpBackingCleanupBackingsManyQueueProcessor as any).handler({
+      instanceId: 'instance-1',
+      integrationId: 'integration-1'
+    });
+
+    expect(
+      subspaceMagicMcpBackingService.resolveIntegrationResourceLinks
+    ).toHaveBeenCalledWith({
+      instance,
+      integrationId: 'integration-1',
+      integrationInstanceId: undefined,
+      backingCursor: undefined,
+      limit: 100,
+      includeBackings: true,
+      includeIntegrationInstances: false
+    });
+    expect(db.magicMcpServer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['backing-server-1'] }
+        })
+      })
+    );
+    expect(magicMcpBackingCleanupServerQueue.addManyWithOps).toHaveBeenCalledWith([
+      {
+        data: { instanceId: 'instance-1', magicMcpServerId: 'server-1' },
+        opts: { id: 'server-instance-1-server-1' }
+      },
+      {
+        data: { instanceId: 'instance-1', magicMcpServerId: 'server-2' },
+        opts: { id: 'server-instance-1-server-2' }
+      }
+    ]);
+    expect(db.magicMcpServer.update).not.toHaveBeenCalled();
+  });
+
+  it('enqueues single server cleanup jobs from one integration instance page', async () => {
+    let instance = { id: 'instance-1', oid: 1n };
+    vi.mocked(db.instance.findUnique).mockResolvedValue(instance as any);
+    vi.mocked(
+      subspaceMagicMcpBackingService.resolveIntegrationResourceLinks
+    ).mockResolvedValue({
+      magicMcpServerBackingIds: [],
+      integrationInstanceIds: ['integration-instance-1'],
+      nextBackingCursor: null,
+      nextIntegrationInstanceCursor: null
+    });
+    vi.mocked(db.magicMcpServer.findMany).mockResolvedValue([{ id: 'server-1' }] as any);
+
+    await (magicMcpBackingCleanupIntegrationInstancesManyQueueProcessor as any).handler({
+      instanceId: 'instance-1',
+      integrationId: 'integration-1'
+    });
+
+    expect(
+      subspaceMagicMcpBackingService.resolveIntegrationResourceLinks
+    ).toHaveBeenCalledWith({
+      instance,
+      integrationId: 'integration-1',
+      integrationInstanceId: undefined,
+      integrationInstanceCursor: undefined,
+      limit: 100,
+      includeBackings: false,
+      includeIntegrationInstances: true
+    });
+    expect(db.magicMcpServer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          subspaceIntegrationInstanceId: { in: ['integration-instance-1'] }
+        })
+      })
+    );
+    expect(magicMcpBackingCleanupServerQueue.addManyWithOps).toHaveBeenCalledWith([
+      {
+        data: { instanceId: 'instance-1', magicMcpServerId: 'server-1' },
+        opts: { id: 'server-instance-1-server-1' }
+      }
+    ]);
+  });
+
+  it('enqueues provider-template owned servers without resolving the full integration', async () => {
+    let instance = { id: 'instance-1', oid: 1n };
+    vi.mocked(db.instance.findUnique).mockResolvedValue(instance as any);
+    vi.mocked(
+      subspaceMagicMcpBackingService.resolveIntegrationResourceLinks
+    ).mockResolvedValue({
+      magicMcpServerBackingIds: [],
+      integrationInstanceIds: [],
+      nextBackingCursor: null,
+      nextIntegrationInstanceCursor: null
+    });
+    vi.mocked(db.magicMcpServer.findMany).mockResolvedValue([{ id: 'server-1' }] as any);
+
+    await (magicMcpBackingCleanupManyQueueProcessor as any).handler({
+      instanceId: 'instance-1',
+      providerTemplateId: 'provider-template-1'
+    });
+
+    expect(
+      subspaceMagicMcpBackingService.resolveIntegrationResourceLinks
+    ).not.toHaveBeenCalled();
+    expect(db.magicMcpServer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          providerTemplateId: 'provider-template-1'
+        })
+      })
+    );
+    expect(magicMcpBackingCleanupServerQueue.addManyWithOps).toHaveBeenCalledWith([
+      {
+        data: { instanceId: 'instance-1', magicMcpServerId: 'server-1' },
+        opts: { id: 'server-instance-1-server-1' }
+      }
+    ]);
+  });
+
+  it('archives one server from the single cleanup queue', async () => {
+    let instance = { id: 'instance-1', oid: 1n, organization: { id: 'org-1' } };
+    vi.mocked(db.magicMcpServer.findFirst).mockResolvedValue({
+      oid: 10n,
+      id: 'server-1',
+      status: 'active',
+      instance
+    } as any);
+    vi.mocked(db.magicMcpEndpointServer.findMany).mockResolvedValue([]);
+    vi.mocked(db.magicMcpServer.update).mockResolvedValue({
+      oid: 10n,
+      id: 'server-1',
+      status: 'archived'
+    } as any);
+
+    await (magicMcpBackingCleanupServerQueueProcessor as any).handler({
+      instanceId: 'instance-1',
+      magicMcpServerId: 'server-1'
+    });
+
+    expect(db.magicMcpServer.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { oid: 10n } })
+    );
+  });
+
+  it('enqueues archived provider templates for single cleanup', async () => {
+    vi.mocked(db.providerTemplate.findMany).mockResolvedValue([
+      { id: 'provider-template-1' }
+    ] as any);
+
+    await (magicMcpBackingCleanupProviderTemplatesManyQueueProcessor as any).handler({
+      instanceId: 'instance-1',
+      integrationId: 'integration-1'
+    });
+
+    expect(db.providerTemplate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { not: 'deleted' }
+        })
+      })
+    );
+    expect(magicMcpBackingCleanupProviderTemplateQueue.addManyWithOps).toHaveBeenCalledWith([
+      {
+        data: { instanceId: 'instance-1', providerTemplateId: 'provider-template-1' },
+        opts: { id: 'provider-template-instance-1-provider-template-1' }
+      }
+    ]);
+  });
+
+  it('cleans access for already archived provider templates', async () => {
+    vi.mocked(db.providerTemplate.findFirst).mockResolvedValue({
+      oid: 30n,
+      id: 'provider-template-1',
+      status: 'archived',
+      instance: {
+        organization: { id: 'org-1' }
+      }
+    } as any);
+
+    await (magicMcpBackingCleanupProviderTemplateQueueProcessor as any).handler({
+      instanceId: 'instance-1',
+      providerTemplateId: 'provider-template-1'
+    });
+
+    expect(db.providerTemplate.update).not.toHaveBeenCalled();
+    expect(enqueueConsumerTargetAccessCleanup).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      providerTemplateId: 'provider-template-1'
     });
   });
 

--- a/src/metorial/modules/magic/test/providerTemplateService.test.ts
+++ b/src/metorial/modules/magic/test/providerTemplateService.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  db,
+  subspaceMagicMcpBackingServiceMock,
+  providerTemplateArchivedQueueAddMock,
+  providerTemplateCreatedQueueAddMock,
+  providerTemplateUpdatedQueueAddMock,
+  enqueueProviderTemplateBackingCleanupMock
+} = vi.hoisted(() => {
+  let db = {
+    providerTemplate: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn()
+    }
+  };
+
+  return {
+    db,
+    subspaceMagicMcpBackingServiceMock: {
+      upsertProviderTemplateFromIntegration: vi.fn(),
+      upsertProviderTemplate: vi.fn(),
+      archiveProviderTemplate: vi.fn()
+    },
+    providerTemplateArchivedQueueAddMock: vi.fn(),
+    providerTemplateCreatedQueueAddMock: vi.fn(),
+    providerTemplateUpdatedQueueAddMock: vi.fn(),
+    enqueueProviderTemplateBackingCleanupMock: vi.fn()
+  };
+});
+
+vi.mock('@metorial/db', () => ({
+  db,
+  ID: {
+    generateId: vi.fn(async prefix => `${prefix}-new`)
+  },
+  Prisma: {
+    PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
+      code: string;
+      constructor(code: string) {
+        super(code);
+        this.code = code;
+      }
+    }
+  },
+  withTransaction: vi.fn(async callback => await callback(db))
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_: string, factory: () => unknown) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('@metorial/module-subspace', () => ({
+  subspaceMagicMcpBackingService: subspaceMagicMcpBackingServiceMock
+}));
+
+vi.mock('@metorial/module-access', () => ({
+  accessTagService: {
+    getAccessTagFilter: vi.fn(),
+    checkResourceAccess: vi.fn()
+  },
+  consumerProviderTemplateReadRoles: []
+}));
+
+vi.mock('@metorial/module-search', () => ({
+  searchProviderTemplateIds: vi.fn()
+}));
+
+vi.mock('../src/queues/lifecycle/providerTemplate', () => ({
+  providerTemplateArchivedQueue: {
+    add: providerTemplateArchivedQueueAddMock
+  },
+  providerTemplateCreatedQueue: {
+    add: providerTemplateCreatedQueueAddMock
+  },
+  providerTemplateUpdatedQueue: {
+    add: providerTemplateUpdatedQueueAddMock
+  }
+}));
+
+vi.mock('../src/queues/lifecycle/magicMcpBackingCleanup', () => ({
+  enqueueProviderTemplateBackingCleanup: enqueueProviderTemplateBackingCleanupMock
+}));
+
+import { providerTemplateService } from '../src/services/providerTemplate';
+
+describe('providerTemplateService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('archives provider templates without archiving the linked integration', async () => {
+    let instance = { id: 'instance-1' };
+    let providerTemplate = {
+      oid: 10n,
+      id: 'provider-template-1',
+      status: 'active',
+      hasSubspaceBacking: true,
+      subspaceIntegrationId: 'integration-1'
+    };
+    db.providerTemplate.update.mockResolvedValue({
+      ...providerTemplate,
+      status: 'archived'
+    });
+
+    await providerTemplateService.archiveProviderTemplate({
+      instance: instance as any,
+      providerTemplate: providerTemplate as any
+    });
+
+    expect(subspaceMagicMcpBackingServiceMock.archiveProviderTemplate).not.toHaveBeenCalled();
+    expect(providerTemplateArchivedQueueAddMock).toHaveBeenCalledWith({
+      providerTemplateId: 'provider-template-1'
+    });
+    expect(enqueueProviderTemplateBackingCleanupMock).toHaveBeenCalledWith({
+      instanceId: 'instance-1',
+      integrationId: 'integration-1',
+      providerTemplateId: 'provider-template-1'
+    });
+  });
+
+  it('resurrects an archived provider template for the same integration', async () => {
+    let organization = { oid: 1n };
+    let instance = { oid: 2n, id: 'instance-1' };
+    let archivedProviderTemplate = {
+      oid: 10n,
+      id: 'provider-template-1',
+      status: 'archived',
+      subspaceIntegrationId: 'integration-1'
+    };
+    let activeProviderTemplate = {
+      ...archivedProviderTemplate,
+      status: 'active',
+      name: 'New template'
+    };
+
+    db.providerTemplate.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(archivedProviderTemplate);
+    db.providerTemplate.update.mockResolvedValue(activeProviderTemplate);
+    subspaceMagicMcpBackingServiceMock.upsertProviderTemplateFromIntegration.mockResolvedValue(
+      {
+        id: 'provider-template-1',
+        integrationId: 'integration-1'
+      }
+    );
+
+    let result = await providerTemplateService.createProviderTemplate({
+      organization: organization as any,
+      instance: instance as any,
+      input: {
+        integrationId: 'integration-1',
+        name: 'New template',
+        description: 'New description',
+        metadata: { resurrected: true }
+      }
+    });
+
+    expect(db.providerTemplate.create).not.toHaveBeenCalled();
+    expect(db.providerTemplate.update).toHaveBeenCalledWith({
+      where: { oid: 10n },
+      data: {
+        status: 'active',
+        archivedAt: null,
+        deletedAt: null,
+        name: 'New template',
+        description: 'New description',
+        metadata: { resurrected: true },
+        organizationOid: 1n,
+        instanceOid: 2n,
+        hasSubspaceBacking: true,
+        subspaceIntegrationId: 'integration-1'
+      }
+    });
+    expect(providerTemplateCreatedQueueAddMock).toHaveBeenCalledWith({
+      providerTemplateId: 'provider-template-1'
+    });
+    expect(result).toBe(activeProviderTemplate);
+  });
+});

--- a/src/metorial/modules/subspace/src/services/magicMcpBacking.ts
+++ b/src/metorial/modules/subspace/src/services/magicMcpBacking.ts
@@ -1,3 +1,4 @@
+import type { Instance } from '@metorial/db';
 import { createSubspaceService } from '../lib/subspaceService';
 import { subspace } from '../subspace';
 
@@ -16,6 +17,7 @@ export let subspaceMagicMcpBackingService = createSubspaceService(
     'listServerProviders',
     'resolveServerProviderBackingIds',
     'resolveServerBackingIdsByIntegrationResource',
+    'resolveIntegrationResourceLinks',
     'resolveServerBackingIdsForIntegrationInstanceUsage',
     'getServerProvider',
     'createServerProvider',
@@ -26,5 +28,18 @@ export let subspaceMagicMcpBackingService = createSubspaceService(
     'archiveServer',
     'archiveEndpoint'
   ],
-  () => ({})
+  inner => ({
+    resolveIntegrationResourceLinks: async (d: {
+      instance: Instance;
+      integrationId?: string | null;
+      integrationInstanceId?: string | null;
+      backingCursor?: string | null;
+      integrationInstanceCursor?: string | null;
+      limit?: number | null;
+      includeBackings?: boolean | null;
+      includeIntegrationInstances?: boolean | null;
+    }) => {
+      return await (inner.resolveIntegrationResourceLinks as any)(d);
+    }
+  })
 );

--- a/src/shuttle/sdk/packages/mcp-server/src/instance.ts
+++ b/src/shuttle/sdk/packages/mcp-server/src/instance.ts
@@ -48,6 +48,7 @@ export class McpServerInstance {
     for (let ac of authConfigs) McpServerOAuthConfig.assertRegistered(ac);
     for (let co of configs) McpServerConfig.assertRegistered(co);
 
+    // @ts-ignore
     this.#server = getServer(instance);
   }
 

--- a/src/subspace/apps/controller/src/controllers/magicMcpBacking.ts
+++ b/src/subspace/apps/controller/src/controllers/magicMcpBacking.ts
@@ -291,7 +291,12 @@ export let magicMcpBackingController = app.controller({
         tenantId: v.string(),
         environmentId: v.string(),
         integrationId: v.optional(v.nullable(v.string())),
-        integrationInstanceId: v.optional(v.nullable(v.string()))
+        integrationInstanceId: v.optional(v.nullable(v.string())),
+        backingCursor: v.optional(v.nullable(v.string())),
+        integrationInstanceCursor: v.optional(v.nullable(v.string())),
+        limit: v.optional(v.number({ modifiers: [v.integer(), v.positive()] })),
+        includeBackings: v.optional(v.boolean()),
+        includeIntegrationInstances: v.optional(v.boolean())
       })
     )
     .do(async ctx => {
@@ -307,6 +312,31 @@ export let magicMcpBackingController = app.controller({
         );
 
       return { magicMcpServerBackingIds };
+    }),
+
+  resolveIntegrationResourceLinks: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        environmentId: v.string(),
+        integrationId: v.optional(v.nullable(v.string())),
+        integrationInstanceId: v.optional(v.nullable(v.string()))
+      })
+    )
+    .do(async ctx => {
+      return await magicMcpServerBackingService.resolveMagicMcpIntegrationResourceLinks({
+        tenant: ctx.tenant,
+        solution: ctx.solution,
+        environment: ctx.environment,
+        integrationId: ctx.input.integrationId,
+        integrationInstanceId: ctx.input.integrationInstanceId,
+        backingCursor: ctx.input.backingCursor,
+        integrationInstanceCursor: ctx.input.integrationInstanceCursor,
+        limit: ctx.input.limit,
+        includeBackings: ctx.input.includeBackings,
+        includeIntegrationInstances: ctx.input.includeIntegrationInstances
+      });
     }),
 
   resolveServerBackingIdsForIntegrationInstanceUsage: tenantApp

--- a/src/subspace/apps/controller/src/controllers/magicMcpBacking.ts
+++ b/src/subspace/apps/controller/src/controllers/magicMcpBacking.ts
@@ -321,7 +321,12 @@ export let magicMcpBackingController = app.controller({
         tenantId: v.string(),
         environmentId: v.string(),
         integrationId: v.optional(v.nullable(v.string())),
-        integrationInstanceId: v.optional(v.nullable(v.string()))
+        integrationInstanceId: v.optional(v.nullable(v.string())),
+        backingCursor: v.optional(v.nullable(v.string())),
+        integrationInstanceCursor: v.optional(v.nullable(v.string())),
+        limit: v.optional(v.number({ modifiers: [v.integer(), v.positive()] })),
+        includeBackings: v.optional(v.boolean()),
+        includeIntegrationInstances: v.optional(v.boolean())
       })
     )
     .do(async ctx => {

--- a/src/subspace/modules/integration/src/services/integration.ts
+++ b/src/subspace/modules/integration/src/services/integration.ts
@@ -1,4 +1,4 @@
-import { badRequestError, conflictError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
@@ -415,38 +415,6 @@ class integrationServiceImpl {
           code: 'magic_mcp_backing_integration_delete_blocked'
         })
       );
-    }
-
-    if (!d._canModifyMagicMcpBacking) {
-      let [activeInstanceCount, activeProviderCount] = await Promise.all([
-        db.integrationInstance.count({
-          where: {
-            integrationOid: d.integration.oid,
-            status: { in: ['draft', 'active'] }
-          }
-        }),
-        db.integrationProvider.count({
-          where: {
-            integrationOid: d.integration.oid,
-            status: 'active'
-          }
-        })
-      ]);
-
-      if (activeInstanceCount > 0 || activeProviderCount > 0) {
-        throw new ServiceError(
-          conflictError({
-            message:
-              'Integration still has active instances or providers and cannot be archived directly.',
-            code: 'integration_archive_blocked_by_active_children',
-            data: {
-              integrationId: d.integration.id,
-              activeInstanceCount,
-              activeProviderCount
-            }
-          })
-        );
-      }
     }
 
     return await withTransaction(async db => {

--- a/src/subspace/modules/integration/src/services/magicMcpBacking/providerTemplate.ts
+++ b/src/subspace/modules/integration/src/services/magicMcpBacking/providerTemplate.ts
@@ -191,15 +191,6 @@ class providerTemplateBackingServiceImpl {
     environment: Environment;
     providerTemplateBackingId: string;
   }) {
-    let backing = await this.getProviderTemplateBackingById(d);
-    await integrationService.archiveIntegration({
-      tenant: d.tenant,
-      solution: d.solution,
-      environment: d.environment,
-      integration: backing.integration,
-      _canModifyMagicMcpBacking: true
-    });
-
     return await this.getProviderTemplateBackingById(d);
   }
 }

--- a/src/subspace/modules/integration/src/services/magicMcpBacking/server.ts
+++ b/src/subspace/modules/integration/src/services/magicMcpBacking/server.ts
@@ -405,7 +405,10 @@ class magicMcpServerBackingServiceImpl {
       }
     });
 
-    if (policy.archivesIntegrationInstance) {
+    if (
+      policy.archivesIntegrationInstance &&
+      !['archived', 'deleted'].includes(backing.integrationInstance.status)
+    ) {
       await integrationInstanceService.archiveIntegrationInstance({
         tenant: d.tenant,
         solution: d.solution,
@@ -414,7 +417,11 @@ class magicMcpServerBackingServiceImpl {
         _canModifyMagicMcpBacking: true
       });
     }
-    if (policy.archivesIntegration && backing.integration) {
+    if (
+      policy.archivesIntegration &&
+      backing.integration &&
+      !['archived', 'deleted'].includes(backing.integration.status)
+    ) {
       await integrationService.archiveIntegration({
         tenant: d.tenant,
         solution: d.solution,
@@ -423,25 +430,30 @@ class magicMcpServerBackingServiceImpl {
         _canModifyMagicMcpBacking: true
       });
     }
-    await sessionTemplateService.archiveSessionTemplate({
-      tenant: d.tenant,
-      solution: d.solution,
-      environment: d.environment,
-      sessionTemplate: backing.sessionTemplate,
-      _allowLinked: true
-    });
-    await ephemeralManagedSessionService.archiveEphemeralManagedSession({
-      tenant: d.tenant,
-      solution: d.solution,
-      environment: d.environment,
-      ephemeralManagedSession:
-        await ephemeralManagedSessionService.getEphemeralManagedSessionById({
-          tenant: d.tenant,
-          solution: d.solution,
-          environment: d.environment,
-          ephemeralManagedSessionId: backing.ephemeralManagedSession.id
-        })
-    });
+    if (!['archived', 'deleted'].includes(backing.sessionTemplate.status)) {
+      await sessionTemplateService.archiveSessionTemplate({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        sessionTemplate: backing.sessionTemplate,
+        _allowLinked: true
+      });
+    }
+
+    if (!['archived', 'deleted'].includes(backing.ephemeralManagedSession.status)) {
+      await ephemeralManagedSessionService.archiveEphemeralManagedSession({
+        tenant: d.tenant,
+        solution: d.solution,
+        environment: d.environment,
+        ephemeralManagedSession:
+          await ephemeralManagedSessionService.getEphemeralManagedSessionById({
+            tenant: d.tenant,
+            solution: d.solution,
+            environment: d.environment,
+            ephemeralManagedSessionId: backing.ephemeralManagedSession.id
+          })
+      });
+    }
 
     return await this.getMagicMcpServerBackingById(d);
   }
@@ -472,6 +484,133 @@ class magicMcpServerBackingServiceImpl {
     });
 
     return [...new Set(rows.map(row => row.id))].sort();
+  }
+
+  async resolveMagicMcpIntegrationResourceLinks(d: {
+    tenant: Tenant;
+    solution: Solution;
+    environment: Environment;
+    integrationId?: string | null;
+    integrationInstanceId?: string | null;
+    backingCursor?: string | null;
+    integrationInstanceCursor?: string | null;
+    limit?: number | null;
+    includeBackings?: boolean | null;
+    includeIntegrationInstances?: boolean | null;
+  }) {
+    let limit = Math.min(Math.max(d.limit ?? 100, 1), 500);
+    let includeBackings = d.includeBackings !== false;
+    let includeIntegrationInstances = d.includeIntegrationInstances !== false;
+
+    if (!d.integrationId && !d.integrationInstanceId) {
+      return {
+        magicMcpServerBackingIds: [],
+        integrationInstanceIds: [],
+        nextBackingCursor: null,
+        nextIntegrationInstanceCursor: null
+      };
+    }
+
+    let integrationInstances = includeIntegrationInstances
+      ? await db.integrationInstance.findMany({
+          where: {
+            tenantOid: d.tenant.oid,
+            solutionOid: d.solution.oid,
+            environmentOid: d.environment.oid,
+            id: d.integrationInstanceId
+              ? d.integrationInstanceId
+              : d.integrationInstanceCursor
+                ? { gt: d.integrationInstanceCursor }
+                : undefined,
+            integration: d.integrationId ? { id: d.integrationId } : undefined
+          },
+          orderBy: { id: 'asc' },
+          take: limit,
+          select: {
+            id: true
+          }
+        })
+      : [];
+
+    let rows = includeBackings
+      ? await db.magicMcpServerBacking.findMany({
+          where: {
+            integrationInstance: {
+              tenantOid: d.tenant.oid,
+              solutionOid: d.solution.oid,
+              environmentOid: d.environment.oid
+            },
+            id: d.backingCursor ? { gt: d.backingCursor } : undefined,
+            OR: [
+              ...(d.integrationInstanceId
+                ? [
+                    {
+                      integrationInstance: {
+                        id: d.integrationInstanceId
+                      }
+                    }
+                  ]
+                : []),
+              ...(d.integrationId
+                ? [
+                    {
+                      integrationInstance: {
+                        integration: {
+                          id: d.integrationId
+                        }
+                      }
+                    },
+                    {
+                      integration: {
+                        id: d.integrationId
+                      }
+                    },
+                    {
+                      ownerIntegration: {
+                        id: d.integrationId
+                      }
+                    },
+                    {
+                      providerTemplateBacking: {
+                        integration: {
+                          id: d.integrationId
+                        }
+                      }
+                    }
+                  ]
+                : [])
+            ]
+          },
+          orderBy: { id: 'asc' },
+          take: limit,
+          select: {
+            id: true,
+            integrationInstance: {
+              select: {
+                id: true
+              }
+            }
+          }
+        })
+      : [];
+
+    let lastBacking = rows[rows.length - 1];
+    let lastIntegrationInstance = integrationInstances[integrationInstances.length - 1];
+
+    return {
+      magicMcpServerBackingIds: [...new Set(rows.map(row => row.id))].sort(),
+      integrationInstanceIds: [
+        ...new Set([
+          ...integrationInstances.map(integrationInstance => integrationInstance.id),
+          ...rows.map(row => row.integrationInstance.id)
+        ])
+      ].sort(),
+      nextBackingCursor: rows.length === limit && lastBacking ? lastBacking.id : null,
+      nextIntegrationInstanceCursor:
+        integrationInstances.length === limit && lastIntegrationInstance
+          ? lastIntegrationInstance.id
+          : null
+    };
   }
 
   async resolveMagicMcpServerBackingIdsForIntegrationInstanceUsage(d: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large cross-module lifecycle changes affect integration deletion, consumer access policies, and async fan-out; mistakes could leave stale access or over-archive resources.
> 
> **Overview**
> Integration and Magic MCP teardown is reworked so deletion/archiving **fans out through paginated queues** instead of doing bulk work in one job. Magic backing cleanup splits into separate queues for backings, integration instances, provider templates, and per-server archive; subspace gains **`resolveIntegrationResourceLinks`** (cursor/limit) to drive that paging. Archiving a provider template no longer archives the linked subspace integration inline—cleanup is queued via **`enqueueProviderTemplateBackingCleanup`**, which can also archive templates and enqueue consumer access cleanup.
> 
> The **consumer module** adds **`enqueueConsumerTargetAccessCleanup`**: paginated deletion of access listings then unlisted accesses for a provider template or Magic MCP server, with idempotent deletes (P2025 still revokes access policies). Magic server delete clears **`consumerIntegration`** rows and triggers that cleanup; server archive also unlinks endpoints and marks related sessions for consumer reconciliation.
> 
> **Provider templates** can be **resurrected** when recreating for the same integration; integration archive drops the “active children” block. Subspace server backing archive skips resources already archived/deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f304495df97a94d5f35877ae8dc6b91f1d1258a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->