### PR TITLE
Fix scm issues

### DIFF
--- a/src/cargo/modules/skill/src/services/skillMarketplace.ts
+++ b/src/cargo/modules/skill/src/services/skillMarketplace.ts
@@ -359,6 +359,12 @@ class SkillMarketplaceServiceImpl {
         }
       });
 
+      await db.skillMarketplaceRepository.deleteMany({
+        where: {
+          skillMarketplaceOid: d.skillMarketplace.oid
+        }
+      });
+
       await db.skillMarketplace.update({
         where: {
           id: d.skillMarketplace.id

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/_layout.tsx
@@ -8,7 +8,7 @@ import {
   useCurrentProject,
   useSkillMarketplace
 } from '@metorial/state';
-import { Button, Flex, LinkTabs, toast } from '@metorial/ui';
+import { Button, Callout, Flex, LinkTabs, Spacer, toast } from '@metorial/ui';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import { useInterval } from 'react-use';
 
@@ -132,15 +132,15 @@ export let SkillMarketplaceLayout = () => {
               ]}
             />
 
-            {/* {marketplace.data?.syncStatus !== 'synced' && (
+            {marketplace.data?.syncStatus !== 'synced' && (
               <>
                 <Callout color="blue">
                   <span>
-                    <strong>Upcoming changes:</strong> Plugins or skills linked to this
-                    marketplace have changed. Metorial is processing these changes and updating
-                    the marketplace.
+                    <strong>Upcoming changes:</strong> Plugins, skills, or configurations
+                    linked to this marketplace have changed. Metorial is processing these
+                    changes and updating the marketplace. This can take a few minutes.
                   </span>
-                  {marketplace.data?.syncStatus === 'pending' && (
+                  {/* {marketplace.data?.syncStatus === 'pending' && (
                     <Button
                       size="2"
                       loading={syncMarketplace.isLoading}
@@ -149,12 +149,12 @@ export let SkillMarketplaceLayout = () => {
                     >
                       Sync Now
                     </Button>
-                  )}
+                  )} */}
                 </Callout>
 
                 <Spacer height={20} />
               </>
-            )} */}
+            )}
 
             <Outlet />
           </>

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
@@ -8,7 +8,7 @@ import {
   useCurrentProject,
   useSkillPlugin
 } from '@metorial/state';
-import { Button, Flex, LinkTabs, toast } from '@metorial/ui';
+import { Button, Callout, Flex, LinkTabs, Spacer, toast } from '@metorial/ui';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import { useInterval } from 'react-use';
 
@@ -128,15 +128,15 @@ export let SkillPluginLayout = () => {
               ]}
             />
 
-            {/* {plugin.data?.syncStatus !== 'synced' && (
+            {plugin.data?.syncStatus !== 'synced' && (
               <>
                 <Callout color="blue">
                   <span>
                     <strong>Upcoming changes:</strong> Skills or configurations linked to this
                     plugin have changed. Metorial is processing these changes and updating the
-                    plugin.
+                    plugin. This can take a few minutes.
                   </span>
-                  {plugin.data?.syncStatus === 'pending' && (
+                  {/* {plugin.data?.syncStatus === 'pending' && (
                     <Button
                       size="2"
                       loading={syncPlugin.isLoading}
@@ -145,12 +145,12 @@ export let SkillPluginLayout = () => {
                     >
                       Sync Now
                     </Button>
-                  )}
+                  )} */}
                 </Callout>
 
                 <Spacer height={20} />
               </>
-            )} */}
+            )}
 
             <Outlet />
           </>

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
@@ -8,7 +8,7 @@ import {
   useCurrentProject,
   useSkillPlugin
 } from '@metorial/state';
-import { Button, Callout, Flex, LinkTabs, Spacer, toast } from '@metorial/ui';
+import { Button, Flex, LinkTabs, toast } from '@metorial/ui';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import { useInterval } from 'react-use';
 
@@ -128,7 +128,7 @@ export let SkillPluginLayout = () => {
               ]}
             />
 
