### PR TITLE
Fix file upload

### DIFF
--- a/clients/metorial-dashboard/src/sdk.ts
+++ b/clients/metorial-dashboard/src/sdk.ts
@@ -498,8 +498,11 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
 
       console.log('Uploading file with body:', Object.fromEntries(body.entries()));
 
+      let base = manager.apiHost;
+      if (!base.endsWith('/')) base += '/';
+
       try {
-        let res = await fetch(`${manager.apiHost}files`, {
+        let res = await fetch(`${base}files`, {
           method: 'POST',
           body,
           headers: manager.getHeaders(manager.config),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small URL-construction fix in the dashboard SDK upload helper with no auth or data-model changes.
> 
> **Overview**
> Fixes broken dashboard **file uploads** when `apiHost` is configured without a trailing slash.
> 
> The custom `files.upload` helper now ensures `manager.apiHost` ends with `/` before building the `POST` URL (`…/files`), instead of concatenating `apiHost` and `files` directly (which could produce invalid hosts like `https://api.example.comfiles`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d45a8cfeffecbd35c58dd7f36ac5acc77dfcc7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->