### PR TITLE
Add live bus for documents

### DIFF
--- a/src/cargo/modules/doc/src/live/documentLiveBus.test.ts
+++ b/src/cargo/modules/doc/src/live/documentLiveBus.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type DocumentLiveBusMessage,
+  isDocumentLiveBusMessage,
+  shouldDeliverBusMessage
+} from './documentLiveBusProtocol';
+
+describe('document live bus helpers', () => {
+  let message: DocumentLiveBusMessage = {
+    originInstanceId: 'cargo-a',
+    originSessionId: 'session-a',
+    documentId: 'doc_123',
+    type: 'yjs_update',
+    data: {
+      update: 'AAAA'
+    }
+  };
+
+  it('does not deliver messages from the same Cargo instance', () => {
+    expect(shouldDeliverBusMessage(message, 'cargo-a')).toBe(false);
+  });
+
+  it('delivers messages from another Cargo instance', () => {
+    expect(shouldDeliverBusMessage(message, 'cargo-b')).toBe(true);
+  });
+
+  it('validates the expected live bus envelope shape', () => {
+    expect(isDocumentLiveBusMessage(message)).toBe(true);
+    expect(
+      isDocumentLiveBusMessage({
+        ...message,
+        documentId: undefined
+      })
+    ).toBe(false);
+  });
+});

--- a/src/cargo/modules/doc/src/live/documentLiveBus.ts
+++ b/src/cargo/modules/doc/src/live/documentLiveBus.ts
@@ -1,0 +1,86 @@
+import { generatePlainId } from '@lowerdeck/id';
+import { createRedisClient } from '@lowerdeck/redis';
+import { env } from '@metorial-cargo/db';
+import { hostname } from 'node:os';
+import {
+  type DocumentLiveBusMessage,
+  isDocumentLiveBusMessage,
+  shouldDeliverBusMessage
+} from './documentLiveBusProtocol';
+
+let liveBusChannel = 'cargo:document:collaboration:live';
+
+let publisherRedisFactory = createRedisClient({
+  redisUrl: env.service.REDIS_URL
+});
+let subscriberRedisFactory = createRedisClient({
+  redisUrl: env.service.REDIS_URL
+});
+
+let publisherPromise: Promise<any> | undefined;
+let subscriberPromise: Promise<any> | undefined;
+let subscribed = false;
+let handlers = new Set<(message: DocumentLiveBusMessage) => void | Promise<void>>();
+
+export let documentLiveInstanceId =
+  process.env.CARGO_INSTANCE_ID ??
+  `${hostname() || 'cargo'}:${process.pid}:${generatePlainId(8)}`;
+
+let getPublisher = async () => {
+  publisherPromise ??= publisherRedisFactory.eager();
+  return await publisherPromise;
+};
+
+let getSubscriber = async () => {
+  subscriberPromise ??= subscriberRedisFactory.eager();
+  return await subscriberPromise;
+};
+
+export let publishDocumentLiveBusMessage = async (
+  message: Omit<DocumentLiveBusMessage, 'originInstanceId'>
+) => {
+  try {
+    let publisher = await getPublisher();
+    await publisher.publish(
+      liveBusChannel,
+      JSON.stringify({
+        ...message,
+        originInstanceId: documentLiveInstanceId
+      } satisfies DocumentLiveBusMessage)
+    );
+  } catch (error) {
+    console.error('Failed to publish Cargo live document event', error);
+  }
+};
+
+export let subscribeToDocumentLiveBus = async (
+  handler: (message: DocumentLiveBusMessage) => void | Promise<void>
+) => {
+  handlers.add(handler);
+  if (subscribed) return;
+
+  subscribed = true;
+  try {
+    let subscriber = await getSubscriber();
+
+    await subscriber.subscribe(liveBusChannel, async (raw: string) => {
+      try {
+        let parsed = JSON.parse(raw);
+        if (!isDocumentLiveBusMessage(parsed)) return;
+        if (!shouldDeliverBusMessage(parsed, documentLiveInstanceId)) return;
+
+        await Promise.all([...handlers].map(handler => handler(parsed)));
+      } catch (error) {
+        console.error('Failed to handle Cargo live document event', error);
+      }
+    });
+  } catch (error) {
+    subscribed = false;
+    throw error;
+  }
+};
+
+export let __documentLiveBusTestUtils = {
+  isDocumentLiveBusMessage,
+  shouldDeliverBusMessage
+};

