### PR TITLE
Fix stuck telemetry export jobs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@metorial/oss",
@@ -4367,6 +4368,7 @@
         "@lowerdeck/lock": "workspace:2.0.0",
         "@lowerdeck/pagination": "workspace:2.0.0",
         "@lowerdeck/queue": "workspace:2.0.0",
+        "@lowerdeck/sentry": "workspace:2.0.0",
         "@lowerdeck/service": "workspace:2.0.0",
         "@lowerdeck/validation": "workspace:2.0.0",
         "@metorial-subspace/connection-utils": "^1.0.0",

--- a/src/subspace/modules/session/package.json
+++ b/src/subspace/modules/session/package.json
@@ -14,6 +14,7 @@
     "@lowerdeck/id": "workspace:2.0.0",
     "@lowerdeck/pagination": "workspace:2.0.0",
     "@lowerdeck/queue": "workspace:2.0.0",
+    "@lowerdeck/sentry": "workspace:2.0.0",
     "@lowerdeck/service": "workspace:2.0.0",
     "@lowerdeck/validation": "workspace:2.0.0",
     "@lowerdeck/cron": "workspace:2.0.0",

--- a/src/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.test.ts
+++ b/src/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-let { db, enrichMessages, getProviderTelemetryErrorGroupsStorageTarget } = vi.hoisted(() => ({
-  db: {
-    sessionError: {
-      findMany: vi.fn()
-    }
-  },
-  enrichMessages: vi.fn(async (messages: any[]) => messages),
-  getProviderTelemetryErrorGroupsStorageTarget: vi.fn()
-}));
+let { db, enrichMessages, getProviderTelemetryErrorGroupsStorageTarget, captureMessage } =
+  vi.hoisted(() => ({
+    db: {
+      sessionError: {
+        findMany: vi.fn()
+      }
+    },
+    enrichMessages: vi.fn(async (messages: any[]) => messages),
+    getProviderTelemetryErrorGroupsStorageTarget: vi.fn(),
+    captureMessage: vi.fn()
+  }));
 
 vi.mock('@metorial-subspace/db', () => ({ db }));
 vi.mock('@metorial-subspace/connection-utils', () => ({
@@ -20,36 +22,57 @@ vi.mock('../services/sessionMessage', () => ({
     enrichMessages
   }
 }));
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({ captureMessage })
+}));
 
 import {
+  PROVIDER_TELEMETRY_EXPORT_QUEUE_JOB_OPTIONS,
   PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY,
+  PROVIDER_TELEMETRY_QUARANTINE_KEY_PREFIX,
+  ProviderTelemetryExportInfraError,
+  getProviderTelemetryFailedMessageQuarantineKey,
   getProviderTelemetryFailedMessagesExportChunkKey,
   listProviderTelemetryFailedMessagesForExport,
   runProviderTelemetryErrorGroupsExport,
   type ProviderTelemetryErrorGroupsExportState,
   type ProviderTelemetryFailedMessageExportCandidate,
-  type ProviderTelemetryFailedMessagesExportListInput
+  type ProviderTelemetryFailedMessagesExportList,
+  type ProviderTelemetryFailedMessagesExportListInput,
+  type ProviderTelemetryFailedMessagesExportPageError
 } from './providerTelemetryErrorGroupExport';
 
