### PR TITLE
Harden scm sync

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2333,6 +2333,7 @@
         "@lowerdeck/error": "workspace:2.0.0",
         "@lowerdeck/pagination": "workspace:2.0.0",
         "@lowerdeck/service": "workspace:2.0.0",
+        "@lowerdeck/tokens": "workspace:2.0.0",
         "@lowerdeck/validation": "workspace:2.0.0",
         "@metorial-platform-systems/cargo-client": "1.0.0",
         "@metorial/config": "^1.0.0",

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/archive.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/archive.ts
@@ -17,7 +17,6 @@ export type DashboardInstanceSkillsMarketplacesArchiveOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapDashboardInstanceSkillsMarketplacesArchiveOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/create.ts
@@ -17,7 +17,6 @@ export type DashboardInstanceSkillsMarketplacesCreateOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapDashboardInstanceSkillsMarketplacesCreateOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/get.ts
@@ -17,7 +17,6 @@ export type DashboardInstanceSkillsMarketplacesGetOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapDashboardInstanceSkillsMarketplacesGetOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/list.ts
@@ -18,7 +18,6 @@ export type DashboardInstanceSkillsMarketplacesListOutput = {
       identifier: string;
       skillConfigurationId: string | null;
       skillMarketplaceId: string | null;
-      skillPluginId: string | null;
       skillPlugin: {
         object: 'skill.plugin';
         id: string;
@@ -93,10 +92,6 @@ export let mapDashboardInstanceSkillsMarketplacesListOutput =
                 ),
                 skillMarketplaceId: mtMap.objectField(
                   'skill_marketplace_id',
-                  mtMap.passthrough()
-                ),
-                skillPluginId: mtMap.objectField(
-                  'skill_plugin_id',
                   mtMap.passthrough()
                 ),
                 skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/add.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/add.ts
@@ -7,7 +7,6 @@ export type DashboardInstanceSkillsMarketplacesPluginsAddOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapDashboardInstanceSkillsMarketplacesPluginsAddOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/get.ts
@@ -7,7 +7,6 @@ export type DashboardInstanceSkillsMarketplacesPluginsGetOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapDashboardInstanceSkillsMarketplacesPluginsGetOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/list.ts
@@ -8,7 +8,6 @@ export type DashboardInstanceSkillsMarketplacesPluginsListOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -61,10 +60,6 @@ export let mapDashboardInstanceSkillsMarketplacesPluginsListOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/remove.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/plugins/remove.ts
@@ -7,7 +7,6 @@ export type DashboardInstanceSkillsMarketplacesPluginsRemoveOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapDashboardInstanceSkillsMarketplacesPluginsRemoveOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/sync.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/sync.ts
@@ -17,7 +17,6 @@ export type DashboardInstanceSkillsMarketplacesSyncOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapDashboardInstanceSkillsMarketplacesSyncOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/marketplaces/update.ts
@@ -17,7 +17,6 @@ export type DashboardInstanceSkillsMarketplacesUpdateOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapDashboardInstanceSkillsMarketplacesUpdateOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/archive.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/archive.ts
@@ -17,7 +17,6 @@ export type ManagementInstanceSkillsMarketplacesArchiveOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapManagementInstanceSkillsMarketplacesArchiveOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/create.ts
@@ -17,7 +17,6 @@ export type ManagementInstanceSkillsMarketplacesCreateOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapManagementInstanceSkillsMarketplacesCreateOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/get.ts
@@ -17,7 +17,6 @@ export type ManagementInstanceSkillsMarketplacesGetOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapManagementInstanceSkillsMarketplacesGetOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/list.ts
@@ -18,7 +18,6 @@ export type ManagementInstanceSkillsMarketplacesListOutput = {
       identifier: string;
       skillConfigurationId: string | null;
       skillMarketplaceId: string | null;
-      skillPluginId: string | null;
       skillPlugin: {
         object: 'skill.plugin';
         id: string;
@@ -93,10 +92,6 @@ export let mapManagementInstanceSkillsMarketplacesListOutput =
                 ),
                 skillMarketplaceId: mtMap.objectField(
                   'skill_marketplace_id',
-                  mtMap.passthrough()
-                ),
-                skillPluginId: mtMap.objectField(
-                  'skill_plugin_id',
                   mtMap.passthrough()
                 ),
                 skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/add.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/add.ts
@@ -7,7 +7,6 @@ export type ManagementInstanceSkillsMarketplacesPluginsAddOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapManagementInstanceSkillsMarketplacesPluginsAddOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/get.ts
@@ -7,7 +7,6 @@ export type ManagementInstanceSkillsMarketplacesPluginsGetOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapManagementInstanceSkillsMarketplacesPluginsGetOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/list.ts
@@ -8,7 +8,6 @@ export type ManagementInstanceSkillsMarketplacesPluginsListOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -61,10 +60,6 @@ export let mapManagementInstanceSkillsMarketplacesPluginsListOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/remove.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/plugins/remove.ts
@@ -7,7 +7,6 @@ export type ManagementInstanceSkillsMarketplacesPluginsRemoveOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapManagementInstanceSkillsMarketplacesPluginsRemoveOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/sync.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/sync.ts
@@ -17,7 +17,6 @@ export type ManagementInstanceSkillsMarketplacesSyncOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapManagementInstanceSkillsMarketplacesSyncOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/marketplaces/update.ts
@@ -17,7 +17,6 @@ export type ManagementInstanceSkillsMarketplacesUpdateOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapManagementInstanceSkillsMarketplacesUpdateOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/archive.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/archive.ts
@@ -17,7 +17,6 @@ export type SkillsMarketplacesArchiveOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapSkillsMarketplacesArchiveOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/create.ts
@@ -17,7 +17,6 @@ export type SkillsMarketplacesCreateOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapSkillsMarketplacesCreateOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/get.ts
@@ -17,7 +17,6 @@ export type SkillsMarketplacesGetOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapSkillsMarketplacesGetOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/list.ts
@@ -18,7 +18,6 @@ export type SkillsMarketplacesListOutput = {
       identifier: string;
       skillConfigurationId: string | null;
       skillMarketplaceId: string | null;
-      skillPluginId: string | null;
       skillPlugin: {
         object: 'skill.plugin';
         id: string;
@@ -93,10 +92,6 @@ export let mapSkillsMarketplacesListOutput =
                 ),
                 skillMarketplaceId: mtMap.objectField(
                   'skill_marketplace_id',
-                  mtMap.passthrough()
-                ),
-                skillPluginId: mtMap.objectField(
-                  'skill_plugin_id',
                   mtMap.passthrough()
                 ),
                 skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/add.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/add.ts
@@ -7,7 +7,6 @@ export type SkillsMarketplacesPluginsAddOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapSkillsMarketplacesPluginsAddOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/get.ts
@@ -7,7 +7,6 @@ export type SkillsMarketplacesPluginsGetOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapSkillsMarketplacesPluginsGetOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/list.ts
@@ -8,7 +8,6 @@ export type SkillsMarketplacesPluginsListOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -61,10 +60,6 @@ export let mapSkillsMarketplacesPluginsListOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/remove.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/plugins/remove.ts
@@ -7,7 +7,6 @@ export type SkillsMarketplacesPluginsRemoveOutput = {
   identifier: string;
   skillConfigurationId: string | null;
   skillMarketplaceId: string | null;
-  skillPluginId: string | null;
   skillPlugin: {
     object: 'skill.plugin';
     id: string;
@@ -56,7 +55,6 @@ export let mapSkillsMarketplacesPluginsRemoveOutput =
       'skill_marketplace_id',
       mtMap.passthrough()
     ),
-    skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     skillPlugin: mtMap.objectField(
       'skill_plugin',
       mtMap.object({

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/sync.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/sync.ts
@@ -17,7 +17,6 @@ export type SkillsMarketplacesSyncOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapSkillsMarketplacesSyncOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/marketplaces/update.ts
@@ -17,7 +17,6 @@ export type SkillsMarketplacesUpdateOutput = {
     identifier: string;
     skillConfigurationId: string | null;
     skillMarketplaceId: string | null;
-    skillPluginId: string | null;
     skillPlugin: {
       object: 'skill.plugin';
       id: string;
@@ -83,10 +82,6 @@ export let mapSkillsMarketplacesUpdateOutput =
           ),
           skillMarketplaceId: mtMap.objectField(
             'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
             mtMap.passthrough()
           ),
           skillPlugin: mtMap.objectField(

--- a/clients/metorial-dashboard/src/sdk.ts
+++ b/clients/metorial-dashboard/src/sdk.ts
@@ -24,8 +24,8 @@ import {
   MetorialDashboardInstanceCustomProvidersEndpoint,
   MetorialDashboardInstanceCustomProvidersEnvironmentsEndpoint,
   MetorialDashboardInstanceCustomProvidersVersionsEndpoint,
-  MetorialDashboardInstanceDocumentsEndpoint,
   MetorialDashboardInstanceDocumentsEditTokenEndpoint,
+  MetorialDashboardInstanceDocumentsEndpoint,
   MetorialDashboardInstanceDocumentsParticipantsEndpoint,
   MetorialDashboardInstanceDocumentsPermissionsEndpoint,
   MetorialDashboardInstanceDocumentsVersionsEndpoint,
@@ -71,6 +71,8 @@ import {
   MetorialDashboardInstancePortalsEndpoint,
   MetorialDashboardInstancePortalsListingsEndpoint,
   MetorialDashboardInstancePortalsSurfaceProviderGroupsEndpoint,
+  MetorialDashboardInstanceProtoGuardAlertsEndpoint,
+  MetorialDashboardInstanceProtoGuardConfigEndpoint,
   MetorialDashboardInstanceProviderAuthConfigErrorsEndpoint,
   MetorialDashboardInstanceProviderAuthConfigErrorsGroupsEndpoint,
   MetorialDashboardInstanceProviderAuthConfigEventsEndpoint,
@@ -95,10 +97,7 @@ import {
   MetorialDashboardInstanceProvidersTriggersEndpoint,
   MetorialDashboardInstanceProvidersVersionsEndpoint,
   MetorialDashboardInstanceProviderTemplatesEndpoint,
-  MetorialDashboardInstanceProtoGuardAlertsEndpoint,
-  MetorialDashboardInstanceProtoGuardConfigEndpoint,
   MetorialDashboardInstancePublishersEndpoint,
-  MetorialDashboardInstancesResourceCountsEndpoint,
   MetorialDashboardInstanceScmAccountsEndpoint,
   MetorialDashboardInstanceScmConnectionsEndpoint,
   MetorialDashboardInstanceScmInstallationEndpoint,
@@ -133,6 +132,7 @@ import {
   MetorialDashboardInstanceSkillsTemplatesItemsEndpoint,
   MetorialDashboardInstanceSkillsVersionsEndpoint,
   MetorialDashboardInstanceSkillsVersionsSnapshotEndpoint,
+  MetorialDashboardInstancesResourceCountsEndpoint,
   MetorialDashboardInstanceStoresEndpoint,
   MetorialDashboardInstanceStoresItemsEndpoint,
   MetorialDashboardInstanceStoresParticipantsEndpoint,
@@ -490,12 +490,53 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
         body.append('path', input.store.path);
       }
 
-      return await manager
-        ._post({
-          path: ['files'],
-          body
-        })
-        .transform(mapDashboardInstanceFilesGetOutput);
+      console.log('Uploading file with body:', Object.fromEntries(body.entries()));
+
+      try {
+        let res = await fetch(`${manager.apiHost}files`, {
+          method: 'POST',
+          body,
+          headers: manager.getHeaders(manager.config),
+          credentials: 'include',
+          redirect: 'follow',
+          referrerPolicy: 'no-referrer-when-downgrade',
+          cache: 'no-cache',
+          mode: 'cors'
+        });
+
+        let json = await res.json();
+
+        if (!res.ok) {
+          let errorData: {
+            status: number;
+            code: string;
+            message: string;
+          };
+          try {
+            errorData = json;
+          } catch {
+            errorData = {
+              status: res.status,
+              code: 'file_upload_failed',
+              message: `File upload failed with status ${res.status}`
+            };
+          }
+
+          throw new MetorialSDKError(errorData);
+        }
+
+        let mapped = mapDashboardInstanceFilesGetOutput.transformFrom(json);
+
+        return mapped;
+      } catch (error) {
+        console.error('File upload failed:', error);
+
+        throw new MetorialSDKError({
+          status: 500,
+          code: 'file_upload_failed',
+          message: 'File upload failed due to an unexpected error'
+        });
+      }
     }
   }),
 

--- a/src/cargo/clients/cargo/src/index.ts
+++ b/src/cargo/clients/cargo/src/index.ts
@@ -211,7 +211,14 @@ export let uploadFile = async (
   });
 
   if (!response.ok) {
-    throw new Error(`Cargo upload failed with status ${response.status}`);
+    let text: string;
+    try {
+      text = await response.text();
+    } catch {
+      text = '';
+    }
+
+    throw new Error(`Cargo upload failed with status ${response.status} - ${text}`);
   }
 
   return (await response.json()) as CargoUploadResult;

--- a/src/cargo/modules/skill/src/queues/sync/_lib/item.test.ts
+++ b/src/cargo/modules/skill/src/queues/sync/_lib/item.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getSyncItemKey, getSyncTaskItemWhere } from './item';
+
+describe('sync destination item identity', () => {
+  it('keeps marketplace, plugin, and skill records distinct', () => {
+    expect(
+      getSyncItemKey({
+        skillMarketplace: { id: 'marketplace' },
+        skillPlugin: null,
+        skill: null
+      })
+    ).toBe('marketplace:marketplace');
+    expect(
+      getSyncItemKey({
+        skillMarketplace: { id: 'marketplace' },
+        skillPlugin: { id: 'plugin' },
+        skill: null
+      })
+    ).toBe('plugin:plugin');
+    expect(
+      getSyncItemKey({
+        skillMarketplace: { id: 'marketplace' },
+        skillPlugin: { id: 'plugin' },
+        skill: { id: 'skill' }
+      })
+    ).toBe('skill:skill:plugin');
+  });
+
+  it('uses type-strict filters when updating hashes', () => {
+    expect(
+      getSyncTaskItemWhere({
+        type: 'marketplace',
+        action: 'set',
+        skillMarketplaceId: 'marketplace'
+      })
+    ).toEqual({
+      skillMarketplace: { id: 'marketplace' },
+      skillPluginOid: null,
+      skillOid: null
+    });
+    expect(
+      getSyncTaskItemWhere({
+        type: 'plugin',
+        action: 'set',
+        skillPluginId: 'plugin'
+      })
+    ).toEqual({
+      skillPlugin: { id: 'plugin' },
+      skillOid: null
+    });
+  });
+});

--- a/src/cargo/modules/skill/src/queues/sync/_lib/item.ts
+++ b/src/cargo/modules/skill/src/queues/sync/_lib/item.ts
@@ -1,0 +1,47 @@
+import type { Prisma } from '@metorial-cargo/db';
+import type { SyncTask } from './task';
+
+export let getSyncTaskItemKey = (task: SyncTask) => {
+  if (task.type === 'skill') return `skill:${task.skillId}:${task.skillPluginId}`;
+  if (task.type === 'plugin') return `plugin:${task.skillPluginId}`;
+  return `marketplace:${task.skillMarketplaceId}`;
+};
+
+export let getSyncItemKey = (item: {
+  skill?: { id: string } | null;
+  skillPlugin?: { id: string } | null;
+  skillMarketplace?: { id: string } | null;
+}) => {
+  if (item.skill) {
+    if (!item.skillPlugin) throw new Error('Skill item must have skillPlugin');
+    return `skill:${item.skill.id}:${item.skillPlugin.id}`;
+  }
+
+  if (item.skillPlugin) return `plugin:${item.skillPlugin.id}`;
+  if (item.skillMarketplace) return `marketplace:${item.skillMarketplace.id}`;
+  throw new Error('Invalid item');
+};
+
+export let getSyncTaskItemWhere = (
+  task: SyncTask
+): Prisma.SkillDestinationItemWhereInput => {
+  if (task.type === 'skill') {
+    return {
+      skill: { id: task.skillId },
+      skillPlugin: { id: task.skillPluginId }
+    };
+  }
+
+  if (task.type === 'plugin') {
+    return {
+      skillPlugin: { id: task.skillPluginId },
+      skillOid: null
+    };
+  }
+
+  return {
+    skillMarketplace: { id: task.skillMarketplaceId },
+    skillPluginOid: null,
+    skillOid: null
+  };
+};

--- a/src/cargo/modules/skill/src/queues/sync/collect.ts
+++ b/src/cargo/modules/skill/src/queues/sync/collect.ts
@@ -4,6 +4,7 @@ import { CargoSkillLimitError } from '../../lib/limits';
 import { applyMarketplace } from '../../serializers/marketplace';
 import { applyPlugin } from '../../serializers/plugin';
 import { applySkill } from '../../serializers/skill';
+import { getSyncItemKey, getSyncTaskItemKey } from './_lib/item';
 import { appendSkillDestinationSyncLog } from './_lib/logs';
 import { createTaskManager, type SyncTask } from './_lib/task';
 import { syncFinishQueue } from './finish';
@@ -43,27 +44,6 @@ let getSyncTaskLabel = (
   return `${action} skill ${names.skills.get(task.skillId) ?? task.skillId} in plugin ${
     names.plugins.get(task.skillPluginId) ?? task.skillPluginId
   }`;
-};
-
-let getSyncTaskItemKey = (task: SyncTask) => {
-  if (task.type === 'skill') return `skill:${task.skillId}:${task.skillPluginId}`;
-  if (task.type === 'plugin') return `plugin:${task.skillPluginId}`;
-  return `marketplace:${task.skillMarketplaceId}`;
-};
-
-let getSyncTaskItemKeyFromItem = (item: {
-  skill?: { id: string } | null;
-  skillPlugin?: { id: string } | null;
-  skillMarketplace?: { id: string } | null;
-}) => {
-  if (item.skill) {
-    if (!item.skillPlugin) throw new Error('Skill item must have skillPlugin');
-    return `skill:${item.skill.id}:${item.skillPlugin.id}`;
-  }
-
-  if (item.skillPlugin) return `plugin:${item.skillPlugin.id}`;
-  if (item.skillMarketplace) return `marketplace:${item.skillMarketplace.id}`;
-  throw new Error('Invalid item');
 };
 
 let getSyncPrMetadata = (d: {
@@ -188,7 +168,8 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
   });
 
   let taskManager = createTaskManager(currentItems);
-  let existingItemKeys = new Set(currentItems.map(item => getSyncTaskItemKeyFromItem(item)));
+  let currentItemsByKey = new Map(currentItems.map(item => [getSyncItemKey(item), item]));
+  let existingItemKeys = new Set(currentItemsByKey.keys());
 
   let getSerializerHash = async <Input, InitResult>(
     serializer: {
@@ -210,15 +191,13 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
   };
 
   let getCurrentMarketplaceItem = (marketplaceId: string) =>
-    currentItems.find(item => item.skillMarketplace?.id === marketplaceId);
+    currentItemsByKey.get(`marketplace:${marketplaceId}`);
 
   let getCurrentPluginItem = (pluginId: string) =>
-    currentItems.find(item => !item.skill && item.skillPlugin?.id === pluginId);
+    currentItemsByKey.get(`plugin:${pluginId}`);
 
   let getCurrentSkillItem = (d: { skillId: string; skillPluginId: string }) =>
-    currentItems.find(
-      item => item.skill?.id === d.skillId && item.skillPlugin?.id === d.skillPluginId
-    );
+    currentItemsByKey.get(`skill:${d.skillId}:${d.skillPluginId}`);
 
   if (sync.destination.skillMarketplace) {
     let marketplace = await db.skillMarketplace.findFirst({
@@ -412,7 +391,8 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
       'No content updates were needed.'
     );
     await syncFinishQueue.add({
-      skillDestinationSyncId: data.skillDestinationSyncId
+      skillDestinationSyncId: data.skillDestinationSyncId,
+      status: 'canceled'
     });
     return;
   }
@@ -424,6 +404,7 @@ export let syncCollectQueueProcessor = syncCollectQueue.process(async data => {
 
   await syncProcessQueue.add({
     skillDestinationSyncId: data.skillDestinationSyncId,
-    tasks
+    tasks,
+    hasChanges: false
   });
 });

--- a/src/cargo/modules/skill/src/queues/sync/finish.ts
+++ b/src/cargo/modules/skill/src/queues/sync/finish.ts
@@ -4,6 +4,7 @@ import { appendSkillDestinationSyncLog } from './_lib/logs';
 
 export let syncFinishQueue = createQueue<{
   skillDestinationSyncId: string;
+  status?: 'completed' | 'canceled';
 }>({
   redisUrl: env.service.REDIS_URL,
   name: 'cargo/skill/sync/finish',
@@ -18,9 +19,15 @@ export let syncFinishQueueProcessor = syncFinishQueue.process(async data => {
   });
   if (!sync || sync.status !== 'processing') return;
 
-  await db.skillDestinationSync.updateMany({
-    where: { id: data.skillDestinationSyncId },
-    data: { status: 'completed', completedAt: new Date() }
+  let status = data.status ?? 'completed';
+  let updated = await db.skillDestinationSync.updateMany({
+    where: { id: data.skillDestinationSyncId, status: 'processing' },
+    data: { status, completedAt: new Date() }
   });
-  await appendSkillDestinationSyncLog(data.skillDestinationSyncId, 'Sync completed.');
+  if (updated.count === 0) return;
+
+  await appendSkillDestinationSyncLog(
+    data.skillDestinationSyncId,
+    status === 'canceled' ? 'Sync canceled.' : 'Sync completed.'
+  );
 });

--- a/src/cargo/modules/skill/src/queues/sync/process.ts
+++ b/src/cargo/modules/skill/src/queues/sync/process.ts
@@ -8,8 +8,10 @@ import type { SerializerContext } from '../../serializers/_lib/types';
 import { applyMarketplace } from '../../serializers/marketplace';
 import { applyPlugin, getPluginPath } from '../../serializers/plugin';
 import { applySkill, getSkillPath } from '../../serializers/skill';
+import { getSyncTaskItemWhere } from './_lib/item';
 import { appendSkillDestinationSyncLog } from './_lib/logs';
 import { type SyncTask } from './_lib/task';
+import { syncFinishQueue } from './finish';
 import { syncPropagateStartQueue } from './propagate';
 
 let codeBucketClient = createCodeBucketClient({
@@ -56,6 +58,7 @@ let failSyncForLimitError = async (d: { skillDestinationSyncId: string; error: u
 export let syncProcessQueue = createQueue<{
   skillDestinationSyncId: string;
   tasks: SyncTask[];
+  hasChanges?: boolean;
 }>({
   redisUrl: env.service.REDIS_URL,
   name: 'cargo/skill/sync/process',
@@ -80,32 +83,31 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
 
   let task = data.tasks[0];
   if (!task) {
-    await appendSkillDestinationSyncLog(
-      data.skillDestinationSyncId,
-      'Content updates are ready.'
-    );
-    await syncPropagateStartQueue.add({
-      skillDestinationSyncId: data.skillDestinationSyncId
-    });
+    if (data.hasChanges) {
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        'Content updates are ready.'
+      );
+      await syncPropagateStartQueue.add({
+        skillDestinationSyncId: data.skillDestinationSyncId
+      });
+    } else {
+      await appendSkillDestinationSyncLog(
+        data.skillDestinationSyncId,
+        'Content updates were no longer needed.'
+      );
+      await syncFinishQueue.add({
+        skillDestinationSyncId: data.skillDestinationSyncId,
+        status: 'canceled'
+      });
+    }
     return;
   }
 
   let item = await db.skillDestinationItem.findFirst({
     where: {
       destinationOid: sync.destinationOid,
-
-      ...(task?.type === 'marketplace'
-        ? { skillMarketplace: { id: task.skillMarketplaceId } }
-        : {}),
-
-      ...(task?.type === 'plugin' ? { skillPlugin: { id: task.skillPluginId } } : {}),
-
-      ...(task?.type === 'skill'
-        ? {
-            skill: { id: task.skillId },
-            skillPlugin: { id: task.skillPluginId }
-          }
-        : {})
+      ...getSyncTaskItemWhere(task)
     }
   });
 
@@ -176,11 +178,11 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
       throw error;
     }
 
-    if (item?.hash === hash) return true;
+    if (item?.hash === hash) return 'skipped' as const;
 
     try {
       await serializer.apply(input, context, initResult);
-      return true;
+      return 'applied' as const;
     } catch (error) {
       if (await failSyncForLimitError({ skillDestinationSyncId: data.skillDestinationSyncId, error })) {
         return false;
@@ -189,6 +191,7 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
       throw error;
     }
   };
+  let taskChanged = false;
 
   let loadSkillPlugin = async (skillPluginId: string) => {
     let skillPlugin = await db.skillPlugin.findUnique({
@@ -310,6 +313,7 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
           skillPluginOid: skillPlugin.oid
         }
       });
+      taskChanged = true;
     } else {
       await appendSkillDestinationSyncLog(
         data.skillDestinationSyncId,
@@ -323,6 +327,7 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
         skillMarketplacePlugin
       });
       if (!applied) return;
+      taskChanged = applied === 'applied';
       await fileProcessor.flush();
 
       if (hashRef.current) {
@@ -360,6 +365,7 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
           skillPluginOid: skillPlugin.oid
         }
       });
+      taskChanged = true;
     } else {
       await appendSkillDestinationSyncLog(
         data.skillDestinationSyncId,
@@ -371,6 +377,7 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
         skillMarketplacePlugin
       });
       if (!applied) return;
+      taskChanged = applied === 'applied';
       await fileProcessor.flush();
 
       if (hashRef.current) {
@@ -389,6 +396,7 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
     );
     let applied = await applySerializer(applyMarketplace, { skillMarketplace });
     if (!applied) return;
+    taskChanged = applied === 'applied';
     await fileProcessor.flush();
 
     if (hashRef.current) {
@@ -404,7 +412,17 @@ export let syncProcessQueueProcessor = syncProcessQueue.process(async data => {
   if (tasks.length > 0) {
     await syncProcessQueue.add({
       skillDestinationSyncId: data.skillDestinationSyncId,
-      tasks
+      tasks,
+      hasChanges: data.hasChanges || taskChanged
+    });
+  } else if (!data.hasChanges && !taskChanged) {
+    await appendSkillDestinationSyncLog(
+      data.skillDestinationSyncId,
+      'Content updates were no longer needed.'
+    );
+    await syncFinishQueue.add({
+      skillDestinationSyncId: data.skillDestinationSyncId,
+      status: 'canceled'
     });
   } else {
     await appendSkillDestinationSyncLog(

--- a/src/cargo/modules/skill/src/queues/sync/propagate.ts
+++ b/src/cargo/modules/skill/src/queues/sync/propagate.ts
@@ -1,3 +1,4 @@
+import { generatePlainId } from '@lowerdeck/id';
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db, env, getId, withTransaction } from '@metorial-cargo/db';
 import { getOriginTenant, origin } from '../../internal/skillDestination';
@@ -138,7 +139,7 @@ export let syncPropagateStartQueueProcessor = syncPropagateStartQueue.process(as
           status: 'pending',
           skillDestinationSyncOid: sync.oid,
           skillRepositoryOid: link.skillRepository.oid,
-          branchName: `metorial/sync-${target}-${repository.syncCounter}`,
+          branchName: `metorial/sync-${target}-${repository.syncCounter}-${generatePlainId(4).toLowerCase()}`,
           prName: sync.prName ?? `Sync ${target}`,
           prDescription: sync.prDescription,
           commitMessage: sync.commitMessage ?? sync.prName ?? `Sync ${target}`

--- a/src/cargo/modules/skill/src/queues/sync/start.ts
+++ b/src/cargo/modules/skill/src/queues/sync/start.ts
@@ -28,10 +28,12 @@ export let syncStartQueueProcessor = syncStartQueue.process(async data => {
   if (!sync) throw new QueueRetryError();
   if (sync.status !== 'pending') return;
 
-  await db.skillDestinationSync.updateMany({
+  let claimedSync = await db.skillDestinationSync.updateMany({
     where: { oid: sync.oid, status: 'pending' },
     data: { status: 'processing', startedAt: new Date() }
   });
+  if (claimedSync.count === 0) return;
+
   await appendSkillDestinationSyncLog(data.skillDestinationSyncId, 'Starting sync.');
 
   // Cancel other syncs for the same destination

--- a/src/cargo/modules/skill/src/serializers/marketplace/index.ts
+++ b/src/cargo/modules/skill/src/serializers/marketplace/index.ts
@@ -1,3 +1,4 @@
+import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import { db } from '@metorial-cargo/db';
 import semver from 'semver';
@@ -40,46 +41,73 @@ export let applyMarketplace = createApplicator(
       skillMarketplaceOid: input.skillMarketplace.oid
     });
 
-    let pluginHashes = plugins
-      .map(s =>
+    let tenant = await db.tenant.findFirstOrThrow({
+      where: { oid: input.skillMarketplace.tenantOid }
+    });
+    let legacyPluginHashes = plugins
+      .map(plugin =>
         [
           1,
-          s.oid,
-          s.skillPlugin.oid,
-          s.updatedAt.getTime(),
-          s.skillPlugin.updatedAt.getTime()
+          plugin.oid,
+          plugin.skillPlugin.oid,
+          plugin.updatedAt.getTime(),
+          plugin.skillPlugin.updatedAt.getTime()
         ].join(':')
       )
       .join('|');
-
-    let hash = await Hash.sha256(
+    let legacyHash = await Hash.sha256(
       [
         1,
         input.skillMarketplace.oid,
         input.skillMarketplace.updatedAt.getTime(),
-        pluginHashes
+        legacyPluginHashes
       ].join(':')
     );
 
-    let tenant = await db.tenant.findFirstOrThrow({
-      where: { oid: input.skillMarketplace.tenantOid }
-    });
+    // Hash only values that affect generated files. Timestamps and the generated
+    // version are deliberately excluded so importing our own version-only commit
+    // cannot schedule another version-only sync.
+    let hash = await Hash.sha256(
+      canonicalize({
+        serializerVersion: 2,
+        marketplace: {
+          slug: input.skillMarketplace.slug,
+          name: input.skillMarketplace.name,
+          ownerName: tenant.organizationName ?? tenant.name
+        },
+        plugins: plugins.map(plugin => ({
+          slug: plugin.pluginSlug,
+          category: plugin.skillPlugin.category ?? 'Productivity',
+          description:
+            plugin.skillPlugin.description ??
+            plugin.skillPlugin.skillPluginSkills[0]?.skill.description ??
+            ''
+        }))
+      })
+    );
 
     return {
       plugins,
       tenant,
-      hash
+      hash,
+      legacyHash
     };
   },
   {
     getHash: async (_input, { hash }) => hash,
 
-    apply: async (input, context, { plugins, tenant, hash }) => {
+    apply: async (input, context, { plugins, tenant, hash, legacyHash }) => {
       if (input.skillMarketplace.versionHash !== hash) {
-        let nextVersion = semver.inc(input.skillMarketplace.version ?? '0.0.0', 'patch')!;
+        let isHashMigration = input.skillMarketplace.versionHash === legacyHash;
+        let nextVersion = isHashMigration
+          ? input.skillMarketplace.version
+          : semver.inc(input.skillMarketplace.version ?? '0.0.0', 'patch')!;
 
-        await db.skillMarketplace.updateMany({
-          where: { oid: input.skillMarketplace.oid },
+        let updated = await db.skillMarketplace.updateMany({
+          where: {
+            oid: input.skillMarketplace.oid,
+            versionHash: input.skillMarketplace.versionHash
+          },
           data: {
             versionHash: hash,
             version: nextVersion,
@@ -89,7 +117,20 @@ export let applyMarketplace = createApplicator(
           }
         });
 
-        input.skillMarketplace.version = nextVersion;
+        if (updated.count > 0) {
+          input.skillMarketplace.version = nextVersion;
+          input.skillMarketplace.versionHash = hash;
+        } else {
+          let current = await db.skillMarketplace.findUniqueOrThrow({
+            where: { oid: input.skillMarketplace.oid }
+          });
+          if (current.versionHash !== hash) {
+            throw new Error('Marketplace changed while its sync was being processed');
+          }
+
+          input.skillMarketplace.version = current.version;
+          input.skillMarketplace.versionHash = current.versionHash;
+        }
       }
 
       let codexMarketplace = json({

--- a/src/cargo/modules/skill/src/serializers/plugin/index.ts
+++ b/src/cargo/modules/skill/src/serializers/plugin/index.ts
@@ -1,3 +1,4 @@
+import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import { slugify } from '@lowerdeck/slugify';
 import { db, env } from '@metorial-cargo/db';
@@ -34,37 +35,96 @@ export let applyPlugin = createApplicator(
       skillPluginOid: input.skillPlugin.oid
     });
 
-    let skillHashes = skills
-      .map(s =>
+    let tenant = await db.tenant.findFirstOrThrow({
+      where: { oid: input.skillPlugin.tenantOid }
+    });
+    let agents = await db.skillAgent.findMany({
+      where: {
+        skillOid: { in: skills.map(skill => skill.skill.oid) },
+        status: 'active'
+      },
+      include: { document: { include: { content: true } } },
+      orderBy: { id: 'asc' }
+    });
+    let image = input.skillPlugin.image;
+    if (image?.type !== 'file') {
+      for (let skill of skills) {
+        if (skill.skill.image?.type === 'file') image = skill.skill.image;
+      }
+    }
+    if (image?.type !== 'file' && tenant.image?.type === 'file') {
+      image = tenant.image;
+    }
+    let legacySkillHashes = skills
+      .map(skill =>
         [
           1,
-          s.oid,
-          s.skill.oid,
-          s.updatedAt.getTime(),
-          s.skill.updatedAt.getTime(),
-          s.skill.store.lastEditedAt.getTime()
+          skill.oid,
+          skill.skill.oid,
+          skill.updatedAt.getTime(),
+          skill.skill.updatedAt.getTime(),
+          skill.skill.store.lastEditedAt.getTime()
         ].join(':')
       )
       .join('|');
+    let legacyHash = await Hash.sha256(
+      [1, input.skillPlugin.oid, input.skillPlugin.updatedAt.getTime(), legacySkillHashes].join(
+        ':'
+      )
+    );
 
+    // Hash only values that affect generated files. In particular, exclude
+    // updatedAt and the generated version to make repository round-trips
+    // idempotent.
     let hash = await Hash.sha256(
-      [1, input.skillPlugin.oid, input.skillPlugin.updatedAt.getTime(), skillHashes].join(':')
+      canonicalize({
+        serializerVersion: 2,
+        plugin: {
+          slug: input.skillPlugin.slug,
+          name: input.skillPlugin.name,
+          description: input.skillPlugin.description,
+          longDescription: input.skillPlugin.longDescription,
+          category: input.skillPlugin.category,
+          image
+        },
+        marketplacePluginSlug: input.skillMarketplacePlugin?.pluginSlug,
+        standaloneMarketplace: input.skillMarketplace
+          ? null
+          : {
+              ownerName: tenant.organizationName ?? tenant.name
+            },
+        agents: agents.map(agent => ({
+          slug: agent.slug,
+          content: agent.document.content.content
+        })),
+        mcpUrl: `${env.service.API_URL}/connect/plugin/${input.skillPlugin.slug}`
+      })
     );
 
     return {
       skills,
-      hash
+      tenant,
+      agents,
+      image,
+      hash,
+      legacyHash
     };
   },
   {
     getHash: async (_input, { hash }) => hash,
 
-    apply: async (input, context, { skills, hash }) => {
+    apply: async (input, context, { tenant, agents, image, hash, legacyHash }) => {
       if (input.skillPlugin.versionHash !== hash) {
-        let nextVersion = semver.inc(input.skillPlugin.version ?? '0.0.0', 'patch')!;
+        let isHashMigration = input.skillPlugin.versionHash === legacyHash;
+        let nextVersion = isHashMigration
+          ? input.skillPlugin.version
+          : semver.inc(input.skillPlugin.version ?? '0.0.0', 'patch')!;
 
-        await db.skillPlugin.updateMany({
-          where: { oid: input.skillPlugin.oid },
+        let updated = await db.skillPlugin.updateMany({
+          where: {
+            oid: input.skillPlugin.oid,
+            versionHash: input.skillPlugin.versionHash
+          },
           data: {
             versionHash: hash,
             version: nextVersion,
@@ -74,7 +134,20 @@ export let applyPlugin = createApplicator(
           }
         });
 
-        input.skillPlugin.version = nextVersion;
+        if (updated.count > 0) {
+          input.skillPlugin.version = nextVersion;
+          input.skillPlugin.versionHash = hash;
+        } else {
+          let current = await db.skillPlugin.findUniqueOrThrow({
+            where: { oid: input.skillPlugin.oid }
+          });
+          if (current.versionHash !== hash) {
+            throw new Error('Plugin changed while its sync was being processed');
+          }
+
+          input.skillPlugin.version = current.version;
+          input.skillPlugin.versionHash = current.versionHash;
+        }
       }
 
       context.setBasePath(getPluginPath(input));
@@ -88,23 +161,6 @@ export let applyPlugin = createApplicator(
       let mcpJson = json(mcpServers);
       await context.setFile('mcp.json', mcpJson);
       await context.setFile('.mcp.json', mcpJson);
-
-      let image = input.skillPlugin.image;
-      if (image?.type !== 'file') {
-        for (let skill of skills) {
-          if (skill.skill.image?.type === 'file') {
-            image = skill.skill.image;
-          }
-        }
-      }
-      if (image?.type !== 'file') {
-        let tenant = await db.tenant.findFirstOrThrow({
-          where: { oid: input.skillPlugin.tenantOid }
-        });
-        if (tenant.image?.type === 'file') {
-          image = tenant.image;
-        }
-      }
 
       let downloadImage = await internalImageService.downloadImage({
         id: input.skillPlugin.id,
@@ -163,10 +219,6 @@ export let applyPlugin = createApplicator(
       // Standalone plugins are a single-plugin marketplace, so we still need to
       // create the marketplace files for them.
       if (!input.skillMarketplace) {
-        let tenant = await db.tenant.findFirstOrThrow({
-          where: { oid: input.skillPlugin.tenantOid }
-        });
-
         let codexMarketplace = json({
           name: baseInfo.name,
           interface: {
@@ -212,26 +264,8 @@ export let applyPlugin = createApplicator(
         await context.setFile('.github/plugin/marketplace.json', cursorAndClaudeMarketplace);
       }
 
-      let cursor: string | null = null;
-      let limit = 25;
-
-      while (true) {
-        let agents = await db.skillAgent.findMany({
-          where: {
-            skillOid: { in: skills.map(s => s.skill.oid) },
-            status: 'active',
-            id: cursor ? { gt: cursor } : undefined
-          },
-          include: { document: { include: { content: true } } },
-          take: limit
-        });
-
-        for (let agent of agents) {
-          await context.setFile(`agents/${agent.slug}.md`, agent.document.content.content);
-        }
-
-        if (agents.length < limit) break;
-        cursor = agents[agents.length - 1]!.id as string;
+      for (let agent of agents) {
+        await context.setFile(`agents/${agent.slug}.md`, agent.document.content.content);
       }
     }
   }

--- a/src/cargo/modules/skill/src/serializers/skill/index.ts
+++ b/src/cargo/modules/skill/src/serializers/skill/index.ts
@@ -1,3 +1,4 @@
+import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import { slugify } from '@lowerdeck/slugify';
 import type { Prisma } from '@metorial-cargo/db';
@@ -148,17 +149,26 @@ export let applySkill = createApplicator(
   {
     getHash: async (input, { skillStore, config, effectiveAllowedFileExtensions }) => {
       return await Hash.sha256(
-        [
-          3,
-          input.skill.oid,
-          input.skillPlugin.oid,
-          input.skill.updatedAt.getTime(),
-          skillStore.lastEditedAt.getTime(),
-          config.allowScripts,
-          config.allowNonStandardDirectories,
-          effectiveAllowedFileExtensions.shouldFilter,
-          [...effectiveAllowedFileExtensions.extensions].sort().join(',')
-        ].join(':')
+        canonicalize({
+          serializerVersion: 4,
+          path: getSkillPath(input),
+          skill: {
+            name: input.skill.name,
+            clientName: input.skill.clientName,
+            description: input.skill.description,
+            clientDescription: input.skill.clientDescription,
+            license: input.skill.license,
+            compatibility: input.skill.compatibility,
+            clientMetadata: input.skill.clientMetadata
+          },
+          storeLastEditedAt: skillStore.lastEditedAt,
+          config: {
+            allowScripts: config.allowScripts,
+            allowNonStandardDirectories: config.allowNonStandardDirectories,
+            shouldFilterExtensions: effectiveAllowedFileExtensions.shouldFilter,
+            allowedFileExtensions: [...effectiveAllowedFileExtensions.extensions].sort()
+          }
+        })
       );
     },
 

--- a/src/cargo/modules/skill/src/services/skillSync.ts
+++ b/src/cargo/modules/skill/src/services/skillSync.ts
@@ -118,7 +118,7 @@ class SkillSyncServiceImpl {
             ...opts,
             where: {
               id: d.ids?.length ? { in: d.ids } : undefined,
-              status: d.statuses?.length ? { in: d.statuses } : undefined,
+              status: d.statuses?.length ? { in: d.statuses } : { not: 'canceled' },
               createdAt: d.createdAt ? normalizeDateFilter(d.createdAt) : undefined,
               destination: {
                 AND: [

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
@@ -8,7 +8,7 @@ import {
   useCurrentProject,
   useSkillMarketplace
 } from '@metorial/state';
-import { Button, Callout, Flex, LinkTabs, Spacer, toast } from '@metorial/ui';
+import { Button, Flex, LinkTabs, toast } from '@metorial/ui';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import { useInterval } from 'react-use';
 
@@ -132,7 +132,7 @@ export let SkillMarketplaceLayout = () => {
               ]}
             />
 
-            {marketplace.data?.syncStatus !== 'synced' && (
+            {/* {marketplace.data?.syncStatus !== 'synced' && (
               <>
                 <Callout color="blue">
                   <span>
@@ -154,7 +154,7 @@ export let SkillMarketplaceLayout = () => {
 
                 <Spacer height={20} />
               </>
-            )}
+            )} */}
 
             <Outlet />
           </>

--- a/src/metorial-frontend/packages/ui-product/src/itemGrid.tsx
+++ b/src/metorial-frontend/packages/ui-product/src/itemGrid.tsx
@@ -1,4 +1,14 @@
-import { Button, getLink, Menu, Spacer, Text, theme, Title, toast } from '@metorial/ui';
+import {
+  Button,
+  getLink,
+  Menu,
+  Spacer,
+  Spinner,
+  Text,
+  theme,
+  Title,
+  toast
+} from '@metorial/ui';
 import { RiMore2Fill } from '@remixicon/react';
 import copy from 'copy-to-clipboard';
 import React from 'react';
@@ -58,9 +68,13 @@ let Grid = styled.ul.withConfig({
       : ''}
 `;
 
-let Wrapper = styled.li.withConfig({ shouldForwardProp: p => p !== '$mode' })<{
+let Wrapper = styled.li.withConfig({
+  shouldForwardProp: p => p !== '$mode' && p !== '$disabled'
+})<{
   $mode?: ItemGridItemMode;
+  $disabled?: boolean;
 }>`
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -73,6 +87,7 @@ let Wrapper = styled.li.withConfig({ shouldForwardProp: p => p !== '$mode' })<{
   text-align: left;
   text-decoration: none;
   transition: all 0.2s;
+  opacity: ${p => (p.$disabled ? 0.45 : 1)};
 
   &[data-button='true'] {
     cursor: pointer;
@@ -84,6 +99,19 @@ let Wrapper = styled.li.withConfig({ shouldForwardProp: p => p !== '$mode' })<{
       box-shadow: ${theme.shadows.medium};
     }
   }
+`;
+
+let LoadingIndicator = styled.div`
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
 `;
 
 let Header = styled.header`
@@ -160,19 +188,21 @@ let MenuWrapper = styled.div`
 type ItemGridActionProps = {
   href?: string;
   onClick?: () => void;
+  disabled?: boolean;
 };
 
-let getActionProps = ({ href, onClick }: ItemGridActionProps) => {
+let getActionProps = ({ href, onClick, disabled }: ItemGridActionProps) => {
   if (onClick) {
     return {
       as: 'button' as const,
       type: 'button' as const,
       onClick,
+      disabled,
       'data-button': 'true'
     };
   }
 
-  if (href) {
+  if (href && !disabled) {
     return {
       as: 'span' as const,
       'data-button': 'true'
@@ -182,8 +212,8 @@ let getActionProps = ({ href, onClick }: ItemGridActionProps) => {
   return {};
 };
 
-let wrapAction = (children: React.ReactNode, href?: string) => {
-  if (!href) return children;
+let wrapAction = (children: React.ReactNode, href?: string, disabled?: boolean) => {
+  if (!href || disabled) return children;
 
   let Link = getLink();
 
@@ -222,7 +252,9 @@ export let ItemGrid = {
     bottom,
     mode = 'default',
     small,
-    height
+    height,
+    disabled = false,
+    loading = false
   }: {
     title: React.ReactNode;
     description?: React.ReactNode;
@@ -236,6 +268,8 @@ export let ItemGrid = {
     mode?: ItemGridItemMode;
     small?: boolean;
     height?: number;
+    disabled?: boolean;
+    loading?: boolean;
   }) => {
     let menuItems = [
       ...(entity && showCopyId ? [{ id: 'id', label: 'Copy ID' }] : []),
@@ -244,14 +278,22 @@ export let ItemGrid = {
 
     return wrapAction(
       <Wrapper
-        {...getActionProps({ href, onClick })}
+        {...getActionProps({ href, onClick, disabled })}
         $mode={mode}
+        $disabled={disabled}
+        aria-busy={loading}
         style={{
           height: mode === 'compactHorizontal' ? height : undefined,
           minHeight: height ?? (mode === 'compactHorizontal' || small ? 'unset' : 200),
           overflow: mode === 'compactHorizontal' && height ? 'hidden' : undefined
         }}
       >
+        {loading && (
+          <LoadingIndicator>
+            <Spinner size={20} />
+          </LoadingIndicator>
+        )}
+
         <Header>
           {mode === 'compactHorizontal' ? (
             <CompactHeaderContent>
@@ -319,7 +361,8 @@ export let ItemGrid = {
           </>
         )}
       </Wrapper>,
-      onClick ? undefined : href
+      onClick ? undefined : href,
+      disabled
     );
   },
   CenteredItem: ({
@@ -327,17 +370,23 @@ export let ItemGrid = {
     description,
     icon,
     href,
-    onClick
+    onClick,
+    disabled = false,
+    loading = false
   }: {
     title: React.ReactNode;
     description?: React.ReactNode;
     icon: React.ReactNode;
     href?: string;
     onClick?: () => void;
+    disabled?: boolean;
+    loading?: boolean;
   }) => {
     return wrapAction(
       <Wrapper
-        {...getActionProps({ href, onClick })}
+        {...getActionProps({ href, onClick, disabled })}
+        $disabled={disabled}
+        aria-busy={loading}
         style={{
           alignItems: 'center',
           justifyContent: 'center',
@@ -345,6 +394,12 @@ export let ItemGrid = {
           minHeight: 200
         }}
       >
+        {loading && (
+          <LoadingIndicator>
+            <Spinner size={20} />
+          </LoadingIndicator>
+        )}
+
         <div>{icon}</div>
 
         <TitleWrapper>
@@ -359,7 +414,8 @@ export let ItemGrid = {
           </Text>
         )}
       </Wrapper>,
-      onClick ? undefined : href
+      onClick ? undefined : href,
+      disabled
     );
   },
   RawItem: Wrapper

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillLinkProviders.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillLinkProviders.tsx
@@ -667,25 +667,27 @@ let showSkillTemplateItemPickerPanel = (p: {
 let AddSkillItemMenu = (p: {
   disabled?: boolean;
   onSelect: (kind: SkillItemPickerKind) => void;
-}) => (
-  <Menu
-    items={[
-      { id: 'provider', label: 'Provider', description: 'Link an individual provider.' },
-      {
-        id: 'integration',
-        label: 'Integration',
-        description: 'Link an integration with multiple providers.'
-      }
-    ]}
-    onItemClick={item => {
-      if (item === 'provider' || item === 'integration') p.onSelect(item);
-    }}
-  >
-    <Button size="2" iconLeft={<RiAddLine />} disabled={p.disabled} variant="outline">
-      Add Provider
-    </Button>
-  </Menu>
-);
+}) => {
+  return (
+    <Menu
+      items={[
+        { id: 'provider', label: 'Provider', description: 'Link an individual provider.' },
+        {
+          id: 'integration',
+          label: 'Integration',
+          description: 'Link an integration with multiple providers.'
+        }
+      ]}
+      onItemClick={item => {
+        if (item === 'provider' || item === 'integration') p.onSelect(item);
+      }}
+    >
+      <Button size="2" iconLeft={<RiAddLine />} disabled={p.disabled} variant="outline">
+        Add Provider
+      </Button>
+    </Menu>
+  );
+};
 
 export let SkillLinkProvidersScene = (p: {
   instanceId: string | null | undefined;

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
@@ -163,6 +163,8 @@ let PluginPickerPanel = (p: {
                         description={truncate(plugin.description)}
                         height={200}
                         onClick={() => selectPlugin(plugin)}
+                        disabled={selectedId !== null && selectedId !== plugin.id}
+                        loading={selectedId === plugin.id}
                         icon={
                           <Avatar
                             entity={{
@@ -218,11 +220,8 @@ let SkillPickerPanel = (p: {
     <>
       <Panel.Header>
         <div>
-          <Panel.Title>Add Single Skill</Panel.Title>
-          <Panel.Description>
-            A dedicated plugin will be created for the selected skill and added to this
-            marketplace.
-          </Panel.Description>
+          <Panel.Title>Add Skill</Panel.Title>
+          <Panel.Description>Choose a skill to add to this marketplace.</Panel.Description>
         </div>
       </Panel.Header>
 
@@ -259,6 +258,8 @@ let SkillPickerPanel = (p: {
                       description={truncate(skill.description)}
                       height={200}
                       onClick={() => selectSkill(skill)}
+                      disabled={selectedId !== null && selectedId !== skill.id}
+                      loading={selectedId === skill.id}
                       icon={
                         <Avatar
                           entity={{
@@ -324,7 +325,7 @@ let getPluginTableRow = (p: {
         <Avatar
           entity={{
             name: title,
-            photoUrl: plugin?.imageUrl ?? undefined
+            imageUrl: plugin?.imageUrl ?? undefined
           }}
           size={32}
           radius={999}
@@ -392,7 +393,7 @@ export let SkillMarketplacePluginsScene = (p: {
   let linkedPluginIds = useMemo(
     () =>
       (marketplacePlugins.data ?? [])
-        .map(item => item.skillPlugin?.id ?? item.skillPluginId)
+        .map(item => item.skillPlugin?.id ?? item.skillPlugin?.id)
         .filter((id): id is string => !!id),
     [marketplacePlugins.data]
   );
@@ -477,13 +478,13 @@ export let SkillMarketplacePluginsScene = (p: {
 
   return renderWithLoader({ marketplacePlugins })(({ marketplacePlugins }) => (
     <Box
-      title="Plugins"
-      description="Choose which plugins are available in this marketplace."
+      title="Plugins and Skills"
+      description="Choose which plugins and skills are available in this marketplace."
       rightActions={
         <Menu
           items={[
-            { id: 'plugin', label: 'Add Existing Plugin' },
-            { id: 'skill', label: 'Add Single Skill' }
+            // { id: 'plugin', label: 'Add Existing Plugin' },
+            { id: 'skill', label: 'Add Skill' }
           ]}
           onItemClick={item => {
             if (item === 'plugin') addExistingPlugin();

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillRepositories.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillRepositories.tsx
@@ -188,7 +188,7 @@ let ConnectGitHubButton = (p: { instanceId: string; onConnected: () => void }) =
       fullWidth
       type="button"
     >
-      Connect GitHub
+      Connect GitHub or GitLab
     </Button>
   );
 };
@@ -269,7 +269,7 @@ let RepositoryPickerContent = (p: {
           <FormStack>
             {installations.data.items.length > 1 && (
               <Select
-                label="GitHub Installation"
+                label="Installation"
                 items={installations.data.items.map(i => ({
                   label:
                     i.externalAccount.name ??
@@ -287,7 +287,7 @@ let RepositoryPickerContent = (p: {
 
             {accountItems.length > 0 && (
               <Select
-                label="GitHub Account"
+                label="Account"
                 items={accountItems.map(i => ({
                   label: i.name,
                   id: i.externalId
@@ -350,7 +350,7 @@ let RepositoryPickerContent = (p: {
                           )
                         }
                       >
-                        Import
+                        Connect
                       </Button>
                     </RepoItem>
                   ))}

--- a/src/metorial/apis/core/src/presenters/implementation/skills/skillMarketplacePlugin.ts
+++ b/src/metorial/apis/core/src/presenters/implementation/skills/skillMarketplacePlugin.ts
@@ -27,7 +27,6 @@ export let v1SkillMarketplacePluginPresenter = Presenter.create(skillMarketplace
       identifier: v.string(),
       skill_configuration_id: v.nullable(v.string()),
       skill_marketplace_id: v.nullable(v.string()),
-      skill_plugin_id: v.nullable(v.string()),
       skill_plugin: v.nullable(v1SkillPluginPresenter.schema),
       created_at: v.date(),
       updated_at: v.date()

--- a/src/metorial/modules/file/src/definitions.ts
+++ b/src/metorial/modules/file/src/definitions.ts
@@ -1,47 +1,78 @@
-import { ensureFilePurpose } from '@metorial/db';
+import { delay } from '@lowerdeck/delay';
+import { ensureFilePurpose as ensureFilePurposeInLocalDB } from '@metorial/db';
+import { cargo } from './cargo';
+
+let ensureFilePurpose = async (d: {
+  name: string;
+  slug: string;
+  ownerType: 'user' | 'organization' | 'instance';
+  canHaveLinks: boolean;
+}) => {
+  let res = await ensureFilePurposeInLocalDB(() => d);
+
+  void (async () => {
+    while (true) {
+      try {
+        await cargo.filePurpose.upsert({
+          slug: d.slug,
+          name: d.name,
+          ownerType: d.ownerType,
+          canHaveLinks: d.canHaveLinks
+        });
+        return;
+      } catch (error) {
+        console.log('Failed to ensure file purpose in cargo ... retrying', error);
+      }
+
+      await delay(500);
+    }
+  })();
+
+  return res;
+};
 
 export let purposes = {
-  user_image: ensureFilePurpose(() => ({
+  user_image: ensureFilePurpose({
     name: 'User Image',
     slug: 'user_image',
     ownerType: 'user',
     canHaveLinks: true
-  })),
+  }),
 
-  organization_image: ensureFilePurpose(() => ({
+  organization_image: ensureFilePurpose({
     name: 'Organization Image',
     slug: 'organization_image',
     ownerType: 'organization',
     canHaveLinks: true
-  })),
+  }),
 
-  project_brand_image: ensureFilePurpose(() => ({
+  project_brand_image: ensureFilePurpose({
     name: 'Project Brand Image',
     slug: 'project_brand_image',
     ownerType: 'organization',
     canHaveLinks: true
-  })),
+  }),
 
-  skill_image: ensureFilePurpose(() => ({
+  skill_image: ensureFilePurpose({
     name: 'Skill Image',
     slug: 'skill_image',
     ownerType: 'instance',
     canHaveLinks: true
-  })),
+  }),
 
-  skill_export: ensureFilePurpose(() => ({
+  skill_export: ensureFilePurpose({
     name: 'Skill Export',
     slug: 'skill_export',
     ownerType: 'instance',
     canHaveLinks: true
-  })),
+  }),
 
-  generic: ensureFilePurpose(() => ({
+  generic: ensureFilePurpose({
     name: 'Generic',
     slug: 'generic',
     ownerType: 'instance',
     canHaveLinks: true
-  }))
+  })
 };
 
 export let purposeSlugs = Object.keys(purposes);

--- a/src/origin/apps/service/src/lib/gitlab.ts
+++ b/src/origin/apps/service/src/lib/gitlab.ts
@@ -2,6 +2,7 @@ import { Gitlab } from '@gitbeaker/rest';
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import type { ScmBackend, ScmInstallation } from '../../prisma/generated/client';
 import { db } from '../db';
+import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
 
 type GitLabClient = InstanceType<typeof Gitlab>;
 
@@ -54,25 +55,27 @@ export let exchangeGitLabOAuthCode = async (i: {
   let clientId = i.backend.clientId;
   let clientSecret = i.backend.clientSecret;
 
-  let response = await fetch(`${webUrl}/oauth/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      client_id: clientId,
-      client_secret: clientSecret,
-      code: i.code,
-      grant_type: 'authorization_code',
-      redirect_uri: i.redirectUri
+  let response = await withScmProviderError('gitlab', 'exchange the OAuth token', () =>
+    fetch(`${webUrl}/oauth/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code: i.code,
+        grant_type: 'authorization_code',
+        redirect_uri: i.redirectUri
+      })
     })
-  });
+  );
 
   if (!response.ok) {
-    throw new ServiceError(
-      badRequestError({
-        message: `GitLab OAuth token exchange failed: ${response.statusText}`
-      })
+    throw wrapScmProviderError(
+      'gitlab',
+      { response: { status: response.status } },
+      'exchange the OAuth token'
     );
   }
 
@@ -100,24 +103,26 @@ export let refreshGitLabAccessToken = async (i: {
   let clientId = i.backend.clientId;
   let clientSecret = i.backend.clientSecret;
 
-  let response = await fetch(`${webUrl}/oauth/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      client_id: clientId,
-      client_secret: clientSecret,
-      refresh_token: i.refreshToken,
-      grant_type: 'refresh_token'
+  let response = await withScmProviderError('gitlab', 'refresh the OAuth token', () =>
+    fetch(`${webUrl}/oauth/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: i.refreshToken,
+        grant_type: 'refresh_token'
+      })
     })
-  });
+  );
 
   if (!response.ok) {
-    throw new ServiceError(
-      badRequestError({
-        message: `GitLab token refresh failed: ${response.statusText}`
-      })
+    throw wrapScmProviderError(
+      'gitlab',
+      { response: { status: response.status } },
+      'refresh the OAuth token'
     );
   }
 

--- a/src/origin/apps/service/src/lib/gitlabNamespace.test.ts
+++ b/src/origin/apps/service/src/lib/gitlabNamespace.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getGitLabNamespaceId,
+  getGitLabPersonalNamespaceId,
+  isGitLabNamespaceError
+} from './gitlabNamespace';
+
+describe('GitLab namespace helpers', () => {
+  it('uses the personal namespace ID instead of the user ID', () => {
+    expect(getGitLabPersonalNamespaceId({ namespaceId: 456 })).toBe(456);
+  });
+
+  it('supports GitLab API responses that use snake_case fields', () => {
+    expect(getGitLabPersonalNamespaceId({ namespace_id: '456' })).toBe(456);
+  });
+
+  it('falls back to the personal namespace returned by the namespaces API', () => {
+    expect(
+      getGitLabPersonalNamespaceId(
+        { username: 'tobias' },
+        [
+          { id: 123, kind: 'group', path: 'metorial' },
+          { id: 456, kind: 'user', path: 'tobias' }
+        ]
+      )
+    ).toBe(456);
+  });
+
+  it('rejects non-numeric namespace IDs before creating a project', () => {
+    expect(() => getGitLabNamespaceId('team/metorial')).toThrow(
+      'GitLab namespace ID must be a positive integer'
+    );
+  });
+
+  it('identifies GitLab namespace validation failures', () => {
+    expect(
+      isGitLabNamespaceError({
+        cause: { description: '{"namespace":["is not valid"]}' }
+      })
+    ).toBe(true);
+  });
+});

--- a/src/origin/apps/service/src/lib/gitlabNamespace.ts
+++ b/src/origin/apps/service/src/lib/gitlabNamespace.ts
@@ -1,0 +1,41 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+
+export let getGitLabNamespaceId = (externalAccountId: string) => {
+  if (!/^\d+$/.test(externalAccountId)) {
+    throw new ServiceError(
+      badRequestError({ message: 'GitLab namespace ID must be a positive integer' })
+    );
+  }
+
+  let namespaceId = Number(externalAccountId);
+  if (!Number.isSafeInteger(namespaceId) || namespaceId <= 0) {
+    throw new ServiceError(
+      badRequestError({ message: 'GitLab namespace ID must be a positive integer' })
+    );
+  }
+
+  return namespaceId;
+};
+
+export let getGitLabPersonalNamespaceId = (user: {
+  username?: string | null;
+  namespaceId?: number | string | null;
+  namespace_id?: number | string | null;
+}, namespaces: { id: number | string; kind?: string; path?: string }[] = []) => {
+  let namespaceId =
+    user.namespaceId ??
+    user.namespace_id ??
+    namespaces.find(namespace => namespace.kind === 'user' && namespace.path === user.username)?.id;
+  if (namespaceId == null) {
+    throw new ServiceError(
+      badRequestError({ message: 'GitLab account does not have a personal namespace' })
+    );
+  }
+
+  return getGitLabNamespaceId(namespaceId.toString());
+};
+
+export let isGitLabNamespaceError = (error: any) =>
+  JSON.stringify(error?.cause?.description ?? error?.description ?? error?.message ?? '').includes(
+    'namespace'
+  );

--- a/src/origin/apps/service/src/lib/scmProviderError.test.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.test.ts
@@ -1,0 +1,38 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { describe, expect, it } from 'vitest';
+import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
+
+describe('SCM provider errors', () => {
+  it.each([
+    [{ status: 401 }, 401, 'unauthorized'],
+    [{ response: { status: 403 } }, 403, 'forbidden'],
+    [{ cause: { response: { statusCode: 404 } } }, 404, 'not_found'],
+    [{ status: 409 }, 409, 'conflict'],
+    [{ response: { status: 422 } }, 400, 'bad_request'],
+    [{ status: 429 }, 429, 'too_many_requests'],
+    [new Error('network failure'), 500, 'internal_server_error']
+  ])('maps provider failures to structured errors', (error, status, code) => {
+    let mapped = wrapScmProviderError('gitlab', error, 'list repositories');
+
+    expect(mapped.data.status).toBe(status);
+    expect(mapped.data.code).toBe(code);
+    expect(mapped.message).not.toContain('network failure');
+  });
+
+  it('preserves existing ServiceErrors', async () => {
+    let serviceError = new ServiceError(badRequestError({ message: 'Known validation error' }));
+
+    await expect(
+      withScmProviderError('github', 'create repository', async () => {
+        throw serviceError;
+      })
+    ).rejects.toBe(serviceError);
+  });
+
+  it('retains the provider failure for observability', () => {
+    let providerError = new Error('provider request failed');
+    let mapped = wrapScmProviderError('github', providerError, 'load repositories');
+
+    expect(mapped.parent).toBe(providerError);
+  });
+});

--- a/src/origin/apps/service/src/lib/scmProviderError.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.ts
@@ -1,0 +1,62 @@
+import {
+  badRequestError,
+  conflictError,
+  forbiddenError,
+  internalServerError,
+  isServiceError,
+  notFoundError,
+  ServiceError,
+  timeoutError,
+  tooManyRequestsError,
+  unauthorizedError
+} from '@lowerdeck/error';
+
+type ScmProvider = 'github' | 'gitlab';
+
+export let getScmProviderErrorStatus = (error: any): number | undefined =>
+  error?.status ?? error?.response?.status ?? error?.cause?.response?.statusCode;
+
+let providerName = (provider: ScmProvider) => (provider === 'github' ? 'GitHub' : 'GitLab');
+
+export let wrapScmProviderError = (
+  provider: ScmProvider,
+  error: unknown,
+  operation: string
+): ServiceError<any> => {
+  if (isServiceError(error)) return error;
+
+  let status = getScmProviderErrorStatus(error);
+  let prefix = `${providerName(provider)} could not ${operation}`;
+  let mapped =
+    status === 400 || status === 422
+      ? badRequestError({ message: `${prefix} because the request was invalid.` })
+      : status === 401
+        ? unauthorizedError({ message: `${prefix} because authentication failed.` })
+        : status === 403
+          ? forbiddenError({ message: `${prefix} because the integration lacks permission.` })
+          : status === 404
+            ? notFoundError({ entity: 'SCM provider resource', message: `${prefix}: resource not found.` })
+            : status === 409
+              ? conflictError({ message: `${prefix} because the resource already exists or changed.` })
+              : status === 429
+                ? tooManyRequestsError({ message: `${prefix} because the provider rate limit was reached.` })
+                : status === 408 || status === 504
+                  ? timeoutError({ message: `${prefix} because the provider request timed out.` })
+                  : internalServerError({ message: `${prefix} due to an upstream provider error.` });
+
+  let serviceError = new ServiceError(mapped);
+  if (error instanceof Error) serviceError.setParent(error);
+  return serviceError;
+};
+
+export let withScmProviderError = async <T>(
+  provider: ScmProvider,
+  operation: string,
+  fn: () => Promise<T>
+): Promise<T> => {
+  try {
+    return await fn();
+  } catch (error) {
+    throw wrapScmProviderError(provider, error, operation);
+  }
+};

--- a/src/origin/apps/service/src/lib/scmRepositorySyncProvider.test.ts
+++ b/src/origin/apps/service/src/lib/scmRepositorySyncProvider.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGitLabClientWithToken } from './gitlab';
+import {
+  createRepositorySyncBranch,
+  getRepositorySyncCiState,
+  mergeRepositorySyncPullRequest
+} from './scmRepositorySyncProvider';
+
+vi.mock('./gitlab', () => ({
+  createGitLabClientWithToken: vi.fn()
+}));
+
+vi.mock('./githubApp', () => ({
+  createGitHubInstallationClient: vi.fn()
+}));
+
+let createGitLabClient = vi.mocked(createGitLabClientWithToken);
+
+let createSync = () =>
+  ({
+    id: 'sync_123',
+    branchName: 'metorial/sync-marketplace-8',
+    baseBranch: 'main',
+    providerPrId: '42',
+    repo: {
+      id: 'repo_123',
+      provider: 'gitlab',
+      externalId: '123',
+      installation: {
+        accessToken: 'token',
+        backend: {}
+      }
+    }
+  }) as any;
+
+describe('GitLab repository sync', () => {
+  let gitlab: any;
+
+  beforeEach(() => {
+    gitlab = {
+      Branches: {
+        create: vi.fn(),
+        show: vi.fn(),
+        remove: vi.fn()
+      },
+      MergeRequests: {
+        merge: vi.fn(),
+        show: vi.fn()
+      },
+      Pipelines: {
+        all: vi.fn()
+      }
+    };
+    createGitLabClient.mockReset();
+    createGitLabClient.mockReturnValue(gitlab);
+  });
+
+  it.each([{ response: { status: 400 } }, { cause: { response: { statusCode: 409 } } }])(
+    'reuses a verified branch when GitLab reports it already exists',
+    async error => {
+      gitlab.Branches.create.mockRejectedValue(error);
+      gitlab.Branches.show.mockResolvedValue({ name: 'metorial/sync-marketplace-8' });
+
+      await createRepositorySyncBranch(createSync());
+
+      expect(gitlab.Branches.show).toHaveBeenCalledWith(123, 'metorial/sync-marketplace-8');
+    }
+  );
+
+  it('propagates non-conflict branch creation failures', async () => {
+    let error = { cause: { response: { statusCode: 403 } } };
+    gitlab.Branches.create.mockRejectedValue(error);
+
+    await expect(createRepositorySyncBranch(createSync())).rejects.toBe(error);
+    expect(gitlab.Branches.show).not.toHaveBeenCalled();
+  });
+
+  it('lets GitLab remove the source branch during merge without deleting it again', async () => {
+    gitlab.MergeRequests.merge.mockResolvedValue({ merge_commit_sha: 'merge_sha' });
+
+    await expect(mergeRepositorySyncPullRequest(createSync())).resolves.toEqual({
+      mergeSha: 'merge_sha'
+    });
+
+    expect(gitlab.MergeRequests.merge).toHaveBeenCalledWith(123, 42, {
+      shouldRemoveSourceBranch: true
+    });
+    expect(gitlab.Branches.remove).not.toHaveBeenCalled();
+  });
+
+  it('waits for GitLab to finish checking mergeability', async () => {
+    gitlab.Pipelines.all.mockResolvedValue([]);
+    gitlab.MergeRequests.show.mockResolvedValue({
+      state: 'opened',
+      detailed_merge_status: 'checking'
+    });
+
+    await expect(getRepositorySyncCiState(createSync())).resolves.toBe('pending');
+  });
+
+  it('allows a merge only when GitLab reports the merge request is mergeable', async () => {
+    gitlab.Pipelines.all.mockResolvedValue([{ id: 1, status: 'success' }]);
+    gitlab.MergeRequests.show.mockResolvedValue({
+      state: 'opened',
+      detailed_merge_status: 'mergeable'
+    });
+
+    await expect(getRepositorySyncCiState(createSync())).resolves.toBe('success');
+  });
+
+  it('treats a 405 as success when GitLab already merged the merge request', async () => {
+    gitlab.MergeRequests.merge.mockRejectedValue({ cause: { response: { statusCode: 405 } } });
+    gitlab.MergeRequests.show.mockResolvedValue({
+      state: 'merged',
+      merge_commit_sha: 'merge_sha'
+    });
+
+    await expect(mergeRepositorySyncPullRequest(createSync())).resolves.toEqual({
+      mergeSha: 'merge_sha'
+    });
+  });
+
+  it('propagates merge failures', async () => {
+    let error = new Error('merge rejected');
+    gitlab.MergeRequests.merge.mockRejectedValue(error);
+
+    await expect(mergeRepositorySyncPullRequest(createSync())).rejects.toBe(error);
+  });
+});

--- a/src/origin/apps/service/src/lib/scmRepositorySyncProvider.ts
+++ b/src/origin/apps/service/src/lib/scmRepositorySyncProvider.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../prisma/generated/client';
 import { createGitHubInstallationClient } from './githubApp';
 import { createGitLabClientWithToken } from './gitlab';
+import { getScmProviderErrorStatus } from './scmProviderError';
 
 type SyncWithRepo = ScmRepositorySync & {
   repo: ScmRepository & {
@@ -381,7 +382,8 @@ export let createRepositorySyncBranch = async (sync: SyncWithRepo) => {
         sync.baseBranch
       );
     } catch (e: any) {
-      if (e.response?.status !== 400 && e.response?.status !== 409) throw e;
+      let status = getScmProviderErrorStatus(e);
+      if (status !== 400 && status !== 409) throw e;
 
       await gitlab.Branches.show(parseInt(sync.repo.externalId), sync.branchName);
     }
@@ -794,11 +796,17 @@ export let getRepositorySyncCiState = async (
     });
 
     let pipelines;
+    let mergeRequest;
     try {
-      pipelines = await gitlab.Pipelines.all(parseInt(sync.repo.externalId), {
-        ref: sync.branchName,
-        perPage: 1
-      });
+      [pipelines, mergeRequest] = await Promise.all([
+        gitlab.Pipelines.all(parseInt(sync.repo.externalId), {
+          ref: sync.branchName,
+          perPage: 1
+        }),
+        gitlab.MergeRequests.show(parseInt(sync.repo.externalId), parseInt(sync.providerPrId!), {
+          withMergeStatusRecheck: true
+        })
+      ]);
     } catch (e: any) {
       logGitLabSyncError('failed to load CI state', e, {
         syncId: sync.id,
@@ -811,25 +819,42 @@ export let getRepositorySyncCiState = async (
 
     let pipeline = pipelines[0];
     if (!pipeline) {
-      logGitLabSyncDebug('no pipeline found; treating CI as success', {
+      logGitLabSyncDebug('no pipeline found; checking merge request status', {
         syncId: sync.id,
         repoId: sync.repo.id,
         branchName: sync.branchName
       });
-      return 'success';
+    } else {
+      logGitLabSyncDebug('loaded CI state', {
+        syncId: sync.id,
+        repoId: sync.repo.id,
+        branchName: sync.branchName,
+        pipelineId: pipeline.id,
+        pipelineStatus: pipeline.status
+      });
+
+      if (['failed', 'canceled'].includes(pipeline.status)) return 'failed';
+      if (!['success', 'skipped', 'manual'].includes(pipeline.status)) return 'pending';
     }
 
-    logGitLabSyncDebug('loaded CI state', {
-      syncId: sync.id,
-      repoId: sync.repo.id,
-      branchName: sync.branchName,
-      pipelineId: pipeline.id,
-      pipelineStatus: pipeline.status
-    });
+    if (mergeRequest.state === 'merged') return 'success';
 
-    if (['success', 'skipped', 'manual'].includes(pipeline.status)) return 'success';
-    if (['failed', 'canceled'].includes(pipeline.status)) return 'failed';
-    return 'pending';
+    let mergeStatus = mergeRequest.detailed_merge_status ?? mergeRequest.detailedMergeStatus;
+    if (mergeStatus === 'mergeable') return 'success';
+    if (
+      [
+        'unchecked',
+        'checking',
+        'preparing',
+        'approvals_syncing',
+        'ci_still_running',
+        'status_checks_must_pass'
+      ].includes(mergeStatus)
+    ) {
+      return 'pending';
+    }
+
+    return 'failed';
   }
 
   throw new ServiceError(badRequestError({ message: 'Unsupported repository provider' }));
@@ -955,6 +980,17 @@ export let mergeRepositorySyncPullRequest = async (
         projectId: sync.repo.externalId,
         providerPrId: sync.providerPrId
       });
+
+      if (getScmProviderErrorStatus(e) === 405) {
+        let mergeRequest = await gitlab.MergeRequests.show(
+          parseInt(sync.repo.externalId),
+          parseInt(sync.providerPrId)
+        );
+        if (mergeRequest.state === 'merged') {
+          return { mergeSha: mergeRequest.merge_commit_sha ?? mergeRequest.squash_commit_sha };
+        }
+      }
+
       throw e;
     }
 
@@ -964,48 +1000,6 @@ export let mergeRepositorySyncPullRequest = async (
       providerPrId: sync.providerPrId,
       mergeSha: merge.merge_commit_sha ?? merge.sha
     });
-
-    if (sync.branchName !== sync.baseBranch) {
-      try {
-        await gitlab.Branches.remove(parseInt(sync.repo.externalId), sync.branchName);
-
-        logGitLabSyncDebug('deleted merged sync branch', {
-          syncId: sync.id,
-          repoId: sync.repo.id,
-          projectId: sync.repo.externalId,
-          branchName: sync.branchName
-        });
-      } catch (e: any) {
-        let status = e?.response?.status ?? e?.cause?.response?.statusCode;
-        if (status !== 404) {
-          logGitLabSyncError('failed to delete merged sync branch', e, {
-            syncId: sync.id,
-            repoId: sync.repo.id,
-            projectId: sync.repo.externalId,
-            branchName: sync.branchName
-          });
-          throw e;
-        }
-
-        logGitLabSyncDebug('merged sync branch was already deleted', {
-          syncId: sync.id,
-          repoId: sync.repo.id,
-          projectId: sync.repo.externalId,
-          branchName: sync.branchName
-        });
-      }
-    } else {
-      logGitLabSyncDebug(
-        'skipped deleting merged sync branch because it matches base branch',
-        {
-          syncId: sync.id,
-          repoId: sync.repo.id,
-          projectId: sync.repo.externalId,
-          baseBranch: sync.baseBranch,
-          branchName: sync.branchName
-        }
-      );
-    }
 
     return { mergeSha: merge.merge_commit_sha ?? merge.sha };
   }

--- a/src/origin/apps/service/src/services/scmAuth.ts
+++ b/src/origin/apps/service/src/services/scmAuth.ts
@@ -10,6 +10,7 @@ import {
   exchangeGitLabOAuthCode,
   getGitLabOAuthUrl
 } from '../lib/gitlab';
+import { withScmProviderError } from '../lib/scmProviderError';
 
 class scmAuthServiceImpl {
   async getAuthorizationUrl(i: {
@@ -106,9 +107,14 @@ class scmAuthServiceImpl {
       }
 
       let octokit = createGitHubAppClient(existingInstallation.backend);
-      let installationRes = await octokit.request('GET /app/installations/{installation_id}', {
-        installation_id: parseInt(i.installationId)
-      });
+      let installationRes = await withScmProviderError(
+        'github',
+        'load the app installation',
+        () =>
+          octokit.request('GET /app/installations/{installation_id}', {
+            installation_id: parseInt(i.installationId)
+          })
+      );
 
       let installation = installationRes.data;
       let account = installation.account;
@@ -178,9 +184,14 @@ class scmAuthServiceImpl {
       // Get installation details using GitHub App authentication
       let octokit = createGitHubAppClient(backend);
 
-      let installationRes = await octokit.request('GET /app/installations/{installation_id}', {
-        installation_id: parseInt(i.installationId)
-      });
+      let installationRes = await withScmProviderError(
+        'github',
+        'load the app installation',
+        () =>
+          octokit.request('GET /app/installations/{installation_id}', {
+            installation_id: parseInt(i.installationId)
+          })
+      );
 
       let installation = installationRes.data;
       let account = installation.account;
@@ -288,7 +299,9 @@ class scmAuthServiceImpl {
 
       // Get user info
       let gitlab = createGitLabClientWithToken(accessToken, backend);
-      let user = await gitlab.Users.showCurrentUser();
+      let user = await withScmProviderError('gitlab', 'load the authenticated user', () =>
+        gitlab.Users.showCurrentUser()
+      );
 
       let data = {
         provider: i.provider,

--- a/src/origin/apps/service/src/services/scmRepo.ts
+++ b/src/origin/apps/service/src/services/scmRepo.ts
@@ -12,9 +12,22 @@ import { db } from '../db';
 import { getId } from '../id';
 import { createGitHubInstallationClient } from '../lib/githubApp';
 import { createGitLabClientWithToken } from '../lib/gitlab';
+import {
+  getGitLabNamespaceId,
+  getGitLabPersonalNamespaceId,
+  isGitLabNamespaceError
+} from '../lib/gitlabNamespace';
+import { withScmProviderError, wrapScmProviderError } from '../lib/scmProviderError';
 import { createRepoWebhookQueue } from '../queues/scm/createRepoWebhook';
 import { createHandleRepoPushQueue } from '../queues/scm/handleRepoPush';
 import type { ScmAccountPreview, ScmRepoPreview } from '../types';
+
+let getGitLabPersonalNamespaceIdForUser = async (gitlab: any, user: any) => {
+  let namespaces = await withScmProviderError<any[]>('gitlab', 'list personal namespaces', () =>
+    gitlab.Namespaces.all({ ownedOnly: true, perPage: 100 })
+  );
+  return getGitLabPersonalNamespaceId(user, namespaces);
+};
 
 class scmRepoServiceImpl {
   async listAccountPreviews(i: { installation: ScmInstallation & { backend: ScmBackend } }) {
@@ -40,14 +53,19 @@ class scmRepoServiceImpl {
         i.installation.backend
       );
 
-      // Get user's groups/namespaces
-      let groups = await gitlab.Groups.all({ minAccessLevel: 10, perPage: 100 });
-      let user = await gitlab.Users.showCurrentUser();
+      // Only show group namespaces where the token can normally create projects.
+      let groups = await withScmProviderError('gitlab', 'list groups', () =>
+        gitlab.Groups.all({ minAccessLevel: 30, perPage: 100 })
+      );
+      let user = await withScmProviderError('gitlab', 'load the authenticated user', () =>
+        gitlab.Users.showCurrentUser()
+      );
+      let personalNamespaceId = await getGitLabPersonalNamespaceIdForUser(gitlab, user);
 
       return [
         {
           provider: i.installation.provider,
-          externalId: user.id.toString(),
+          externalId: personalNamespaceId.toString(),
           name: user.username,
           identifier: `${new URL(i.installation.backend.webUrl).hostname}/${user.username}`
         } satisfies ScmAccountPreview,
@@ -85,10 +103,12 @@ class scmRepoServiceImpl {
       let page = 1;
 
       while (true) {
-        let response = await octokit.request('GET /installation/repositories', {
-          per_page: 100,
-          page
-        });
+        let response = await withScmProviderError('github', 'list installation repositories', () =>
+          octokit.request('GET /installation/repositories', {
+            per_page: 100,
+            page
+          })
+        );
 
         allRepos.push(...response.data.repositories);
 
@@ -131,14 +151,29 @@ class scmRepoServiceImpl {
       );
 
       let allProjects: any[] = [];
+      let user = await withScmProviderError('gitlab', 'load the authenticated user', () =>
+        gitlab.Users.showCurrentUser()
+      );
+      let personalNamespaceId = (
+        await getGitLabPersonalNamespaceIdForUser(gitlab, user)
+      ).toString();
 
-      // If external account ID matches user ID, list user's projects; otherwise list group projects
-      if (i.externalAccountId == i.installation.externalAccountId) {
-        allProjects = await gitlab.Projects.all({ membership: true, perPage: 100 });
+      // Existing clients can still supply the installation's user ID. New account previews
+      // supply the actual personal namespace ID required by GitLab's project APIs.
+      if (
+        !i.externalAccountId ||
+        i.externalAccountId == personalNamespaceId ||
+        i.externalAccountId == i.installation.externalAccountId
+      ) {
+        allProjects = await withScmProviderError('gitlab', 'list user projects', () =>
+          gitlab.Users.allProjects(user.id, { perPage: 100 })
+        );
       } else {
         // List projects for a specific group
-        let groupId = parseInt(i.externalAccountId!);
-        allProjects = await gitlab.Groups.allProjects(groupId, { perPage: 100 });
+        let groupId = getGitLabNamespaceId(i.externalAccountId);
+        allProjects = await withScmProviderError('gitlab', 'list group projects', () =>
+          gitlab.Groups.allProjects(groupId, { perPage: 100 })
+        );
       }
 
       let hostname = new URL(i.installation.backend.webUrl).hostname;
@@ -199,7 +234,7 @@ class scmRepoServiceImpl {
             })
           );
         }
-        throw error;
+        throw wrapScmProviderError('github', error, 'load the repository');
       }
     }
 
@@ -231,7 +266,7 @@ class scmRepoServiceImpl {
             })
           );
         }
-        throw error;
+        throw wrapScmProviderError('gitlab', error, 'load the repository');
       }
     }
 
@@ -265,9 +300,11 @@ class scmRepoServiceImpl {
         i.installation.backend
       );
 
-      let repoRes = await octokit.request('GET /repositories/{repository_id}', {
-        repository_id: parseInt(i.externalId)
-      });
+      let repoRes = await withScmProviderError('github', 'load the repository', () =>
+        octokit.request('GET /repositories/{repository_id}', {
+          repository_id: parseInt(i.externalId)
+        })
+      );
 
       let accountData = {
         name: repoRes.data.owner.login,
@@ -345,7 +382,9 @@ class scmRepoServiceImpl {
         i.installation.backend
       );
 
-      let project = await gitlab.Projects.show(parseInt(i.externalId));
+      let project = await withScmProviderError('gitlab', 'load the repository', () =>
+        gitlab.Projects.show(parseInt(i.externalId))
+      );
 
       let hostname = new URL(i.installation.backend.webUrl).hostname;
 
@@ -466,7 +505,7 @@ class scmRepoServiceImpl {
             );
           }
         }
-        throw error;
+        throw wrapScmProviderError('github', error, 'create the repository');
       }
 
       return await this.linkRepository({
@@ -484,13 +523,36 @@ class scmRepoServiceImpl {
         i.installation.backend
       );
 
-      // Always pass namespaceId to create in the correct namespace (user or group)
-      let projectRes = await gitlab.Projects.create({
-        name: i.name,
-        description: i.description,
-        visibility: i.isPrivate ? 'private' : 'public',
-        namespaceId: parseInt(i.externalAccountId)
-      });
+      let namespaceId = getGitLabNamespaceId(i.externalAccountId);
+
+      // Older clients use the installation's GitLab user ID. Resolve it to the
+      // personal namespace ID, which is the value required by Projects.create.
+      if (i.externalAccountId == i.installation.externalAccountId) {
+        let user = await withScmProviderError('gitlab', 'load the authenticated user', () =>
+          gitlab.Users.showCurrentUser()
+        );
+        namespaceId = await getGitLabPersonalNamespaceIdForUser(gitlab, user);
+      }
+
+      let projectRes;
+      try {
+        projectRes = await gitlab.Projects.create({
+          name: i.name,
+          description: i.description,
+          visibility: i.isPrivate ? 'private' : 'public',
+          namespaceId
+        });
+      } catch (error: any) {
+        if (isGitLabNamespaceError(error)) {
+          throw new ServiceError(
+            badRequestError({
+              message:
+                'The selected GitLab namespace is invalid or you do not have permission to create projects in it'
+            })
+          );
+        }
+        throw wrapScmProviderError('gitlab', error, 'create the repository');
+      }
 
       return await this.linkRepository({
         installation: i.installation,
@@ -832,7 +894,7 @@ class scmRepoServiceImpl {
           return null;
         }
 
-        throw e;
+        throw wrapScmProviderError('github', e, 'load the latest repository commit');
       }
     }
 
@@ -885,7 +947,7 @@ class scmRepoServiceImpl {
           return null;
         }
 
-        throw e;
+        throw wrapScmProviderError('gitlab', e, 'load the latest repository commit');
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches skill sync versioning/hashing, repository PR merge paths, GitLab namespace/project creation, and dashboard file uploads—areas where mistakes can cause sync loops, failed SCM operations, or upload regressions.
> 
> **Overview**
> Hardens **skill destination sync** so marketplace/plugin/skill destination items are keyed and updated with type-strict filters, canonical content hashes (excluding timestamps/version noise), optimistic version-hash updates, and clearer **canceled** outcomes when collect/process finds nothing to apply. Repo propagation branch names get a short random suffix; canceled syncs are hidden from default sync listings.
> 
> **GitHub/GitLab SCM** gains structured `ServiceError` mapping, GitLab **personal namespace** resolution for account previews and project create/list, safer merge-request CI/merge handling (including already-merged 405s), and branch reuse on create conflicts.
> 
> **API/dashboard:** `skill.marketplace_plugin` responses drop top-level `skill_plugin_id` (plugin id stays on nested `skill_plugin`). Dashboard file upload uses a direct `fetch` multipart POST with explicit error handling; marketplace plugin UI favors “Add Skill” with loading/disabled grid items; file purposes are upserted to Cargo asynchronously.
> 
> **Other:** Cargo upload errors include response body text; `module-file` adds `@lowerdeck/tokens` and Cargo file-purpose sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e229ceabeabdcc176945a01a6d110e7af93c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->