-            {plugin.data?.syncStatus !== 'synced' && (
+            {/* {plugin.data?.syncStatus !== 'synced' && (
               <>
                 <Callout color="blue">
                   <span>
@@ -150,7 +150,7 @@ export let SkillPluginLayout = () => {
 
                 <Spacer height={20} />
               </>
-            )}
+            )} */}
 
             <Outlet />
           </>

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/skills/marketplaceGrid.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/skills/marketplaceGrid.tsx
@@ -46,7 +46,7 @@ export let SkillMarketplacesGrid = (
   let navigate = useNavigate();
   let marketplaces = useSkillMarketplaces(instanceId, {
     order: 'desc',
-    status: ['active', 'archived'],
+    status: ['active'],
     ...query
   });
   let hasActiveFilters = !!(

--- a/src/metorial/modules/subspace/src/services/skill.ts
+++ b/src/metorial/modules/subspace/src/services/skill.ts
@@ -180,6 +180,18 @@ export let syncSkillFromSubspace = async (d: {
     }
   });
 
+  if (skill.status === 'archived') {
+    await db.skillGroupItem.updateMany({
+      where: {
+        skillOid: skill.oid,
+        status: 'active'
+      },
+      data: {
+        status: 'archived'
+      }
+    });
+  }
+
   if (!existingSkill && skill.status == 'active') {
     await Fabric.fire('skill.created:after', {
       instance: d.instance,

--- a/src/origin/apps/service/src/lib/gitlab.test.ts
+++ b/src/origin/apps/service/src/lib/gitlab.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  db: {
+    scmInstallation: {
+      findUnique: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}));
+
+vi.mock('../db', () => ({ db: mocks.db }));
+
+import { getGitLabAccessTokenWithInstallation } from './gitlab';
+
+let createInstallation = (overrides: Record<string, unknown> = {}) =>
+  ({
+    oid: 42n,
+    accessToken: 'old-access-token',
+    refreshToken: 'old-refresh-token',
+    accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    backend: {
+      webUrl: 'https://gitlab.example.com',
+      clientId: 'client-id',
+      clientSecret: 'client-secret'
+    },
+    ...overrides
+  }) as any;
+
+describe('GitLab installation access tokens', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.db.scmInstallation.findUnique.mockReset();
+    mocks.db.scmInstallation.update.mockReset();
+  });
+
+  it('uses a token that is not close to expiring', async () => {
+    let fetch = vi.spyOn(globalThis, 'fetch');
+    let installation = createInstallation();
+
+    await expect(getGitLabAccessTokenWithInstallation(installation)).resolves.toBe(
+      'old-access-token'
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.db.scmInstallation.update).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a near-expiry token and persists rotated credentials', async () => {
+    let fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          token_type: 'Bearer',
+          expires_in: 7200
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    let installation = createInstallation({
+      accessTokenExpiresAt: new Date(Date.now() + 4 * 60 * 1000)
+    });
+
+    await expect(getGitLabAccessTokenWithInstallation(installation)).resolves.toBe(
+      'new-access-token'
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://gitlab.example.com/oauth/token',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          client_id: 'client-id',
+          client_secret: 'client-secret',
+          refresh_token: 'old-refresh-token',
+          grant_type: 'refresh_token'
+        })
+      })
+    );
+    expect(mocks.db.scmInstallation.update).toHaveBeenCalledWith({
+      where: { oid: 42n },
+      data: {
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        accessTokenExpiresAt: expect.any(Date)
+      }
+    });
+  });
+
+  it('uses credentials persisted by a concurrent refresh winner', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    mocks.db.scmInstallation.findUnique.mockResolvedValue({
+      accessToken: 'winner-access-token',
+      refreshToken: 'winner-refresh-token',
+      accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000)
+    });
+    let installation = createInstallation({ accessTokenExpiresAt: new Date(0) });
+
+    await expect(getGitLabAccessTokenWithInstallation(installation)).resolves.toBe(
+      'winner-access-token'
+    );
+    expect(mocks.db.scmInstallation.findUnique).toHaveBeenCalledWith({
+      where: { oid: 42n }
+    });
+  });
+
+  it('surfaces an invalid refresh token when no concurrent refresh won', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    mocks.db.scmInstallation.findUnique.mockResolvedValue({
+      accessToken: 'old-access-token',
+      refreshToken: 'old-refresh-token',
+      accessTokenExpiresAt: new Date(0)
+    });
+    let installation = createInstallation({ accessTokenExpiresAt: new Date(0) });
+
+    await expect(getGitLabAccessTokenWithInstallation(installation)).rejects.toMatchObject({
+      data: { status: 401, code: 'unauthorized' }
+    });
+  });
+});

--- a/src/origin/apps/service/src/lib/gitlab.ts
+++ b/src/origin/apps/service/src/lib/gitlab.ts
@@ -1,10 +1,18 @@
 import { Gitlab } from '@gitbeaker/rest';
-import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, ServiceError, unauthorizedError } from '@lowerdeck/error';
 import type { ScmBackend, ScmInstallation } from '../../prisma/generated/client';
 import { db } from '../db';
 import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
 
 type GitLabClient = InstanceType<typeof Gitlab>;