-let createStorage = (state?: ProviderTelemetryErrorGroupsExportState | null) => ({
-  upsertBucket: vi.fn(async (_bucket: string) => ({})),
-  getObject: vi.fn(async (_bucket: string, key: string) => {
-    if (key !== PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY || state === undefined) {
-      throw { statusCode: 404 };
-    }
+let createStorage = (state?: ProviderTelemetryErrorGroupsExportState) => {
+  let objects = new Map<string, string>();
+  if (state !== undefined) {
+    objects.set(PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY, JSON.stringify(state));
+  }
 
-    return { data: Buffer.from(JSON.stringify(state)) };
-  }),
-  putObject: vi.fn(
-    async (
-      _bucket: string,
-      _key: string,
-      _data: Buffer | Uint8Array | Blob | ReadableStream | string,
-      _contentType?: string,
-      _metadata?: Record<string, string>
-    ) => ({})
-  )
-});
+  return {
+    objects,
+    upsertBucket: vi.fn(async (_bucket: string) => ({})),
+    getObject: vi.fn(async (_bucket: string, key: string) => {
+      let data = objects.get(key);
+      if (data === undefined) throw { statusCode: 404 };
+      return { data: Buffer.from(data) };
+    }),
+    putObject: vi.fn(
+      async (
+        _bucket: string,
+        key: string,
+        data: Buffer | Uint8Array | Blob | ReadableStream | string,
+        _contentType?: string,
+        _metadata?: Record<string, string>
+      ) => {
+        objects.set(
+          key,
+          typeof data === 'string' ? data : Buffer.from(data as Uint8Array).toString('utf8')
+        );
+        return {};
+      }
+    )
+  };
+};
 
 let createCandidate = (
   input: Partial<{
@@ -63,7 +86,6 @@ let createCandidate = (
     toolKey: string | null;
     toolNativeKey: string;
     toolName: string;
-    methodOrToolKey: string | null;
   }> = {}
 ): ProviderTelemetryFailedMessageExportCandidate => {
   let occurredAt = new Date(input.occurredAt ?? '2026-06-18T00:10:00.000Z');
@@ -74,6 +96,7 @@ let createCandidate = (
   return {
     error: {
       id: input.errorId ?? 'serr_1',
+      type: 'message_processing_provider_error',
       code: 'provider_error',
       group: {
         id: input.groupId ?? 'serg_1'
@@ -82,7 +105,6 @@ let createCandidate = (
     message: {
       id: input.messageId ?? 'msg_1',
       type: input.messageType ?? 'tool_call',
-      methodOrToolKey: input.methodOrToolKey ?? 'fallback_method',
       toolCall: toolKey
         ? {
             id: `tc_${input.messageId ?? '1'}`,
@@ -110,6 +132,29 @@ let createCandidate = (
   };
 };
 
+let pageError = (
+  candidates: ProviderTelemetryFailedMessageExportCandidate[],
+  opts: { isReady?: boolean } = {}
+): ProviderTelemetryFailedMessagesExportPageError => ({
+  error: candidates[0]!.error,
+  occurredAt: candidates[0]!.occurredAt,
+  isReady: opts.isReady ?? true,
+  candidates
+});
+
+let singlePage = (
+  entries: ProviderTelemetryFailedMessagesExportPageError[],
+  hasMore = false
+) =>
+  vi.fn(
+    async (
+      _input: ProviderTelemetryFailedMessagesExportListInput
+    ): Promise<ProviderTelemetryFailedMessagesExportList> => ({
+      errors: entries,
+      hasMore
+    })
+  );
+
 let parseJsonCall = (call: any[]) => JSON.parse(call[2]);
 
 let createPresentedMessage = (candidate: ProviderTelemetryFailedMessageExportCandidate) => ({
@@ -122,62 +167,27 @@ let createPresentedMessage = (candidate: ProviderTelemetryFailedMessageExportCan
     data: {
       email: 'alice@example.com',
       token: 'Bearer abcdefghijklmnopqrstuvwxyz012345',
-      phone: '+1 202-555-0110',
-      query: 'https://api.example.com/callback?client_secret=top-secret&safe=yes',
       retryCount: 2,
-      ok: false,
-      missing: null,
-      createdAt: new Date('2026-06-18T00:09:00.000Z')
+      ok: false
     }
   },
-  output: {
-    jsonrpc: '2.0',
-    id: 1,
-    error: {
-      code: -32000,
-      message: 'Tool call failed',
-      data: {
-        ok: false,
-        code: 'PROVIDER_ERROR',
-        message: 'Nested provider message',
-        details: {
-          Message: 'Case-insensitive message'
-        }
-      }
-    }
-  },
-  toolCall: candidate.tool
-    ? {
-        id: candidate.tool.id,
-        toolKey: candidate.tool.key,
-        rationale: 'User asked for this tool',
-        operation: 'call_tool',
-        tool: {
-          id: 'tool_1',
-          key: candidate.tool.key,
-          name: candidate.tool.name,
-          providerId: candidate.provider?.id ?? null
-        }
-      }
-    : null,
   error: {
     id: candidate.error.id,
     code: candidate.error.code,
     message: 'Top-level provider error',
-    data: {
-      authorization: 'Bearer abcdefghijklmnopqrstuvwxyz012345',
-      code: 'PROVIDER_ERROR',
-      object: 'provider.error',
-      status: 500,
-      message: 'Failed for bob@example.com',
-      nested: {
-        MESSAGE: 'Uppercase message key'
-      }
-    },
     groupId: candidate.error.group.id
   },
-  createdAt: new Date('2026-06-18T00:10:00.000Z')
+  createdAt: candidate.occurredAt
 });
+
+let emptyResultShape = {
+  exportedKeys: [],
+  quarantinedKeys: [],
+  state: null,
+  exportedCount: 0,
+  quarantinedCount: 0,
+  deferredCount: 0
+};
 
 describe('runProviderTelemetryErrorGroupsExport', () => {
   beforeEach(() => {
@@ -186,7 +196,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
 
   it('no-ops when the export bucket is not configured', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
-    let storage = createStorage(undefined);
+    let storage = createStorage();
     let listFailedMessages = vi.fn();
 
     let result = await runProviderTelemetryErrorGroupsExport({
@@ -200,16 +210,12 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     expect(storage.getObject).not.toHaveBeenCalled();
     expect(storage.putObject).not.toHaveBeenCalled();
     expect(listFailedMessages).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      exportedKeys: [],
-      state: null,
-      exportedCount: 0
-    });
+    expect(result).toEqual(emptyResultShape);
   });
 
   it('uses the shared connection-utils storage target when storage is not injected', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
-    let storage = createStorage(undefined);
+    let storage = createStorage();
     getProviderTelemetryErrorGroupsStorageTarget.mockReturnValueOnce({
       storage,
       bucketName: 'exports'
@@ -217,11 +223,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
 
     await runProviderTelemetryErrorGroupsExport({
       now,
-      listFailedMessages: vi.fn(async () => ({
-        items: [],
-        nextWatermark: null,
-        hasMore: false
-      }))
+      listFailedMessages: singlePage([])
     });
 
     expect(getProviderTelemetryErrorGroupsStorageTarget).toHaveBeenCalledWith(undefined);
@@ -230,7 +232,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
 
   it('no-ops when the configured export bucket is missing', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
-    let storage = createStorage(undefined);
+    let storage = createStorage();
     storage.upsertBucket.mockRejectedValueOnce({ statusCode: 404 });
     let listFailedMessages = vi.fn();
 
@@ -242,19 +244,14 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     });
 
     expect(storage.upsertBucket).toHaveBeenCalledWith('exports');
-    expect(storage.getObject).not.toHaveBeenCalled();
     expect(storage.putObject).not.toHaveBeenCalled();
     expect(listFailedMessages).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      exportedKeys: [],
-      state: null,
-      exportedCount: 0
-    });
+    expect(result).toEqual(emptyResultShape);
   });
 
-  it('treats a missing v2 state object as a first run and exports a failed-message chunk', async () => {
+  it('treats a missing state object as a first run: 7-day lookback, lagged upper bound, chunk + state', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
-    let storage = createStorage(undefined);
+    let storage = createStorage();
     let candidate = createCandidate({
       providerName: 'Elasticsearch',
       providerSlug: 'elasticsearch',
@@ -262,16 +259,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
       toolNativeKey: 'search_documents',
       toolName: 'Search Documents'
     });
-    let listFailedMessages = vi.fn(
-      async (_input: ProviderTelemetryFailedMessagesExportListInput) => ({
-        items: [candidate],
-        nextWatermark: {
-          occurred_at: '2026-06-18T00:10:00.000Z',
-          id: 'serr_1'
-        },
-        hasMore: false
-      })
-    );
+    let listFailedMessages = singlePage([pageError([candidate])]);
 
     let result = await runProviderTelemetryErrorGroupsExport({
       now,
@@ -287,7 +275,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     expect(listFailedMessages).toHaveBeenCalledWith({
       range: {
         from: new Date('2026-06-11T00:15:00.000Z'),
-        to: now
+        to: new Date('2026-06-18T00:13:00.000Z')
       },
       limit: 100,
       after: null
@@ -309,7 +297,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
       generated_at: '2026-06-18T00:15:00.000Z',
       range: {
         from: '2026-06-11T00:15:00.000Z',
-        to: '2026-06-18T00:15:00.000Z'
+        to: '2026-06-18T00:13:00.000Z'
       },
       item_count: 1,
       items: [
@@ -331,86 +319,48 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
         }
       ]
     });
-    let payload = exportChunk.items[0].payload;
-    expect(payload).toMatchObject({
-      object: 'session.message',
-      id: 'msg_1',
-      type: 'tool_call',
-      status: 'failed',
-      source: 'model',
-      input: {
-        data: {
-          token: '[REDACTED]',
-          phone: '[REDACTED]',
-          retryCount: 2,
-          ok: false,
-          missing: null,
-          createdAt: '2026-06-18T00:09:00.000Z'
-        }
-      },
-      toolCall: {
-        id: 'tc_1',
-        toolKey: 'elasticsearch_search_documents',
-        rationale: '[REDACTED]',
-        operation: 'call_tool',
-        tool: {
-          id: 'tool_1',
-          key: 'elasticsearch_search_documents',
-          name: '[REDACTED]',
-          providerId: 'prv_1'
-        }
-      },
-      error: {
-        id: 'serr_1',
-        code: 'provider_error',
-        message: '[REDACTED]',
-        data: {
-          authorization: '[REDACTED]',
-          code: 'PROVIDER_ERROR',
-          object: 'provider.error',
-          status: 500
-        },
-        groupId: 'serg_1'
-      },
-      createdAt: '2026-06-18T00:10:00.000Z'
-    });
 
+    let payload = exportChunk.items[0].payload;
+    expect(payload.input.data.token).toBe('[REDACTED]');
+    expect(payload.input.data.retryCount).toBe(2);
+
+    let watermark = {
+      occurred_at: '2026-06-18T00:10:00.000Z',
+      id: 'serr_1'
+    };
     let stateFile = parseJsonCall(storage.putObject.mock.calls[1]!);
     expect(stateFile).toEqual({
       version: 2,
-      last_exported: {
-        occurred_at: '2026-06-18T00:10:00.000Z',
-        id: 'serr_1'
-      },
-      last_checked_at: '2026-06-18T00:15:00.000Z'
+      last_exported: watermark,
+      last_checked_at: '2026-06-18T00:15:00.000Z',
+      last_processed: watermark,
+      last_run: {
+        status: 'completed',
+        exported_count: 1,
+        quarantined_count: 0,
+        deferred_count: 0
+      }
     });
     expect(result).toEqual({
       exportedKeys: [expectedKey],
+      quarantinedKeys: [],
       state: stateFile,
-      exportedCount: 1
+      exportedCount: 1,
+      quarantinedCount: 0,
+      deferredCount: 0
     });
   });
 
   it('redacts a broad set of OpenRedaction-supported PII categories in export payloads', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
-    let storage = createStorage(undefined);
+    let storage = createStorage();
     let candidate = createCandidate();
-    let listFailedMessages = vi.fn(
-      async (_input: ProviderTelemetryFailedMessagesExportListInput) => ({
-        items: [candidate],
-        nextWatermark: {
-          occurred_at: '2026-06-18T00:10:00.000Z',
-          id: 'serr_1'
-        },
-        hasMore: false
-      })
-    );
 
     await runProviderTelemetryErrorGroupsExport({
       now,
       storage,
       bucketName: 'exports',
-      listFailedMessages,
+      listFailedMessages: singlePage([pageError([candidate])]),
       presentMessage: async () => ({
         object: 'session.message',
         id: candidate.message.id,
@@ -568,9 +518,9 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     });
   });
 
-  it('exports each page as a chunk and counts exported messages', async () => {
+  it('exports pages with a mid-run checkpoint and counts exported messages', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
-    let storage = createStorage(undefined);
+    let storage = createStorage();
     let first = createCandidate({
       errorId: 'serr_1',
       messageId: 'msg_1',
@@ -586,26 +536,13 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
       messageId: 'msg_3',
       occurredAt: '2026-06-18T00:12:00.000Z'
     });
-    let firstWatermark = {
-      occurred_at: '2026-06-18T00:10:00.000Z',
-      id: 'serr_1'
-    };
     let listFailedMessages = vi.fn(
-      async (input: ProviderTelemetryFailedMessagesExportListInput) =>
+      async (
+        input: ProviderTelemetryFailedMessagesExportListInput
+      ): Promise<ProviderTelemetryFailedMessagesExportList> =>
         input.after
-          ? {
-              items: [second, third],
-              nextWatermark: {
-                occurred_at: '2026-06-18T00:12:00.000Z',
-                id: 'serr_3'
-              },
-              hasMore: false
-            }
-          : {
-              items: [first],
-              nextWatermark: firstWatermark,
-              hasMore: true
-            }
+          ? { errors: [pageError([second]), pageError([third])], hasMore: false }
+          : { errors: [pageError([first])], hasMore: true }
     );
 
     let result = await runProviderTelemetryErrorGroupsExport({
@@ -622,7 +559,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     expect(listFailedMessages).toHaveBeenNthCalledWith(1, {
       range: {
         from: new Date('2026-06-11T00:15:00.000Z'),
-        to: now
+        to: new Date('2026-06-18T00:13:00.000Z')
       },
       limit: 100,
       after: null
@@ -630,12 +567,27 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     expect(listFailedMessages).toHaveBeenNthCalledWith(2, {
       range: {
         from: new Date('2026-06-11T00:15:00.000Z'),
-        to: now
+        to: new Date('2026-06-18T00:13:00.000Z')
       },
       limit: 100,
-      after: firstWatermark
+      after: {
+        occurred_at: '2026-06-18T00:10:00.000Z',
+        id: 'serr_1'
+      }
     });
-    expect(storage.putObject).toHaveBeenCalledTimes(3);
+
+    // chunk 1, checkpoint state, chunk 2, final state
+    expect(storage.putObject).toHaveBeenCalledTimes(4);
+    let checkpoint = parseJsonCall(storage.putObject.mock.calls[1]!);
+    expect(storage.putObject.mock.calls[1]![1]).toBe(
+      PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY
+    );
+    expect(checkpoint.last_run.status).toBe('running');
+    expect(checkpoint.last_processed).toEqual({
+      occurred_at: '2026-06-18T00:10:00.000Z',
+      id: 'serr_1'
+    });
+
     expect(result.exportedKeys).toEqual([
       getProviderTelemetryFailedMessagesExportChunkKey([first]),
       getProviderTelemetryFailedMessagesExportChunkKey([second, third])
@@ -645,9 +597,15 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
       occurred_at: '2026-06-18T00:12:00.000Z',
       id: 'serr_3'
     });
+    expect(result.state?.last_run).toEqual({
+      status: 'completed',
+      exported_count: 3,
+      quarantined_count: 0,
+      deferred_count: 0
+    });
   });
 
-  it('resumes after the existing high-water mark', async () => {
+  it('resumes after a legacy last_exported watermark', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
     let watermark = {
       occurred_at: '2026-06-18T00:00:00.000Z',
@@ -658,13 +616,7 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
       last_exported: watermark,
       last_checked_at: '2026-06-18T00:00:00.000Z'
     });
-    let listFailedMessages = vi.fn(
-      async (_input: ProviderTelemetryFailedMessagesExportListInput) => ({
-        items: [],
-        nextWatermark: null,
-        hasMore: false
-      })
-    );
+    let listFailedMessages = singlePage([]);
 
     await runProviderTelemetryErrorGroupsExport({
       now,
@@ -676,27 +628,30 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     expect(listFailedMessages).toHaveBeenCalledWith({
       range: {
         from: new Date('2026-06-18T00:00:00.000Z'),
-        to: now
+        to: new Date('2026-06-18T00:13:00.000Z')
       },
       limit: 100,
       after: watermark
     });
   });
 
-  it('uses last_checked_at as the next range start when no item was previously exported', async () => {
+  it('prefers last_processed over last_exported when resuming', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
+    let exportedWatermark = {
+      occurred_at: '2026-06-18T00:00:00.000Z',
+      id: 'serr_b'
+    };
+    let processedWatermark = {
+      occurred_at: '2026-06-18T00:05:00.000Z',
+      id: 'serr_c'
+    };
     let storage = createStorage({
       version: 2,
-      last_exported: null,
-      last_checked_at: '2026-06-18T00:00:00.000Z'
+      last_exported: exportedWatermark,
+      last_checked_at: '2026-06-18T00:00:00.000Z',
+      last_processed: processedWatermark
     });
-    let listFailedMessages = vi.fn(
-      async (_input: ProviderTelemetryFailedMessagesExportListInput) => ({
-        items: [],
-        nextWatermark: null,
-        hasMore: false
-      })
-    );
+    let listFailedMessages = singlePage([]);
 
     await runProviderTelemetryErrorGroupsExport({
       now,
@@ -707,37 +662,57 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
 
     expect(listFailedMessages).toHaveBeenCalledWith({
       range: {
-        from: new Date('2026-06-18T00:00:00.000Z'),
-        to: now
+        from: new Date('2026-06-18T00:05:00.000Z'),
+        to: new Date('2026-06-18T00:13:00.000Z')
+      },
+      limit: 100,
+      after: processedWatermark
+    });
+  });
+
+  it('falls back to the 7-day lookback and ignores last_checked_at when no watermark exists', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage({
+      version: 2,
+      last_exported: null,
+      last_checked_at: '2026-06-18T00:00:00.000Z'
+    });
+    let listFailedMessages = singlePage([]);
+
+    await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages
+    });
+
+    expect(listFailedMessages).toHaveBeenCalledWith({
+      range: {
+        from: new Date('2026-06-11T00:15:00.000Z'),
+        to: new Date('2026-06-18T00:13:00.000Z')
       },
       limit: 100,
       after: null
     });
   });
 
-  it('updates only state when there are no grouped failed messages to export', async () => {
+  it('updates only state when there is nothing to export', async () => {
     let now = new Date('2026-06-18T00:15:00.000Z');
+    let watermark = {
+      occurred_at: '2026-06-18T00:00:00.000Z',
+      id: 'serr_b'
+    };
     let storage = createStorage({
       version: 2,
-      last_exported: {
-        occurred_at: '2026-06-18T00:00:00.000Z',
-        id: 'serr_b'
-      },
+      last_exported: watermark,
       last_checked_at: '2026-06-18T00:00:00.000Z'
     });
-    let listFailedMessages = vi.fn(
-      async (_input: ProviderTelemetryFailedMessagesExportListInput) => ({
-        items: [],
-        nextWatermark: null,
-        hasMore: false
-      })
-    );
 
     let result = await runProviderTelemetryErrorGroupsExport({
       now,
       storage,
       bucketName: 'exports',
-      listFailedMessages
+      listFailedMessages: singlePage([])
     });
 
     expect(storage.putObject).toHaveBeenCalledTimes(1);
@@ -746,14 +721,429 @@ describe('runProviderTelemetryErrorGroupsExport', () => {
     );
     expect(parseJsonCall(storage.putObject.mock.calls[0]!)).toEqual({
       version: 2,
-      last_exported: {
-        occurred_at: '2026-06-18T00:00:00.000Z',
-        id: 'serr_b'
-      },
-      last_checked_at: '2026-06-18T00:15:00.000Z'
+      last_exported: watermark,
+      last_checked_at: '2026-06-18T00:15:00.000Z',
+      last_processed: watermark,
+      last_run: {
+        status: 'completed',
+        exported_count: 0,
+        quarantined_count: 0,
+        deferred_count: 0
+      }
     });
     expect(result.exportedKeys).toEqual([]);
     expect(result.exportedCount).toBe(0);
+  });
+
+  it('quarantines a poison message and keeps exporting later records', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let first = createCandidate({
+      errorId: 'serr_1',
+      messageId: 'msg_1',
+      occurredAt: '2026-06-18T00:10:00.000Z'
+    });
+    let poison = createCandidate({
+      errorId: 'serr_2',
+      messageId: 'msg_2',
+      occurredAt: '2026-06-18T00:11:00.000Z'
+    });
+    let third = createCandidate({
+      errorId: 'serr_3',
+      messageId: 'msg_3',
+      occurredAt: '2026-06-18T00:12:00.000Z'
+    });
+
+    let result = await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages: singlePage([
+        pageError([first]),
+        pageError([poison]),
+        pageError([third])
+      ]),
+      presentMessage: async message => {
+        if (message.id === 'msg_2') {
+          throw new TypeError('Cannot read properties of undefined (reading data)');
+        }
+        return createPresentedMessage(
+          [first, third].find(candidate => candidate.message.id === message.id)!
+        );
+      }
+    });
+
+    let expectedChunkKey = getProviderTelemetryFailedMessagesExportChunkKey([first, third]);
+    let expectedQuarantineKey = getProviderTelemetryFailedMessageQuarantineKey({
+      occurred_at: '2026-06-18T00:11:00.000Z',
+      error_id: 'serr_2',
+      message_id: 'msg_2',
+      stage: 'present'
+    });
+
+    expect(result.exportedKeys).toEqual([expectedChunkKey]);
+    expect(result.quarantinedKeys).toEqual([expectedQuarantineKey]);
+    expect(result.exportedCount).toBe(2);
+    expect(result.quarantinedCount).toBe(1);
+    expect(result.state?.last_processed).toEqual({
+      occurred_at: '2026-06-18T00:12:00.000Z',
+      id: 'serr_3'
+    });
+    expect(result.state?.last_exported).toEqual({
+      occurred_at: '2026-06-18T00:12:00.000Z',
+      id: 'serr_3'
+    });
+
+    let exportChunk = JSON.parse(storage.objects.get(expectedChunkKey)!);
+    expect(exportChunk.items.map((item: any) => item.message_id)).toEqual(['msg_1', 'msg_3']);
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(captureMessage.mock.calls[0]![1]).toMatchObject({
+      level: 'warning',
+      extra: {
+        stage: 'present',
+        reason: 'presentation_failed',
+        errorId: 'serr_2',
+        messageId: 'msg_2'
+      }
+    });
+  });
+
+  it('writes quarantine records without payloads, raw error text, or a .json suffix', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let poison = createCandidate({
+      errorId: 'serr_2',
+      messageId: 'msg_2',
+      occurredAt: '2026-06-18T00:11:00.000Z'
+    });
+
+    await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages: singlePage([pageError([poison])]),
+      presentMessage: async () => {
+        throw new TypeError('secret-user-data@example.com leaked into an error');
+      }
+    });
+
+    let quarantineKey = getProviderTelemetryFailedMessageQuarantineKey({
+      occurred_at: '2026-06-18T00:11:00.000Z',
+      error_id: 'serr_2',
+      message_id: 'msg_2',
+      stage: 'present'
+    });
+
+    expect(quarantineKey.startsWith(PROVIDER_TELEMETRY_QUARANTINE_KEY_PREFIX)).toBe(true);
+    expect(quarantineKey.endsWith('.json')).toBe(false);
+    expect(quarantineKey.endsWith('.jsonl')).toBe(true);
+
+    let raw = storage.objects.get(quarantineKey)!;
+    expect(raw).toBeDefined();
+    expect(raw).not.toContain('secret-user-data');
+    expect(raw).not.toContain('example.com');
+
+    let record = JSON.parse(raw);
+    expect(Object.keys(record).sort()).toEqual(
+      [
+        'object',
+        'version',
+        'stage',
+        'reason',
+        'error_id',
+        'message_id',
+        'occurred_at',
+        'fingerprint',
+        'quarantined_at'
+      ].sort()
+    );
+    expect(record).toMatchObject({
+      object: 'provider_telemetry.failed_message_export_quarantine',
+      version: 1,
+      stage: 'present',
+      reason: 'presentation_failed',
+      error_id: 'serr_2',
+      message_id: 'msg_2',
+      occurred_at: '2026-06-18T00:11:00.000Z',
+      quarantined_at: '2026-06-18T00:15:00.000Z'
+    });
+    expect(record.fingerprint).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('quarantines a message whose payload cannot be redacted', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let poison = createCandidate({
+      errorId: 'serr_2',
+      messageId: 'msg_2',
+      occurredAt: '2026-06-18T00:11:00.000Z'
+    });
+
+    let result = await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages: singlePage([pageError([poison])]),
+      // BigInt payloads cannot be JSON-serialized, so redaction fails
+      presentMessage: async () => ({ big: 1n })
+    });
+
+    expect(result.quarantinedCount).toBe(1);
+    let record = JSON.parse(storage.objects.get(result.quarantinedKeys[0]!)!);
+    expect(record.stage).toBe('redact');
+    expect(record.reason).toBe('redaction_failed');
+    expect(result.state?.last_processed).toEqual({
+      occurred_at: '2026-06-18T00:11:00.000Z',
+      id: 'serr_2'
+    });
+    expect(result.state?.last_exported).toBeNull();
+  });
+
+  it('fails the run without touching state when preparation hits an infrastructure error', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let candidate = createCandidate();
+
+    await expect(
+      runProviderTelemetryErrorGroupsExport({
+        now,
+        storage,
+        bucketName: 'exports',
+        listFailedMessages: singlePage([pageError([candidate])]),
+        presentMessage: async () => {
+          throw new ProviderTelemetryExportInfraError('storage read failed');
+        }
+      })
+    ).rejects.toThrow('storage read failed');
+
+    expect(storage.putObject).not.toHaveBeenCalled();
+  });
+
+  it('defers at the first recent ungrouped error and never advances past it', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let ready = createCandidate({
+      errorId: 'serr_1',
+      messageId: 'msg_1',
+      occurredAt: '2026-06-18T00:01:00.000Z'
+    });
+    // 10 minutes old: inside the readiness grace period
+    let ungrouped = createCandidate({
+      errorId: 'serr_2',
+      messageId: 'msg_2',
+      occurredAt: '2026-06-18T00:05:00.000Z'
+    });
+    let later = createCandidate({
+      errorId: 'serr_3',
+      messageId: 'msg_3',
+      occurredAt: '2026-06-18T00:12:00.000Z'
+    });
+    let listFailedMessages = singlePage(
+      [pageError([ready]), pageError([ungrouped], { isReady: false }), pageError([later])],
+      true
+    );
+
+    let result = await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages,
+      presentMessage: async () => createPresentedMessage(ready)
+    });
+
+    // a deferred run stops paging entirely
+    expect(listFailedMessages).toHaveBeenCalledTimes(1);
+    expect(result.exportedCount).toBe(1);
+    expect(result.quarantinedCount).toBe(0);
+    expect(result.deferredCount).toBe(2);
+    expect(result.state?.last_processed).toEqual({
+      occurred_at: '2026-06-18T00:01:00.000Z',
+      id: 'serr_1'
+    });
+    expect(result.state?.last_run).toEqual({
+      status: 'deferred',
+      exported_count: 1,
+      quarantined_count: 0,
+      deferred_count: 2
+    });
+  });
+
+  it('quarantines an ungrouped error older than the grace period and continues', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    // more than 4 hours old: past the readiness grace period
+    let stale = createCandidate({
+      errorId: 'serr_1',
+      messageId: 'msg_1',
+      occurredAt: '2026-06-17T19:00:00.000Z'
+    });
+    let ready = createCandidate({
+      errorId: 'serr_2',
+      messageId: 'msg_2',
+      occurredAt: '2026-06-18T00:10:00.000Z'
+    });
+
+    let result = await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages: singlePage([
+        pageError([stale], { isReady: false }),
+        pageError([ready])
+      ]),
+      presentMessage: async () => createPresentedMessage(ready)
+    });
+
+    expect(result.exportedCount).toBe(1);
+    expect(result.quarantinedCount).toBe(1);
+    expect(result.deferredCount).toBe(0);
+    expect(result.state?.last_processed).toEqual({
+      occurred_at: '2026-06-18T00:10:00.000Z',
+      id: 'serr_2'
+    });
+
+    let record = JSON.parse(storage.objects.get(result.quarantinedKeys[0]!)!);
+    expect(record).toMatchObject({
+      stage: 'readiness',
+      reason: 'not_grouped_within_grace_period',
+      error_id: 'serr_1',
+      message_id: null,
+      message_ids: ['msg_1']
+    });
+  });
+
+  it('reuses an existing chunk object instead of rewriting it', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let candidate = createCandidate();
+    let expectedKey = getProviderTelemetryFailedMessagesExportChunkKey([candidate]);
+    storage.objects.set(expectedKey, JSON.stringify({ existing: true }));
+
+    let result = await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages: singlePage([pageError([candidate])]),
+      presentMessage: async () => createPresentedMessage(candidate)
+    });
+
+    let chunkWrites = storage.putObject.mock.calls.filter(call => call[1] === expectedKey);
+    expect(chunkWrites).toHaveLength(0);
+    expect(storage.objects.get(expectedKey)).toBe(JSON.stringify({ existing: true }));
+    expect(result.exportedKeys).toEqual([expectedKey]);
+    expect(result.exportedCount).toBe(1);
+    expect(result.state?.last_exported).toEqual({
+      occurred_at: '2026-06-18T00:10:00.000Z',
+      id: 'serr_1'
+    });
+  });
+
+  it('reuses an existing quarantine object instead of rewriting it', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let poison = createCandidate({
+      errorId: 'serr_2',
+      messageId: 'msg_2',
+      occurredAt: '2026-06-18T00:11:00.000Z'
+    });
+    let quarantineKey = getProviderTelemetryFailedMessageQuarantineKey({
+      occurred_at: '2026-06-18T00:11:00.000Z',
+      error_id: 'serr_2',
+      message_id: 'msg_2',
+      stage: 'present'
+    });
+    storage.objects.set(quarantineKey, 'existing');
+
+    let result = await runProviderTelemetryErrorGroupsExport({
+      now,
+      storage,
+      bucketName: 'exports',
+      listFailedMessages: singlePage([pageError([poison])]),
+      presentMessage: async () => {
+        throw new TypeError('poison');
+      }
+    });
+
+    let quarantineWrites = storage.putObject.mock.calls.filter(
+      call => call[1] === quarantineKey
+    );
+    expect(quarantineWrites).toHaveLength(0);
+    expect(storage.objects.get(quarantineKey)).toBe('existing');
+    expect(result.quarantinedKeys).toEqual([quarantineKey]);
+    expect(result.quarantinedCount).toBe(1);
+  });
+
+  it('leaves state untouched when a storage write fails', async () => {
+    let now = new Date('2026-06-18T00:15:00.000Z');
+    let storage = createStorage();
+    let candidate = createCandidate();
+    storage.putObject.mockRejectedValueOnce(new Error('s3 unavailable'));
+
+    await expect(
+      runProviderTelemetryErrorGroupsExport({
+        now,
+        storage,
+        bucketName: 'exports',
+        listFailedMessages: singlePage([pageError([candidate])]),
+        presentMessage: async () => createPresentedMessage(candidate)
+      })
+    ).rejects.toThrow('s3 unavailable');
+
+    let stateWrites = storage.putObject.mock.calls.filter(
+      call => call[1] === PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY
+    );
+    expect(stateWrites).toHaveLength(0);
+    expect(storage.objects.has(PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY)).toBe(false);
+  });
+});
+
+describe('getProviderTelemetryFailedMessagesExportChunkKey', () => {
+  it('produces identical keys for identical member sets', () => {
+    let a = createCandidate({ errorId: 'serr_1', messageId: 'msg_1' });
+    let b = createCandidate({ errorId: 'serr_2', messageId: 'msg_2' });
+
+    expect(getProviderTelemetryFailedMessagesExportChunkKey([a, b])).toBe(
+      getProviderTelemetryFailedMessagesExportChunkKey([a, b])
+    );
+  });
+
+  it('produces different keys when the middle of the set changes', () => {
+    let a = createCandidate({
+      errorId: 'serr_1',
+      messageId: 'msg_1',
+      occurredAt: '2026-06-18T00:10:00.000Z'
+    });
+    let b = createCandidate({
+      errorId: 'serr_2',
+      messageId: 'msg_2',
+      occurredAt: '2026-06-18T00:11:00.000Z'
+    });
+    let c = createCandidate({
+      errorId: 'serr_3',
+      messageId: 'msg_3',
+      occurredAt: '2026-06-18T00:12:00.000Z'
+    });
+
+    // same first/last members, different middle
+    expect(getProviderTelemetryFailedMessagesExportChunkKey([a, b, c])).not.toBe(
+      getProviderTelemetryFailedMessagesExportChunkKey([a, c])
+    );
+  });
+
+  it('keeps the export key prefix and .json suffix', () => {
+    let key = getProviderTelemetryFailedMessagesExportChunkKey([createCandidate()]);
+    expect(key.startsWith('provider-telemetry/failed-messages-')).toBe(true);
+    expect(key.endsWith('.json')).toBe(true);
+  });
+});
+
+describe('queue policy', () => {
+  it('retries three times and removes terminally failed jobs', () => {
+    expect(PROVIDER_TELEMETRY_EXPORT_QUEUE_JOB_OPTIONS).toEqual({
+      attempts: 3,
+      removeOnFail: true
+    });
   });
 });
 
@@ -762,7 +1152,7 @@ describe('listProviderTelemetryFailedMessagesForExport', () => {
     vi.clearAllMocks();
   });
 
-  it('queries grouped errors through failed session messages and presents provider/tool metadata', async () => {
+  it('scans all session errors, marking ungrouped ones as not ready', async () => {
     let from = new Date('2026-06-18T00:00:00.000Z');
     let to = new Date('2026-06-18T01:00:00.000Z');
     let after = {
@@ -774,7 +1164,14 @@ describe('listProviderTelemetryFailedMessagesForExport', () => {
       id: 'msg_1',
       type: 'tool_call',
       status: 'failed',
-      methodOrToolKey: 'fallback_tool',
+      providerRun: null,
+      toolCall: null
+    };
+    let ungroupedMessage = {
+      oid: 11n,
+      id: 'msg_2',
+      type: 'tool_call',
+      status: 'failed',
       providerRun: null,
       toolCall: null
     };
@@ -783,6 +1180,7 @@ describe('listProviderTelemetryFailedMessagesForExport', () => {
         id: 'serr_1',
         code: 'provider_error',
         createdAt: new Date('2026-06-18T00:20:00.000Z'),
+        groupOid: 5n,
         group: { id: 'serg_1' },
         providerRun: {
           provider: {
@@ -795,6 +1193,15 @@ describe('listProviderTelemetryFailedMessagesForExport', () => {
           }
         },
         sessionMessages: [rawMessage]
+      },
+      {
+        id: 'serr_2',
+        code: 'provider_error',
+        createdAt: new Date('2026-06-18T00:25:00.000Z'),
+        groupOid: null,
+        group: null,
+        providerRun: null,
+        sessionMessages: [ungroupedMessage]
       }
     ]);
     enrichMessages.mockResolvedValue([
@@ -825,7 +1232,6 @@ describe('listProviderTelemetryFailedMessagesForExport', () => {
     let query = db.sessionError.findMany.mock.calls[0]![0];
     expect(query.where).toEqual({
       AND: [
-        { groupOid: { not: null } },
         { createdAt: { gte: from, lte: to } },
         { sessionMessages: { some: { status: 'failed' } } },
         {
@@ -839,22 +1245,19 @@ describe('listProviderTelemetryFailedMessagesForExport', () => {
         }
       ]
     });
-    expect(query.include.sessionMessages.where).toEqual({ status: 'failed' });
-    expect(query.include.sessionMessages.include.providerRun.include.provider.include).toEqual(
-      {
-        listing: true
-      }
-    );
     expect(query.orderBy).toEqual([{ createdAt: 'asc' }, { id: 'asc' }]);
     expect(query.take).toBe(26);
 
-    expect(result).toMatchObject({
-      hasMore: false,
-      nextWatermark: {
-        occurred_at: '2026-06-18T00:20:00.000Z',
-        id: 'serr_1'
-      },
-      items: [
+    // only messages of ready errors are enriched
+    expect(enrichMessages).toHaveBeenCalledTimes(1);
+    expect(enrichMessages.mock.calls[0]![0]).toEqual([rawMessage]);
+
+    expect(result.hasMore).toBe(false);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toMatchObject({
+      isReady: true,
+      occurredAt: new Date('2026-06-18T00:20:00.000Z'),
+      candidates: [
         {
           provider: {
             id: 'prv_1',
@@ -869,5 +1272,10 @@ describe('listProviderTelemetryFailedMessagesForExport', () => {
         }
       ]
     });
+    expect(result.errors[1]).toMatchObject({
+      isReady: false,
+      occurredAt: new Date('2026-06-18T00:25:00.000Z')
+    });
+    expect(result.errors[1]!.candidates[0]!.message.id).toBe('msg_2');
   });
 });

--- a/src/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
+++ b/src/subspace/modules/session/src/lib/providerTelemetryErrorGroupExport.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+import { getSentry } from '@lowerdeck/sentry';
 import {
   getOffloadedSessionMessage,
   getProviderTelemetryErrorGroupsStorageTarget
@@ -9,18 +11,46 @@ import { sessionMessageService } from '../services/sessionMessage';
 export let PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY =
   'provider-telemetry/error-groups/failed-messages/state.json';
 
+// Downstream ingestion only picks up `.json` keys; quarantine objects use
+// `.jsonl` so they are ignored.
+export let PROVIDER_TELEMETRY_QUARANTINE_KEY_PREFIX =
+  'provider-telemetry/failed-messages/quarantine/';
+
 let DEFAULT_EXPORT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
 let EXPORT_PAGE_SIZE = 100;
+
+// Must cover the grouping queue's ~4h retry horizon; quarantining earlier
+// would drop errors that would still group.
+export let PROVIDER_TELEMETRY_EXPORT_READINESS_GRACE_MS = 4 * 60 * 60 * 1000;
+
+// Keeps the createdAt cursor behind in-flight writes so no row is missed.
+export let PROVIDER_TELEMETRY_EXPORT_VISIBILITY_LAG_MS = 2 * 60 * 1000;
+
+// A terminally failed job must be removed or it blocks later enqueues of the
+// static job id.
+export let PROVIDER_TELEMETRY_EXPORT_QUEUE_JOB_OPTIONS = {
+  attempts: 3,
+  removeOnFail: true
+};
 
 export type ProviderTelemetryFailedMessagesExportWatermark = {
   occurred_at: string;
   id: string;
 };
 
+export type ProviderTelemetryFailedMessagesExportRunSummary = {
+  status: 'running' | 'completed' | 'deferred';
+  exported_count: number;
+  quarantined_count: number;
+  deferred_count: number;
+};
+
 export type ProviderTelemetryFailedMessagesExportState = {
   version: 2;
   last_exported: ProviderTelemetryFailedMessagesExportWatermark | null;
   last_checked_at: string;
+  last_processed?: ProviderTelemetryFailedMessagesExportWatermark | null;
+  last_run?: ProviderTelemetryFailedMessagesExportRunSummary | null;
 };
 
 export type ProviderTelemetryErrorGroupsExportState =
@@ -54,11 +84,58 @@ export type ProviderTelemetryFailedMessageExportCandidate = {
   } | null;
 };
 
+export type ProviderTelemetryFailedMessagesExportPageError = {
+  error: any;
+  occurredAt: Date;
+  isReady: boolean;
+  candidates: ProviderTelemetryFailedMessageExportCandidate[];
+};
+
+export type ProviderTelemetryFailedMessagesExportList = {
+  errors: ProviderTelemetryFailedMessagesExportPageError[];
+  hasMore: boolean;
+};
+
 export type ProviderTelemetryFailedMessagesExportListInput = {
   range: { from: Date; to: Date };
   limit?: number;
   after?: ProviderTelemetryFailedMessagesExportWatermark | null;
 };
+
+export type ProviderTelemetryFailedMessageQuarantineRecord = {
+  object: 'provider_telemetry.failed_message_export_quarantine';
+  version: 1;
+  stage: 'readiness' | 'present' | 'redact';
+  reason: string;
+  error_id: string;
+  message_id: string | null;
+  message_ids?: string[];
+  occurred_at: string;
+  fingerprint: string;
+  quarantined_at: string;
+};
+
+export class ProviderTelemetryExportInfraError extends Error {
+  causedBy?: unknown;
+
+  constructor(message: string, causedBy?: unknown) {
+    super(message);
+    this.name = 'ProviderTelemetryExportInfraError';
+    this.causedBy = causedBy;
+  }
+}
+
+class ProviderTelemetryExportItemError extends Error {
+  stage: 'present' | 'redact';
+  causedBy: unknown;
+
+  constructor(stage: 'present' | 'redact', causedBy: unknown) {
+    super(`Provider telemetry export item preparation failed during ${stage}`);
+    this.name = 'ProviderTelemetryExportItemError';
+    this.stage = stage;
+    this.causedBy = causedBy;
+  }
+}
 
 let objectDataToString = (data: Buffer | Uint8Array | string) =>
   typeof data === 'string' ? data : Buffer.from(data).toString('utf8');
@@ -93,20 +170,25 @@ let getExportRange = (
   state: ProviderTelemetryFailedMessagesExportState | null | undefined,
   now: Date
 ) => {
-  let from = state?.last_exported
-    ? new Date(state.last_exported.occurred_at)
-    : state?.last_checked_at
-      ? new Date(state.last_checked_at)
-      : new Date(now.getTime() - DEFAULT_EXPORT_LOOKBACK_MS);
+  // Never use `last_checked_at` here: it advances on empty runs and would
+  // skip errors that become ready afterwards.
+  let watermark = state?.last_processed ?? state?.last_exported ?? null;
+  let from = watermark
+    ? new Date(watermark.occurred_at)
+    : new Date(now.getTime() - DEFAULT_EXPORT_LOOKBACK_MS);
 
-  return { from, to: now };
+  return {
+    from,
+    to: new Date(now.getTime() - PROVIDER_TELEMETRY_EXPORT_VISIBILITY_LAG_MS)
+  };
 };
 
-let watermarkFromProviderTelemetryFailedMessage = (
-  item: Pick<ProviderTelemetryFailedMessageExportCandidate, 'error' | 'occurredAt'>
+let watermarkFor = (
+  errorId: string,
+  occurredAt: Date
 ): ProviderTelemetryFailedMessagesExportWatermark => ({
-  occurred_at: item.occurredAt.toISOString(),
-  id: item.error.id
+  occurred_at: occurredAt.toISOString(),
+  id: errorId
 });
 
 let providerFromCandidate = (error: any, message: any) => {
@@ -137,14 +219,15 @@ let toolFromMessage = (message: any) => {
 
 export let listProviderTelemetryFailedMessagesForExport = async (
   input: ProviderTelemetryFailedMessagesExportListInput
-) => {
+): Promise<ProviderTelemetryFailedMessagesExportList> => {
   let limit = Math.max(1, Math.min(input.limit ?? EXPORT_PAGE_SIZE, EXPORT_PAGE_SIZE));
   let afterDate = input.after ? new Date(input.after.occurred_at) : null;
 
   let errors = await db.sessionError.findMany({
     where: {
       AND: [
-        { groupOid: { not: null } },
+        // Ungrouped errors are included so the cursor cannot advance past an
+        // error that is not ready yet.
         { createdAt: { gte: input.range.from, lte: input.range.to } },
         { sessionMessages: { some: { status: 'failed' as const } } },
         input.after && afterDate
@@ -193,41 +276,40 @@ export let listProviderTelemetryFailedMessagesForExport = async (
   });
 
   let pageErrors = errors.slice(0, limit);
-  let rawMessages = pageErrors.flatMap(error => error.sessionMessages);
-  let enrichedMessages = await sessionMessageService.enrichMessages(rawMessages as any);
+  let isReady = (error: any) => error.groupOid != null || !!error.group;
+
+  let readyMessages = pageErrors.filter(isReady).flatMap(error => error.sessionMessages);
+  let enrichedMessages = await sessionMessageService.enrichMessages(readyMessages as any);
   let enrichedMessageMap = new Map(enrichedMessages.map(message => [message.oid, message]));
 
-  let items = pageErrors.flatMap(error =>
-    error.sessionMessages.map(rawMessage => {
-      let message = enrichedMessageMap.get(rawMessage.oid) ?? rawMessage;
+  let pageEntries = pageErrors.map(error => {
+    let ready = isReady(error);
 
-      return {
-        error,
-        message,
-        occurredAt: error.createdAt,
-        provider: providerFromCandidate(error, message),
-        tool: toolFromMessage(message)
-      };
-    })
-  );
+    return {
+      error,
+      occurredAt: error.createdAt,
+      isReady: ready,
+      candidates: error.sessionMessages.map(rawMessage => {
+        let message = ready
+          ? (enrichedMessageMap.get(rawMessage.oid) ?? rawMessage)
+          : rawMessage;
 
-  let lastError = pageErrors[pageErrors.length - 1];
+        return {
+          error,
+          message,
+          occurredAt: error.createdAt,
+          provider: providerFromCandidate(error, message),
+          tool: toolFromMessage(message)
+        };
+      })
+    };
+  });
 
   return {
-    items,
-    nextWatermark: lastError
-      ? {
-          occurred_at: lastError.createdAt.toISOString(),
-          id: lastError.id
-        }
-      : null,
+    errors: pageEntries,
     hasMore: errors.length > limit
   };
 };
-
-export type ProviderTelemetryFailedMessagesExportList = Awaited<
-  ReturnType<typeof listProviderTelemetryFailedMessagesForExport>
->;
 
 export type ProviderTelemetryErrorGroupsExportDeps = {
   now?: Date;
@@ -253,6 +335,20 @@ let writeJsonObject = async (d: {
     'application/json',
     d.metadata
   );
+};
+
+let objectExists = async (d: {
+  storage: ProviderTelemetryErrorGroupsExportStorage;
+  bucketName: string;
+  key: string;
+}) => {
+  try {
+    await d.storage.getObject(d.bucketName, d.key);
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) return false;
+    throw error;
+  }
 };
 
 let providerTelemetryExportRedactor = new OpenRedaction({
@@ -292,6 +388,12 @@ let normalizeS3KeyComponent = (value: string | null | undefined) => {
   return normalized || 'unknown';
 };
 
+let fingerprintOf = (parts: Array<string | null | undefined>) =>
+  createHash('sha256')
+    .update(parts.map(part => part ?? '').join('\n'))
+    .digest('hex')
+    .slice(0, 16);
+
 export let getProviderTelemetryFailedMessagesExportChunkKey = (
   candidates: ProviderTelemetryFailedMessageExportCandidate[]
 ) => {
@@ -301,17 +403,44 @@ export let getProviderTelemetryFailedMessagesExportChunkKey = (
     throw new Error('Cannot create a provider telemetry export chunk key without items');
   }
 
+  // The key encodes the member identity (count + id hash): identical sets map
+  // to the same key, different sets never collide.
+  let memberHash = createHash('sha256')
+    .update(JSON.stringify(candidates.map(item => [item.error.id, item.message.id])))
+    .digest('hex')
+    .slice(0, 12);
+
   let filename = [
     'failed-messages',
     String(Math.floor(first.occurredAt.getTime() / 1000)),
     String(Math.floor(last.occurredAt.getTime() / 1000)),
     first.error.id,
-    last.error.id
+    last.error.id,
+    String(candidates.length),
+    memberHash
   ]
     .map(normalizeS3KeyComponent)
     .join('-');
 
   return ['provider-telemetry', `${filename}.json`].join('/');
+};
+
+export let getProviderTelemetryFailedMessageQuarantineKey = (
+  record: Pick<
+    ProviderTelemetryFailedMessageQuarantineRecord,
+    'occurred_at' | 'error_id' | 'message_id' | 'stage'
+  >
+) => {
+  let filename = [
+    String(Math.floor(new Date(record.occurred_at).getTime() / 1000)),
+    record.error_id,
+    record.message_id ?? 'error',
+    record.stage
+  ]
+    .map(normalizeS3KeyComponent)
+    .join('-');
+
+  return `${PROVIDER_TELEMETRY_QUARANTINE_KEY_PREFIX}${filename}.jsonl`;
 };
 
 let createExportPayload = async (message: any) => {
@@ -372,24 +501,36 @@ let createExportItem = async (d: {
   candidate: ProviderTelemetryFailedMessageExportCandidate;
   presentMessage: (message: any) => Promise<unknown>;
 }) => {
-  let payload = await d.presentMessage(d.candidate.message);
+  let payload: unknown;
+  try {
+    payload = await d.presentMessage(d.candidate.message);
+  } catch (error) {
+    if (error instanceof ProviderTelemetryExportInfraError) throw error;
+    throw new ProviderTelemetryExportItemError('present', error);
+  }
+
+  let redactedPayload: unknown;
+  try {
+    redactedPayload = await redactProviderTelemetryExportPayload(payload);
+  } catch (error) {
+    throw new ProviderTelemetryExportItemError('redact', error);
+  }
 
   return {
     occurred_at: d.candidate.occurredAt.toISOString(),
-    error_group_id: d.candidate.error.group.id,
+    error_group_id: d.candidate.error.group?.id ?? null,
     error_id: d.candidate.error.id,
     message_id: d.candidate.message.id,
     provider: d.candidate.provider,
     tool: d.candidate.tool,
-    payload: await redactProviderTelemetryExportPayload(payload)
+    payload: redactedPayload
   };
 };
 
-let createExportChunk = async (d: {
-  candidates: ProviderTelemetryFailedMessageExportCandidate[];
+let createExportChunk = (d: {
+  items: unknown[];
   range: { from: Date; to: Date };
   now: Date;
-  presentMessage: (message: any) => Promise<unknown>;
 }) => ({
   object: 'admin.provider_error_group.failed_message_export_chunk',
   version: 1,
@@ -398,16 +539,32 @@ let createExportChunk = async (d: {
     from: d.range.from.toISOString(),
     to: d.range.to.toISOString()
   },
-  item_count: d.candidates.length,
-  items: await Promise.all(
-    d.candidates.map(candidate =>
-      createExportItem({
-        candidate,
-        presentMessage: d.presentMessage
-      })
-    )
-  )
+  item_count: d.items.length,
+  items: d.items
 });
+
+let captureQuarantineDiagnostics = (
+  record: ProviderTelemetryFailedMessageQuarantineRecord,
+  objectKey: string
+) => {
+  try {
+    getSentry().captureMessage('Provider telemetry export quarantined a record', {
+      level: 'warning' as const,
+      extra: {
+        stage: record.stage,
+        reason: record.reason,
+        errorId: record.error_id,
+        messageId: record.message_id,
+        messageIds: record.message_ids,
+        occurredAt: record.occurred_at,
+        fingerprint: record.fingerprint,
+        objectKey
+      }
+    });
+  } catch {
+    // Diagnostics must never fail the export run.
+  }
+};
 
 export let runProviderTelemetryErrorGroupsExport = async (
   deps: ProviderTelemetryErrorGroupsExportDeps = {}
@@ -424,95 +581,237 @@ export let runProviderTelemetryErrorGroupsExport = async (
   let listFailedMessages =
     deps.listFailedMessages ?? listProviderTelemetryFailedMessagesForExport;
 
-  if (!storage || !bucketName) {
-    return {
-      exportedKeys: [],
-      state: null,
-      exportedCount: 0
-    };
-  }
+  let emptyResult = {
+    exportedKeys: [] as string[],
+    quarantinedKeys: [] as string[],
+    state: null as ProviderTelemetryFailedMessagesExportState | null,
+    exportedCount: 0,
+    quarantinedCount: 0,
+    deferredCount: 0
+  };
+
+  if (!storage || !bucketName) return emptyResult;
+
+  let store = storage;
+  let bucket = bucketName;
 
   try {
-    await storage.upsertBucket(bucketName);
+    await store.upsertBucket(bucket);
   } catch (error) {
-    if (isNotFoundError(error)) {
-      return {
-        exportedKeys: [],
-        state: null,
-        exportedCount: 0
-      };
-    }
-
+    if (isNotFoundError(error)) return emptyResult;
     throw error;
   }
 
-  let state = await readProviderTelemetryErrorGroupsExportState({ storage, bucketName });
-  let watermarkBefore = state?.last_exported ?? null;
+  let state = await readProviderTelemetryErrorGroupsExportState({
+    storage: store,
+    bucketName: bucket
+  });
   let range = getExportRange(state, now);
+
   let exportedKeys: string[] = [];
+  let quarantinedKeys: string[] = [];
   let exportedCount = 0;
-  let lastExportedItem: ProviderTelemetryFailedMessageExportCandidate | null = null;
-  let after: ProviderTelemetryFailedMessagesExportWatermark | null = watermarkBefore;
+  let quarantinedCount = 0;
+  let deferredCount = 0;
+  let deferred = false;
+
+  // `last_processed` covers exported and quarantined errors, never deferred
+  // ones; `last_exported` keeps its legacy meaning so rollbacks resume safely.
+  let lastProcessed = state?.last_processed ?? state?.last_exported ?? null;
+  let lastExported = state?.last_exported ?? null;
+
+  let writeState = async (status: 'running' | 'completed' | 'deferred') => {
+    let nextState: ProviderTelemetryFailedMessagesExportState = {
+      version: 2,
+      last_exported: lastExported,
+      last_checked_at: now.toISOString(),
+      last_processed: lastProcessed,
+      last_run: {
+        status,
+        exported_count: exportedCount,
+        quarantined_count: quarantinedCount,
+        deferred_count: deferredCount
+      }
+    };
+
+    await writeJsonObject({
+      storage: store,
+      bucketName: bucket,
+      key: PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY,
+      value: nextState,
+      metadata: {
+        type: 'provider-telemetry-failed-messages-state'
+      }
+    });
+
+    return nextState;
+  };
 
   while (true) {
     let page = await listFailedMessages({
       range,
       limit: EXPORT_PAGE_SIZE,
-      after
+      after: lastProcessed
     });
 
-    if (page.items.length) {
-      let exportKey = getProviderTelemetryFailedMessagesExportChunkKey(page.items);
-      let exportChunk = await createExportChunk({
-        candidates: page.items,
-        range,
-        now,
-        presentMessage
-      });
+    if (!page.errors.length) break;
 
-      await writeJsonObject({
-        storage,
-        bucketName,
-        key: exportKey,
-        value: exportChunk,
-        metadata: {
-          type: 'provider-telemetry-failed-message-export-chunk',
-          itemCount: String(page.items.length)
+    let exportCandidates: ProviderTelemetryFailedMessageExportCandidate[] = [];
+    let quarantineRecords: ProviderTelemetryFailedMessageQuarantineRecord[] = [];
+    let processedThrough: ProviderTelemetryFailedMessagesExportWatermark | null = null;
+
+    for (let index = 0; index < page.errors.length; index++) {
+      let entry = page.errors[index]!;
+
+      if (!entry.isReady) {
+        let ageMs = now.getTime() - entry.occurredAt.getTime();
+
+        if (ageMs < PROVIDER_TELEMETRY_EXPORT_READINESS_GRACE_MS) {
+          // Grouping still pending: stop so the cursor never passes this error.
+          deferred = true;
+          deferredCount += page.errors.length - index;
+          break;
         }
+
+        quarantineRecords.push({
+          object: 'provider_telemetry.failed_message_export_quarantine',
+          version: 1,
+          stage: 'readiness',
+          reason: 'not_grouped_within_grace_period',
+          error_id: entry.error.id,
+          message_id: null,
+          message_ids: entry.candidates.map(candidate => candidate.message.id),
+          occurred_at: entry.occurredAt.toISOString(),
+          fingerprint: fingerprintOf(['readiness', entry.error.type, entry.error.code]),
+          quarantined_at: now.toISOString()
+        });
+        processedThrough = watermarkFor(entry.error.id, entry.occurredAt);
+        continue;
+      }
+
+      exportCandidates.push(...entry.candidates);
+      processedThrough = watermarkFor(entry.error.id, entry.occurredAt);
+    }
+
+    let prepared = await Promise.allSettled(
+      exportCandidates.map(candidate => createExportItem({ candidate, presentMessage }))
+    );
+
+    let chunkCandidates: ProviderTelemetryFailedMessageExportCandidate[] = [];
+    let chunkItems: unknown[] = [];
+
+    for (let index = 0; index < prepared.length; index++) {
+      let result = prepared[index]!;
+      let candidate = exportCandidates[index]!;
+
+      if (result.status === 'fulfilled') {
+        chunkCandidates.push(candidate);
+        chunkItems.push(result.value);
+        continue;
+      }
+
+      // Only data-shaped failures are quarantined; anything else aborts the
+      // run so state never advances.
+      if (!(result.reason instanceof ProviderTelemetryExportItemError)) {
+        throw result.reason;
+      }
+
+      let cause = result.reason.causedBy;
+      quarantineRecords.push({
+        object: 'provider_telemetry.failed_message_export_quarantine',
+        version: 1,
+        stage: result.reason.stage,
+        reason: result.reason.stage === 'redact' ? 'redaction_failed' : 'presentation_failed',
+        error_id: candidate.error.id,
+        message_id: candidate.message.id,
+        occurred_at: candidate.occurredAt.toISOString(),
+        fingerprint: fingerprintOf([
+          result.reason.stage,
+          cause instanceof Error ? cause.name : typeof cause,
+          cause instanceof Error ? cause.message : String(cause)
+        ]),
+        quarantined_at: now.toISOString()
       });
+    }
+
+    if (chunkItems.length) {
+      let exportKey = getProviderTelemetryFailedMessagesExportChunkKey(chunkCandidates);
+
+      // Rewriting an existing key changes its ETag and re-triggers downstream
+      // ingestion; identical member sets reuse the object.
+      let exists = await objectExists({ storage: store, bucketName: bucket, key: exportKey });
+      if (!exists) {
+        await writeJsonObject({
+          storage: store,
+          bucketName: bucket,
+          key: exportKey,
+          value: createExportChunk({ items: chunkItems, range, now }),
+          metadata: {
+            type: 'provider-telemetry-failed-message-export-chunk',
+            itemCount: String(chunkItems.length)
+          }
+        });
+      }
 
       exportedKeys.push(exportKey);
-      exportedCount += page.items.length;
-      lastExportedItem = page.items[page.items.length - 1]!;
+      exportedCount += chunkItems.length;
+
+      let lastChunkCandidate = chunkCandidates[chunkCandidates.length - 1]!;
+      lastExported = watermarkFor(lastChunkCandidate.error.id, lastChunkCandidate.occurredAt);
     }
 
-    if (!page.hasMore || !page.nextWatermark) break;
+    for (let record of quarantineRecords) {
+      let quarantineKey = getProviderTelemetryFailedMessageQuarantineKey(record);
 
-    after = page.nextWatermark;
+      let exists = await objectExists({
+        storage: store,
+        bucketName: bucket,
+        key: quarantineKey
+      });
+      if (!exists) {
+        await store.putObject(
+          bucket,
+          quarantineKey,
+          `${JSON.stringify(record)}\n`,
+          'application/x-ndjson',
+          {
+            type: 'provider-telemetry-failed-message-export-quarantine'
+          }
+        );
+      }
+
+      quarantinedKeys.push(quarantineKey);
+      quarantinedCount += 1;
+      captureQuarantineDiagnostics(record, quarantineKey);
+    }
+
+    if (processedThrough) lastProcessed = processedThrough;
+
+    if (deferred || !page.hasMore) break;
+
+    // Checkpoint so a crash cannot roll the cursor back to the run start.
+    await writeState('running');
   }
 
-  let watermarkAfter = lastExportedItem
-    ? watermarkFromProviderTelemetryFailedMessage(lastExportedItem)
-    : watermarkBefore;
-  let nextState: ProviderTelemetryFailedMessagesExportState = {
-    version: 2,
-    last_exported: watermarkAfter,
-    last_checked_at: now.toISOString()
-  };
+  let nextState = await writeState(deferred ? 'deferred' : 'completed');
 
-  await writeJsonObject({
-    storage,
-    bucketName,
-    key: PROVIDER_TELEMETRY_FAILED_MESSAGES_STATE_KEY,
-    value: nextState,
-    metadata: {
-      type: 'provider-telemetry-failed-messages-state'
-    }
-  });
+  console.log(
+    '[PROVIDER TELEMETRY EXPORT]:',
+    JSON.stringify({
+      exportedCount,
+      quarantinedCount,
+      deferredCount,
+      lastProcessed,
+      lastExported
+    })
+  );
 
   return {
     exportedKeys,
+    quarantinedKeys,
     state: nextState,
-    exportedCount
+    exportedCount,
+    quarantinedCount,
+    deferredCount
   };
 };

--- a/src/subspace/modules/session/src/queues/providerTelemetryErrorGroups.ts
+++ b/src/subspace/modules/session/src/queues/providerTelemetryErrorGroups.ts
@@ -1,11 +1,13 @@
 import { createCron } from '@lowerdeck/cron';
 import { combineQueueProcessors, createQueue } from '@lowerdeck/queue';
 import { env } from '../env';
+import { PROVIDER_TELEMETRY_EXPORT_QUEUE_JOB_OPTIONS } from '../lib/providerTelemetryErrorGroupExport';
 import { providerTelemetryErrorGroupExportService } from '../services/providerTelemetryErrorGroupExport';
 
 export let providerTelemetryErrorGroupsExportQueue = createQueue<{}>({
   name: 'sub/ses/provider-error-groups/export',
   redisUrl: env.service.REDIS_URL,
+  jobOpts: PROVIDER_TELEMETRY_EXPORT_QUEUE_JOB_OPTIONS,
   workerOpts: {
     concurrency: 1
   }


### PR DESCRIPTION
Fix stuck telemetry export jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes export watermarking, paging, and object keys for a background telemetry pipeline; mistakes could skip or duplicate exports, though extensive tests and conservative defer/quarantine rules mitigate that.
> 
> **Overview**
> **Fixes stuck provider telemetry export jobs** by configuring the cron queue with **3 attempts** and **`removeOnFail: true`**, so a terminally failed job no longer blocks the static enqueue id.
> 
> The **failed-message export pipeline** is reworked for safer cursors and poison handling. Resume uses **`last_processed`** (exported or quarantined) ahead of legacy **`last_exported`**, stops using **`last_checked_at`** for the range start, and caps the scan window with a **2-minute visibility lag**. Listing now returns **per-error pages** (including **ungrouped** rows): recent ungrouped errors **defer** the run (cursor does not pass them); stale ungrouped errors are **quarantined** after a **4-hour** grace period.
> 
> **Presentation/redaction failures** are quarantined to **`.jsonl`** objects (no payload leakage) with **Sentry** warnings while the run continues; **infrastructure errors** fail the run **without** advancing state. **Mid-run state checkpoints**, **idempotent** chunk/quarantine writes, and richer **`last_run`** metadata are added; tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e534531099f4f833eeab41d4b5b89d978cec64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->