### PR TITLE
Remove useless version selector in provider page

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/provider/versions.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/provider/versions.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Entity, Flex, RenderDate, Spacer, Text } from '@metorial/ui';
+import { Badge, Entity, Flex, RenderDate, Spacer, Text } from '@metorial/ui';
 import { ID } from '@metorial/ui-product';
 import { useProviderVersionContext } from './providerVersionContext';
 
@@ -48,17 +48,6 @@ export let ProviderVersionsPage = () => {
                 />
 
                 <Entity.Field title="ID" value={<ID id={version.id} />} />
-
-                <Entity.Field title="Actions" right>
-                  <Button
-                    size="2"
-                    variant={isSelected ? 'outline' : 'solid'}
-                    onClick={() => setSelectedVersionId(version.id)}
-                    disabled={isSelected}
-                  >
-                    {isSelected ? 'Selected' : 'Select version'}
-                  </Button>
-                </Entity.Field>
               </Entity.Content>
             </Entity.Wrapper>
           );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only cleanup on the versions list; version selection context and capabilities flows are unchanged.
> 
> **Overview**
> Removes the per-version **Actions** row with **Select version** / **Selected** buttons from the provider **Versions** tab, since version switching is already handled elsewhere (e.g. the capabilities layout **Version** dropdown).
> 
> The versions list is now read-only metadata: version label, **Default** badge, release date, and ID. Drops the unused `Button` import from `@metorial/ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4168de1dc9d6ecc57b1b0abda1e01258d135f0c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->