--- a/src/cargo/modules/doc/src/live/documentLiveBusProtocol.ts
+++ b/src/cargo/modules/doc/src/live/documentLiveBusProtocol.ts
@@ -1,0 +1,26 @@
+export type DocumentLiveBusMessageType =
+  | 'yjs_update'
+  | 'awareness_update'
+  | 'awareness_remove'
+  | 'document_snapshot'
+  | 'document_snapshot_saved'
+  | 'participant_list';
+
+export type DocumentLiveBusMessage = {
+  originInstanceId: string;
+  originSessionId?: string;
+  documentId: string;
+  type: DocumentLiveBusMessageType;
+  data: any;
+};
+
+export let isDocumentLiveBusMessage = (message: any): message is DocumentLiveBusMessage =>
+  !!message &&
+  typeof message == 'object' &&
+  typeof message.originInstanceId == 'string' &&
+  typeof message.documentId == 'string' &&
+  typeof message.type == 'string' &&
+  'data' in message;
+
+export let shouldDeliverBusMessage = (message: DocumentLiveBusMessage, instanceId: string) =>
+  message.originInstanceId !== instanceId;

--- a/src/cargo/modules/doc/src/live/documentLiveSessionRegistry.test.ts
+++ b/src/cargo/modules/doc/src/live/documentLiveSessionRegistry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type DocumentLiveSessionState,
+  filterActiveSessions,
+  parseSessionState
+} from './documentLiveSessionRegistryUtils';
+
+describe('document live session registry helpers', () => {
+  let activeSession: DocumentLiveSessionState = {
+    id: 'session-active',
+    documentId: 'doc_123',
+    actorId: 'actor_123',
+    instanceId: 'cargo-a',
+    lastPingAt: 10_000,
+    awarenessClientId: 1,
+    awarenessUpdate: 'AAAA'
+  };
+
+  let staleSession: DocumentLiveSessionState = {
+    id: 'session-stale',
+    documentId: 'doc_123',
+    actorId: 'actor_456',
+    instanceId: 'cargo-b',
+    lastPingAt: 1_000
+  };
+
+  it('filters out sessions older than the timeout', () => {
+    expect(
+      filterActiveSessions({
+        sessions: [activeSession, staleSession],
+        now: 11_000,
+        timeoutMs: 5_000
+      })
+    ).toEqual([activeSession]);
+  });
+
+  it('parses valid session state payloads', () => {
+    expect(parseSessionState(JSON.stringify(activeSession))).toEqual(activeSession);
+  });
+
+  it('ignores invalid session state payloads', () => {
+    expect(
+      parseSessionState(JSON.stringify({ ...activeSession, actorId: undefined }))
+    ).toBeNull();
+    expect(parseSessionState('not-json')).toBeNull();
+  });
+});

