### PR TITLE
Add skill sharing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1789,6 +1789,7 @@
         "@metorial/data-hooks": "^1.0.0",
         "@metorial/dynamic-component": "^1.0.0",
         "@metorial/frontend-config": "^1.0.0",
+        "@metorial/scene-skills": "^1.0.0",
         "@metorial/state": "^1.0.0",
         "@metorial/ui": "^1.0.0",
         "@radix-ui/react-popover": "^1.1.13",

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills.ts
@@ -15,6 +15,8 @@ import {
   mapDashboardInstanceSkillsListOutput,
   mapDashboardInstanceSkillsListQuery,
   mapDashboardInstanceSkillsPublishConsumerSkillOutput,
+  mapDashboardInstanceSkillsShareBody,
+  mapDashboardInstanceSkillsShareOutput,
   mapDashboardInstanceSkillsUpdateBody,
   mapDashboardInstanceSkillsUpdateOutput,
   type DashboardInstanceSkillsCreateBody,
@@ -28,6 +30,8 @@ import {
   type DashboardInstanceSkillsListOutput,
   type DashboardInstanceSkillsListQuery,
   type DashboardInstanceSkillsPublishConsumerSkillOutput,
+  type DashboardInstanceSkillsShareBody,
+  type DashboardInstanceSkillsShareOutput,
   type DashboardInstanceSkillsUpdateBody,
   type DashboardInstanceSkillsUpdateOutput
 } from '../resources';
@@ -264,6 +268,36 @@ export class MetorialDashboardInstanceSkillsEndpoint {
     return this._post(request).transform(
       mapDashboardInstanceSkillsPublishConsumerSkillOutput
     );
+  }
+
+  /**
+   * @name Share skill
+   * @description Shares a skill with consumers or organization members.
+   *
+   * @param `instanceId` - string
+   * @param `skillId` - string
+   * @param `body` - DashboardInstanceSkillsShareBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceSkillsShareOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  share(
+    instanceId: string,
+    skillId: string,
+    body: DashboardInstanceSkillsShareBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceSkillsShareOutput> {
+    let path = `dashboard/instances/${instanceId}/skills/${skillId}/shares`;
+
+    let request = {
+      path,
+      body: mapDashboardInstanceSkillsShareBody.transformTo(body),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._post(request).transform(mapDashboardInstanceSkillsShareOutput);
   }
 
   /**

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_skills.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/management_instance_skills.ts
@@ -15,6 +15,8 @@ import {
   mapDashboardInstanceSkillsListOutput,
   mapDashboardInstanceSkillsListQuery,
   mapDashboardInstanceSkillsPublishConsumerSkillOutput,
+  mapDashboardInstanceSkillsShareBody,
+  mapDashboardInstanceSkillsShareOutput,
   mapDashboardInstanceSkillsUpdateBody,
   mapDashboardInstanceSkillsUpdateOutput,
   type DashboardInstanceSkillsCreateBody,
@@ -28,6 +30,8 @@ import {
   type DashboardInstanceSkillsListOutput,
   type DashboardInstanceSkillsListQuery,
   type DashboardInstanceSkillsPublishConsumerSkillOutput,
+  type DashboardInstanceSkillsShareBody,
+  type DashboardInstanceSkillsShareOutput,
   type DashboardInstanceSkillsUpdateBody,
   type DashboardInstanceSkillsUpdateOutput
 } from '../resources';
@@ -264,6 +268,36 @@ export class MetorialManagementInstanceSkillsEndpoint {
     return this._post(request).transform(
       mapDashboardInstanceSkillsPublishConsumerSkillOutput
     );
+  }
+
+  /**
+   * @name Share skill
+   * @description Shares a skill with consumers or organization members.
+   *
+   * @param `instanceId` - string
+   * @param `skillId` - string
+   * @param `body` - DashboardInstanceSkillsShareBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceSkillsShareOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  share(
+    instanceId: string,
+    skillId: string,
+    body: DashboardInstanceSkillsShareBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceSkillsShareOutput> {
+    let path = `instances/${instanceId}/skills/${skillId}/shares`;
+
+    let request = {
+      path,
+      body: mapDashboardInstanceSkillsShareBody.transformTo(body),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._post(request).transform(mapDashboardInstanceSkillsShareOutput);
   }
 
   /**

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/skills.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/skills.ts
@@ -15,6 +15,8 @@ import {
   mapDashboardInstanceSkillsListOutput,
   mapDashboardInstanceSkillsListQuery,
   mapDashboardInstanceSkillsPublishConsumerSkillOutput,
+  mapDashboardInstanceSkillsShareBody,
+  mapDashboardInstanceSkillsShareOutput,
   mapDashboardInstanceSkillsUpdateBody,
   mapDashboardInstanceSkillsUpdateOutput,
   type DashboardInstanceSkillsCreateBody,
@@ -28,6 +30,8 @@ import {
   type DashboardInstanceSkillsListOutput,
   type DashboardInstanceSkillsListQuery,
   type DashboardInstanceSkillsPublishConsumerSkillOutput,
+  type DashboardInstanceSkillsShareBody,
+  type DashboardInstanceSkillsShareOutput,
   type DashboardInstanceSkillsUpdateBody,
   type DashboardInstanceSkillsUpdateOutput
 } from '../resources';
@@ -250,6 +254,34 @@ export class MetorialSkillsEndpoint {
     return this._post(request).transform(
       mapDashboardInstanceSkillsPublishConsumerSkillOutput
     );
+  }
+
+  /**
+   * @name Share skill
+   * @description Shares a skill with consumers or organization members.
+   *
+   * @param `skillId` - string
+   * @param `body` - DashboardInstanceSkillsShareBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceSkillsShareOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  share(
+    skillId: string,
+    body: DashboardInstanceSkillsShareBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceSkillsShareOutput> {
+    let path = `skills/${skillId}/shares`;
+
+    let request = {
+      path,
+      body: mapDashboardInstanceSkillsShareBody.transformTo(body),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._post(request).transform(mapDashboardInstanceSkillsShareOutput);
   }
 
   /**

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/index.ts
@@ -13,6 +13,7 @@ export * from './marketplaces';
 export * from './participants';
 export * from './plugins';
 export * from './publish-consumer-skill';
+export * from './share';
 export * from './syncs';
 export * from './templates';
 export * from './update';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/share.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/share.ts
@@ -1,0 +1,486 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceSkillsShareOutput = {
+  object: 'skill';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  slug: string;
+  name: string;
+  description: string | null;
+  imageUrl: string;
+  clientName: string;
+  clientDescription: string | null;
+  clientMetadata: Record<string, any> | null;
+  license: string | null;
+  compatibility: string | null;
+  metadata: Record<string, any>;
+  storeId: string;
+  hierarchy: {
+    object: 'skill.hierarchy';
+    type: 'root' | 'fork' | 'duplicated';
+    parentSkillId: string | null;
+    creator: {
+      type: 'organization_actor' | 'consumer' | 'unknown';
+      name: string;
+      imageUrl: string | null;
+      email: string | null;
+      organizationActor: {
+        object: 'organization.actor';
+        id: string;
+        type: 'member' | 'machine_access';
+        organizationId: string;
+        name: string;
+        email: string | null;
+        imageUrl: string;
+        teams: {
+          id: string;
+          name: string;
+          slug: string;
+          assignmentId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        }[];
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      consumer: {
+        object: 'consumer';
+        id: string;
+        name: string;
+        email: string;
+        imageUrl: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+    } | null;
+    fork: {
+      id: string;
+      parentSkillId: string;
+      creator: {
+        type: 'organization_actor' | 'consumer' | 'unknown';
+        name: string;
+        imageUrl: string | null;
+        email: string | null;
+        organizationActor: {
+          object: 'organization.actor';
+          id: string;
+          type: 'member' | 'machine_access';
+          organizationId: string;
+          name: string;
+          email: string | null;
+          imageUrl: string;
+          teams: {
+            id: string;
+            name: string;
+            slug: string;
+            assignmentId: string;
+            createdAt: Date;
+            updatedAt: Date;
+          }[];
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        consumer: {
+          object: 'consumer';
+          id: string;
+          name: string;
+          email: string;
+          imageUrl: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+      } | null;
+      originalCreator: {
+        type: 'organization_actor' | 'consumer' | 'unknown';
+        name: string;
+        imageUrl: string | null;
+        email: string | null;
+        organizationActor: {
+          object: 'organization.actor';
+          id: string;
+          type: 'member' | 'machine_access';
+          organizationId: string;
+          name: string;
+          email: string | null;
+          imageUrl: string;
+          teams: {
+            id: string;
+            name: string;
+            slug: string;
+            assignmentId: string;
+            createdAt: Date;
+            updatedAt: Date;
+          }[];
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        consumer: {
+          object: 'consumer';
+          id: string;
+          name: string;
+          email: string;
+          imageUrl: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+      } | null;
+      createdAt: Date;
+    } | null;
+    entity: {
+      object: 'skill.entity';
+      id: string;
+      name: string;
+      slug: string;
+      description: string | null;
+      parentSkillId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+  };
+  integrations: {
+    object: 'integration#preview';
+    id: string;
+    slug: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    configuration: {
+      canAttachCustomToolFilters: boolean;
+      canAttachCustomProviderConfig: boolean;
+      canOverrideToolFilters: boolean;
+      useIntegrationNameInToolNames: boolean | null;
+    };
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  providers: {
+    object: 'provider#preview';
+    id: string;
+    name: string;
+    description: string | null;
+    slug: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export let mapDashboardInstanceSkillsShareOutput =
+  mtMap.object<DashboardInstanceSkillsShareOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+    clientName: mtMap.objectField('client_name', mtMap.passthrough()),
+    clientDescription: mtMap.objectField(
+      'client_description',
+      mtMap.passthrough()
+    ),
+    clientMetadata: mtMap.objectField('client_metadata', mtMap.passthrough()),
+    license: mtMap.objectField('license', mtMap.passthrough()),
+    compatibility: mtMap.objectField('compatibility', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    storeId: mtMap.objectField('store_id', mtMap.passthrough()),
+    hierarchy: mtMap.objectField(
+      'hierarchy',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        parentSkillId: mtMap.objectField(
+          'parent_skill_id',
+          mtMap.passthrough()
+        ),
+        creator: mtMap.objectField(
+          'creator',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            organizationActor: mtMap.objectField(
+              'organization_actor',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                organizationId: mtMap.objectField(
+                  'organization_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                teams: mtMap.objectField(
+                  'teams',
+                  mtMap.array(
+                    mtMap.object({
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      slug: mtMap.objectField('slug', mtMap.passthrough()),
+                      assignmentId: mtMap.objectField(
+                        'assignment_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  )
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            consumer: mtMap.objectField(
+              'consumer',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            )
+          })
+        ),
+        fork: mtMap.objectField(
+          'fork',
+          mtMap.object({
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            parentSkillId: mtMap.objectField(
+              'parent_skill_id',
+              mtMap.passthrough()
+            ),
+            creator: mtMap.objectField(
+              'creator',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                organizationActor: mtMap.objectField(
+                  'organization_actor',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    organizationId: mtMap.objectField(
+                      'organization_id',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    teams: mtMap.objectField(
+                      'teams',
+                      mtMap.array(
+                        mtMap.object({
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          slug: mtMap.objectField('slug', mtMap.passthrough()),
+                          assignmentId: mtMap.objectField(
+                            'assignment_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      )
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                consumer: mtMap.objectField(
+                  'consumer',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                )
+              })
+            ),
+            originalCreator: mtMap.objectField(
+              'original_creator',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                organizationActor: mtMap.objectField(
+                  'organization_actor',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    organizationId: mtMap.objectField(
+                      'organization_id',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    teams: mtMap.objectField(
+                      'teams',
+                      mtMap.array(
+                        mtMap.object({
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          slug: mtMap.objectField('slug', mtMap.passthrough()),
+                          assignmentId: mtMap.objectField(
+                            'assignment_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      )
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                consumer: mtMap.objectField(
+                  'consumer',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                )
+              })
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date())
+          })
+        ),
+        entity: mtMap.objectField(
+          'entity',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            parentSkillId: mtMap.objectField(
+              'parent_skill_id',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
+      })
+    ),
+    integrations: mtMap.objectField(
+      'integrations',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          configuration: mtMap.objectField(
+            'configuration',
+            mtMap.object({
+              canAttachCustomToolFilters: mtMap.objectField(
+                'can_attach_custom_tool_filters',
+                mtMap.passthrough()
+              ),
+              canAttachCustomProviderConfig: mtMap.objectField(
+                'can_attach_custom_provider_config',
+                mtMap.passthrough()
+              ),
+              canOverrideToolFilters: mtMap.objectField(
+                'can_override_tool_filters',
+                mtMap.passthrough()
+              ),
+              useIntegrationNameInToolNames: mtMap.objectField(
+                'use_integration_name_in_tool_names',
+                mtMap.passthrough()
+              )
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+  });
+
+export type DashboardInstanceSkillsShareBody = {
+  consumerProfileIds?: string[] | undefined;
+  organizationMemberIds?: string[] | undefined;
+  permission: 'none' | 'read' | 'write';
+};
+
+export let mapDashboardInstanceSkillsShareBody =
+  mtMap.object<DashboardInstanceSkillsShareBody>({
+    consumerProfileIds: mtMap.objectField(
+      'consumer_profile_ids',
+      mtMap.array(mtMap.passthrough())
+    ),
+    organizationMemberIds: mtMap.objectField(
+      'organization_member_ids',
+      mtMap.array(mtMap.passthrough())
+    ),
+    permission: mtMap.objectField('permission', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/index.ts
@@ -13,6 +13,7 @@ export * from './marketplaces';
 export * from './participants';
 export * from './plugins';
 export * from './publish-consumer-skill';
+export * from './share';
 export * from './templates';
 export * from './update';
 export * from './versions';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/share.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/share.ts
@@ -1,0 +1,486 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type ManagementInstanceSkillsShareOutput = {
+  object: 'skill';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  slug: string;
+  name: string;
+  description: string | null;
+  imageUrl: string;
+  clientName: string;
+  clientDescription: string | null;
+  clientMetadata: Record<string, any> | null;
+  license: string | null;
+  compatibility: string | null;
+  metadata: Record<string, any>;
+  storeId: string;
+  hierarchy: {
+    object: 'skill.hierarchy';
+    type: 'root' | 'fork' | 'duplicated';
+    parentSkillId: string | null;
+    creator: {
+      type: 'organization_actor' | 'consumer' | 'unknown';
+      name: string;
+      imageUrl: string | null;
+      email: string | null;
+      organizationActor: {
+        object: 'organization.actor';
+        id: string;
+        type: 'member' | 'machine_access';
+        organizationId: string;
+        name: string;
+        email: string | null;
+        imageUrl: string;
+        teams: {
+          id: string;
+          name: string;
+          slug: string;
+          assignmentId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        }[];
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      consumer: {
+        object: 'consumer';
+        id: string;
+        name: string;
+        email: string;
+        imageUrl: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+    } | null;
+    fork: {
+      id: string;
+      parentSkillId: string;
+      creator: {
+        type: 'organization_actor' | 'consumer' | 'unknown';
+        name: string;
+        imageUrl: string | null;
+        email: string | null;
+        organizationActor: {
+          object: 'organization.actor';
+          id: string;
+          type: 'member' | 'machine_access';
+          organizationId: string;
+          name: string;
+          email: string | null;
+          imageUrl: string;
+          teams: {
+            id: string;
+            name: string;
+            slug: string;
+            assignmentId: string;
+            createdAt: Date;
+            updatedAt: Date;
+          }[];
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        consumer: {
+          object: 'consumer';
+          id: string;
+          name: string;
+          email: string;
+          imageUrl: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+      } | null;
+      originalCreator: {
+        type: 'organization_actor' | 'consumer' | 'unknown';
+        name: string;
+        imageUrl: string | null;
+        email: string | null;
+        organizationActor: {
+          object: 'organization.actor';
+          id: string;
+          type: 'member' | 'machine_access';
+          organizationId: string;
+          name: string;
+          email: string | null;
+          imageUrl: string;
+          teams: {
+            id: string;
+            name: string;
+            slug: string;
+            assignmentId: string;
+            createdAt: Date;
+            updatedAt: Date;
+          }[];
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        consumer: {
+          object: 'consumer';
+          id: string;
+          name: string;
+          email: string;
+          imageUrl: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+      } | null;
+      createdAt: Date;
+    } | null;
+    entity: {
+      object: 'skill.entity';
+      id: string;
+      name: string;
+      slug: string;
+      description: string | null;
+      parentSkillId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+  };
+  integrations: {
+    object: 'integration#preview';
+    id: string;
+    slug: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    configuration: {
+      canAttachCustomToolFilters: boolean;
+      canAttachCustomProviderConfig: boolean;
+      canOverrideToolFilters: boolean;
+      useIntegrationNameInToolNames: boolean | null;
+    };
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  providers: {
+    object: 'provider#preview';
+    id: string;
+    name: string;
+    description: string | null;
+    slug: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export let mapManagementInstanceSkillsShareOutput =
+  mtMap.object<ManagementInstanceSkillsShareOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    id: mtMap.objectField('id', mtMap.passthrough()),
+    status: mtMap.objectField('status', mtMap.passthrough()),
+    slug: mtMap.objectField('slug', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough()),
+    description: mtMap.objectField('description', mtMap.passthrough()),
+    imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+    clientName: mtMap.objectField('client_name', mtMap.passthrough()),
+    clientDescription: mtMap.objectField(
+      'client_description',
+      mtMap.passthrough()
+    ),
+    clientMetadata: mtMap.objectField('client_metadata', mtMap.passthrough()),
+    license: mtMap.objectField('license', mtMap.passthrough()),
+    compatibility: mtMap.objectField('compatibility', mtMap.passthrough()),
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    storeId: mtMap.objectField('store_id', mtMap.passthrough()),
+    hierarchy: mtMap.objectField(
+      'hierarchy',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        type: mtMap.objectField('type', mtMap.passthrough()),
+        parentSkillId: mtMap.objectField(
+          'parent_skill_id',
+          mtMap.passthrough()
+        ),
+        creator: mtMap.objectField(
+          'creator',
+          mtMap.object({
+            type: mtMap.objectField('type', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+            email: mtMap.objectField('email', mtMap.passthrough()),
+            organizationActor: mtMap.objectField(
+              'organization_actor',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                organizationId: mtMap.objectField(
+                  'organization_id',
+                  mtMap.passthrough()
+                ),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                teams: mtMap.objectField(
+                  'teams',
+                  mtMap.array(
+                    mtMap.object({
+                      id: mtMap.objectField('id', mtMap.passthrough()),
+                      name: mtMap.objectField('name', mtMap.passthrough()),
+                      slug: mtMap.objectField('slug', mtMap.passthrough()),
+                      assignmentId: mtMap.objectField(
+                        'assignment_id',
+                        mtMap.passthrough()
+                      ),
+                      createdAt: mtMap.objectField('created_at', mtMap.date()),
+                      updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                    })
+                  )
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            consumer: mtMap.objectField(
+              'consumer',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            )
+          })
+        ),
+        fork: mtMap.objectField(
+          'fork',
+          mtMap.object({
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            parentSkillId: mtMap.objectField(
+              'parent_skill_id',
+              mtMap.passthrough()
+            ),
+            creator: mtMap.objectField(
+              'creator',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                organizationActor: mtMap.objectField(
+                  'organization_actor',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    organizationId: mtMap.objectField(
+                      'organization_id',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    teams: mtMap.objectField(
+                      'teams',
+                      mtMap.array(
+                        mtMap.object({
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          slug: mtMap.objectField('slug', mtMap.passthrough()),
+                          assignmentId: mtMap.objectField(
+                            'assignment_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      )
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                consumer: mtMap.objectField(
+                  'consumer',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                )
+              })
+            ),
+            originalCreator: mtMap.objectField(
+              'original_creator',
+              mtMap.object({
+                type: mtMap.objectField('type', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                email: mtMap.objectField('email', mtMap.passthrough()),
+                organizationActor: mtMap.objectField(
+                  'organization_actor',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    type: mtMap.objectField('type', mtMap.passthrough()),
+                    organizationId: mtMap.objectField(
+                      'organization_id',
+                      mtMap.passthrough()
+                    ),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    teams: mtMap.objectField(
+                      'teams',
+                      mtMap.array(
+                        mtMap.object({
+                          id: mtMap.objectField('id', mtMap.passthrough()),
+                          name: mtMap.objectField('name', mtMap.passthrough()),
+                          slug: mtMap.objectField('slug', mtMap.passthrough()),
+                          assignmentId: mtMap.objectField(
+                            'assignment_id',
+                            mtMap.passthrough()
+                          ),
+                          createdAt: mtMap.objectField(
+                            'created_at',
+                            mtMap.date()
+                          ),
+                          updatedAt: mtMap.objectField(
+                            'updated_at',
+                            mtMap.date()
+                          )
+                        })
+                      )
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                ),
+                consumer: mtMap.objectField(
+                  'consumer',
+                  mtMap.object({
+                    object: mtMap.objectField('object', mtMap.passthrough()),
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    email: mtMap.objectField('email', mtMap.passthrough()),
+                    imageUrl: mtMap.objectField(
+                      'image_url',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                )
+              })
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date())
+          })
+        ),
+        entity: mtMap.objectField(
+          'entity',
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            id: mtMap.objectField('id', mtMap.passthrough()),
+            name: mtMap.objectField('name', mtMap.passthrough()),
+            slug: mtMap.objectField('slug', mtMap.passthrough()),
+            description: mtMap.objectField('description', mtMap.passthrough()),
+            parentSkillId: mtMap.objectField(
+              'parent_skill_id',
+              mtMap.passthrough()
+            ),
+            createdAt: mtMap.objectField('created_at', mtMap.date()),
+            updatedAt: mtMap.objectField('updated_at', mtMap.date())
+          })
+        )
+      })
+    ),
+    integrations: mtMap.objectField(
+      'integrations',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+          configuration: mtMap.objectField(
+            'configuration',
+            mtMap.object({
+              canAttachCustomToolFilters: mtMap.objectField(
+                'can_attach_custom_tool_filters',
+                mtMap.passthrough()
+              ),
+              canAttachCustomProviderConfig: mtMap.objectField(
+                'can_attach_custom_provider_config',
+                mtMap.passthrough()
+              ),
+              canOverrideToolFilters: mtMap.objectField(
+                'can_override_tool_filters',
+                mtMap.passthrough()
+              ),
+              useIntegrationNameInToolNames: mtMap.objectField(
+                'use_integration_name_in_tool_names',
+                mtMap.passthrough()
+              )
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+          archivedAt: mtMap.objectField('archived_at', mtMap.date())
+        })
+      )
+    ),
+    providers: mtMap.objectField(
+      'providers',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    ),
+    createdAt: mtMap.objectField('created_at', mtMap.date()),
+    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+  });
+
+export type ManagementInstanceSkillsShareBody = {
+  consumerProfileIds?: string[] | undefined;
+  organizationMemberIds?: string[] | undefined;
+  permission: 'none' | 'read' | 'write';
+};
+
+export let mapManagementInstanceSkillsShareBody =
+  mtMap.object<ManagementInstanceSkillsShareBody>({
+    consumerProfileIds: mtMap.objectField(
+      'consumer_profile_ids',
+      mtMap.array(mtMap.passthrough())
+    ),
+    organizationMemberIds: mtMap.objectField(
+      'organization_member_ids',
+      mtMap.array(mtMap.passthrough())
+    ),
+    permission: mtMap.objectField('permission', mtMap.passthrough())
+  });
+

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/index.ts
@@ -13,6 +13,7 @@ export * from './marketplaces';
 export * from './participants';
 export * from './plugins';
 export * from './publish-consumer-skill';
+export * from './share';
 export * from './templates';
 export * from './update';
 export * from './versions';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/share.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/share.ts
@@ -1,0 +1,463 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type SkillsShareOutput = {
+  object: 'skill';
+  id: string;
+  status: 'active' | 'archived' | 'deleted';
+  slug: string;
+  name: string;
+  description: string | null;
+  imageUrl: string;
+  clientName: string;
+  clientDescription: string | null;
+  clientMetadata: Record<string, any> | null;
+  license: string | null;
+  compatibility: string | null;
+  metadata: Record<string, any>;
+  storeId: string;
+  hierarchy: {
+    object: 'skill.hierarchy';
+    type: 'root' | 'fork' | 'duplicated';
+    parentSkillId: string | null;
+    creator: {
+      type: 'organization_actor' | 'consumer' | 'unknown';
+      name: string;
+      imageUrl: string | null;
+      email: string | null;
+      organizationActor: {
+        object: 'organization.actor';
+        id: string;
+        type: 'member' | 'machine_access';
+        organizationId: string;
+        name: string;
+        email: string | null;
+        imageUrl: string;
+        teams: {
+          id: string;
+          name: string;
+          slug: string;
+          assignmentId: string;
+          createdAt: Date;
+          updatedAt: Date;
+        }[];
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+      consumer: {
+        object: 'consumer';
+        id: string;
+        name: string;
+        email: string;
+        imageUrl: string;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
+    } | null;
+    fork: {
+      id: string;
+      parentSkillId: string;
+      creator: {
+        type: 'organization_actor' | 'consumer' | 'unknown';
+        name: string;
+        imageUrl: string | null;
+        email: string | null;
+        organizationActor: {
+          object: 'organization.actor';
+          id: string;
+          type: 'member' | 'machine_access';
+          organizationId: string;
+          name: string;
+          email: string | null;
+          imageUrl: string;
+          teams: {
+            id: string;
+            name: string;
+            slug: string;
+            assignmentId: string;
+            createdAt: Date;
+            updatedAt: Date;
+          }[];
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        consumer: {
+          object: 'consumer';
+          id: string;
+          name: string;
+          email: string;
+          imageUrl: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+      } | null;
+      originalCreator: {
+        type: 'organization_actor' | 'consumer' | 'unknown';
+        name: string;
+        imageUrl: string | null;
+        email: string | null;
+        organizationActor: {
+          object: 'organization.actor';
+          id: string;
+          type: 'member' | 'machine_access';
+          organizationId: string;
+          name: string;
+          email: string | null;
+          imageUrl: string;
+          teams: {
+            id: string;
+            name: string;
+            slug: string;
+            assignmentId: string;
+            createdAt: Date;
+            updatedAt: Date;
+          }[];
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+        consumer: {
+          object: 'consumer';
+          id: string;
+          name: string;
+          email: string;
+          imageUrl: string;
+          createdAt: Date;
+          updatedAt: Date;
+        } | null;
+      } | null;
+      createdAt: Date;
+    } | null;
+    entity: {
+      object: 'skill.entity';
+      id: string;
+      name: string;
+      slug: string;
+      description: string | null;
+      parentSkillId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+  };
+  integrations: {
+    object: 'integration#preview';
+    id: string;
+    slug: string;
+    name: string;
+    description: string | null;
+    metadata: Record<string, any> | null;
+    configuration: {
+      canAttachCustomToolFilters: boolean;
+      canAttachCustomProviderConfig: boolean;
+      canOverrideToolFilters: boolean;
+      useIntegrationNameInToolNames: boolean | null;
+    };
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }[];
+  providers: {
+    object: 'provider#preview';
+    id: string;
+    name: string;
+    description: string | null;
+    slug: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export let mapSkillsShareOutput = mtMap.object<SkillsShareOutput>({
+  object: mtMap.objectField('object', mtMap.passthrough()),
+  id: mtMap.objectField('id', mtMap.passthrough()),
+  status: mtMap.objectField('status', mtMap.passthrough()),
+  slug: mtMap.objectField('slug', mtMap.passthrough()),
+  name: mtMap.objectField('name', mtMap.passthrough()),
+  description: mtMap.objectField('description', mtMap.passthrough()),
+  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+  clientName: mtMap.objectField('client_name', mtMap.passthrough()),
+  clientDescription: mtMap.objectField(
+    'client_description',
+    mtMap.passthrough()
+  ),
+  clientMetadata: mtMap.objectField('client_metadata', mtMap.passthrough()),
+  license: mtMap.objectField('license', mtMap.passthrough()),
+  compatibility: mtMap.objectField('compatibility', mtMap.passthrough()),
+  metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+  storeId: mtMap.objectField('store_id', mtMap.passthrough()),
+  hierarchy: mtMap.objectField(
+    'hierarchy',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      type: mtMap.objectField('type', mtMap.passthrough()),
+      parentSkillId: mtMap.objectField('parent_skill_id', mtMap.passthrough()),
+      creator: mtMap.objectField(
+        'creator',
+        mtMap.object({
+          type: mtMap.objectField('type', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+          email: mtMap.objectField('email', mtMap.passthrough()),
+          organizationActor: mtMap.objectField(
+            'organization_actor',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              organizationId: mtMap.objectField(
+                'organization_id',
+                mtMap.passthrough()
+              ),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              email: mtMap.objectField('email', mtMap.passthrough()),
+              imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+              teams: mtMap.objectField(
+                'teams',
+                mtMap.array(
+                  mtMap.object({
+                    id: mtMap.objectField('id', mtMap.passthrough()),
+                    name: mtMap.objectField('name', mtMap.passthrough()),
+                    slug: mtMap.objectField('slug', mtMap.passthrough()),
+                    assignmentId: mtMap.objectField(
+                      'assignment_id',
+                      mtMap.passthrough()
+                    ),
+                    createdAt: mtMap.objectField('created_at', mtMap.date()),
+                    updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                  })
+                )
+              ),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          ),
+          consumer: mtMap.objectField(
+            'consumer',
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              id: mtMap.objectField('id', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              email: mtMap.objectField('email', mtMap.passthrough()),
+              imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+              createdAt: mtMap.objectField('created_at', mtMap.date()),
+              updatedAt: mtMap.objectField('updated_at', mtMap.date())
+            })
+          )
+        })
+      ),
+      fork: mtMap.objectField(
+        'fork',
+        mtMap.object({
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          parentSkillId: mtMap.objectField(
+            'parent_skill_id',
+            mtMap.passthrough()
+          ),
+          creator: mtMap.objectField(
+            'creator',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+              email: mtMap.objectField('email', mtMap.passthrough()),
+              organizationActor: mtMap.objectField(
+                'organization_actor',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  organizationId: mtMap.objectField(
+                    'organization_id',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  teams: mtMap.objectField(
+                    'teams',
+                    mtMap.array(
+                      mtMap.object({
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        assignmentId: mtMap.objectField(
+                          'assignment_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    )
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              consumer: mtMap.objectField(
+                'consumer',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
+            })
+          ),
+          originalCreator: mtMap.objectField(
+            'original_creator',
+            mtMap.object({
+              type: mtMap.objectField('type', mtMap.passthrough()),
+              name: mtMap.objectField('name', mtMap.passthrough()),
+              imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+              email: mtMap.objectField('email', mtMap.passthrough()),
+              organizationActor: mtMap.objectField(
+                'organization_actor',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  type: mtMap.objectField('type', mtMap.passthrough()),
+                  organizationId: mtMap.objectField(
+                    'organization_id',
+                    mtMap.passthrough()
+                  ),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  teams: mtMap.objectField(
+                    'teams',
+                    mtMap.array(
+                      mtMap.object({
+                        id: mtMap.objectField('id', mtMap.passthrough()),
+                        name: mtMap.objectField('name', mtMap.passthrough()),
+                        slug: mtMap.objectField('slug', mtMap.passthrough()),
+                        assignmentId: mtMap.objectField(
+                          'assignment_id',
+                          mtMap.passthrough()
+                        ),
+                        createdAt: mtMap.objectField(
+                          'created_at',
+                          mtMap.date()
+                        ),
+                        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                      })
+                    )
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              consumer: mtMap.objectField(
+                'consumer',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  email: mtMap.objectField('email', mtMap.passthrough()),
+                  imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              )
+            })
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date())
+        })
+      ),
+      entity: mtMap.objectField(
+        'entity',
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          id: mtMap.objectField('id', mtMap.passthrough()),
+          name: mtMap.objectField('name', mtMap.passthrough()),
+          slug: mtMap.objectField('slug', mtMap.passthrough()),
+          description: mtMap.objectField('description', mtMap.passthrough()),
+          parentSkillId: mtMap.objectField(
+            'parent_skill_id',
+            mtMap.passthrough()
+          ),
+          createdAt: mtMap.objectField('created_at', mtMap.date()),
+          updatedAt: mtMap.objectField('updated_at', mtMap.date())
+        })
+      )
+    })
+  ),
+  integrations: mtMap.objectField(
+    'integrations',
+    mtMap.array(
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+        configuration: mtMap.objectField(
+          'configuration',
+          mtMap.object({
+            canAttachCustomToolFilters: mtMap.objectField(
+              'can_attach_custom_tool_filters',
+              mtMap.passthrough()
+            ),
+            canAttachCustomProviderConfig: mtMap.objectField(
+              'can_attach_custom_provider_config',
+              mtMap.passthrough()
+            ),
+            canOverrideToolFilters: mtMap.objectField(
+              'can_override_tool_filters',
+              mtMap.passthrough()
+            ),
+            useIntegrationNameInToolNames: mtMap.objectField(
+              'use_integration_name_in_tool_names',
+              mtMap.passthrough()
+            )
+          })
+        ),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        archivedAt: mtMap.objectField('archived_at', mtMap.date())
+      })
+    )
+  ),
+  providers: mtMap.objectField(
+    'providers',
+    mtMap.array(
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        description: mtMap.objectField('description', mtMap.passthrough()),
+        slug: mtMap.objectField('slug', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date())
+      })
+    )
+  ),
+  createdAt: mtMap.objectField('created_at', mtMap.date()),
+  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+});
+
+export type SkillsShareBody = {
+  consumerProfileIds?: string[] | undefined;
+  organizationMemberIds?: string[] | undefined;
+  permission: 'none' | 'read' | 'write';
+};
+
+export let mapSkillsShareBody = mtMap.object<SkillsShareBody>({
+  consumerProfileIds: mtMap.objectField(
+    'consumer_profile_ids',
+    mtMap.array(mtMap.passthrough())
+  ),
+  organizationMemberIds: mtMap.objectField(
+    'organization_member_ids',
+    mtMap.array(mtMap.passthrough())
+  ),
+  permission: mtMap.objectField('permission', mtMap.passthrough())
+});
+

--- a/src/cargo/modules/skill/src/services/skill.ts
+++ b/src/cargo/modules/skill/src/services/skill.ts
@@ -423,6 +423,7 @@ class SkillServiceImpl {
       skill: SkillRecord;
       actorId: string;
       permissions: StoreParticipantPermissions[];
+      overridePermissions?: boolean;
     }
   ) {
     let actor = await actorService.getActorById({
@@ -433,7 +434,8 @@ class SkillServiceImpl {
     let participant = await storeAccessService.ensureActorStorePermissions({
       store: d.skill.store,
       actor,
-      permissions: d.permissions
+      permissions: d.permissions,
+      overridePermissions: d.overridePermissions
     });
     if (!participant) {
       throw new ServiceError(notFoundError('store.participant'));

--- a/src/cargo/modules/store/src/services/storeAccess.ts
+++ b/src/cargo/modules/store/src/services/storeAccess.ts
@@ -451,7 +451,19 @@ class StoreAccessServiceImpl {
     store: Pick<Store, 'oid'>;
     actor: TenantActor;
     permissions: StoreParticipantPermissions[];
+    overridePermissions?: boolean;
   }) {
+    if (d.overridePermissions) {
+      let [participant] = await this.upsertStoreParticipants({
+        storeOids: [d.store.oid],
+        actor: d.actor,
+        defaultPermissions: d.permissions,
+        overridePermissions: true
+      });
+
+      return participant;
+    }
+
     let [participant] = await this.ensureStoreParticipantsHavePermissions({
       actor: d.actor,
       items: [

--- a/src/cargo/service/src/controllers/skill.ts
+++ b/src/cargo/service/src/controllers/skill.ts
@@ -204,7 +204,8 @@ export let skillController = app.controller({
         environmentId: v.string(),
         skillId: v.string(),
         actorId: v.string(),
-        permissions: storePermissionsSchema
+        permissions: storePermissionsSchema,
+        overridePermissions: v.optional(v.boolean())
       })
     )
     .do(
@@ -214,7 +215,8 @@ export let skillController = app.controller({
           environment: ctx.environment,
           skill: ctx.skill,
           actorId: ctx.input.actorId,
-          permissions: ctx.input.permissions
+          permissions: ctx.input.permissions,
+          overridePermissions: ctx.input.overridePermissions
         })
     ),
 

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/index.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/index.tsx
@@ -36,6 +36,11 @@ export let SkillPage = () => {
             storeId={skill.data.storeId}
             title="Skill Files"
             description="Manage the documents and files of this skill. Describe workflows, behaviors, and tasks for agentic workflows."
+            shareContext={{
+              mode: 'dashboard',
+              organizationId: organization.data?.id,
+              skills: [{ id: skill.data.id, name: skill.data.name }]
+            }}
             getDocumentPath={documentId =>
               Paths.instance(organization.data, project.data, instance.data, 'doc', documentId)
             }

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/participants.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill/participants.tsx
@@ -1,10 +1,25 @@
 import { SkillParticipantsScene } from '@metorial/scene-skills';
-import { useCurrentInstance } from '@metorial/state';
+import { useCurrentInstance, useCurrentOrganization } from '@metorial/state';
 import { useParams } from 'react-router-dom';
 
 export let SkillParticipantsPage = () => {
   let instance = useCurrentInstance();
+  let organization = useCurrentOrganization();
   let { skillId } = useParams();
 
-  return <SkillParticipantsScene instanceId={instance.data?.id} skillId={skillId} />;
+  return (
+    <SkillParticipantsScene
+      instanceId={instance.data?.id}
+      skillId={skillId}
+      shareContext={
+        skillId
+          ? {
+              mode: 'dashboard',
+              organizationId: organization.data?.id,
+              skills: [{ id: skillId }]
+            }
+          : null
+      }
+    />
+  );
 };

--- a/src/metorial-frontend/packages/state/src/consumer/index.ts
+++ b/src/metorial-frontend/packages/state/src/consumer/index.ts
@@ -1,2 +1,3 @@
 export * from './loaders/consumers';
+export * from './loaders/portalConsumers';
 export * from './loaders/portals';

--- a/src/metorial-frontend/packages/state/src/consumer/loaders/portalConsumers.ts
+++ b/src/metorial-frontend/packages/state/src/consumer/loaders/portalConsumers.ts
@@ -1,0 +1,163 @@
+import type {
+  DashboardInstancePortalsAccessCreateBody,
+  DashboardInstancePortalsAccessListQuery,
+  DashboardInstancePortalsConsumerGroupsListQuery,
+  DashboardInstancePortalsConsumerProfilesListQuery,
+  DashboardInstancePortalsAccessUpdateBody
+} from '@metorial/dashboard-sdk';
+import { createLoader } from '@metorial/data-hooks';
+import { autoPaginate } from '../../lib/autoPaginate';
+import { usePaginator } from '../../lib/usePaginator';
+import { withAuth } from '../../user';
+
+export let portalConsumerProfilesLoader = createLoader({
+  name: 'portalConsumerProfiles',
+  parents: [],
+  fetch: (
+    i: {
+      instanceId: string;
+      portalId: string;
+    } & DashboardInstancePortalsConsumerProfilesListQuery
+  ) => withAuth(sdk => sdk.portals.consumerProfiles.list(i.instanceId, i.portalId, i)),
+  mutators: {}
+});
+
+export let usePortalConsumerProfiles = (
+  instanceId: string | null | undefined,
+  portalId: string | null | undefined,
+  query?: DashboardInstancePortalsConsumerProfilesListQuery | null
+) => {
+  return usePaginator(
+    pagination =>
+      portalConsumerProfilesLoader.use(
+        instanceId && portalId && query !== null
+          ? { instanceId, portalId, ...pagination, ...(query ?? {}) }
+          : null
+      ),
+    instanceId && portalId
+      ? `${instanceId}:${portalId}:consumer-profiles:${JSON.stringify(query ?? {})}`
+      : null
+  );
+};
+
+export let portalConsumerGroupsLoader = createLoader({
+  name: 'portalConsumerGroups',
+  parents: [],
+  fetch: (
+    i: {
+      instanceId: string;
+      portalId: string;
+    } & DashboardInstancePortalsConsumerGroupsListQuery
+  ) => withAuth(sdk => sdk.portals.consumerGroups.list(i.instanceId, i.portalId, i)),
+  mutators: {}
+});
+
+export let usePortalConsumerGroups = (
+  instanceId: string | null | undefined,
+  portalId: string | null | undefined,
+  query?: DashboardInstancePortalsConsumerGroupsListQuery | null
+) => {
+  return usePaginator(
+    pagination =>
+      portalConsumerGroupsLoader.use(
+        instanceId && portalId && query !== null
+          ? { instanceId, portalId, ...pagination, ...(query ?? {}) }
+          : null
+      ),
+    instanceId && portalId
+      ? `${instanceId}:${portalId}:consumer-groups:${JSON.stringify(query ?? {})}`
+      : null
+  );
+};
+
+export let useCreatePortalConsumerAccess = portalConsumerGroupsLoader.createExternalMutator(
+  (
+    i: DashboardInstancePortalsAccessCreateBody & {
+      instanceId: string;
+      portalId: string;
+    }
+  ) => withAuth(sdk => sdk.portals.consumerAccess.create(i.instanceId, i.portalId, i))
+);
+
+export let allPortalConsumerAccessLoader = createLoader({
+  name: 'allPortalConsumerAccess',
+  parents: [portalConsumerGroupsLoader],
+  fetch: (
+    i: {
+      instanceId: string;
+      portalId: string;
+    } & Omit<DashboardInstancePortalsAccessListQuery, 'after' | 'before' | 'cursor'>
+  ) =>
+    withAuth(sdk =>
+      autoPaginate(cursor =>
+        sdk.portals.consumerAccess.list(i.instanceId, i.portalId, {
+          ...i,
+          ...cursor,
+          limit: i.limit ?? 100
+        })
+      )
+    ),
+  mutators: {}
+});
+
+export let useAllPortalConsumerAccess = (
+  instanceId: string | null | undefined,
+  portalId: string | null | undefined,
+  query?: Omit<DashboardInstancePortalsAccessListQuery, 'after' | 'before' | 'cursor'> | null
+) => {
+  return allPortalConsumerAccessLoader.use(
+    instanceId && portalId && query !== null
+      ? { instanceId, portalId, ...(query ?? {}) }
+      : null
+  );
+};
+
+export let portalConsumerAccessLoader = createLoader({
+  name: 'portalConsumerAccess',
+  parents: [allPortalConsumerAccessLoader, portalConsumerGroupsLoader],
+  fetch: (
+    i: {
+      instanceId: string;
+      portalId: string;
+    } & DashboardInstancePortalsAccessListQuery
+  ) => withAuth(sdk => sdk.portals.consumerAccess.list(i.instanceId, i.portalId, i)),
+  mutators: {
+    update: (
+      body: DashboardInstancePortalsAccessUpdateBody & { consumerAccessId: string },
+      { input: { instanceId, portalId } }: { input: { instanceId: string; portalId: string } }
+    ) =>
+      withAuth(sdk =>
+        sdk.portals.consumerAccess.update(instanceId, portalId, body.consumerAccessId, body)
+      ),
+
+    delete: (
+      body: { consumerAccessId: string },
+      { input: { instanceId, portalId } }: { input: { instanceId: string; portalId: string } }
+    ) =>
+      withAuth(sdk =>
+        sdk.portals.consumerAccess.delete(instanceId, portalId, body.consumerAccessId)
+      )
+  }
+});
+
+export let usePortalConsumerAccess = (
+  instanceId: string | null | undefined,
+  portalId: string | null | undefined,
+  query?: DashboardInstancePortalsAccessListQuery | null
+) => {
+  let access = usePaginator(
+    pagination =>
+      portalConsumerAccessLoader.use(
+        instanceId && portalId && query !== null
+          ? { instanceId, portalId, ...pagination, ...(query ?? {}) }
+          : null
+      ),
+    instanceId && portalId ? `${instanceId}:${portalId}:consumer-access` : null
+  );
+
+  return {
+    ...access,
+    updateMutator: access.useMutator('update'),
+    deleteMutator: access.useMutator('delete')
+  };
+};

--- a/src/metorial-frontend/packages/state/src/skills/loaders/skills.ts
+++ b/src/metorial-frontend/packages/state/src/skills/loaders/skills.ts
@@ -15,6 +15,7 @@ import type {
   DashboardInstanceSkillsListQuery,
   DashboardInstanceSkillsParticipantsGetOutput,
   DashboardInstanceSkillsParticipantsListQuery,
+  DashboardInstanceSkillsShareBody,
   DashboardInstanceSkillsUpdateBody,
   DashboardInstanceSkillsVersionsGetOutput,
   DashboardInstanceSkillsVersionsListQuery,
@@ -117,6 +118,11 @@ export let useSkill = (
     deleteMutator: data.useMutator('delete')
   };
 };
+
+export let useShareSkill = skillLoader.createExternalMutator(
+  (i: DashboardInstanceSkillsShareBody & { instanceId: string; skillId: string }) =>
+    withAuth(sdk => sdk.skills.share(i.instanceId, i.skillId, i))
+);
 
 export let defaultSkillConfigurationLoader = createLoader({
   name: 'defaultSkillConfiguration',

--- a/src/metorial-frontend/packages/ui/src/dialog/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/dialog/index.tsx
@@ -1,4 +1,4 @@
 export * from './dialog';
 export * from './largePanel';
 export * from './panel';
-export { useDialogZIndex } from './state';
+export { useDialogZIndex, useZIndex, useZindex } from './state';

--- a/src/metorial-frontend/packages/ui/src/dialog/state.ts
+++ b/src/metorial-frontend/packages/ui/src/dialog/state.ts
@@ -21,7 +21,7 @@ export let useDialog = (initialState = false) => {
 };
 
 let currentZIndexRef = { value: 1000 };
-export let useDialogZIndex = (isOpen: boolean) => {
+export let useZindex = (isOpen: boolean) => {
   let [zIndex, setZIndex] = useState(() => currentZIndexRef.value + 5);
 
   useEffect(() => {
@@ -31,6 +31,9 @@ export let useDialogZIndex = (isOpen: boolean) => {
 
   return zIndex;
 };
+
+export let useZIndex = useZindex;
+export let useDialogZIndex = useZindex;
 
 let DialogContext = React.createContext<DialogState | null>(null);
 export let DialogProvider = DialogContext.Provider;

--- a/src/metorial-frontend/packages/ui/src/popover/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/popover/index.tsx
@@ -1,7 +1,7 @@
 import * as RadixPopover from '@radix-ui/react-popover';
 import React, { useEffect, useState } from 'react';
 import { keyframes, styled } from 'styled-components';
-import { useDialogZIndex } from '../dialog/state';
+import { useZindex } from '../dialog/state';
 import { theme } from '../theme';
 
 let fadeInTop = keyframes`
@@ -195,7 +195,7 @@ let Root = ({
     if (typeof openProp === 'boolean') setOpen(openProp);
   }, [openProp]);
 
-  let zIndex = useDialogZIndex(open);
+  let zIndex = useZindex(open);
 
   return (
     <RadixPopover.Root open={open} onOpenChange={setOpen}>
@@ -208,6 +208,10 @@ let Root = ({
           align={align}
           sideOffset={sideOffset}
           alignOffset={alignOffset}
+          onInteractOutside={event => {
+            let target = event.target as Element | null;
+            if (target?.closest('[data-metorial-select-content]')) event.preventDefault();
+          }}
         >
           {children}
 

--- a/src/metorial-frontend/packages/ui/src/select/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/select/index.tsx
@@ -4,7 +4,7 @@ import { RiArrowDownSLine, RiArrowUpSLine, RiCheckLine } from '@remixicon/react'
 import React, { useEffect, useId, useMemo, useState } from 'react';
 import { keyframes, styled } from 'styled-components';
 import { ButtonSize, getButtonSize } from '../button/constants';
-import { useDialogZIndex } from '../dialog/state';
+import { useZindex } from '../dialog/state';
 import { Error } from '../error';
 import { InputDescription, InputLabel } from '../input';
 import { theme } from '../theme';
@@ -155,7 +155,7 @@ export let Select = ({
   let normalizedValue = value === '' ? undefined : value;
 
   let [isOpen, setIsOpen] = useState(false);
-  let zIndex = useDialogZIndex(isOpen);
+  let zIndex = useZindex(isOpen);
 
   let disabledItems = useMemo(
     () =>
@@ -215,7 +215,7 @@ export let Select = ({
           </RadixSelect.Icon>
         </Trigger>
         <RadixSelect.Portal>
-          <Content style={{ zIndex }}>
+          <Content data-metorial-select-content="true" style={{ zIndex }}>
             <RadixSelect.ScrollUpButton className="SelectScrollButton">
               <RiArrowUpSLine size={14} />
             </RadixSelect.ScrollUpButton>

--- a/src/metorial-frontend/scenes/docs/package.json
+++ b/src/metorial-frontend/scenes/docs/package.json
@@ -13,6 +13,7 @@
     "@metorial/data-hooks": "^1.0.0",
     "@metorial/dynamic-component": "^1.0.0",
     "@metorial/frontend-config": "^1.0.0",
+    "@metorial/scene-skills": "^1.0.0",
     "@metorial/state": "^1.0.0",
     "@metorial/ui": "^1.0.0",
     "@radix-ui/react-popover": "^1.1.13",

--- a/src/metorial-frontend/scenes/docs/src/components/Popover.tsx
+++ b/src/metorial-frontend/scenes/docs/src/components/Popover.tsx
@@ -1,3 +1,4 @@
+import { useZindex } from '@metorial/ui';
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
@@ -14,7 +15,6 @@ interface WrapProps {
 
 let Wrap = styled.div<WrapProps>`
   position: fixed;
-  z-index: 1000;
   ${({ $width }) =>
     $width != null ? `width: ${typeof $width === 'number' ? `${$width}px` : $width};` : ''}
   display: flex;
@@ -65,6 +65,7 @@ export function Popover({
   let presence = usePresence(open, EXIT);
   let wrapRef = useRef<HTMLDivElement | null>(null);
   let [position, setPosition] = useState({ left: anchor.left, top: anchor.top });
+  let zIndex = useZindex(open);
 
   useEffect(() => {
     if (!open) return;
@@ -72,6 +73,7 @@ export function Popover({
       let target = e.target as Element | null;
       if (!wrapRef.current) return;
       if (wrapRef.current.contains(target as Node)) return;
+      if (target?.closest('[data-metorial-select-content]')) return;
       if (ignoreClickOnSelector && target?.closest(ignoreClickOnSelector)) return;
       onClose();
     };
@@ -118,10 +120,9 @@ export function Popover({
     <Wrap
       ref={wrapRef}
       data-state={presence.dataState}
-      style={{ left: position.left, top: position.top }}
+      style={{ left: position.left, top: position.top, zIndex }}
       $width={width}
       $alignRight={align === 'right'}
-      onMouseDown={e => e.preventDefault()}
     >
       {children}
     </Wrap>,

--- a/src/metorial-frontend/scenes/docs/src/editor/HeaderActions.tsx
+++ b/src/metorial-frontend/scenes/docs/src/editor/HeaderActions.tsx
@@ -1,3 +1,4 @@
+import { SkillSharePanelContent, type SkillSharePanelContext } from '@metorial/scene-skills';
 import { Button, Input, Tooltip } from '@metorial/ui';
 import { useCallback, useState, type ReactNode } from 'react';
 import styled from 'styled-components';
@@ -8,10 +9,10 @@ import {
   IconCheck,
   IconCloudCheck,
   IconCopy,
-  IconInfo,
   IconDots,
   IconDownload,
   IconHistory,
+  IconInfo,
   IconKeyboard,
   IconShare,
   IconUpload
@@ -497,12 +498,22 @@ export interface SharedPerson {
 }
 
 interface ShareButtonProps {
+  instanceId: string;
   documentLink: string;
   people: SharedPerson[];
   onCopyLink: () => void;
+  skillShareContext?: SkillSharePanelContext | null;
+  onSharedSkill?: () => void | Promise<void>;
 }
 
-export function ShareButton({ documentLink, people, onCopyLink }: ShareButtonProps) {
+export function ShareButton({
+  instanceId,
+  documentLink,
+  people,
+  onCopyLink,
+  skillShareContext,
+  onSharedSkill
+}: ShareButtonProps) {
   let { triggerRef, open, anchor, closeMenu, toggle } = usePopoverAnchor('right');
   let [copied, setCopied] = useState(false);
 
@@ -531,43 +542,51 @@ export function ShareButton({ documentLink, people, onCopyLink }: ShareButtonPro
         open={open}
         anchor={anchor}
         align="right"
-        width={320}
+        width={skillShareContext ? 450 : 320}
         ignoreClickOnSelector={POPOVER_TRIGGER_SELECTOR}
         onClose={closeMenu}
       >
-        <PopoverList>
-          <SectionLabel>Document link</SectionLabel>
-          <RowAction type="button" onClick={handleCopy}>
-            <span className="icon">{copied ? <IconCheck /> : <IconCopy />}</span>
-            <span className="label">
-              <span className="title">{copied ? 'Copied to clipboard' : 'Copy link'}</span>
-              <span className="desc" title={documentLink}>
-                {documentLink}
+        {skillShareContext ? (
+          <SkillSharePanelContent
+            instanceId={instanceId}
+            context={skillShareContext}
+            onShared={onSharedSkill}
+          />
+        ) : (
+          <PopoverList>
+            <SectionLabel>Document link</SectionLabel>
+            <RowAction type="button" onClick={handleCopy}>
+              <span className="icon">{copied ? <IconCheck /> : <IconCopy />}</span>
+              <span className="label">
+                <span className="title">{copied ? 'Copied to clipboard' : 'Copy link'}</span>
+                <span className="desc" title={documentLink}>
+                  {documentLink}
+                </span>
               </span>
-            </span>
-          </RowAction>
-          <RowDivider />
-          <SectionLabel>People with access</SectionLabel>
-          {people.map(p => {
-            let activity = describePersonActivity(p.lastEditedAt, p.lastViewedAt);
-            return (
-              <PersonRow key={p.email}>
-                <Avatar name={p.name} imageUrl={p.imageUrl} email={p.email} size={28} />
-                <PersonInfo>
-                  <PersonName>{p.name}</PersonName>
-                  <PersonEmail>{p.email}</PersonEmail>
-                </PersonInfo>
-                <PersonMeta>
-                  <RoleBadge $role={p.role}>{p.role}</RoleBadge>
-                  <PersonActivity title={activity.fullDate ?? activity.text}>
-                    {activity.text}
-                  </PersonActivity>
-                </PersonMeta>
-              </PersonRow>
-            );
-          })}
-          {people.length === 0 && <FooterText>No collaborators yet.</FooterText>}
-        </PopoverList>
+            </RowAction>
+            <RowDivider />
+            <SectionLabel>People with access</SectionLabel>
+            {people.map(p => {
+              let activity = describePersonActivity(p.lastEditedAt, p.lastViewedAt);
+              return (
+                <PersonRow key={p.email}>
+                  <Avatar name={p.name} imageUrl={p.imageUrl} email={p.email} size={28} />
+                  <PersonInfo>
+                    <PersonName>{p.name}</PersonName>
+                    <PersonEmail>{p.email}</PersonEmail>
+                  </PersonInfo>
+                  <PersonMeta>
+                    <RoleBadge $role={p.role}>{p.role}</RoleBadge>
+                    <PersonActivity title={activity.fullDate ?? activity.text}>
+                      {activity.text}
+                    </PersonActivity>
+                  </PersonMeta>
+                </PersonRow>
+              );
+            })}
+            {people.length === 0 && <FooterText>No collaborators yet.</FooterText>}
+          </PopoverList>
+        )}
       </Popover>
     </>
   );

--- a/src/metorial-frontend/scenes/docs/src/scenes/documentEditor.tsx
+++ b/src/metorial-frontend/scenes/docs/src/scenes/documentEditor.tsx
@@ -1,3 +1,4 @@
+import type { SkillSharePanelContext } from '@metorial/scene-skills';
 import {
   DocumentParticipant,
   DocumentVersion as StateDocumentVersion,
@@ -13,7 +14,7 @@ import {
 import type { Editor as TiptapEditor } from '@tiptap/react';
 import type { ChangeEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useBlocker, useNavigate } from 'react-router-dom';
+import { useBlocker, useLocation, useNavigate } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 import { parseDocument } from 'yaml';
 import { Editor } from '../editor/Editor';
@@ -298,6 +299,7 @@ type PendingDocumentSave = { title: string; content: string };
 export type DocumentEditorSceneProps = {
   instanceId: string | null | undefined;
   documentId: string | null | undefined;
+  currentConsumerId?: string | null;
   onBack?: () => void;
   setRestrictHeight?: (enabled: boolean) => void;
 };
@@ -439,6 +441,59 @@ let getErrorMessage = (error: unknown) => {
   return 'Failed to load document.';
 };
 
+let parseJsonObject = (value: string): unknown => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+let getObjectFromUnknown = (value: unknown): Record<string, unknown> | null => {
+  let normalized = typeof value == 'string' ? parseJsonObject(value) : value;
+  if (!normalized || typeof normalized != 'object' || Array.isArray(normalized)) return null;
+  return normalized as Record<string, unknown>;
+};
+
+let getSkillShareContextFromState = (
+  state: unknown,
+  currentConsumerId?: string | null
+): SkillSharePanelContext | null => {
+  let stateObject = getObjectFromUnknown(state);
+  if (!stateObject) return null;
+
+  let context = getObjectFromUnknown(stateObject.metorialSkillShare ?? stateObject);
+  if (!context) return null;
+
+  let candidate = context as Partial<SkillSharePanelContext>;
+  if (candidate.mode != 'portal' && candidate.mode != 'dashboard') return null;
+  if (!Array.isArray(candidate.skills) || candidate.skills.length == 0) return null;
+
+  let skills = candidate.skills
+    .filter(skill => skill && typeof skill == 'object' && typeof skill.id == 'string')
+    .map(skill => ({
+      id: (skill as { id: string }).id,
+      name:
+        typeof (skill as { name?: unknown }).name == 'string'
+          ? ((skill as { name?: string }).name ?? null)
+          : null
+    }));
+
+  if (skills.length == 0) return null;
+
+  return {
+    mode: candidate.mode,
+    portalId: typeof candidate.portalId == 'string' ? candidate.portalId : null,
+    organizationId:
+      typeof candidate.organizationId == 'string' ? candidate.organizationId : null,
+    currentConsumerId:
+      typeof candidate.currentConsumerId == 'string'
+        ? candidate.currentConsumerId
+        : (currentConsumerId ?? null),
+    skills
+  };
+};
+
 let DocumentEditorSkeleton = (p: { onBack?: () => void }) => {
   let theme = useMemo(() => lightTheme, []);
 
@@ -527,6 +582,7 @@ let DocumentEditorLoadError = (p: { onBack?: () => void; message: string }) => {
 let DocumentEditorInner = (p: {
   instanceId: string;
   documentId: string;
+  currentConsumerId?: string | null;
   onBack?: () => void;
 }) => {
   let document = useDocument(p.instanceId, p.documentId);
@@ -571,7 +627,9 @@ let DocumentEditorInner = (p: {
       user={user.data}
       instanceId={p.instanceId}
       documentId={p.documentId}
+      currentConsumerId={p.currentConsumerId}
       onBack={p.onBack}
+      onSharedSkill={() => participants.refetch()}
     />
   );
 
@@ -595,7 +653,9 @@ let DocumentEditorLoaded = (p: {
   participants: DocumentParticipant[];
   versions: StateDocumentVersion[];
   user: NonNullable<ReturnType<typeof useUser>['data']>;
+  currentConsumerId?: string | null;
   onBack?: () => void;
+  onSharedSkill?: () => void | Promise<void>;
 }) => {
   let [viewMode, setViewMode] = useState<ViewMode>('editor');
   let initialDocumentState = useMemo(
@@ -628,6 +688,7 @@ let DocumentEditorLoaded = (p: {
   let uploadFile = useUploadFile();
   let createFileLink = useCreateFileLink();
   let navigate = useNavigate();
+  let location = useLocation();
   let mainRef = useRef<HTMLDivElement | null>(null);
   let toastTimer = useRef<number | null>(null);
   let fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -884,6 +945,10 @@ let DocumentEditorLoaded = (p: {
     if (editors.some(person => person.email === p.user.email)) return editors;
     return [currentAsEditor, ...editors];
   }, [canWrite, lastUpdatedAt, p.user.email, p.user.imageUrl, p.user.name, people]);
+  let skillShareContext = useMemo(
+    () => getSkillShareContextFromState(location.state, p.currentConsumerId),
+    [location.state, p.currentConsumerId]
+  );
   let hasUnsavedChanges =
     canWrite &&
     (title !== lastPersistedRef.current.title ||
@@ -1117,9 +1182,12 @@ let DocumentEditorLoaded = (p: {
                 email={p.user.email}
               />
               <ShareButton
+                instanceId={p.instanceId}
                 documentLink={documentLink}
                 people={people}
                 onCopyLink={handleCopyLink}
+                skillShareContext={skillShareContext}
+                onSharedSkill={p.onSharedSkill}
               />
               <SettingsButton
                 contentWidth={contentWidth}
@@ -1220,6 +1288,7 @@ let DocumentEditorLoaded = (p: {
 export let DocumentEditorScene = ({
   instanceId,
   documentId,
+  currentConsumerId,
   onBack,
   setRestrictHeight
 }: DocumentEditorSceneProps) => {
@@ -1231,6 +1300,11 @@ export let DocumentEditorScene = ({
   if (!instanceId || !documentId) return null;
 
   return (
-    <DocumentEditorInner instanceId={instanceId} documentId={documentId} onBack={onBack} />
+    <DocumentEditorInner
+      instanceId={instanceId}
+      documentId={documentId}
+      currentConsumerId={currentConsumerId}
+      onBack={onBack}
+    />
   );
 };

--- a/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
+++ b/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
@@ -14,6 +14,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { SkillFilePreviewLightbox } from './filePreviewLightbox';
+import type { SkillSharePanelContext } from './skillSharePanel';
 
 export type SkillFileTreeNode = {
   id: string;
@@ -28,6 +29,9 @@ export type SkillFileTreeNode = {
   isPending?: boolean;
   children: SkillFileTreeNode[];
 };
+
+let getSkillShareNavigationState = (shareContext?: SkillSharePanelContext | null) =>
+  shareContext ? { metorialSkillShare: shareContext } : undefined;
 
 let TreeRoot = styled.div`
   display: flex;
@@ -506,6 +510,7 @@ let SkillFileTreeRow = (p: {
   onFileSelect: (parentPath: string, file: File) => Promise<void>;
   onFilesDrop: (parentPath: string, files: File[]) => Promise<void>;
   getDocumentPath: (documentId: string) => string;
+  shareContext?: SkillSharePanelContext | null;
   instanceId: string | null | undefined;
   editingItemPath: string | null;
   onCancelRename: () => void;
@@ -592,8 +597,12 @@ let SkillFileTreeRow = (p: {
         draggable={canDrag}
         onClick={e => {
           if (isNestedTreeActionClick(e)) return;
-          if (documentPath) navigate(documentPath);
-          else if (p.node.kind == 'file' && p.node.fileId) previewTriggerRef.current?.click();
+          if (documentPath) {
+            navigate(documentPath, {
+              state: getSkillShareNavigationState(p.shareContext)
+            });
+          } else if (p.node.kind == 'file' && p.node.fileId)
+            previewTriggerRef.current?.click();
         }}
         onDragStart={e => {
           if (!canDrag || !p.node.itemId || !p.node.parentPath || p.node.kind == 'directory') {
@@ -655,7 +664,7 @@ let SkillFileTreeRow = (p: {
         }}
       >
         {documentPath ? (
-          <TreeRowLink to={documentPath}>
+          <TreeRowLink to={documentPath} state={getSkillShareNavigationState(p.shareContext)}>
             <TreeIndent $depth={p.depth} />
             <ChevronSpacer />
             <TreeIconWrap $kind={p.node.kind}>
@@ -986,6 +995,7 @@ let SkillFileTreeRow = (p: {
                   onFileSelect={p.onFileSelect}
                   onFilesDrop={p.onFilesDrop}
                   getDocumentPath={p.getDocumentPath}
+                  shareContext={p.shareContext}
                   instanceId={p.instanceId}
                   editingItemPath={p.editingItemPath}
                   onCancelRename={p.onCancelRename}
@@ -1026,6 +1036,7 @@ let SkillFileTreeInner = (p: {
   onFileSelect: (parentPath: string, file: File) => Promise<void>;
   onFilesDrop: (parentPath: string, files: File[]) => Promise<void>;
   getDocumentPath: (documentId: string) => string;
+  shareContext?: SkillSharePanelContext | null;
   instanceId: string | null | undefined;
   editingItemPath: string | null;
   onCancelRename: () => void;
@@ -1055,6 +1066,7 @@ let SkillFileTreeInner = (p: {
             onFileSelect={p.onFileSelect}
             onFilesDrop={p.onFilesDrop}
             getDocumentPath={p.getDocumentPath}
+            shareContext={p.shareContext}
             instanceId={p.instanceId}
             editingItemPath={p.editingItemPath}
             onCancelRename={p.onCancelRename}
@@ -1090,6 +1102,7 @@ export let SkillFileTree = (p: {
   onFileSelect: (parentPath: string, file: File) => Promise<void>;
   onFilesDrop: (parentPath: string, files: File[]) => Promise<void>;
   getDocumentPath: (documentId: string) => string;
+  shareContext?: SkillSharePanelContext | null;
   instanceId: string | null | undefined;
   onRename: (itemId: string, parentPath: string, name: string) => Promise<void>;
   onMove: (itemId: string, parentPath: string, name: string) => Promise<void>;
@@ -1120,6 +1133,7 @@ export let SkillFileTree = (p: {
       onFileSelect={p.onFileSelect}
       onFilesDrop={p.onFilesDrop}
       getDocumentPath={p.getDocumentPath}
+      shareContext={p.shareContext}
       instanceId={p.instanceId}
       onCancelRename={() => setEditingItemPath(null)}
       onDragTargetChange={setDragTargetPath}

--- a/src/metorial-frontend/scenes/skills/src/components/index.ts
+++ b/src/metorial-frontend/scenes/skills/src/components/index.ts
@@ -1,3 +1,4 @@
-export * from './fileTree';
 export * from './filePreviewLightbox';
+export * from './fileTree';
+export * from './skillSharePanel';
 export * from './surfaceCard';

--- a/src/metorial-frontend/scenes/skills/src/components/skillSharePanel.tsx
+++ b/src/metorial-frontend/scenes/skills/src/components/skillSharePanel.tsx
@@ -1,0 +1,885 @@
+import {
+  useCreatePortalConsumerAccess,
+  useOrganizationMembers,
+  usePortalConsumerAccess,
+  usePortalConsumerGroups,
+  usePortalConsumerProfiles,
+  usePortals,
+  useShareSkill,
+  useSkillParticipants,
+  useUser
+} from '@metorial/state';
+import {
+  Avatar,
+  Button,
+  Input,
+  Popover,
+  Select,
+  Spacer,
+  Tabs,
+  Text,
+  theme
+} from '@metorial/ui';
+import { RiArrowLeftSLine, RiCheckLine } from '@remixicon/react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import styled from 'styled-components';
+
+export type SkillSharePanelMode = 'portal' | 'dashboard';
+
+export type SkillSharePanelSkill = {
+  id: string;
+  name?: string | null;
+};
+
+export type SkillSharePanelContext = {
+  mode: SkillSharePanelMode;
+  portalId?: string | null;
+  organizationId?: string | null;
+  currentConsumerId?: string | null;
+  skills: SkillSharePanelSkill[];
+};
+
+type AccountCandidate =
+  | {
+      type: 'consumer';
+      id: string;
+      name: string;
+      email: string;
+      imageUrl?: string | null;
+    }
+  | {
+      type: 'member';
+      id: string;
+      actorId: string;
+      name: string;
+      email: string | null;
+      imageUrl?: string | null;
+    };
+
+let PanelStack = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+let InviteRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+`;
+
+let ContentPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 500px;
+  padding: 10px 20px 20px 20px;
+`;
+
+let RowList = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-height: 350px;
+  overflow: auto;
+  gap: 3px;
+`;
+
+let AccessRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 56px;
+  padding: 6px 0;
+`;
+
+let CandidateRow = styled.button<{ $selected?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 56px;
+  padding: 6px 15px 6px 8px;
+  border: 0;
+  border-radius: 8px;
+  background: ${p => (p.$selected ? theme.colors.blue200 : 'transparent')};
+  color: ${theme.colors.foreground};
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: ${p => (p.$selected ? theme.colors.blue300 : theme.colors.gray200)};
+  }
+`;
+
+let PersonInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+`;
+
+let PersonName = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: ${theme.colors.foreground};
+`;
+
+let Truncate = styled.span`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+let Muted = styled.span`
+  font-size: 12px;
+  color: ${theme.colors.gray700};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+let Pill = styled.span`
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: ${theme.colors.orange200};
+  color: ${theme.colors.orange900};
+  font-size: 11px;
+  font-weight: 600;
+`;
+
+let AccessSelectWrap = styled.div`
+  width: 132px;
+  flex: 0 0 auto;
+`;
+
+let InvitePermissionFooter = styled.div`
+  position: sticky;
+  bottom: -20px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 10px 0 0 0;
+  margin-top: auto;
+  background: ${theme.colors.background};
+`;
+
+let InvitePermissionLabel = styled.div`
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: ${theme.colors.gray700};
+`;
+
+let EmptyState = styled.div``;
+
+let inviteAccessItems = [
+  { id: 'read', label: 'Can view' },
+  { id: 'write', label: 'Full access' }
+];
+
+let accountAccessItems = [{ id: 'none', label: 'No access' }, ...inviteAccessItems];
+
+let getSkillLabel = (skill: SkillSharePanelSkill) => skill.name || skill.id;
+
+let getPortalItems = (
+  portals:
+    | {
+        id: string;
+        name: string;
+      }[]
+    | undefined
+) => (portals ?? []).map(portal => ({ id: portal.id, label: portal.name }));
+
+let getSkillItems = (skills: SkillSharePanelSkill[]) =>
+  skills.map(skill => ({ id: skill.id, label: getSkillLabel(skill) }));
+
+let getParticipantPermission = (roles: string[]): 'read' | 'write' =>
+  roles.some(role => role == 'creator' || role == 'editor' || role == 'forker')
+    ? 'write'
+    : 'read';
+
+let canParticipantWrite = (roles: string[]) =>
+  roles.some(role => role == 'creator' || role == 'editor' || role == 'forker');
+
+let filterBySearch = (value: string, search: string) =>
+  value.toLowerCase().includes(search.trim().toLowerCase());
+
+export let SkillSharePanelContent = (p: {
+  instanceId: string | null | undefined;
+  context: SkillSharePanelContext | null | undefined;
+  onShared?: () => void | Promise<void>;
+}) => {
+  let skills = useMemo(
+    () => (p.context?.skills ?? []).filter(skill => !!skill.id),
+    [p.context?.skills]
+  );
+  let [selectedSkillId, setSelectedSkillId] = useState(skills[0]?.id ?? '');
+  let [selectedPortalId, setSelectedPortalId] = useState(p.context?.portalId ?? '');
+  let [search, setSearch] = useState('');
+  let [isSearching, setIsSearching] = useState(false);
+  let [selectedAccountKeys, setSelectedAccountKeys] = useState<Set<string>>(new Set());
+  let [permission, setPermission] = useState<'read' | 'write'>('read');
+  let [activeTab, setActiveTab] = useState<'accounts' | 'portal-groups'>('accounts');
+  let [sharingGroupId, setSharingGroupId] = useState<string | null>(null);
+  let [removingGroupId, setRemovingGroupId] = useState<string | null>(null);
+
+  let mode = p.context?.mode ?? 'dashboard';
+  let canManagePortalGroups = mode == 'dashboard';
+  let portals = usePortals(mode == 'dashboard' ? p.instanceId : null, {
+    limit: 100,
+    order: 'asc'
+  });
+  let activePortalId = mode == 'portal' ? (p.context?.portalId ?? '') : selectedPortalId;
+  let showPortalSelect = mode == 'dashboard' && (portals.data?.items?.length ?? 0) > 1;
+  let participants = useSkillParticipants(p.instanceId, selectedSkillId, {
+    limit: 100,
+    order: 'asc'
+  });
+  let consumerProfiles = usePortalConsumerProfiles(p.instanceId, activePortalId, {
+    limit: 100,
+    order: 'asc',
+    search: search.trim() || undefined
+  });
+  let organizationMembers = useOrganizationMembers(
+    mode == 'dashboard' ? p.context?.organizationId : null
+  );
+  let consumerGroups = usePortalConsumerGroups(p.instanceId, activePortalId, {
+    limit: 100,
+    order: 'asc',
+    search: search.trim() || undefined
+  });
+  let portalAccess = usePortalConsumerAccess(p.instanceId, activePortalId, {
+    limit: 100,
+    order: 'asc',
+    skillId: selectedSkillId || undefined
+  });
+  let shareSkill = useShareSkill();
+  let createPortalAccess = useCreatePortalConsumerAccess();
+  let deletePortalAccess = portalAccess.deleteMutator();
+  let currentUser = useUser();
+
+  useEffect(() => {
+    if (skills.some(skill => skill.id == selectedSkillId)) return;
+    setSelectedSkillId(skills[0]?.id ?? '');
+  }, [selectedSkillId, skills]);
+
+  useEffect(() => {
+    if (mode != 'portal') return;
+    setSelectedPortalId(p.context?.portalId ?? '');
+  }, [mode, p.context?.portalId]);
+
+  useEffect(() => {
+    if (mode != 'dashboard') return;
+    if (selectedPortalId) return;
+
+    let firstPortal = portals.data?.items?.[0];
+    if (firstPortal) setSelectedPortalId(firstPortal.id);
+  }, [mode, portals.data?.items, selectedPortalId]);
+
+  useEffect(() => {
+    setSelectedAccountKeys(new Set());
+    setSearch('');
+    setIsSearching(false);
+    setSharingGroupId(null);
+    setRemovingGroupId(null);
+  }, [activePortalId, selectedSkillId]);
+
+  useEffect(() => {
+    if (canManagePortalGroups) return;
+    setActiveTab('accounts');
+  }, [canManagePortalGroups]);
+
+  let selectedSkill = skills.find(skill => skill.id == selectedSkillId);
+  let hasShareTarget =
+    !!p.instanceId && !!selectedSkillId && (mode == 'dashboard' ? !!activePortalId : true);
+  let selectedAccountCount = selectedAccountKeys.size;
+  let currentUserEmail = currentUser.data?.email ?? null;
+  let currentConsumerParticipant = useMemo(() => {
+    if (mode != 'portal' || !p.context?.currentConsumerId) return null;
+    return (
+      (participants.data?.items ?? []).find(
+        participant => participant.actor.consumer?.id == p.context?.currentConsumerId
+      ) ?? null
+    );
+  }, [mode, p.context, participants.data?.items]);
+  let canManageAccess =
+    mode == 'dashboard' ||
+    (!!currentConsumerParticipant && canParticipantWrite(currentConsumerParticipant.roles));
+
+  let memberByActorId = useMemo(() => {
+    let map = new Map<string, NonNullable<typeof organizationMembers.data>['items'][number]>();
+    for (let member of organizationMembers.data?.items ?? []) {
+      map.set(member.actorId, member);
+    }
+    return map;
+  }, [organizationMembers.data?.items]);
+
+  let profileByConsumerId = useMemo(() => {
+    let map = new Map<string, NonNullable<typeof consumerProfiles.data>['items'][number]>();
+    for (let profile of consumerProfiles.data?.items ?? []) {
+      map.set(profile.consumerId, profile);
+    }
+    return map;
+  }, [consumerProfiles.data?.items]);
+
+  let participantAccountKeys = useMemo(() => {
+    let set = new Set<string>();
+    for (let participant of participants.data?.items ?? []) {
+      let consumerProfile = participant.actor.consumer?.id
+        ? profileByConsumerId.get(participant.actor.consumer.id)
+        : null;
+      if (consumerProfile) set.add(`consumer:${consumerProfile.id}`);
+      let actorId = participant.actor.organizationActor?.id;
+      let member = actorId ? memberByActorId.get(actorId) : null;
+      if (member) set.add(`member:${member.id}`);
+    }
+    return set;
+  }, [memberByActorId, participants.data?.items, profileByConsumerId]);
+
+  let accountCandidates = useMemo<AccountCandidate[]>(() => {
+    let candidates: AccountCandidate[] = [];
+
+    for (let profile of consumerProfiles.data?.items ?? []) {
+      if (profile.consumerId == p.context?.currentConsumerId) continue;
+      let key = `consumer:${profile.id}`;
+      if (participantAccountKeys.has(key)) continue;
+      candidates.push({
+        type: 'consumer',
+        id: profile.id,
+        name: profile.name || profile.email,
+        email: profile.email,
+        imageUrl: profile.imageUrl
+      });
+    }
+
+    if (mode == 'dashboard') {
+      for (let member of organizationMembers.data?.items ?? []) {
+        if (currentUserEmail && member.actor.email == currentUserEmail) continue;
+        let key = `member:${member.id}`;
+        if (participantAccountKeys.has(key)) continue;
+        candidates.push({
+          type: 'member',
+          id: member.id,
+          actorId: member.actorId,
+          name: member.actor.name,
+          email: member.actor.email,
+          imageUrl: member.actor.imageUrl
+        });
+      }
+    }
+
+    if (!search.trim()) return candidates;
+
+    return candidates.filter(candidate =>
+      filterBySearch(`${candidate.name} ${candidate.email ?? ''}`, search)
+    );
+  }, [
+    consumerProfiles.data?.items,
+    currentUserEmail,
+    mode,
+    organizationMembers.data?.items,
+    p.context?.currentConsumerId,
+    participantAccountKeys,
+    search
+  ]);
+
+  let toggleAccount = (candidate: AccountCandidate) => {
+    let key = `${candidate.type}:${candidate.id}`;
+    setSelectedAccountKeys(current => {
+      let next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  let stopInviteSearch = () => {
+    setSearch('');
+    setIsSearching(false);
+    setSelectedAccountKeys(new Set());
+  };
+
+  useEffect(() => {
+    if (canManageAccess) return;
+    setSearch('');
+    setIsSearching(false);
+    setSelectedAccountKeys(new Set());
+  }, [canManageAccess]);
+
+  let shareWithAccounts = async () => {
+    if (!p.instanceId || !selectedSkillId || selectedAccountKeys.size == 0) return;
+
+    let consumerProfileIds: string[] = [];
+    let organizationMemberIds: string[] = [];
+
+    for (let key of selectedAccountKeys) {
+      let [type, id] = key.split(':');
+      if (type == 'consumer' && id) {
+        let profile = consumerProfiles.data?.items?.find(profile => profile.id == id);
+        if (profile?.consumerId != p.context?.currentConsumerId) consumerProfileIds.push(id);
+      }
+      if (type == 'member' && id && mode == 'dashboard') {
+        let member = organizationMembers.data?.items?.find(member => member.id == id);
+        if (!currentUserEmail || member?.actor.email != currentUserEmail) {
+          organizationMemberIds.push(id);
+        }
+      }
+    }
+
+    if (!consumerProfileIds.length && !organizationMemberIds.length) return;
+
+    let [shared] = await shareSkill.mutate({
+      instanceId: p.instanceId,
+      skillId: selectedSkillId,
+      consumerProfileIds,
+      organizationMemberIds,
+      permission
+    });
+
+    if (!shared) return;
+
+    setSelectedAccountKeys(new Set());
+    setSearch('');
+    setIsSearching(false);
+    await participants.refetch();
+    await p.onShared?.();
+  };
+
+  let updateAccountAccess = async (
+    participant: NonNullable<typeof participants.data>['items'][number],
+    nextPermission: 'none' | 'read' | 'write'
+  ) => {
+    if (!p.instanceId || !selectedSkillId) return;
+
+    let consumerProfileId = participant.actor.consumer?.id
+      ? profileByConsumerId.get(participant.actor.consumer.id)?.id
+      : null;
+    let actorId = participant.actor.organizationActor?.id;
+    let isCurrentConsumer =
+      !!participant.actor.consumer?.id &&
+      participant.actor.consumer.id == p.context?.currentConsumerId;
+    let isCurrentOrganizationMember =
+      mode == 'dashboard' &&
+      !!currentUserEmail &&
+      participant.actor.organizationActor?.email == currentUserEmail;
+    if (isCurrentConsumer || isCurrentOrganizationMember) return;
+    if (mode != 'dashboard' && actorId) return;
+    let memberId = mode == 'dashboard' && actorId ? memberByActorId.get(actorId)?.id : null;
+    if (!consumerProfileId && !memberId) return;
+
+    let [shared] = await shareSkill.mutate({
+      instanceId: p.instanceId,
+      skillId: selectedSkillId,
+      consumerProfileIds: consumerProfileId ? [consumerProfileId] : [],
+      organizationMemberIds: memberId ? [memberId] : [],
+      permission: nextPermission
+    });
+
+    if (!shared) return;
+    await participants.refetch();
+    await p.onShared?.();
+  };
+
+  let shareWithGroup = async (consumerGroupId: string) => {
+    if (!p.instanceId || !selectedSkillId || !activePortalId) return;
+
+    setSharingGroupId(consumerGroupId);
+    try {
+      let [created] = await createPortalAccess.mutate({
+        instanceId: p.instanceId,
+        portalId: activePortalId,
+        consumerGroupId,
+        name: selectedSkill ? getSkillLabel(selectedSkill) : undefined,
+        access: {
+          type: 'skill',
+          skillId: selectedSkillId
+        }
+      });
+
+      if (!created) return;
+
+      await portalAccess.refetch();
+      await p.onShared?.();
+    } finally {
+      setSharingGroupId(null);
+    }
+  };
+
+  let removeGroupAccess = async (consumerAccessId: string) => {
+    if (!p.instanceId || !activePortalId) return;
+
+    setRemovingGroupId(consumerAccessId);
+    try {
+      let [deleted] = await deletePortalAccess.mutate({ consumerAccessId });
+      if (!deleted) return;
+      await portalAccess.refetch();
+      await p.onShared?.();
+    } finally {
+      setRemovingGroupId(null);
+    }
+  };
+
+  if (!p.context || skills.length == 0) {
+    return (
+      <EmptyState>
+        <Text size="2" color="gray600">
+          This document is not linked to a shareable skill.
+        </Text>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <PanelStack>
+      {skills.length > 1 && (
+        <Select
+          label="Skill"
+          size="2"
+          value={selectedSkillId}
+          items={getSkillItems(skills)}
+          onChange={setSelectedSkillId}
+        />
+      )}
+
+      {showPortalSelect && (
+        <Select
+          label="Portal"
+          size="2"
+          value={selectedPortalId}
+          placeholder="Select a portal"
+          items={getPortalItems(portals.data?.items)}
+          onChange={setSelectedPortalId}
+        />
+      )}
+
+      {canManagePortalGroups ? (
+        <div>
+          <Tabs
+            current={activeTab}
+            tabs={[
+              { id: 'accounts', label: 'Accounts' },
+              { id: 'portal-groups', label: 'Portal Groups' }
+            ]}
+            action={id => {
+              if (id == 'accounts' || id == 'portal-groups') {
+                setActiveTab(id);
+                setSearch('');
+                setIsSearching(false);
+              }
+            }}
+            margin={{ bottom: 8, top: 8 }}
+            padding={{ left: 20, right: 20 }}
+          />
+        </div>
+      ) : (
+        <Spacer height={8} />
+      )}
+
+      {!hasShareTarget ? (
+        <EmptyState>
+          <Text size="2" color="gray600">
+            Select a portal before sharing this skill.
+          </Text>
+        </EmptyState>
+      ) : (
+        <>
+          {activeTab == 'accounts' && (
+            <ContentPanel>
+              {canManageAccess ? (
+                <InviteRow>
+                  {isSearching && (
+                    <Button
+                      size="2"
+                      variant="soft"
+                      iconRight={<RiArrowLeftSLine size={16} />}
+                      onClick={stopInviteSearch}
+                    />
+                  )}
+                  <Input
+                    label="Invite accounts"
+                    hideLabel
+                    size="2"
+                    style={{ flex: 1 }}
+                    placeholder="Email or group, separated by commas"
+                    value={search}
+                    onFocus={() => setIsSearching(true)}
+                    onInput={value => {
+                      setSearch(value);
+                      setIsSearching(true);
+                    }}
+                  />
+                  <Button
+                    size="2"
+                    loading={shareSkill.isLoading}
+                    disabled={selectedAccountCount == 0}
+                    onClick={shareWithAccounts}
+                  >
+                    Invite
+                  </Button>
+                </InviteRow>
+              ) : null}
+
+              {isSearching ? (
+                <>
+                  <RowList>
+                    {accountCandidates.map(candidate => {
+                      let key = `${candidate.type}:${candidate.id}`;
+                      let selected = selectedAccountKeys.has(key);
+                      return (
+                        <CandidateRow
+                          key={key}
+                          type="button"
+                          $selected={selected}
+                          onClick={() => toggleAccount(candidate)}
+                        >
+                          <Avatar
+                            entity={{
+                              name: candidate.name,
+                              imageUrl: candidate.imageUrl ?? undefined
+                            }}
+                            size={36}
+                          />
+                          <PersonInfo>
+                            <PersonName>
+                              <Truncate>{candidate.name}</Truncate>
+                              {candidate.type == 'member' && <Pill>Member</Pill>}
+                            </PersonName>
+                            <Muted>{candidate.email}</Muted>
+                          </PersonInfo>
+                          {/* <Text size="1" color={selected ? 'blue800' : 'gray600'}>
+                            {selected ? 'Selected' : 'Select'}
+                          </Text> */}
+
+                          <div>{selected ? <RiCheckLine size={16} /> : null}</div>
+                        </CandidateRow>
+                      );
+                    })}
+                    {!consumerProfiles.isLoading &&
+                      !organizationMembers.isLoading &&
+                      accountCandidates.length == 0 && (
+                        <EmptyState>
+                          <Text size="2" color="gray600">
+                            No invite candidates found.
+                          </Text>
+                        </EmptyState>
+                      )}
+                  </RowList>
+                  <InvitePermissionFooter>
+                    <InvitePermissionLabel>
+                      Invite people to work on this skill
+                    </InvitePermissionLabel>
+                    <AccessSelectWrap>
+                      <Select
+                        label="Permission"
+                        hideLabel
+                        size="2"
+                        value={permission}
+                        items={inviteAccessItems}
+                        onChange={value => {
+                          if (value == 'read' || value == 'write') setPermission(value);
+                        }}
+                      />
+                    </AccessSelectWrap>
+                  </InvitePermissionFooter>
+                </>
+              ) : (
+                <>
+                  <RowList>
+                    {(participants.data?.items ?? []).map(participant => {
+                      let participantPermission = getParticipantPermission(participant.roles);
+                      let isCreator = participant.roles.includes('creator');
+                      let consumerProfileId = participant.actor.consumer?.id
+                        ? profileByConsumerId.get(participant.actor.consumer.id)?.id
+                        : null;
+                      let actorId = participant.actor.organizationActor?.id;
+                      let isOrganizationMember = !!actorId;
+                      let isCurrentConsumer =
+                        !!participant.actor.consumer?.id &&
+                        participant.actor.consumer.id == p.context?.currentConsumerId;
+                      let isCurrentOrganizationMember =
+                        mode == 'dashboard' &&
+                        !!currentUserEmail &&
+                        participant.actor.organizationActor?.email == currentUserEmail;
+                      let isSelf = isCurrentConsumer || isCurrentOrganizationMember;
+                      let memberId =
+                        mode == 'dashboard' && actorId
+                          ? memberByActorId.get(actorId)?.id
+                          : null;
+                      let canChangeAccess =
+                        !!consumerProfileId || (mode == 'dashboard' && !!memberId);
+                      return (
+                        <AccessRow key={participant.id}>
+                          <Avatar
+                            entity={{
+                              name: participant.actor.name,
+                              imageUrl: participant.actor.imageUrl ?? undefined
+                            }}
+                            size={40}
+                          />
+                          <PersonInfo>
+                            <PersonName>
+                              <Truncate>{participant.actor.name}</Truncate>
+                              {isCreator && <Pill>Owner</Pill>}
+                            </PersonName>
+                            <Muted>{participant.actor.email}</Muted>
+                          </PersonInfo>
+                          <AccessSelectWrap>
+                            <Select
+                              label="Access"
+                              hideLabel
+                              size="2"
+                              disabled={
+                                !canManageAccess ||
+                                isCreator ||
+                                isSelf ||
+                                !canChangeAccess ||
+                                (mode == 'portal' && isOrganizationMember)
+                              }
+                              value={participantPermission}
+                              items={accountAccessItems}
+                              onChange={value => {
+                                if (value == 'none' || value == 'read' || value == 'write') {
+                                  updateAccountAccess(participant, value);
+                                }
+                              }}
+                            />
+                          </AccessSelectWrap>
+                        </AccessRow>
+                      );
+                    })}
+                    {!participants.isLoading &&
+                      (participants.data?.items ?? []).length == 0 && (
+                        <EmptyState>
+                          <Text size="2" color="gray600">
+                            No accounts have access yet.
+                          </Text>
+                        </EmptyState>
+                      )}
+                  </RowList>
+                </>
+              )}
+            </ContentPanel>
+          )}
+
+          {activeTab == 'portal-groups' && canManagePortalGroups && (
+            <ContentPanel>
+              <Input
+                label="Search portal groups"
+                hideLabel
+                size="2"
+                placeholder="Search portal groups..."
+                value={search}
+                onInput={setSearch}
+              />
+              <RowList>
+                {(consumerGroups.data?.items ?? []).map(group => {
+                  let existingAccess = (portalAccess.data?.items ?? []).find(
+                    access => access.consumerGroup.id == group.id
+                  );
+                  return (
+                    <AccessRow key={group.id}>
+                      <Avatar
+                        entity={{
+                          name: group.name,
+                          imageUrl: `https://avatar.metorial-cdn.com/${group.id}`
+                        }}
+                        size={40}
+                      />
+                      <PersonInfo>
+                        <PersonName>
+                          <Truncate>{group.name}</Truncate>
+                          {group.isDefault && <Pill>Default</Pill>}
+                        </PersonName>
+                        <Muted>{group.description || 'Portal group'}</Muted>
+                      </PersonInfo>
+                      <AccessSelectWrap>
+                        <Select
+                          label="Access"
+                          hideLabel
+                          size="2"
+                          value={existingAccess ? 'read' : 'none'}
+                          items={[
+                            { id: 'none', label: 'No access' },
+                            { id: 'read', label: 'Can view' }
+                          ]}
+                          disabled={
+                            sharingGroupId == group.id ||
+                            (!!existingAccess && removingGroupId == existingAccess.id)
+                          }
+                          onChange={value => {
+                            if (value == 'read' && !existingAccess) shareWithGroup(group.id);
+                            if (value == 'none' && existingAccess) {
+                              removeGroupAccess(existingAccess.id);
+                            }
+                          }}
+                        />
+                      </AccessSelectWrap>
+                    </AccessRow>
+                  );
+                })}
+                {!consumerGroups.isLoading &&
+                  (consumerGroups.data?.items ?? []).length == 0 && (
+                    <EmptyState>
+                      <Text size="2" color="gray600">
+                        No portal groups found.
+                      </Text>
+                    </EmptyState>
+                  )}
+              </RowList>
+            </ContentPanel>
+          )}
+
+          <div>
+            <shareSkill.RenderError />
+            <createPortalAccess.RenderError />
+            <deletePortalAccess.RenderError />
+          </div>
+        </>
+      )}
+    </PanelStack>
+  );
+};
+
+let SkillSharePopoverContent = styled.div`
+  width: 450px;
+  cursor: default;
+`;
+
+export let SkillSharePopover = (p: {
+  trigger: ReactNode;
+  instanceId: string | null | undefined;
+  context: SkillSharePanelContext | null | undefined;
+  onShared?: () => void | Promise<void>;
+}) => (
+  <Popover
+    trigger={p.trigger}
+    side="bottom"
+    align="end"
+    sideOffset={8}
+    operationKey={p.context?.skills.map(skill => skill.id).join(':')}
+  >
+    <Popover.Content
+      style={{
+        padding: 0,
+        background: 'white',
+        borderRadius: 9
+      }}
+    >
+      <SkillSharePopoverContent>
+        <SkillSharePanelContent
+          instanceId={p.instanceId}
+          context={p.context}
+          onShared={p.onShared}
+        />
+      </SkillSharePopoverContent>
+    </Popover.Content>
+  </Popover>
+);

