### PR TITLE
Update token issuer

### DIFF
--- a/src/metorial/apis/connection/src/oauth/skeleton.ts
+++ b/src/metorial/apis/connection/src/oauth/skeleton.ts
@@ -1,4 +1,3 @@
-import { getConfig } from '@metorial/config';
 import { Context } from '@lowerdeck/hono';
 import { createConnectionHono } from '../hono';
 
@@ -27,7 +26,7 @@ export let buildOAuthClientConfig = (base: string) => ({
   client_id_metadata_document_supported: false,
   code_challenge_methods_supported: ['S256'],
   grant_types_supported: ['authorization_code', 'refresh_token'],
-  issuer: getConfig().urls.apiUrl,
+  issuer: base,
   registration_endpoint: `${base}/oauth/register`,
   response_modes_supported: ['query'],
   response_types_supported: ['code'],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Issuer changes affect OAuth/OIDC client validation and token acceptance; misalignment previously could break clients that compare issuer to the connect base URL.
> 
> **Overview**
> **OAuth authorization-server metadata** now advertises **`issuer` as the per-route `base` URL** (same value used for authorize/token/register endpoints), replacing the global `getConfig().urls.apiUrl`.
> 
> This keeps issuer consistent with portal/plugin connect URLs returned from routing (e.g. `buildOAuthClientConfig(route.base)` in metadata and OpenID configuration handlers). The **`@metorial/config` dependency is removed** from `skeleton.ts` because it is no longer needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7e85b9ac1c07eac4a575b17ada743ba240a6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->