### PR TITLE
Improve ares tokens

### DIFF
--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -4,7 +4,7 @@ import {
   notFoundError,
   ServiceError
 } from '@lowerdeck/error';
-import { generateCode } from '@lowerdeck/id';
+import { generateCode, generateCustomId } from '@lowerdeck/id';
 import { Service } from '@lowerdeck/service';
 import { addMinutes, subMinutes } from 'date-fns';
 import type {
@@ -155,7 +155,7 @@ class AuthServiceImpl {
       let authIntent = await tdb.authIntent.create({
         data: {
           ...getId('authIntent'),
-          clientSecret: getId('authIntent').id,
+          clientSecret: generateCustomId('ait_sec_'),
 
           type: 'email_code',
 
@@ -340,7 +340,7 @@ class AuthServiceImpl {
     let authIntent = await db.authIntent.create({
       data: {
         ...getId('authIntent'),
-        clientSecret: getId('authIntent').id,
+        clientSecret: generateCustomId('ait_sec_'),
 
         type: 'oauth',
         userIdentityOid: userIdentity.oid,
@@ -761,7 +761,7 @@ class AuthServiceImpl {
       return await tdb.authAttempt.create({
         data: {
           ...getId('authAttempt'),
-          clientSecret: getId('authAttempt').id,
+          clientSecret: generateCustomId('aat_sec_'),
 
           status: 'pending',
 

--- a/src/ares/service/src/services/device.ts
+++ b/src/ares/service/src/services/device.ts
@@ -1,5 +1,5 @@
 import { ServiceError, unauthorizedError } from '@lowerdeck/error';
-import { generatePlainId } from '@lowerdeck/id';
+import { generateCustomId, generatePlainId } from '@lowerdeck/id';
 import { addMinutes, addWeeks } from 'date-fns';
 import type {
   App,
@@ -237,7 +237,7 @@ class DeviceService {
     return await db.authDevice.create({
       data: {
         ...getId('authDevice'),
-        clientSecret: getId('authDevice').id,
+        clientSecret: generateCustomId('adv_sec_'),
 
         ip: d.context.ip,
         ua: d.context.ua,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication credential issuance; existing sessions keep old secrets, but any client or test that assumed secret equals public id will break for new entities.
> 
> **Overview**
> **Auth `clientSecret` values are no longer copied from the public record `id`.** New auth intents, auth attempts, and devices now get independent secrets from `generateCustomId` with typed prefixes (`ait_sec_`, `aat_sec_`, `adv_sec_`).
> 
> Lookup still pairs **public id + client secret** (e.g. `getAuthIntent`, `getAuthAttempt`, device bootstrap), so clients must keep sending both; only the secret’s shape and entropy change for **newly created** rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62bb903c6bd42efd55d9aaf3062be79cfd873b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->