--- a/src/cargo/modules/doc/src/live/documentLiveSessionRegistry.ts
+++ b/src/cargo/modules/doc/src/live/documentLiveSessionRegistry.ts
@@ -1,0 +1,90 @@
+import { createRedisClient } from '@lowerdeck/redis';
+import { env } from '@metorial-cargo/db';
+import { documentLiveInstanceId } from './documentLiveBus';
+import {
+  type DocumentLiveSessionState,
+  filterActiveSessions,
+  parseSessionState
+} from './documentLiveSessionRegistryUtils';
+
+let redisFactory = createRedisClient({
+  redisUrl: env.service.REDIS_URL
+});
+
+let redisClientPromise: Promise<any> | undefined;
+
+let getRedis = async () => {
+  redisClientPromise ??= redisFactory.eager();
+  return await redisClientPromise;
+};
+
+let sessionsKey = (documentId: string) =>
+  `cargo:document:collaboration:${documentId}:sessions`;
+
+let participantPayloadKey = (documentId: string) =>
+  `cargo:document:collaboration:${documentId}:participantPayload`;
+
+export let upsertLiveSession = async (
+  session: Omit<DocumentLiveSessionState, 'instanceId'> & { instanceId?: string },
+  timeoutMs: number
+) => {
+  let redis = await getRedis();
+  let key = sessionsKey(session.documentId);
+  let state: DocumentLiveSessionState = {
+    ...session,
+    instanceId: session.instanceId ?? documentLiveInstanceId
+  };
+
+  await redis.hSet(key, state.id, JSON.stringify(state));
+  await redis.expire(key, Math.ceil((timeoutMs * 2) / 1000));
+};
+
+export let removeLiveSession = async (documentId: string, sessionId: string) => {
+  let redis = await getRedis();
+  await redis.hDel(sessionsKey(documentId), sessionId);
+};
+
+export let listActiveLiveSessions = async (
+  documentId: string,
+  timeoutMs: number,
+  now = Date.now()
+) => {
+  let redis = await getRedis();
+  let key = sessionsKey(documentId);
+  let rawSessions = await redis.hGetAll(key);
+  let sessions = Object.values(rawSessions ?? {})
+    .map(value => (typeof value == 'string' ? parseSessionState(value) : null))
+    .filter((session): session is DocumentLiveSessionState => !!session);
+
+  let active = filterActiveSessions({ sessions, now, timeoutMs });
+  let staleSessionIds = sessions
+    .filter(session => now - session.lastPingAt > timeoutMs)
+    .map(session => session.id);
+
+  if (staleSessionIds.length > 0) {
+    await redis.hDel(key, staleSessionIds);
+  }
+
+  return active;
+};
+
+export let shouldPublishParticipantPayload = async (
+  documentId: string,
+  serializedPayload: string,
+  timeoutMs: number
+) => {
+  let redis = await getRedis();
+  let key = participantPayloadKey(documentId);
+  let existing = await redis.get(key);
+  if (existing === serializedPayload) return false;
+
+  await redis.set(key, serializedPayload, {
+    PX: timeoutMs * 2
+  });
+  return true;
+};
+
+export let __documentLiveSessionRegistryTestUtils = {
+  filterActiveSessions,
+  parseSessionState
+};

--- a/src/cargo/modules/doc/src/live/documentLiveSessionRegistryUtils.ts
+++ b/src/cargo/modules/doc/src/live/documentLiveSessionRegistryUtils.ts
@@ -1,0 +1,37 @@
+export type DocumentLiveSessionState = {
+  id: string;
+  documentId: string;
+  actorId: string;
+  instanceId: string;
+  lastPingAt: number;
+  awarenessClientId?: number;
+  awarenessUpdate?: string;
+};
+
+export let parseSessionState = (raw: string | undefined | null) => {
+  if (!raw) return null;
+
+  try {
+    let parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed.id != 'string' ||
+      typeof parsed.documentId != 'string' ||
+      typeof parsed.actorId != 'string' ||
+      typeof parsed.instanceId != 'string' ||
+      typeof parsed.lastPingAt != 'number'
+    ) {
+      return null;
+    }
+
+    return parsed as DocumentLiveSessionState;
+  } catch {
+    return null;
+  }
+};
+
+export let filterActiveSessions = (d: {
+  sessions: DocumentLiveSessionState[];
+  now: number;
+  timeoutMs: number;
+}) => d.sessions.filter(session => d.now - session.lastPingAt <= d.timeoutMs);

--- a/src/cargo/modules/doc/src/live/index.ts
+++ b/src/cargo/modules/doc/src/live/index.ts
@@ -6,8 +6,16 @@ import { upgradeWebSocket, websocket } from 'hono/bun';
 import type { WSContext } from 'hono/ws';
 import { internalDocumentCollaborationService } from '../internal/documentCollaboration';
 import { internalDocumentSyncService } from '../internal/documentSync';
-import { documentService } from '../services/document';
 import { queueDocumentCollaborationFlush } from '../queues/documentCollaborationFlush';
+import { documentService } from '../services/document';
+import { publishDocumentLiveBusMessage, subscribeToDocumentLiveBus } from './documentLiveBus';
+import { type DocumentLiveBusMessageType } from './documentLiveBusProtocol';
+import {
+  listActiveLiveSessions,
+  removeLiveSession,
+  shouldPublishParticipantPayload,
+  upsertLiveSession
+} from './documentLiveSessionRegistry';
 
 export { websocket };
 
@@ -92,10 +100,12 @@ let getActiveSessionIds = (documentId: string) => {
   });
 };
 
-let getActiveActorIds = (documentId: string) =>
+let getActiveActorIds = async (documentId: string) =>
   [
     ...new Set(
-      getActiveSessionIds(documentId).map(sessionId => liveSessions.get(sessionId)?.actorId)
+      (await listActiveLiveSessions(documentId, participantTimeoutMs)).map(
+        session => session.actorId
+      )
     )
   ].filter((actorId): actorId is string => !!actorId);
 
