### PR TITLE
Fix cargo test

### DIFF
--- a/src/cargo/service/src/controllers/tests/skill.e2e.test.ts
+++ b/src/cargo/service/src/controllers/tests/skill.e2e.test.ts
@@ -2325,7 +2325,7 @@ describe('cargo skill.e2e', () => {
       comment: {
         id: comment.id,
         actor: { id: forkReader.id },
-        body: 'Please take the fork version with an edit.',
+        body: '[DELETED]',
         deletedAt: expect.any(Date)
       }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only expectation change; no runtime behavior modified.
> 
> **Overview**
> Updates the skill merge-request e2e assertion so **commented** events on deleted comments expect `body: '[DELETED]'` instead of the original text.
> 
> That matches how merge-request comments are presented when `deletedAt` is set (the test deletes the comment before listing events). **No production code changes** in this diff—test-only alignment with existing presenter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4eae808ab70655e41c46373c973eff7214d806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->