### PR TITLE
Add more metadata endpoints

### DIFF
--- a/src/metorial/apis/connection/src/oauth/skeleton.ts
+++ b/src/metorial/apis/connection/src/oauth/skeleton.ts
@@ -55,6 +55,7 @@ type OAuthRoutePathConfig = {
   metadata: string[];
   connect: string[];
   protectedResource: string[];
+  protectedResourceMetadata: string[];
   openIdConfiguration: string[];
   register: string[];
   authorize: string[];
@@ -77,6 +78,7 @@ let portalOAuthPaths: OAuthRoutePathConfig = {
     ':portalId/:magicMcpTargetId/.well-known/oauth-protected-resource',
     ':portalId/.well-known/oauth-protected-resource'
   ],
+  protectedResourceMetadata: [':portalId/:magicMcpTargetId', ':portalId'],
   openIdConfiguration: [
     ':portalId/:magicMcpTargetId/.well-known/openid-configuration',
     ':portalId/.well-known/openid-configuration'
@@ -98,6 +100,7 @@ let pluginOAuthPaths: OAuthRoutePathConfig = {
   ],
   connect: [':skillPluginId'],
   protectedResource: [':skillPluginId/.well-known/oauth-protected-resource'],
+  protectedResourceMetadata: [':skillPluginId'],
   openIdConfiguration: [':skillPluginId/.well-known/openid-configuration'],
   register: [':skillPluginId/oauth/register'],
   authorize: [':skillPluginId/oauth/authorize'],
@@ -132,6 +135,14 @@ let createOAuthRouteServers = <TInput, TRoute>(d: {
   let metadataServer = createConnectionHono();
   for (let path of d.paths.metadata) {
     metadataServer = metadataServer.get(path, withResolvedRoute(d.handlers.metadata));
+  }
+
+  let protectedResourceServer = createConnectionHono();
+  for (let path of d.paths.protectedResourceMetadata) {
+    protectedResourceServer = protectedResourceServer.get(
+      path,
+      withResolvedRoute(d.handlers.protectedResource)
+    );
   }
 
   let connectServer = createConnectionHono();
@@ -183,6 +194,7 @@ let createOAuthRouteServers = <TInput, TRoute>(d: {
 
   return {
     metadataServer,
+    protectedResourceServer,
     connectServer
   };
 };
@@ -209,6 +221,7 @@ export let createPortalOAuthServers = <TRoute>(
 
   return {
     metadataServer: servers.metadataServer,
+    protectedResourceServer: servers.protectedResourceServer,
     connectPortalServer: servers.connectServer
   };
 };
@@ -224,6 +237,7 @@ export let createPluginOAuthServers = <TRoute>(
 
   return {
     metadataServer: servers.metadataServer,
+    protectedResourceServer: servers.protectedResourceServer,
     connectPluginServer: servers.connectServer
   };
 };

--- a/src/metorial/apis/connection/src/portal.ts
+++ b/src/metorial/apis/connection/src/portal.ts
@@ -94,6 +94,7 @@ export let createPortalHandler = (d: {
   authenticate: Authenticator<AuthInfo>;
 }): {
   metadataServer: ReturnType<typeof createPortalOAuthServers>['metadataServer'];
+  protectedResourceServer: ReturnType<typeof createPortalOAuthServers>['protectedResourceServer'];
   connectPortalServer: ReturnType<typeof createPortalOAuthServers>['connectPortalServer'];
 } => {
   return createPortalOAuthServers({
@@ -286,6 +287,7 @@ export let createPluginHandler = (d: {
   authenticate: Authenticator<AuthInfo>;
 }): {
   metadataServer: ReturnType<typeof createPluginOAuthServers>['metadataServer'];
+  protectedResourceServer: ReturnType<typeof createPluginOAuthServers>['protectedResourceServer'];
   connectPluginServer: ReturnType<typeof createPluginOAuthServers>['connectPluginServer'];
 } => {
   return createPluginOAuthServers({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only metadata routing refactor; same handler and payload as existing `.well-known` endpoints, with new mount points for discovery.
> 
> **Overview**
> Adds a **`protectedResourceServer`** alongside the existing metadata and connect OAuth apps, so **`buildOAuthProtectedResource`** JSON is served on **short portal/plugin base paths** (e.g. `:portalId`, `:skillPluginId`) via new **`protectedResourceMetadata`** route lists—not only on **`/.well-known/oauth-protected-resource`** on the connect server.
> 
> **`createPortalOAuthServers`**, **`createPluginOAuthServers`**, **`createPortalHandler`**, and **`createPluginHandler`** now return **`protectedResourceServer`** so callers can mount this discovery surface separately from connect/MCP traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b73a8ade21a93b94a476026a95d5c52b759aafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->