--- a/src/metorial-frontend/scenes/skills/src/index.ts
+++ b/src/metorial-frontend/scenes/skills/src/index.ts
@@ -1,1 +1,2 @@
+export * from './components';
 export * from './scenes';

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillParticipants.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillParticipants.tsx
@@ -1,8 +1,9 @@
 import { renderWithPagination } from '@metorial/data-hooks';
 import { useSkillParticipants } from '@metorial/state';
-import { Avatar, Badge, Entity, Flex, RenderDate, Text } from '@metorial/ui';
+import { Avatar, Badge, Button, Entity, Flex, RenderDate, Text } from '@metorial/ui';
 import { Box } from '@metorial/ui-product';
 import styled from 'styled-components';
+import { SkillSharePopover, type SkillSharePanelContext } from '../components/skillSharePanel';
 
 let EmptyState = styled.div`
   line-height: 1.6;
@@ -32,12 +33,30 @@ let actorTypeLabels: Record<string, string> = {
 export let SkillParticipantsScene = (p: {
   instanceId: string | null | undefined;
   skillId: string | null | undefined;
+  shareContext?: SkillSharePanelContext | null;
 }) => {
   let participants = useSkillParticipants(p.instanceId, p.skillId, { order: 'asc' });
 
-  return renderWithPagination(participants)(participants => (
-    <Box title="Participants" description="People who have contributed to or used this skill.">
-      {participants.data.items.length === 0 ? (
+  return renderWithPagination(participants)(participantList => (
+    <Box
+      title="Participants"
+      description="People who have contributed to or used this skill."
+      rightActions={
+        p.shareContext ? (
+          <SkillSharePopover
+            instanceId={p.instanceId}
+            context={p.shareContext}
+            onShared={() => participants.refetch()}
+            trigger={
+              <Button size="2" variant="outline">
+                Share
+              </Button>
+            }
+          />
+        ) : null
+      }
+    >
+      {participantList.data.items.length === 0 ? (
         <EmptyState>
           <Text color="gray600" size="2">
             No participants found for this skill yet.
@@ -45,7 +64,7 @@ export let SkillParticipantsScene = (p: {
         </EmptyState>
       ) : (
         <Items>
-          {participants.data.items.map(participant => (
+          {participantList.data.items.map(participant => (
             <Entity.Wrapper key={participant.id} aligned>
               <Entity.Content>
                 <Entity.Field

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillStoreFileViewer.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillStoreFileViewer.tsx
@@ -15,6 +15,7 @@ import {
   SkillFileTreeCreateKind,
   SkillFileTreeNode
 } from '../components/fileTree';
+import type { SkillSharePanelContext } from '../components/skillSharePanel';
 
 let FileTreeWrap = styled.div`
   display: flex;