+type GitLabInstallation = ScmInstallation & { backend: ScmBackend };
+type GitLabCredentials = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: Date;
+};
+
+let tokenRefreshes = new Map<bigint, Promise<GitLabCredentials>>();
 
 export let createGitLabClient = (backend?: ScmBackend): GitLabClient => {
   let host = backend?.webUrl ?? 'https://gitlab.com';
@@ -143,25 +151,34 @@ export let refreshGitLabAccessToken = async (i: {
 };
 
 export let createGitLabClientWithInstallation = async (
-  installation: ScmInstallation & { backend: ScmBackend }
+  installation: GitLabInstallation
 ): Promise<GitLabClient> => {
-  if (!installation.accessToken) {
-    throw new ServiceError(badRequestError({ message: 'Access token not found' }));
+  let accessToken = await getGitLabAccessTokenWithInstallation(installation);
+  return createGitLabClientWithToken(accessToken, installation.backend);
+};
+
+let tokenNeedsRefresh = (expiresAt: Date | null) => {
+  let refreshBuffer = new Date(Date.now() + 5 * 60 * 1000);
+  return !expiresAt || expiresAt < refreshBuffer;
+};
+
+let refreshGitLabInstallationCredentials = async (
+  installation: GitLabInstallation
+): Promise<GitLabCredentials> => {
+  if (!installation.refreshToken) {
+    throw new ServiceError(
+      unauthorizedError({
+        message: 'GitLab authentication expired. Reconnect the GitLab integration.'
+      })
+    );
   }
 
-  // Check if token is expired or will expire in the next 5 minutes
-  let now = new Date();
-  let bufferTime = new Date(now.getTime() + 5 * 60 * 1000);
-  let needsRefresh = !installation.accessTokenExpiresAt || installation.accessTokenExpiresAt < bufferTime;
-
-  if (needsRefresh && installation.refreshToken) {
-    // Refresh the token
+  try {
     let refreshed = await refreshGitLabAccessToken({
       backend: installation.backend,
       refreshToken: installation.refreshToken
     });
 
-    // Update the installation in the database
     await db.scmInstallation.update({
       where: { oid: installation.oid },
       data: {
@@ -171,10 +188,51 @@ export let createGitLabClientWithInstallation = async (
       }
     });
 
-    // Use the new token
-    return createGitLabClientWithToken(refreshed.accessToken, installation.backend);
+    return refreshed;
+  } catch (error) {
+    // GitLab rotates refresh tokens. A concurrent worker may have refreshed first,
+    // making this request's refresh token invalid. Prefer the winner's credentials.
+    let current = await db.scmInstallation.findUnique({
+      where: { oid: installation.oid }
+    });
+    if (
+      current?.accessToken &&
+      current.refreshToken &&
+      !tokenNeedsRefresh(current.accessTokenExpiresAt) &&
+      (current.accessToken !== installation.accessToken ||
+        current.refreshToken !== installation.refreshToken)
+    ) {
+      return {
+        accessToken: current.accessToken,
+        refreshToken: current.refreshToken,
+        expiresAt: current.accessTokenExpiresAt!
+      };
+    }
+
+    throw error;
+  }
+};
+
+export let getGitLabAccessTokenWithInstallation = async (
+  installation: GitLabInstallation
+): Promise<string> => {
+  if (!installation.accessToken) {
+    throw new ServiceError(badRequestError({ message: 'Access token not found' }));
   }
 
-  // Token is still valid, use it
-  return createGitLabClientWithToken(installation.accessToken, installation.backend);
+  if (!tokenNeedsRefresh(installation.accessTokenExpiresAt)) return installation.accessToken;
+
+  let refresh = tokenRefreshes.get(installation.oid);
+  if (!refresh) {
+    refresh = refreshGitLabInstallationCredentials(installation);
+    tokenRefreshes.set(installation.oid, refresh);
+    let clearRefresh = () => {
+      if (tokenRefreshes.get(installation.oid) === refresh) {
+        tokenRefreshes.delete(installation.oid);
+      }
+    };
+    void refresh.then(clearRefresh, clearRefresh);
+  }
+
+  return (await refresh).accessToken;
 };

--- a/src/origin/apps/service/src/lib/scmProviderError.test.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.test.ts
@@ -5,6 +5,7 @@ import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
 describe('SCM provider errors', () => {
   it.each([
     [{ status: 401 }, 401, 'unauthorized'],
+    [{ cause: { response: { status: 401 } } }, 401, 'unauthorized'],
     [{ response: { status: 403 } }, 403, 'forbidden'],
     [{ cause: { response: { statusCode: 404 } } }, 404, 'not_found'],
     [{ status: 409 }, 409, 'conflict'],

--- a/src/origin/apps/service/src/lib/scmProviderError.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.ts
@@ -10,11 +10,17 @@ import {
   tooManyRequestsError,
   unauthorizedError
 } from '@lowerdeck/error';
+import { getSentry } from '@lowerdeck/sentry';
+
+let Sentry = getSentry();
 
 type ScmProvider = 'github' | 'gitlab';
 
 export let getScmProviderErrorStatus = (error: any): number | undefined =>
-  error?.status ?? error?.response?.status ?? error?.cause?.response?.statusCode;
+  error?.status ??
+  error?.response?.status ??
+  error?.cause?.response?.status ??
+  error?.cause?.response?.statusCode;
 
 let providerName = (provider: ScmProvider) => (provider === 'github' ? 'GitHub' : 'GitLab');
 
@@ -24,6 +30,9 @@ export let wrapScmProviderError = (
   operation: string
 ): ServiceError<any> => {
   if (isServiceError(error)) return error;
+
+  console.error(`SCM provider error (${provider}):`, error);
+  Sentry.captureException(error);
 
   let status = getScmProviderErrorStatus(error);
   let prefix = `${providerName(provider)} could not ${operation}`;
@@ -35,14 +44,25 @@ export let wrapScmProviderError = (
         : status === 403
           ? forbiddenError({ message: `${prefix} because the integration lacks permission.` })
           : status === 404
-            ? notFoundError({ entity: 'SCM provider resource', message: `${prefix}: resource not found.` })
+            ? notFoundError({
+                entity: 'SCM provider resource',
+                message: `${prefix}: resource not found.`
+              })
             : status === 409
-              ? conflictError({ message: `${prefix} because the resource already exists or changed.` })
+              ? conflictError({
+                  message: `${prefix} because the resource already exists or changed.`
+                })
               : status === 429
-                ? tooManyRequestsError({ message: `${prefix} because the provider rate limit was reached.` })
+                ? tooManyRequestsError({
+                    message: `${prefix} because the provider rate limit was reached.`
+                  })
                 : status === 408 || status === 504
-                  ? timeoutError({ message: `${prefix} because the provider request timed out.` })
-                  : internalServerError({ message: `${prefix} due to an upstream provider error.` });
+                  ? timeoutError({
+                      message: `${prefix} because the provider request timed out.`
+                    })
+                  : internalServerError({
+                      message: `${prefix} due to an upstream provider error.`
+                    });
 
   let serviceError = new ServiceError(mapped);
   if (error instanceof Error) serviceError.setParent(error);

--- a/src/origin/apps/service/src/lib/scmRepositorySyncProvider.test.ts
+++ b/src/origin/apps/service/src/lib/scmRepositorySyncProvider.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createGitLabClientWithToken } from './gitlab';
+import { createGitLabClientWithInstallation } from './gitlab';
 import {
   createRepositorySyncBranch,
   getRepositorySyncCiState,
@@ -7,14 +7,14 @@ import {
 } from './scmRepositorySyncProvider';
 
 vi.mock('./gitlab', () => ({
-  createGitLabClientWithToken: vi.fn()
+  createGitLabClientWithInstallation: vi.fn()
 }));
 
 vi.mock('./githubApp', () => ({
   createGitHubInstallationClient: vi.fn()
 }));
 
-let createGitLabClient = vi.mocked(createGitLabClientWithToken);
+let createGitLabClient = vi.mocked(createGitLabClientWithInstallation);
 
 let createSync = () =>
   ({
@@ -52,7 +52,7 @@ describe('GitLab repository sync', () => {
       }
     };
     createGitLabClient.mockReset();
-    createGitLabClient.mockReturnValue(gitlab);
+    createGitLabClient.mockResolvedValue(gitlab);
   });
 
   it.each([{ response: { status: 400 } }, { cause: { response: { statusCode: 409 } } }])(

--- a/src/origin/apps/service/src/lib/scmRepositorySyncProvider.ts
+++ b/src/origin/apps/service/src/lib/scmRepositorySyncProvider.ts
@@ -6,7 +6,7 @@ import type {
   ScmRepositorySync
 } from '../../prisma/generated/client';
 import { createGitHubInstallationClient } from './githubApp';
-import { createGitLabClientWithToken } from './gitlab';
+import { createGitLabClientWithInstallation } from './gitlab';
 import { getScmProviderErrorStatus } from './scmProviderError';
 
 type SyncWithRepo = ScmRepositorySync & {
@@ -30,16 +30,8 @@ let getGitHubClient = async (repo: SyncWithRepo['repo']) => {
   );
 };
 
-let getGitLabClient = (repo: SyncWithRepo['repo']) => {
-  if (!repo.installation.accessToken) {
-    throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-  }
-
-  return createGitLabClientWithToken(
-    repo.installation.accessToken,
-    repo.installation.backend
-  ) as any;
-};
+let getGitLabClient = async (repo: SyncWithRepo['repo']) =>
+  (await createGitLabClientWithInstallation(repo.installation)) as any;
 
 let isGitHubEmptyRepositoryError = (e: any) =>
   e.status === 409 &&
@@ -373,7 +365,7 @@ export let createRepositorySyncBranch = async (sync: SyncWithRepo) => {
   }
 
   if (sync.repo.provider === 'gitlab') {
-    let gitlab = getGitLabClient(sync.repo);
+    let gitlab = await getGitLabClient(sync.repo);
 
     try {
       await gitlab.Branches.create(
@@ -470,7 +462,7 @@ export let cleanupRepositorySyncBranchIfNoChanges = async (
   }
 
   if (sync.repo.provider === 'gitlab') {
-    let gitlab = getGitLabClient(sync.repo);
+    let gitlab = await getGitLabClient(sync.repo);
 
     logGitLabSyncDebug('checking sync branch for changes', {
       syncId: sync.id,
@@ -638,7 +630,7 @@ export let createRepositorySyncPullRequest = async (
   }
 
   if (sync.repo.provider === 'gitlab') {
-    let gitlab = getGitLabClient(sync.repo);
+    let gitlab = await getGitLabClient(sync.repo);
 
     try {
       logGitLabSyncDebug('creating merge request', {
@@ -787,7 +779,7 @@ export let getRepositorySyncCiState = async (
   }
 
   if (sync.repo.provider === 'gitlab') {
-    let gitlab = getGitLabClient(sync.repo);
+    let gitlab = await getGitLabClient(sync.repo);
     logGitLabSyncDebug('loading CI state', {
       syncId: sync.id,
       repoId: sync.repo.id,
@@ -803,9 +795,13 @@ export let getRepositorySyncCiState = async (
           ref: sync.branchName,
           perPage: 1
         }),
-        gitlab.MergeRequests.show(parseInt(sync.repo.externalId), parseInt(sync.providerPrId!), {
-          withMergeStatusRecheck: true
-        })
+        gitlab.MergeRequests.show(
+          parseInt(sync.repo.externalId),
+          parseInt(sync.providerPrId!),
+          {
+            withMergeStatusRecheck: true
+          }
+        )
       ]);
     } catch (e: any) {
       logGitLabSyncError('failed to load CI state', e, {
@@ -958,7 +954,7 @@ export let mergeRepositorySyncPullRequest = async (
   }
 
   if (sync.repo.provider === 'gitlab') {
-    let gitlab = getGitLabClient(sync.repo);
+    let gitlab = await getGitLabClient(sync.repo);
     logGitLabSyncDebug('merging merge request', {
       syncId: sync.id,
       repoId: sync.repo.id,

--- a/src/origin/apps/service/src/queues/codeBucket/exportGitlab.ts
+++ b/src/origin/apps/service/src/queues/codeBucket/exportGitlab.ts
@@ -3,6 +3,7 @@ import Long from 'long';
 import { db } from '../../db';
 import { env } from '../../env';
 import { codeBucketClient } from '../../lib/codeWorkspace';
+import { getGitLabAccessTokenWithInstallation } from '../../lib/gitlab';
 import { codeBucketService } from '../../services/codeBucket';
 
 export let exportGitlabQueue = createQueue<{
@@ -22,14 +23,9 @@ export let exportGitlabQueueProcessor = exportGitlabQueue.process(async data => 
     include: { installation: { include: { backend: true } } }
   });
 
-  if (!repo.installation.accessToken) {
-    throw new Error('Access token not found');
-  }
-
   await codeBucketService.waitForCodeBucketReady({ codeBucketId: data.bucketId });
 
-  // Use GitLab access token
-  let token = repo.installation.accessToken;
+  let token = await getGitLabAccessTokenWithInstallation(repo.installation);
   let apiUrl = repo.installation.backend.apiUrl;
 
   await codeBucketClient.exportBucketToGitlab({

--- a/src/origin/apps/service/src/queues/codeBucket/importGitlab.ts
+++ b/src/origin/apps/service/src/queues/codeBucket/importGitlab.ts
@@ -4,6 +4,7 @@ import Long from 'long';
 import { db } from '../../db';
 import { env } from '../../env';
 import { codeBucketClient } from '../../lib/codeWorkspace';
+import { getGitLabAccessTokenWithInstallation } from '../../lib/gitlab';
 
 export let importGitlabQueue = createQueue<{
   newBucketId: string;
@@ -23,12 +24,7 @@ export let importGitlabQueueProcessor = importGitlabQueue.process(async data => 
     include: { installation: { include: { backend: true } } }
   });
 
-  if (!repo.installation.accessToken) {
-    throw new Error('Access token not found');
-  }
-
-  // Use GitLab access token
-  let token = repo.installation.accessToken;
+  let token = await getGitLabAccessTokenWithInstallation(repo.installation);
   let apiUrl = repo.installation.backend.apiUrl;
 
   await codeBucketClient.createBucketFromGitlab({

--- a/src/origin/apps/service/src/queues/scm/createRepoWebhook.ts
+++ b/src/origin/apps/service/src/queues/scm/createRepoWebhook.ts
@@ -4,7 +4,7 @@ import { db } from '../../db';
 import { env } from '../../env';
 import { ID } from '../../id';
 import { createGitHubInstallationClient } from '../../lib/githubApp';
-import { createGitLabClientWithToken } from '../../lib/gitlab';
+import { createGitLabClientWithInstallation } from '../../lib/gitlab';
 
 export let createRepoWebhookQueue = createQueue<{ repoId: string }>({
   name: 'ori/rep/wh-cr',
@@ -146,14 +146,7 @@ export let createRepoWebhookQueueProcessor = createRepoWebhookQueue.process(asyn
   }
 
   if (repo.provider === 'gitlab') {
-    if (!repo.installation.accessToken) {
-      throw new Error('Access token not found');
-    }
-
-    let gitlab = createGitLabClientWithToken(
-      repo.installation.accessToken,
-      repo.installation.backend
-    );
+    let gitlab = await createGitLabClientWithInstallation(repo.installation);
 
     try {
       let hook = await gitlab.ProjectHooks.add(

--- a/src/origin/apps/service/src/queues/scm/repositorySync/waitForCi.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/waitForCi.ts
@@ -10,7 +10,7 @@ import {
 } from './_lib';
 import { mergeRepositorySyncQueue } from './merge';
 
-export let waitForCiRepositorySyncQueue = createQueue<{ syncId: string }>({
+export let waitForCiRepositorySyncQueue = createQueue<{ syncId: string; index?: number }>({
   name: 'ori/rep-sync/wait-ci',
   redisUrl: env.service.REDIS_URL
 });
@@ -22,6 +22,8 @@ export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.
         syncId: data.syncId,
         expectedStatus: 'waiting_for_ci'
       });
+
+      let index = data.index ?? 0;
 
       let sync = await db.scmRepositorySync.findFirst({
         where: {
@@ -70,7 +72,8 @@ export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.
       });
 
       if (ciState === 'pending') {
-        let nextPollAt = new Date(now.getTime() + 60_000);
+        let delay = index < 10 ? 20_000 : index < 100 ? 60_000 : 1000_000;
+        let nextPollAt = new Date(now.getTime() + delay);
 
         await db.scmRepositorySync.update({
           where: { oid: sync.oid },
@@ -82,7 +85,10 @@ export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.
         });
         await appendRepositorySyncLog(sync.id, 'Checks are still running.');
 
-        await waitForCiRepositorySyncQueue.add({ syncId: data.syncId }, { delay: 60_000 });
+        await waitForCiRepositorySyncQueue.add(
+          { syncId: data.syncId, index: index + 1 },
+          { delay }
+        );
         logRepositorySyncQueueEvent('waitForCi', 'CI still pending; requeued poll', {
           syncId: sync.id,
           nextPollAt: nextPollAt.toISOString()

--- a/src/origin/apps/service/src/services/codeBucket.ts
+++ b/src/origin/apps/service/src/services/codeBucket.ts
@@ -8,6 +8,7 @@ import { db } from '../db';
 import { getId } from '../id';
 import { codeBucketClient } from '../lib/codeWorkspace';
 import { getInstallationAccessToken } from '../lib/githubApp';
+import { getGitLabAccessTokenWithInstallation } from '../lib/gitlab';
 import { normalizePath } from '../lib/normalizePath';
 import { cloneBucketQueue } from '../queues/codeBucket/cloneBucket';
 import { copyFromToBucketQueue } from '../queues/codeBucket/copyFromToBucket';
@@ -305,15 +306,13 @@ class codeBucketServiceImpl {
     }
 
     if (repo.provider === 'gitlab') {
-      if (!repo.installation.accessToken) {
-        throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-      }
+      let token = await getGitLabAccessTokenWithInstallation(repo.installation);
 
       await codeBucketClient.exportBucketToGitlab({
         bucketId: d.codeBucket.id,
         projectId: Long.fromString(repo.externalId),
         path: d.path,
-        token: repo.installation.accessToken,
+        token,
         gitlabApiUrl: repo.installation.backend.apiUrl,
         branch,
         commitMessage

--- a/src/origin/apps/service/src/services/scmAuth.ts
+++ b/src/origin/apps/service/src/services/scmAuth.ts
@@ -11,6 +11,7 @@ import {
   getGitLabOAuthUrl
 } from '../lib/gitlab';
 import { withScmProviderError } from '../lib/scmProviderError';
+import { scmInstallationSessionService } from './scmInstallationSession';
 
 class scmAuthServiceImpl {
   async getAuthorizationUrl(i: {
@@ -240,10 +241,9 @@ class scmAuthServiceImpl {
         }
       });
 
-      // Complete the installation session
-      await db.scmInstallationSession.update({
-        where: { id: session.id },
-        data: { installationOid: createdInstallation.oid }
+      await scmInstallationSessionService.completeInstallationSession({
+        sessionId: session.id,
+        installationOid: createdInstallation.oid
       });
 
       return createdInstallation;
@@ -337,10 +337,9 @@ class scmAuthServiceImpl {
         }
       });
 
-      // Complete the installation session
-      await db.scmInstallationSession.update({
-        where: { id: session.id },
-        data: { installationOid: createdInstallation.oid }
+      await scmInstallationSessionService.completeInstallationSession({
+        sessionId: session.id,
+        installationOid: createdInstallation.oid
       });
 
       return createdInstallation;

--- a/src/origin/apps/service/src/services/scmInstallationSession.test.ts
+++ b/src/origin/apps/service/src/services/scmInstallationSession.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ScmBackend } from '../../prisma/generated/client';
+
+let mocks = vi.hoisted(() => ({
+  db: {
+    $transaction: vi.fn()
+  },
+  tx: {
+    scmInstallationSession: {
+      findUniqueOrThrow: vi.fn(),
+      updateMany: vi.fn(),
+      update: vi.fn()
+    },
+    scmBackendSetupSession: {
+      findUniqueOrThrow: vi.fn(),
+      updateMany: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}));
+
+vi.mock('../db', () => ({ db: mocks.db }));
+
+import { scmInstallationSessionService } from './scmInstallationSession';
+
+describe('SCM session completion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.db.$transaction.mockImplementation(async complete => await complete(mocks.tx));
+  });
+
+  it('reassigns an installation from an older session', async () => {
+    mocks.tx.scmInstallationSession.findUniqueOrThrow.mockResolvedValue({
+      id: 'new-session',
+      installationOid: null,
+      installation: null
+    });
+    mocks.tx.scmInstallationSession.update.mockResolvedValue({
+      id: 'new-session',
+      installationOid: 42n,
+      installation: { oid: 42n }
+    });
+
+    await scmInstallationSessionService.completeInstallationSession({
+      sessionId: 'new-session',
+      installationOid: 42n
+    });
+
+    expect(mocks.tx.scmInstallationSession.updateMany).toHaveBeenCalledWith({
+      where: { installationOid: 42n, id: { not: 'new-session' } },
+      data: { installationOid: null }
+    });
+    expect(mocks.tx.scmInstallationSession.update).toHaveBeenCalledWith({
+      where: { id: 'new-session' },
+      data: { installationOid: 42n },
+      include: { installation: true }
+    });
+  });
+
+  it('does not rewrite an already-completed installation session', async () => {
+    let completedSession = {
+      id: 'session',
+      installationOid: 42n,
+      installation: { oid: 42n }
+    };
+    mocks.tx.scmInstallationSession.findUniqueOrThrow.mockResolvedValue(completedSession);
+
+    await expect(
+      scmInstallationSessionService.completeInstallationSession({
+        sessionId: 'session',
+        installationOid: 42n
+      })
+    ).resolves.toBe(completedSession);
+
+    expect(mocks.tx.scmInstallationSession.updateMany).not.toHaveBeenCalled();
+    expect(mocks.tx.scmInstallationSession.update).not.toHaveBeenCalled();
+  });
+
+  it('retries when another callback claims the installation concurrently', async () => {
+    mocks.tx.scmInstallationSession.findUniqueOrThrow.mockResolvedValue({
+      id: 'session',
+      installationOid: null,
+      installation: null
+    });
+    mocks.tx.scmInstallationSession.update.mockResolvedValue({
+      id: 'session',
+      installationOid: 42n,
+      installation: { oid: 42n }
+    });
+    mocks.db.$transaction
+      .mockImplementationOnce(async complete => {
+        await complete(mocks.tx);
+        throw { code: 'P2002' };
+      })
+      .mockImplementationOnce(async complete => await complete(mocks.tx));
+
+    await expect(
+      scmInstallationSessionService.completeInstallationSession({
+        sessionId: 'session',
+        installationOid: 42n
+      })
+    ).resolves.toMatchObject({ installationOid: 42n });
+
+    expect(mocks.db.$transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('reassigns a backend setup session using the same semantics', async () => {
+    mocks.tx.scmBackendSetupSession.findUniqueOrThrow.mockResolvedValue({
+      id: 'new-session',
+      backendOid: null,
+      backend: null
+    });
+    mocks.tx.scmBackendSetupSession.update.mockResolvedValue({
+      id: 'new-session',
+      backendOid: 7n,
+      backend: { oid: 7n }
+    });
+
+    await scmInstallationSessionService.completeBackendSetupSession({
+      sessionId: 'new-session',
+      backend: { oid: 7n } as ScmBackend
+    });
+
+    expect(mocks.tx.scmBackendSetupSession.updateMany).toHaveBeenCalledWith({
+      where: { backendOid: 7n, id: { not: 'new-session' } },
+      data: { backendOid: null }
+    });
+  });
+});

--- a/src/origin/apps/service/src/services/scmInstallationSession.ts
+++ b/src/origin/apps/service/src/services/scmInstallationSession.ts
@@ -11,6 +11,11 @@ import type {
 import { db } from '../db';
 import { getId } from '../id';
 
+type ScmSessionTransaction = Pick<
+  typeof db,
+  'scmInstallationSession' | 'scmBackendSetupSession'
+>;
+
 class ScmInstallationSessionServiceImpl {
   async createInstallationSession(d: { tenant: Tenant; actor: Actor; redirectUrl?: string }) {
     let state = randomBytes(32).toString('hex');
@@ -81,10 +86,27 @@ class ScmInstallationSessionServiceImpl {
   }
 
   async completeInstallationSession(d: { sessionId: string; installationOid: bigint }) {
-    await db.scmInstallationSession.update({
-      where: { id: d.sessionId },
-      data: { installationOid: d.installationOid },
-      include: { installation: true }
+    return await this.completeSessionWithRetry(async tx => {
+      let session = await tx.scmInstallationSession.findUniqueOrThrow({
+        where: { id: d.sessionId },
+        include: { installation: true }
+      });
+
+      if (session.installationOid === d.installationOid) return session;
+
+      await tx.scmInstallationSession.updateMany({
+        where: {
+          installationOid: d.installationOid,
+          id: { not: d.sessionId }
+        },
+        data: { installationOid: null }
+      });
+
+      return await tx.scmInstallationSession.update({
+        where: { id: d.sessionId },
+        data: { installationOid: d.installationOid },
+        include: { installation: true }
+      });
     });
   }
 
@@ -146,11 +168,46 @@ class ScmInstallationSessionServiceImpl {
   }
 
   async completeBackendSetupSession(d: { sessionId: string; backend: ScmBackend }) {
-    await db.scmBackendSetupSession.update({
-      where: { id: d.sessionId },
-      data: { backendOid: d.backend.oid },
-      include: { backend: true }
+    return await this.completeSessionWithRetry(async tx => {
+      let session = await tx.scmBackendSetupSession.findUniqueOrThrow({
+        where: { id: d.sessionId },
+        include: { backend: true }
+      });
+
+      if (session.backendOid === d.backend.oid) return session;
+
+      await tx.scmBackendSetupSession.updateMany({
+        where: {
+          backendOid: d.backend.oid,
+          id: { not: d.sessionId }
+        },
+        data: { backendOid: null }
+      });
+
+      return await tx.scmBackendSetupSession.update({
+        where: { id: d.sessionId },
+        data: { backendOid: d.backend.oid },
+        include: { backend: true }
+      });
     });
+  }
+
+  private async completeSessionWithRetry<T>(
+    complete: (tx: ScmSessionTransaction) => Promise<T>
+  ): Promise<T> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        return await db.$transaction(complete);
+      } catch (error) {
+        if (attempt === 1 || !this.isUniqueConstraintError(error)) throw error;
+      }
+    }
+
+    throw new Error('Unreachable');
+  }
+
+  private isUniqueConstraintError(error: unknown) {
+    return typeof error === 'object' && error !== null && 'code' in error && error.code === 'P2002';
   }
 
   async getAvailableBackends(d: { tenant: Tenant }): Promise<ScmBackend[]> {

--- a/src/origin/apps/service/src/services/scmRepo.test.ts
+++ b/src/origin/apps/service/src/services/scmRepo.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGitLabClientWithInstallation } from '../lib/gitlab';
+
+vi.mock('../db', () => ({ db: {} }));
+vi.mock('../lib/githubApp', () => ({ createGitHubInstallationClient: vi.fn() }));
+vi.mock('../lib/gitlab', () => ({
+  createGitLabClientWithInstallation: vi.fn()
+}));
+vi.mock('../queues/scm/createRepoWebhook', () => ({
+  createRepoWebhookQueue: { add: vi.fn() }
+}));
+vi.mock('../queues/scm/handleRepoPush', () => ({
+  createHandleRepoPushQueue: { add: vi.fn() }
+}));
+
+import { scmRepoService } from './scmRepo';
+
+let createGitLabClient = vi.mocked(createGitLabClientWithInstallation);
+
+describe('SCM repository GitLab authentication', () => {
+  beforeEach(() => {
+    createGitLabClient.mockReset();
+  });
+
+  it('uses the installation-aware client when listing GitLab groups', async () => {
+    let gitlab = {
+      Groups: {
+        all: vi.fn().mockResolvedValue([
+          { id: 8, path: 'metorial', full_path: 'metorial' }
+        ])
+      },
+      Users: {
+        showCurrentUser: vi.fn().mockResolvedValue({
+          id: 6,
+          namespaceId: 7,
+          username: 'tobias'
+        })
+      },
+      Namespaces: {
+        all: vi.fn().mockResolvedValue([])
+      }
+    };
+    createGitLabClient.mockResolvedValue(gitlab as any);
+    let installation = {
+      provider: 'gitlab',
+      backend: { webUrl: 'https://gitlab.com' }
+    } as any;
+
+    await scmRepoService.listAccountPreviews({ installation });
+
+    expect(createGitLabClient).toHaveBeenCalledWith(installation);
+    expect(gitlab.Groups.all).toHaveBeenCalledWith({
+      minAccessLevel: 30,
+      perPage: 100
+    });
+  });
+});

--- a/src/origin/apps/service/src/services/scmRepo.ts
+++ b/src/origin/apps/service/src/services/scmRepo.ts
@@ -11,7 +11,7 @@ import type {
 import { db } from '../db';
 import { getId } from '../id';
 import { createGitHubInstallationClient } from '../lib/githubApp';
-import { createGitLabClientWithToken } from '../lib/gitlab';
+import { createGitLabClientWithInstallation } from '../lib/gitlab';
 import {
   getGitLabNamespaceId,
   getGitLabPersonalNamespaceId,
@@ -45,13 +45,7 @@ class scmRepoServiceImpl {
     }
 
     if (i.installation.provider == 'gitlab') {
-      if (!i.installation.accessToken) {
-        throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-      }
-      let gitlab = createGitLabClientWithToken(
-        i.installation.accessToken,
-        i.installation.backend
-      );
+      let gitlab = await createGitLabClientWithInstallation(i.installation);
 
       // Only show group namespaces where the token can normally create projects.
       let groups = await withScmProviderError('gitlab', 'list groups', () =>
@@ -142,13 +136,7 @@ class scmRepoServiceImpl {
     }
 
     if (i.installation.provider == 'gitlab') {
-      if (!i.installation.accessToken) {
-        throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-      }
-      let gitlab = createGitLabClientWithToken(
-        i.installation.accessToken,
-        i.installation.backend
-      );
+      let gitlab = await createGitLabClientWithInstallation(i.installation);
 
       let allProjects: any[] = [];
       let user = await withScmProviderError('gitlab', 'load the authenticated user', () =>
@@ -239,13 +227,7 @@ class scmRepoServiceImpl {
     }
 
     if (i.installation.provider == 'gitlab') {
-      if (!i.installation.accessToken) {
-        throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-      }
-      let gitlab = createGitLabClientWithToken(
-        i.installation.accessToken,
-        i.installation.backend
-      );
+      let gitlab = await createGitLabClientWithInstallation(i.installation);
 
       let hostname = new URL(i.installation.backend.webUrl).hostname;
       let projectPath = `${i.owner}/${i.repo}`;
@@ -374,13 +356,7 @@ class scmRepoServiceImpl {
     }
 
     if (i.installation.provider == 'gitlab') {
-      if (!i.installation.accessToken) {
-        throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-      }
-      let gitlab = createGitLabClientWithToken(
-        i.installation.accessToken,
-        i.installation.backend
-      );
+      let gitlab = await createGitLabClientWithInstallation(i.installation);
 
       let project = await withScmProviderError('gitlab', 'load the repository', () =>
         gitlab.Projects.show(parseInt(i.externalId))
@@ -515,13 +491,7 @@ class scmRepoServiceImpl {
     }
 
     if (i.installation.provider == 'gitlab') {
-      if (!i.installation.accessToken) {
-        throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-      }
-      let gitlab = createGitLabClientWithToken(
-        i.installation.accessToken,
-        i.installation.backend
-      );
+      let gitlab = await createGitLabClientWithInstallation(i.installation);
 
       let namespaceId = getGitLabNamespaceId(i.externalAccountId);
 
@@ -903,10 +873,7 @@ class scmRepoServiceImpl {
         where: { oid: i.repo.installationOid },
         include: { backend: true }
       });
-      if (!installation.accessToken) {
-        throw new ServiceError(badRequestError({ message: 'Access token not found' }));
-      }
-      let gitlab = createGitLabClientWithToken(installation.accessToken, installation.backend);
+      let gitlab = await createGitLabClientWithInstallation(installation);
 
       try {
         let commits = await gitlab.Commits.all(parseInt(i.repo.externalId), {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes GitLab OAuth refresh, credential persistence, and many SCM call sites; session completion touches install callbacks and DB uniqueness—security-sensitive but covered by new unit tests.
> 
> **Overview**
> **GitLab SCM** now refreshes OAuth tokens through a shared `getGitLabAccessTokenWithInstallation` path instead of using stored access tokens directly. Refreshes are deduplicated per installation, persisted to the DB, and when refresh fails because GitLab rotated tokens concurrently, the code re-reads the installation and uses the winner’s credentials. Repo sync, webhooks, code-bucket import/export, and `scmRepo` all route through installation-aware clients.
> 
> **OAuth session completion** is transactional: completing an install or backend-setup session clears the same installation/backend from older sessions, is idempotent when already linked, and retries once on unique-constraint races. GitHub/GitLab callbacks use this helper instead of a bare session update.
> 
> **Repository sync CI polling** uses backoff (20s → 60s → ~16.7m) via a queue `index` instead of a fixed 60s delay. SCM provider errors gain nested `cause.response.status` mapping plus Sentry/console logging.
> 
> **Skills:** archiving a marketplace deletes linked `skillMarketplaceRepository` rows; subspace skill sync archives active `skillGroupItem` rows when a skill is archived. Dashboard shows sync “upcoming changes” callouts again (manual “Sync Now” commented out), and the marketplace grid lists **active** marketplaces only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2c4929760f2ef151e5e2cf2799768d33161670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->