@@ -135,10 +145,61 @@ let broadcastToDocumentExcept = (
   }
 };
 
-let getAwarenessPayload = (documentId: string) =>
-  getActiveSessionIds(documentId)
-    .map(sessionId => {
-      let session = liveSessions.get(sessionId);
+let broadcastDistributedToDocument = async (
+  documentId: string,
+  type: DocumentLiveBusMessageType,
+  data: any,
+  originSessionId?: string
+) => {
+  broadcastToDocument(documentId, type, data);
+  await publishDocumentLiveBusMessage({
+    originSessionId,
+    documentId,
+    type,
+    data
+  });
+};
+
+let broadcastDistributedToDocumentExcept = async (
+  documentId: string,
+  excludedSessionId: string,
+  type: DocumentLiveBusMessageType,
+  data: any
+) => {
+  broadcastToDocumentExcept(documentId, excludedSessionId, type, data);
+  await publishDocumentLiveBusMessage({
+    originSessionId: excludedSessionId,
+    documentId,
+    type,
+    data
+  });
+};
+
+let handleLiveBusMessage = async (message: {
+  documentId: string;
+  type: DocumentLiveBusMessageType;
+  data: any;
+}) => {
+  broadcastToDocument(message.documentId, message.type, message.data);
+};
+
+let subscribeToLiveBus = () => {
+  subscribeToDocumentLiveBus(handleLiveBusMessage).catch(error => {
+    console.error('Failed to subscribe to Cargo live document events', error);
+    let retryTimer = setTimeout(subscribeToLiveBus, 5000);
+    retryTimer.unref?.();
+  });
+};
+
+subscribeToLiveBus();
+
+let persistLiveSession = async (session: LiveSession) => {
+  await upsertLiveSession(session, participantTimeoutMs);
+};
+
+let getAwarenessPayload = async (documentId: string) =>
+  (await listActiveLiveSessions(documentId, participantTimeoutMs))
+    .map(session => {
       if (
         !session ||
         typeof session.awarenessClientId != 'number' ||
@@ -148,7 +209,7 @@ let getAwarenessPayload = (documentId: string) =>
       }
 
       return {
-        sessionId,
+        sessionId: session.id,
         actorId: session.actorId,
         clientId: session.awarenessClientId,
         update: session.awarenessUpdate
@@ -273,7 +334,7 @@ let buildDocumentPayload = (
 };
 
 let broadcastParticipantList = async (documentId: string) => {
-  let actorIds = getActiveActorIds(documentId);
+  let actorIds = await getActiveActorIds(documentId);
   let payload =
     actorIds.length === 0
       ? []
@@ -317,6 +378,14 @@ let broadcastParticipantList = async (documentId: string) => {
 
   lastParticipantPayloadByDocumentId.set(documentId, serialized);
   broadcastToDocument(documentId, 'participant_list', payload);
+
+  if (await shouldPublishParticipantPayload(documentId, serialized, participantTimeoutMs)) {
+    await publishDocumentLiveBusMessage({
+      documentId,
+      type: 'participant_list',
+      data: payload
+    });
+  }
 };
 
 let removeSession = async (sessionId: string) => {
@@ -325,6 +394,7 @@ let removeSession = async (sessionId: string) => {
 
   liveSessions.delete(sessionId);
   socketsBySessionId.delete(sessionId);
+  await removeLiveSession(session.documentId, sessionId);
 
   let room = sessionIdsByDocumentId.get(session.documentId);
   if (room) {
@@ -336,11 +406,16 @@ let removeSession = async (sessionId: string) => {
   }
 
   if (typeof session.awarenessClientId == 'number') {
-    broadcastToDocument(session.documentId, 'awareness_remove', {
-      sessionId,
-      actorId: session.actorId,
-      clientId: session.awarenessClientId
-    });
+    await broadcastDistributedToDocument(
+      session.documentId,
+      'awareness_remove',
+      {
+        sessionId,
+        actorId: session.actorId,
+        clientId: session.awarenessClientId
+      },
+      sessionId
+    );
   }
 
   await broadcastParticipantList(session.documentId);
@@ -399,21 +474,24 @@ export let documentLiveApi = createHono()
 
       return {
         onOpen: async (_, ws) => {
-          liveSessions.set(sessionId, {
+          let session = {
             id: sessionId,
             documentId,
             actorId,
             lastPingAt: Date.now()
-          });
+          };
+
+          liveSessions.set(sessionId, session);
           socketsBySessionId.set(sessionId, ws);
           getRoomSessionIds(documentId).add(sessionId);
+          await persistLiveSession(session);
 
           send(ws, 'document_snapshot', buildDocumentPayload(scopedDocument.document));
           send(ws, 'collaboration_snapshot', {
             sessionId,
             document: buildDocumentPayload(scopedDocument.document),
             stateUpdate: await internalDocumentCollaborationService.getStateUpdate(documentId),
-            awareness: getAwarenessPayload(documentId)
+            awareness: await getAwarenessPayload(documentId)
           });
           await broadcastParticipantList(documentId);
         },
@@ -426,6 +504,7 @@ export let documentLiveApi = createHono()
 
           try {
             let parsed = JSON.parse(event.data.toString()) as DocumentLiveClientMessage;
+            await persistLiveSession(session);
 
             if (parsed.type === 'ping') {
               let ws = socketsBySessionId.get(sessionId);
@@ -449,11 +528,16 @@ export let documentLiveApi = createHono()
               });
               await queueDocumentCollaborationFlush(session.documentId, merged.revision);
 
-              broadcastToDocumentExcept(session.documentId, sessionId, 'yjs_update', {
+              await broadcastDistributedToDocumentExcept(
+                session.documentId,
                 sessionId,
-                actorId: session.actorId,
-                update: parsed.data.update
-              });
+                'yjs_update',
+                {
+                  sessionId,
+                  actorId: session.actorId,
+                  update: parsed.data.update
+                }
+              );
               return;
             }
 
@@ -483,13 +567,19 @@ export let documentLiveApi = createHono()
 
               session.awarenessClientId = parsed.data.clientId;
               session.awarenessUpdate = parsed.data.update;
+              await persistLiveSession(session);
 
-              broadcastToDocumentExcept(session.documentId, sessionId, 'awareness_update', {
+              await broadcastDistributedToDocumentExcept(
+                session.documentId,
                 sessionId,
-                actorId: session.actorId,
-                clientId: parsed.data.clientId,
-                update: parsed.data.update
-              });
+                'awareness_update',
+                {
+                  sessionId,
+                  actorId: session.actorId,
+                  clientId: parsed.data.clientId,
+                  update: parsed.data.update
+                }
+              );
               return;
             }
 
@@ -548,12 +638,13 @@ export let documentLiveApi = createHono()
               }
             });
 
-            broadcastToDocument(
+            await broadcastDistributedToDocument(
               updatedDocument.id,
               parsed.type === 'document_snapshot_save'
                 ? 'document_snapshot_saved'
                 : 'document_snapshot',
-              buildDocumentPayload(updatedDocument)
+              buildDocumentPayload(updatedDocument),
+              sessionId
             );
 
             let childDocuments =
@@ -565,13 +656,14 @@ export let documentLiveApi = createHono()
             let sharedUpdatedAt = updatedDocument.draftUpdatedAt ?? updatedDocument.updatedAt;
 
             for (let childDocument of childDocuments) {
-              broadcastToDocument(
+              await broadcastDistributedToDocument(
                 childDocument.id,
                 'document_snapshot',
                 buildDocumentPayload(childDocument, {
                   content: sharedContent,
                   updatedAt: sharedUpdatedAt
-                })
+                }),
+                sessionId
               );
             }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes real-time collaboration and Redis-backed session state across instances; mis-delivery or stale sessions could affect multi-user editing, though local-only paths remain and publish failures are logged rather than failing requests.
> 
> **Overview**
> **Adds cross-Cargo-instance live document collaboration** via a Redis pub/sub channel and a shared session registry, so Yjs updates, awareness, snapshots, and participant lists can reach clients connected to other instances.
> 
> New modules define the live bus message envelope (with **same-instance filtering** via `originInstanceId`), publish/subscribe on `cargo:document:collaboration:live`, and store per-document sessions plus deduplicated participant payloads in Redis. The document live WebSocket handler now **persists sessions to Redis**, builds awareness and active actors from **cluster-wide** sessions, and routes outbound events through **distributed broadcast** helpers that still notify local sockets then publish to the bus; inbound bus messages are replayed to local connections. Participant list publishing is gated so identical payloads are not re-broadcast across instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff7c6c193f5fa45cfa3611fc043f38c758185a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->