@@ -209,6 +210,7 @@ export let StoreFileViewerScene = (p: {
   title?: string;
   description?: string;
   readOnly?: boolean;
+  shareContext?: SkillSharePanelContext | null;
 }) => {
   let storeItems = useAllStoreItems(p.instanceId, p.storeId, {
     order: 'asc',
@@ -459,6 +461,7 @@ export let StoreFileViewerScene = (p: {
           isCreating={isCreating}
           nodes={treeNodes}
           instanceId={p.instanceId}
+          shareContext={p.shareContext}
           canWrite={
             !p.readOnly && !!storePermissions.data?.permissions.includes('content_write')
           }

--- a/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerProfile.ts
+++ b/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerProfile.ts
@@ -20,10 +20,17 @@ export let consumerProfileGroup = portalGroup.use(async ctx => {
     );
   }
 
-  let consumerProfile = await consumerProfileService.getConsumerProfileById({
-    consumerSurface: ctx.portal.surface,
-    consumerProfileId: ctx.params.consumerProfileId
-  });
+  let consumerProfile = ctx.consumerProfile
+    ? await consumerProfileService.getConsumerProfileVisibleToConsumer({
+        consumerSurface: ctx.portal.surface,
+        consumerProfile: ctx.consumerProfile,
+        consumerGroups: ctx.consumerGroups ?? [],
+        consumerProfileId: ctx.params.consumerProfileId
+      })
+    : await consumerProfileService.getConsumerProfileById({
+        consumerSurface: ctx.portal.surface,
+        consumerProfileId: ctx.params.consumerProfileId
+      });
 
   return { consumerProfile };
 });
@@ -42,7 +49,11 @@ export let portalConsumerProfileController = Controller.create(
           description: 'Returns a paginated list of consumer profiles for a portal.'
         }
       )
-      .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
+      .use(
+        checkAccess({
+          possibleScopes: ['instance.portal.consumers:read', 'consumer#instance.profile:read']
+        })
+      )
       .use(hasFlags(['paid-portals', 'portals-access']))
       .outputList(consumerProfilePresenter)
       .query(
@@ -67,13 +78,23 @@ export let portalConsumerProfileController = Controller.create(
         )
       )
       .do(async ctx => {
-        let paginator = await consumerProfileService.listConsumerProfiles({
-          consumerSurface: ctx.portal.surface,
-          search: ctx.query.search,
-          emails: normalizeArrayParam(ctx.query.email),
-          consumerGroupId: ctx.query.consumer_group_id,
-          statuses: normalizeArrayParam(ctx.query.status)
-        });
+        let paginator = ctx.consumerProfile
+          ? await consumerProfileService.listConsumerProfilesVisibleToConsumer({
+              consumerSurface: ctx.portal.surface,
+              consumerProfile: ctx.consumerProfile,
+              consumerGroups: ctx.consumerGroups ?? [],
+              search: ctx.query.search,
+              emails: normalizeArrayParam(ctx.query.email),
+              consumerGroupId: ctx.query.consumer_group_id,
+              statuses: normalizeArrayParam(ctx.query.status)
+            })
+          : await consumerProfileService.listConsumerProfiles({
+              consumerSurface: ctx.portal.surface,
+              search: ctx.query.search,
+              emails: normalizeArrayParam(ctx.query.email),
+              consumerGroupId: ctx.query.consumer_group_id,
+              statuses: normalizeArrayParam(ctx.query.status)
+            });
         let list = await paginator.run(ctx.query);
         let assignedConsumerGroupsByProfileId =
           await consumerProfileService.getStoredGroupsForProfiles({
@@ -101,7 +122,11 @@ export let portalConsumerProfileController = Controller.create(
           description: 'Retrieves a portal consumer profile by ID.'
         }
       )
-      .use(checkAccess({ possibleScopes: ['instance.portal.consumers:read'] }))
+      .use(
+        checkAccess({
+          possibleScopes: ['instance.portal.consumers:read', 'consumer#instance.profile:read']
+        })
+      )
       .use(hasFlags(['paid-portals', 'portals-access']))
       .output(consumerProfilePresenter)
       .do(async ctx => {

--- a/src/metorial/apis/core/src/controllers/instance/skills/skill.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skill.ts
@@ -412,6 +412,49 @@ export let skillController = Controller.create(
         return skillPresenter.present({ skill });
       }),
 
+    share: skillGroup
+      .post(instancePath('skills/:skillId/shares', 'skills.share'), {
+        name: 'Share skill',
+        description: 'Shares a skill with consumers or organization members.'
+      })
+      .use(hasFlags(['skills-enabled']))
+      .use(checkAccess({ possibleScopes: [...skillWriteScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
+      .body(
+        'default',
+        v.object({
+          consumer_profile_ids: v.optional(v.array(v.string())),
+          organization_member_ids: v.optional(v.array(v.string())),
+          permission: v.enumOf(['none', 'read', 'write'])
+        })
+      )
+      .output(skillPresenter)
+      .do(async ctx => {
+        await consumerSkillService.shareSkill({
+          organization: ctx.organization,
+          instance: ctx.instance,
+          skill: ctx.skill.localSkill,
+          permission: ctx.body.permission,
+          consumerProfile: ctx.consumerProfile,
+          consumerGroups: ctx.consumerGroups,
+          currentOrganizationMember: ctx.member,
+          targets: {
+            consumerProfileIds: ctx.body.consumer_profile_ids,
+            organizationMemberIds: ctx.body.organization_member_ids
+          }
+        });
+
+        let skill = await subspaceSkillService.get({
+          instance: ctx.instance,
+          skillId: ctx.skill.id,
+          allowDeleted: true,
+          consumerProfile: ctx.consumerProfile,
+          consumerGroups: ctx.consumerGroups
+        });
+
+        return skillPresenter.present({ skill });
+      }),
+
     duplicate: skillGroup
       .post(instancePath('skills/:skillId/duplicate', 'skills.duplicate'), {
         name: 'Duplicate skill',

--- a/src/metorial/modules/consumer/src/services/consumerEntities/consumerSkill.ts
+++ b/src/metorial/modules/consumer/src/services/consumerEntities/consumerSkill.ts
@@ -1,4 +1,5 @@
 import {
+  badRequestError,
   forbiddenError,
   notFoundError,
   preconditionFailedError,
@@ -15,6 +16,8 @@ import {
   ID,
   Instance,
   Organization,
+  OrganizationActor,
+  OrganizationMember,
   Prisma,
   Skill,
   withTransaction
@@ -67,7 +70,26 @@ type ConsumerSkillUpdateInput = {
   imageFileId?: string | null;
 };
 
+type SkillSharePermission = ConsumerSkillPermission | 'none';
+
 export type SubspaceSkillListInput = Parameters<typeof subspaceSkillService.list>[0];
+
+let withSubspaceUpsertActorOverride = (
+  input: Parameters<typeof subspaceSkillService.upsertActor>[0] & {
+    overridePermissions?: boolean;
+  }
+) => input as Parameters<typeof subspaceSkillService.upsertActor>[0];
+
+let consumerAccessInclude = {
+  consumerGroup: true,
+  providerTemplate: true,
+  magicMcpServer: true,
+  skill: true,
+  skillTemplate: true,
+  skillGroup: true,
+  skillMarketplace: true,
+  listing: true
+} as const;
 
 export let uniquePermissions = (permissions: ConsumerSkillPermission[]) => [
   ...new Set(permissions)
@@ -83,6 +105,20 @@ export let toSubspacePaginationQuery = (opts: { take?: number; cursor?: { id: st
   limit: opts.take,
   cursor: opts.cursor?.id
 });
+
+let getContentPermissionsForConsumerSkill = (permissions: ConsumerSkillPermission[]) => {
+  if (permissions.includes('write')) {
+    return ['content_read', 'content_write'] satisfies Array<'content_read' | 'content_write'>;
+  }
+
+  if (permissions.includes('read')) {
+    return ['content_read'] satisfies Array<'content_read' | 'content_write'>;
+  }
+
+  return [] satisfies Array<'content_read' | 'content_write'>;
+};
+
+let getUniqueIds = (ids?: string[]) => Array.from(new Set(ids ?? []));
 
 export let getVisibleSkillWhere = (
   d: ConsumerSkillVisibilityInput
@@ -165,6 +201,280 @@ class ConsumerSkillServiceImpl {
     }
   }
 
+  private async createConsumerPersonalSkillAccess(d: {
+    organization: Organization;
+    consumerSurface: ConsumerSurface;
+    consumerProfile: Pick<ConsumerProfile, 'personalConsumerGroupOid'>;
+    skill: Skill;
+    permissions: ConsumerSkillPermission[];
+  }) {
+    let personalConsumerGroup = await db.consumerGroup.findUniqueOrThrow({
+      where: {
+        oid: d.consumerProfile.personalConsumerGroupOid
+      }
+    });
+
+    let consumerAccess = await consumerAccessService.createConsumerAccess({
+      organization: d.organization,
+      consumerSurface: d.consumerSurface,
+      consumerGroup: personalConsumerGroup,
+      access: {
+        type: 'skill',
+        skill: d.skill
+      }
+    });
+
+    if (d.permissions.includes('write')) {
+      await consumerAccessPolicyService.grantAccess({
+        organization: d.organization,
+        permission: 'skill_write',
+        subject: {
+          consumerGroup: personalConsumerGroup
+        },
+        resource: {
+          skill: d.skill
+        },
+        policyScope: {
+          type: 'consumer_access',
+          consumerAccessId: consumerAccess.id
+        }
+      });
+    }
+
+    return consumerAccess;
+  }
+
+  private getConsumerShareableGroups(consumerGroups: ConsumerGroup[]) {
+    return consumerGroups.filter(group => group.type !== 'user_access');
+  }
+
+  private getProfileSharedGroupWhere(consumerGroups: ConsumerGroup[]) {
+    let shareableGroups = this.getConsumerShareableGroups(consumerGroups);
+    if (shareableGroups.some(group => group.isDefault)) {
+      return undefined;
+    }
+
+    let groupOids = shareableGroups.map(group => group.oid);
+    let ssoGroupIds = Array.from(
+      new Set(shareableGroups.flatMap(group => group.ssoGroupIds ?? []))
+    );
+    let or: Prisma.ConsumerProfileWhereInput[] = [];
+
+    if (groupOids.length) {
+      or.push({
+        groups: {
+          some: {
+            groupOid: {
+              in: groupOids
+            }
+          }
+        }
+      });
+    }
+
+    if (ssoGroupIds.length) {
+      or.push({
+        ssoGroupIds: {
+          hasSome: ssoGroupIds
+        }
+      });
+    }
+
+    if (!or.length) {
+      return { id: { in: [] } } satisfies Prisma.ConsumerProfileWhereInput;
+    }
+
+    return { OR: or } satisfies Prisma.ConsumerProfileWhereInput;
+  }
+
+  private getPermissionsForShare(permission: SkillSharePermission) {
+    if (permission == 'none') return [] as ConsumerSkillPermission[];
+    return permission == 'write'
+      ? (['read', 'write'] as ConsumerSkillPermission[])
+      : (['read'] as ConsumerSkillPermission[]);
+  }
+
+  private assertCanSetConsumerSharePermission(d: {
+    skill: Skill;
+    consumerProfile: ConsumerProfile;
+    permission: SkillSharePermission;
+  }) {
+    if (
+      d.permission == 'none' &&
+      d.skill.createdByConsumerProfileOid === d.consumerProfile.oid
+    ) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'The skill owner cannot be removed.'
+        })
+      );
+    }
+  }
+
+  private assertCanSetOrganizationActorSharePermission(d: {
+    skill: Skill;
+    organizationActor: OrganizationActor;
+    permission: SkillSharePermission;
+  }) {
+    if (
+      d.permission == 'none' &&
+      d.skill.createdByOrganizationActorOid === d.organizationActor.oid
+    ) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'The skill owner cannot be removed.'
+        })
+      );
+    }
+  }
+
+  private async deleteConsumerPersonalSkillAccess(d: {
+    organization: Organization;
+    consumerProfile: Pick<ConsumerProfile, 'personalConsumerGroupOid'>;
+    skill: Skill;
+  }) {
+    let accesses = await db.consumerAccess.findMany({
+      where: {
+        type: 'skill',
+        skillOid: d.skill.oid,
+        consumerGroupOid: d.consumerProfile.personalConsumerGroupOid
+      },
+      include: consumerAccessInclude
+    });
+
+    for (let access of accesses) {
+      await consumerAccessService.deleteConsumerAccess({
+        organization: d.organization,
+        consumerAccess: access
+      });
+    }
+  }
+
+  private async setConsumerSkillSharePermission(d: {
+    organization: Organization;
+    instance: Instance;
+    consumerSurface: ConsumerSurface;
+    consumerProfile: ConsumerProfileForSkill;
+    skill: Skill;
+    permission: SkillSharePermission;
+  }) {
+    this.assertCanSetConsumerSharePermission({
+      skill: d.skill,
+      consumerProfile: d.consumerProfile,
+      permission: d.permission
+    });
+
+    let permissions = this.getPermissionsForShare(d.permission);
+    let contentPermissions = getContentPermissionsForConsumerSkill(permissions);
+    let upsertedActor = await subspaceSkillService.upsertActor({
+      ...withSubspaceUpsertActorOverride({
+        instance: d.instance,
+        skillId: d.skill.id,
+        consumer: d.consumerProfile.consumer,
+        permissions: contentPermissions,
+        overridePermissions: true
+      })
+    });
+
+    if (d.permission == 'none') {
+      await withTransaction(async db => {
+        await db.consumerSkill.deleteMany({
+          where: {
+            skillOid: d.skill.oid,
+            consumerProfileOid: d.consumerProfile.oid,
+            source: {
+              not: 'owner'
+            }
+          }
+        });
+      });
+
+      await this.deleteConsumerPersonalSkillAccess({
+        organization: d.organization,
+        consumerProfile: d.consumerProfile,
+        skill: d.skill
+      });
+      return;
+    }
+
+    let consumerAccess = await this.createConsumerPersonalSkillAccess({
+      organization: d.organization,
+      consumerSurface: d.consumerSurface,
+      consumerProfile: d.consumerProfile,
+      skill: d.skill,
+      permissions
+    });
+    if (!permissions.includes('write')) {
+      await consumerAccessPolicyService.revokeAccess({
+        organization: d.organization,
+        permission: 'skill_write',
+        subject: {
+          consumerGroup: consumerAccess.consumerGroup
+        },
+        resource: {
+          skill: d.skill
+        },
+        policyScope: {
+          type: 'consumer_access',
+          consumerAccessId: consumerAccess.id
+        }
+      });
+    }
+
+    await withTransaction(async db => {
+      await db.consumerSkill.upsert({
+        where: {
+          consumerProfileOid_skillOid: {
+            consumerProfileOid: d.consumerProfile.oid,
+            skillOid: d.skill.oid
+          }
+        },
+        create: {
+          id: await ID.generateId('consumerSkill'),
+          source:
+            d.skill.createdByConsumerProfileOid === d.consumerProfile.oid ? 'owner' : 'access',
+          permissions,
+          organizationOid: d.organization.oid,
+          instanceOid: d.instance.oid,
+          surfaceOid: d.consumerSurface.oid,
+          consumerProfileOid: d.consumerProfile.oid,
+          consumerOid: d.consumerProfile.consumerOid,
+          skillOid: d.skill.oid,
+          cargoStoreParticipantId: upsertedActor?.storeParticipantId ?? null
+        },
+        update: {
+          permissions,
+          cargoStoreParticipantId: upsertedActor?.storeParticipantId ?? null
+        }
+      });
+    });
+  }
+
+  private async setOrganizationMemberSkillSharePermission(d: {
+    instance: Instance;
+    skill: Skill;
+    member: OrganizationMember & { actor: OrganizationActor };
+    permission: SkillSharePermission;
+  }) {
+    this.assertCanSetOrganizationActorSharePermission({
+      skill: d.skill,
+      organizationActor: d.member.actor,
+      permission: d.permission
+    });
+
+    await subspaceSkillService.upsertActor({
+      ...withSubspaceUpsertActorOverride({
+        instance: d.instance,
+        skillId: d.skill.id,
+        organizationActor: d.member.actor,
+        permissions: getContentPermissionsForConsumerSkill(
+          this.getPermissionsForShare(d.permission)
+        ),
+        overridePermissions: true
+      })
+    });
+  }
+
   async ensureConsumerSkill(d: {
     organization: Organization;
     instance: Instance;
@@ -186,12 +496,13 @@ class ConsumerSkillServiceImpl {
       ...(existing?.permissions ?? []),
       ...permissions
     ]);
-    let upsertedActor = nextPermissions.includes('write')
+    let contentPermissions = getContentPermissionsForConsumerSkill(nextPermissions);
+    let upsertedActor = contentPermissions.length
       ? await subspaceSkillService.upsertActor({
           instance: d.instance,
           skillId: d.skill.id,
           consumer: d.consumerProfile.consumer,
-          permissions: ['content_read', 'content_write']
+          permissions: contentPermissions
         })
       : null;
 
@@ -256,7 +567,10 @@ class ConsumerSkillServiceImpl {
         return true;
       }
 
-      if (requestedPermissions.includes('write') && !consumerSkill.cargoStoreParticipantId) {
+      if (
+        getContentPermissionsForConsumerSkill(requestedPermissions).length &&
+        !consumerSkill.cargoStoreParticipantId
+      ) {
         return true;
       }
 
@@ -320,6 +634,13 @@ class ConsumerSkillServiceImpl {
       skill: localSkill,
       permissions: ['read', 'write']
     });
+    await this.createConsumerPersonalSkillAccess({
+      organization: d.organization,
+      consumerSurface: d.consumerSurface,
+      consumerProfile: d.consumerProfile,
+      skill: localSkill,
+      permissions: ['read', 'write']
+    });
 
     return skill;
   }
@@ -375,8 +696,145 @@ class ConsumerSkillServiceImpl {
       skill: localSkill,
       permissions: ['read', 'write']
     });
+    await this.createConsumerPersonalSkillAccess({
+      organization: d.organization,
+      consumerSurface: d.consumerSurface,
+      consumerProfile: d.consumerProfile,
+      skill: localSkill,
+      permissions: ['read', 'write']
+    });
 
     return skill;
+  }
+
+  async shareSkill(d: {
+    organization: Organization;
+    instance: Instance;
+    skill: Skill;
+    permission: SkillSharePermission;
+    consumerProfile?: ConsumerProfileForSkill;
+    consumerGroups?: ConsumerGroup[];
+    currentOrganizationMember?: OrganizationMember;
+    targets: {
+      consumerProfileIds?: string[];
+      organizationMemberIds?: string[];
+    };
+  }) {
+    let consumerProfileIds = getUniqueIds(d.targets.consumerProfileIds);
+    let organizationMemberIds = getUniqueIds(d.targets.organizationMemberIds);
+
+    if (!consumerProfileIds.length && !organizationMemberIds.length) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'At least one share target is required.'
+        })
+      );
+    }
+
+    if (d.consumerProfile) {
+      await this.assertConsumerCanWriteSkill({
+        skill: d.skill,
+        consumerProfile: d.consumerProfile
+      });
+
+      if (consumerProfileIds.includes(d.consumerProfile.id)) {
+        throw new ServiceError(
+          forbiddenError({
+            message: 'Consumers cannot change their own skill share access.'
+          })
+        );
+      }
+
+      if (organizationMemberIds.length) {
+        throw new ServiceError(
+          forbiddenError({
+            message: 'Consumers cannot change organization member skill share access.'
+          })
+        );
+      }
+    }
+
+    if (
+      d.currentOrganizationMember &&
+      organizationMemberIds.includes(d.currentOrganizationMember.id)
+    ) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Organization members cannot change their own skill share access.'
+        })
+      );
+    }
+
+    if (consumerProfileIds.length) {
+      let targetProfiles = await db.consumerProfile.findMany({
+        where: {
+          id: {
+            in: consumerProfileIds
+          },
+          instanceOid: d.instance.oid,
+          status: 'active',
+          ...(d.consumerProfile
+            ? {
+                surfaceOid: d.consumerProfile.surfaceOid,
+                ...this.getProfileSharedGroupWhere(d.consumerGroups ?? [])
+              }
+            : {})
+        },
+        include: {
+          consumer: true,
+          personalConsumerGroup: true,
+          surface: true
+        }
+      });
+
+      if (targetProfiles.length !== consumerProfileIds.length) {
+        throw new ServiceError(notFoundError('consumer.profile'));
+      }
+
+      for (let targetProfile of targetProfiles) {
+        await this.setConsumerSkillSharePermission({
+          organization: d.organization,
+          instance: d.instance,
+          consumerSurface: targetProfile.surface,
+          consumerProfile: targetProfile,
+          skill: d.skill,
+          permission: d.permission
+        });
+      }
+    }
+
+    if (organizationMemberIds.length) {
+      let members = await db.organizationMember.findMany({
+        where: {
+          organizationOid: d.organization.oid,
+          status: 'active',
+          id: {
+            in: organizationMemberIds
+          },
+          user: {
+            type: {
+              not: 'system'
+            }
+          }
+        },
+        include: {
+          actor: true
+        }
+      });
+
+      if (members.length !== organizationMemberIds.length) {
+        throw new ServiceError(notFoundError('organization_member'));
+      }
+
+      for (let member of members as Array<OrganizationMember & { actor: OrganizationActor }>) {
+        await this.setOrganizationMemberSkillSharePermission({
+          instance: d.instance,
+          skill: d.skill,
+          member,
+          permission: d.permission
+        });
+      }
+    }
   }
 
   async updateConsumerSkill(d: {

--- a/src/metorial/modules/consumer/src/services/consumerEntities/consumerSkill.ts
+++ b/src/metorial/modules/consumer/src/services/consumerEntities/consumerSkill.ts
@@ -732,11 +732,6 @@ class ConsumerSkillServiceImpl {
     }
 
     if (d.consumerProfile) {
-      await this.assertConsumerCanWriteSkill({
-        skill: d.skill,
-        consumerProfile: d.consumerProfile
-      });
-
       if (consumerProfileIds.includes(d.consumerProfile.id)) {
         throw new ServiceError(
           forbiddenError({
@@ -752,6 +747,11 @@ class ConsumerSkillServiceImpl {
           })
         );
       }
+
+      await this.assertConsumerCanWriteSkill({
+        skill: d.skill,
+        consumerProfile: d.consumerProfile
+      });
     }
 
     if (

--- a/src/metorial/modules/consumer/src/services/consumers/consumerProfile.ts
+++ b/src/metorial/modules/consumer/src/services/consumers/consumerProfile.ts
@@ -110,6 +110,45 @@ class ConsumerProfileServiceImpl {
     return groups;
   }
 
+  private getSharedGroupVisibilityWhere(consumerGroups: ConsumerGroup[]) {
+    let shareableGroups = consumerGroups.filter(group => group.type !== 'user_access');
+    if (shareableGroups.some(group => group.isDefault)) {
+      return undefined;
+    }
+
+    let groupOids = shareableGroups.map(group => group.oid);
+    let ssoGroupIds = Array.from(
+      new Set(shareableGroups.flatMap(group => group.ssoGroupIds ?? []))
+    );
+    let or: Prisma.ConsumerProfileWhereInput[] = [];
+
+    if (groupOids.length) {
+      or.push({
+        groups: {
+          some: {
+            groupOid: {
+              in: groupOids
+            }
+          }
+        }
+      });
+    }
+
+    if (ssoGroupIds.length) {
+      or.push({
+        ssoGroupIds: {
+          hasSome: ssoGroupIds
+        }
+      });
+    }
+
+    if (!or.length) {
+      return { id: { in: [] } } satisfies Prisma.ConsumerProfileWhereInput;
+    }
+
+    return { OR: or } satisfies Prisma.ConsumerProfileWhereInput;
+  }
+
   async enrichConsumerProfile<T extends ConsumerProfileWithRelations>(d: {
     consumerProfile: T;
     instanceConsumer?: InstanceConsumer | null;
@@ -227,6 +266,7 @@ class ConsumerProfileServiceImpl {
     emails?: string[];
     consumerGroupId?: string;
     statuses?: Array<'active' | 'invited'>;
+    visibleToConsumerGroups?: ConsumerGroup[];
   }) {
     let search = d.search?.trim();
     let emails = normalizeEmailFilter(d.emails);
@@ -267,6 +307,9 @@ class ConsumerProfileServiceImpl {
 
     let groupMembershipWhere: Prisma.ConsumerProfileWhereInput | undefined;
     let inviteStatusWhere: Prisma.ConsumerProfileWhereInput | undefined;
+    let visibilityWhere = d.visibleToConsumerGroups
+      ? this.getSharedGroupVisibilityWhere(d.visibleToConsumerGroups)
+      : undefined;
 
     if (consumerGroupId) {
       let group = await db.consumerGroup.findFirst({
@@ -316,6 +359,7 @@ class ConsumerProfileServiceImpl {
       { surfaceOid: d.consumerSurface.oid },
       { status: 'active' },
       ...(groupMembershipWhere ? [groupMembershipWhere] : []),
+      ...(visibilityWhere ? [visibilityWhere] : []),
       ...(inviteStatusWhere ? [inviteStatusWhere] : []),
       ...(emails?.length ? [{ email: { in: emails } }] : []),
       ...(search ? [{ consumerOid: { in: searchedConsumerOids ?? [] } }] : [])
@@ -345,6 +389,52 @@ class ConsumerProfileServiceImpl {
         };
       }
     };
+  }
+
+  async listConsumerProfilesVisibleToConsumer(d: {
+    consumerSurface: ConsumerSurface;
+    consumerProfile: ConsumerProfile;
+    consumerGroups: ConsumerGroup[];
+    search?: string;
+    emails?: string[];
+    consumerGroupId?: string;
+    statuses?: Array<'active' | 'invited'>;
+  }) {
+    return await this.listConsumerProfiles({
+      consumerSurface: d.consumerSurface,
+      search: d.search,
+      emails: d.emails,
+      consumerGroupId: d.consumerGroupId,
+      statuses: d.statuses,
+      visibleToConsumerGroups: d.consumerGroups
+    });
+  }
+
+  async getConsumerProfileVisibleToConsumer(d: {
+    consumerSurface: ConsumerSurface;
+    consumerProfile: ConsumerProfile;
+    consumerGroups: ConsumerGroup[];
+    consumerProfileId: string;
+  }) {
+    let visibilityWhere = this.getSharedGroupVisibilityWhere(d.consumerGroups);
+    let consumerProfile = await db.consumerProfile.findFirst({
+      where: {
+        AND: [
+          {
+            surfaceOid: d.consumerSurface.oid,
+            id: d.consumerProfileId,
+            status: 'active'
+          },
+          ...(visibilityWhere ? [visibilityWhere] : [])
+        ]
+      },
+      include
+    });
+    if (!consumerProfile) {
+      throw new ServiceError(notFoundError('consumer.profile'));
+    }
+
+    return await this.enrichConsumerProfile({ consumerProfile });
   }
 
   async getConsumerProfileByIdForConsumer(d: {
@@ -808,7 +898,9 @@ class ConsumerProfileServiceImpl {
             }
           }
         });
-        let existingGroupOids = new Set(existingMemberships.map(membership => membership.groupOid));
+        let existingGroupOids = new Set(
+          existingMemberships.map(membership => membership.groupOid)
+        );
         let groupsToAdd = groups.filter(group => !existingGroupOids.has(group.oid));
 
         for (let group of groupsToAdd) {

--- a/src/metorial/modules/consumer/test/consumerSkillSharing.test.ts
+++ b/src/metorial/modules/consumer/test/consumerSkillSharing.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  db,
+  generateIdMock,
+  upsertActorMock,
+  createConsumerAccessMock,
+  grantAccessMock,
+  revokeAccessMock
+} = vi.hoisted(() => ({
+  db: {
+    consumerSkill: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      upsert: vi.fn()
+    },
+    consumerProfile: {
+      findMany: vi.fn()
+    },
+    consumerGroup: {
+      findUniqueOrThrow: vi.fn()
+    },
+    organizationMember: {
+      findMany: vi.fn()
+    }
+  },
+  generateIdMock: vi.fn(),
+  upsertActorMock: vi.fn(),
+  createConsumerAccessMock: vi.fn(),
+  grantAccessMock: vi.fn(),
+  revokeAccessMock: vi.fn()
+}));
+
+vi.mock('@metorial/db', () => ({
+  db,
+  ID: {
+    generateId: generateIdMock
+  },
+  withTransaction: vi.fn(async (fn: any) => await fn(db))
+}));
+
+vi.mock('@metorial/module-subspace', () => ({
+  subspaceSkillService: {
+    upsertActor: upsertActorMock
+  },
+  subspaceSkillTemplateService: {}
+}));
+
+vi.mock('../src/services/consumerAccess/consumerAccess', () => ({
+  consumerAccessService: {
+    createConsumerAccess: createConsumerAccessMock
+  }
+}));
+
+vi.mock('../src/services/consumerAccess/accessPolicy', () => ({
+  consumerAccessPolicyService: {
+    grantAccess: grantAccessMock,
+    revokeAccess: revokeAccessMock
+  }
+}));
+
+import { consumerSkillService } from '../src/services/consumerEntities/consumerSkill';
+
+let organization = { oid: 1n };
+let instance = { oid: 2n };
+let skill = {
+  oid: 3n,
+  id: 'skill_1',
+  createdByConsumerProfileOid: 4n
+};
+let consumerSurface = { oid: 5n };
+let consumer = { oid: 6n, id: 'consumer_1', name: 'Consumer' };
+let targetProfile = {
+  oid: 7n,
+  id: 'profile_1',
+  consumerOid: consumer.oid,
+  consumer,
+  personalConsumerGroupOid: 8n,
+  personalConsumerGroup: { oid: 8n },
+  surface: consumerSurface
+};
+
+describe('consumer skill sharing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    generateIdMock.mockResolvedValue('consumer_skill_1');
+    db.consumerSkill.findUnique.mockResolvedValue(null);
+    db.consumerSkill.upsert.mockImplementation(async (input: any) => input.create);
+    db.consumerGroup.findUniqueOrThrow.mockResolvedValue(targetProfile.personalConsumerGroup);
+    createConsumerAccessMock.mockResolvedValue({
+      id: 'consumer_access_1',
+      consumerGroup: targetProfile.personalConsumerGroup
+    });
+    upsertActorMock.mockResolvedValue({ storeParticipantId: 'store_participant_1' });
+  });
+
+  it('shares read access with a consumer through their personal group and Cargo actor', async () => {
+    db.consumerProfile.findMany.mockResolvedValue([targetProfile]);
+
+    await consumerSkillService.shareSkill({
+      organization: organization as any,
+      instance: instance as any,
+      skill: skill as any,
+      permission: 'read',
+      targets: {
+        consumerProfileIds: [targetProfile.id]
+      }
+    });
+
+    expect(createConsumerAccessMock).toHaveBeenCalledWith({
+      organization,
+      consumerSurface,
+      consumerGroup: targetProfile.personalConsumerGroup,
+      access: {
+        type: 'skill',
+        skill
+      }
+    });
+    expect(upsertActorMock).toHaveBeenCalledWith({
+      instance,
+      skillId: skill.id,
+      consumer,
+      permissions: ['content_read'],
+      overridePermissions: true
+    });
+    expect(db.consumerSkill.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          permissions: ['read'],
+          cargoStoreParticipantId: 'store_participant_1'
+        })
+      })
+    );
+  });
+
+  it('blocks consumer shares to profiles outside shared groups', async () => {
+    db.consumerProfile.findMany.mockResolvedValue([]);
+
+    await expect(
+      consumerSkillService.shareSkill({
+        organization: organization as any,
+        instance: instance as any,
+        skill: skill as any,
+        permission: 'read',
+        consumerProfile: {
+          oid: skill.createdByConsumerProfileOid,
+          surfaceOid: consumerSurface.oid,
+          consumer
+        } as any,
+        consumerGroups: [],
+        targets: {
+          consumerProfileIds: [targetProfile.id]
+        }
+      })
+    ).rejects.toThrow();
+
+    expect(createConsumerAccessMock).not.toHaveBeenCalled();
+  });
+
+  it('shares write access with organization members through their Cargo actor', async () => {
+    let actor = { oid: 10n, id: 'actor_1' };
+    let member = { oid: 11n, id: 'member_1', actor };
+    db.organizationMember.findMany.mockResolvedValue([member]);
+
+    await consumerSkillService.shareSkill({
+      organization: organization as any,
+      instance: instance as any,
+      skill: skill as any,
+      permission: 'write',
+      targets: {
+        organizationMemberIds: [member.id]
+      }
+    });
+
+    expect(upsertActorMock).toHaveBeenCalledWith({
+      instance,
+      skillId: skill.id,
+      organizationActor: actor,
+      permissions: ['content_read', 'content_write'],
+      overridePermissions: true
+    });
+  });
+
+  it('blocks consumers from changing organization member skill access', async () => {
+    let actor = { oid: 10n, id: 'actor_1' };
+    let member = { oid: 11n, id: 'member_1', actor };
+
+    await expect(
+      consumerSkillService.shareSkill({
+        organization: organization as any,
+        instance: instance as any,
+        skill: skill as any,
+        permission: 'write',
+        consumerProfile: {
+          oid: skill.createdByConsumerProfileOid,
+          surfaceOid: consumerSurface.oid,
+          consumer
+        } as any,
+        consumerGroups: [],
+        targets: {
+          organizationMemberIds: [member.id]
+        }
+      })
+    ).rejects.toThrow('Consumers cannot change organization member skill share access.');
+
+    expect(db.organizationMember.findMany).not.toHaveBeenCalled();
+    expect(upsertActorMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks consumers from changing their own skill access', async () => {
+    await expect(
+      consumerSkillService.shareSkill({
+        organization: organization as any,
+        instance: instance as any,
+        skill: skill as any,
+        permission: 'none',
+        consumerProfile: {
+          id: targetProfile.id,
+          oid: targetProfile.oid,
+          surfaceOid: consumerSurface.oid,
+          consumer
+        } as any,
+        consumerGroups: [],
+        targets: {
+          consumerProfileIds: [targetProfile.id]
+        }
+      })
+    ).rejects.toThrow('Consumers cannot change their own skill share access.');
+
+    expect(db.consumerProfile.findMany).not.toHaveBeenCalled();
+    expect(upsertActorMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks organization members from changing their own skill access', async () => {
+    let actor = { oid: 10n, id: 'actor_1' };
+    let member = { oid: 11n, id: 'member_1', actor };
+
+    await expect(
+      consumerSkillService.shareSkill({
+        organization: organization as any,
+        instance: instance as any,
+        skill: skill as any,
+        permission: 'none',
+        currentOrganizationMember: member as any,
+        targets: {
+          organizationMemberIds: [member.id]
+        }
+      })
+    ).rejects.toThrow('Organization members cannot change their own skill share access.');
+
+    expect(db.organizationMember.findMany).not.toHaveBeenCalled();
+    expect(upsertActorMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/subspace/apps/controller/src/controllers/skill.ts
+++ b/src/subspace/apps/controller/src/controllers/skill.ts
@@ -335,7 +335,8 @@ export let skillController = app.controller({
         actorId: v.string(),
         skillId: v.string(),
         allowDeleted: v.optional(v.boolean()),
-        permissions: v.array(v.enumOf(['content_read', 'content_write']))
+        permissions: v.array(v.enumOf(['content_read', 'content_write'])),
+        overridePermissions: v.optional(v.boolean())
       })
     )
     .do(async ctx => {
@@ -350,7 +351,8 @@ export let skillController = app.controller({
         solution: ctx.solution,
         skill: ctx.skill,
         tenantActor,
-        permissions: ctx.input.permissions
+        permissions: ctx.input.permissions,
+        overridePermissions: ctx.input.overridePermissions
       });
     })
 });

--- a/src/subspace/modules/skills/src/services/skill.ts
+++ b/src/subspace/modules/skills/src/services/skill.ts
@@ -68,6 +68,12 @@ export let skillInclude = {
   ownerTenantActor: true
 };
 
+let withCargoSkillUpsertActorOverride = (
+  input: Parameters<typeof cargo.skill.upsertActor>[0] & {
+    overridePermissions?: boolean;
+  }
+) => input as Parameters<typeof cargo.skill.upsertActor>[0];
+
 let getSlug = (input: { name: string }) =>
   `${slugify(input.name)}-${generatePlainId(7).toLowerCase()}`.toLowerCase();
 
@@ -741,6 +747,7 @@ class skillServiceImpl {
     skill: Skill;
     tenantActor: TenantActor;
     permissions: Array<'content_read' | 'content_write'>;
+    overridePermissions?: boolean;
   }) {
     checkTenant(d, d.skill);
     checkDeletedRelation(d.skill);
@@ -748,12 +755,15 @@ class skillServiceImpl {
     let cargoScope = await ensureCargoScope(d);
     let cargoActor = await ensureCargoActor(cargoScope, d.tenantActor);
 
-    return await cargo.skill.upsertActor({
-      ...cargoScope,
-      skillId: d.skill.id,
-      actorId: cargoActor.id,
-      permissions: d.permissions
-    });
+    return await cargo.skill.upsertActor(
+      withCargoSkillUpsertActorOverride({
+        ...cargoScope,
+        skillId: d.skill.id,
+        actorId: cargoActor.id,
+        permissions: d.permissions,
+        overridePermissions: d.overridePermissions
+      })
+    );
   }
 
   async getActiveSkillById(d: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces authorization and access-control paths (share targets, permission override, consumer-visible profiles) across API, consumer module, and Cargo store participants; mistakes could over-grant or leak directory data.
> 
> **Overview**
> Adds end-to-end **skill sharing**: a new `POST …/skills/:skillId/shares` API (and dashboard SDK `share` client) that grants or revokes **read**, **write**, or **none** for **consumer profiles** and **organization members**.
> 
> Backend **`consumerSkillService.shareSkill`** wires shares to personal consumer access, consumer-skill records, and Cargo store participants, including **`overridePermissions`** so share updates replace store permissions instead of only merging. Sharing is guarded (e.g. owners cannot be removed, callers cannot change their own access, consumers cannot target org members or profiles outside shared portal groups). **Portal consumer profile** list/get can scope visibility for consumer tokens when picking invite targets.
> 
> The dashboard and docs UI get a reusable **`SkillSharePanel`** (accounts + portal groups in dashboard mode), hooked into skill file viewer, participants, and the document editor **Share** flow via router state from the file tree. Supporting changes include portal consumer loaders, **`useShareSkill`**, and small popover/select z-index fixes so permission dropdowns work inside share popovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 876a6d9f96a7c97e73232500d4459207e77051c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->