### PR TITLE
Add sso redirects

### DIFF
--- a/src/ares/service/src/apis/auth/endpoints/hooks.ts
+++ b/src/ares/service/src/apis/auth/endpoints/hooks.ts
@@ -9,6 +9,7 @@ import { validateRedirectUrl } from '../../../lib/validateRedirectUrl';
 import { authService } from '../../../services/auth';
 import { deviceService } from '../../../services/device';
 import { ssoAuthService } from '../../../services/sso/auth';
+import { ssoLoginService } from '../../../services/sso/login';
 import { ssoTenantService } from '../../../services/sso/tenant';
 import { resolveApp } from '../lib/resolveApp';
 import { baseCookieOpts, SESSION_ID_COOKIE_NAME } from '../middleware/device';
@@ -213,26 +214,14 @@ export let authHooksApp = createHono()
       .trim();
     let ua = ctx.req.header('user-agent') ?? '';
 
-    let authAttempt = await authService.authWithSso({
-      ssoUser: {
-        email: userProfile.email,
-        firstName: userProfile.firstName,
-        lastName: userProfile.lastName
-      },
-      ssoConnectionId: connection.id,
-      ssoUid: userProfile.uid,
-      ssoTenant: tenant,
-      ssoUserProfile: userProfile,
-      context: { ip, ua },
-      redirectUrl: stateData.redirectUrl,
+    let { authAttempt, session } = await ssoLoginService.completeLogin({
+      tenant,
+      connection,
+      userProfile,
+      app,
       device,
-      app
-    });
-
-    validateRedirectUrl(authAttempt.redirectUrl, app.redirectDomains);
-
-    let session = await deviceService.exchangeAuthAttemptForSession({
-      authAttempt
+      context: { ip, ua },
+      redirectUrl: stateData.redirectUrl
     });
 
     ctx.res.headers.append(

--- a/src/ares/service/src/apis/sso/endpoints/jxn.ts
+++ b/src/ares/service/src/apis/sso/endpoints/jxn.ts
@@ -1,5 +1,17 @@
 import { createHono } from '@lowerdeck/hono';
+import * as Cookies from 'cookie';
+import { db } from '../../../db';
+import { getSamlConnectionDefaultRedirectUrl } from '../../../lib/ssoRedirect';
+import { deviceService } from '../../../services/device';
+import { ssoIdentityService } from '../../../services/sso/identity';
+import { ssoLoginService } from '../../../services/sso/login';
 import { jackson } from '../../../lib/jackson';
+import {
+  baseCookieOpts,
+  DEVICE_TOKEN_COOKIE_NAME,
+  parseDeviceToken,
+  SESSION_ID_COOKIE_NAME
+} from '../../auth/middleware/device';
 import { errorHtml } from '../pages/error';
 
 export let jxnApp = createHono()
@@ -33,6 +45,156 @@ export let jxnApp = createHono()
     }
 
     return c.redirect(res.redirect_url);
+  })
+  .get('/saml/callback', async c => {
+    try {
+      let code = c.req.query('code');
+      let tenantId = c.req.query('tenant_id');
+      let connectionId = c.req.query('connection_id');
+      if (!code || (!!tenantId !== !!connectionId)) {
+        return c.html(
+          errorHtml({
+            title: 'Authentication Error',
+            message: 'Invalid IdP-initiated SAML response.'
+          })
+        );
+      }
+
+      let connections = await db.ssoConnection.findMany({
+        where: {
+          id: connectionId,
+          tenant: tenantId ? { id: tenantId, status: 'completed' } : { status: 'completed' },
+          providerType: 'saml',
+          status: 'active'
+        },
+        include: {
+          tenant: {
+            include: { app: true }
+          }
+        }
+      });
+      if (connections.length === 0) {
+        return c.html(
+          errorHtml({
+            title: 'Authentication Error',
+            message: 'SSO connection is not available.'
+          })
+        );
+      }
+
+      let authenticated:
+        | {
+            connection: (typeof connections)[number];
+            accessToken: string;
+          }
+        | undefined;
+      for (let connection of connections) {
+        try {
+          let tokenRes = await jackson.oauthController.token({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri:
+              tenantId && connectionId
+                ? getSamlConnectionDefaultRedirectUrl({
+                    callbackUrl: jackson.defaultRedirectUrl.saml,
+                    tenantId,
+                    connectionId
+                  })
+                : jackson.defaultRedirectUrl.saml,
+            client_id: connection.internalClientId,
+            client_secret: connection.internalClientSecret
+          });
+          if (tokenRes.access_token) {
+            authenticated = { connection, accessToken: tokenRes.access_token };
+            break;
+          }
+        } catch {
+          // A Jackson code is scoped to one connection. Failed exchanges are expected
+          // while resolving legacy callbacks that predate tenant-bound redirects.
+        }
+      }
+      if (!authenticated) {
+        return c.html(
+          errorHtml({
+            title: 'Authentication Error',
+            message: 'Metorial could not verify your SAML response.'
+          })
+        );
+      }
+
+      let { connection, accessToken } = authenticated;
+      let userInfo = await jackson.oauthController.userInfo(accessToken);
+      let user = await ssoIdentityService.upsertUser({
+        tenant: connection.tenant,
+        email: userInfo.email,
+        firstName: userInfo.firstName,
+        lastName: userInfo.lastName
+      });
+      let userProfile = await ssoIdentityService.upsertUserProfile({
+        tenant: connection.tenant,
+        connection,
+        user,
+        data: {
+          email: userInfo.email,
+          uid: userInfo.id,
+          uidHash: userInfo.idHash,
+          sub: userInfo.sub,
+          firstName: userInfo.firstName,
+          lastName: userInfo.lastName,
+          roles: userInfo.roles ?? [],
+          groups: userInfo.groups ?? [],
+          raw: userInfo.raw
+        }
+      });
+
+      let cookieHeader = c.req.header('cookie') ?? '';
+      let deviceToken = Cookies.parse(cookieHeader)[DEVICE_TOKEN_COOKIE_NAME];
+      let deviceInfo = deviceToken ? parseDeviceToken(deviceToken) : null;
+      let ip = (c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? '')
+        .split(',')[0]!
+        .trim();
+      let ua = c.req.header('user-agent') ?? '';
+      let device = await deviceService.ensureDevice({
+        deviceId: deviceInfo?.deviceId,
+        deviceClientSecret: deviceInfo?.deviceClientSecret,
+        context: { ip, ua }
+      });
+
+      let { authAttempt, session } = await ssoLoginService.completeLogin({
+        tenant: connection.tenant,
+        connection,
+        userProfile,
+        app: connection.tenant.app,
+        device,
+        context: { ip, ua },
+        redirectUrl: connection.tenant.app.defaultRedirectUrl
+      });
+
+      let redirectUrl = new URL(authAttempt.redirectUrl);
+      redirectUrl.searchParams.set('code', session.authorizationCode);
+
+      let res = c.redirect(redirectUrl.toString());
+      res.headers.append(
+        'Set-Cookie',
+        Cookies.serialize(
+          DEVICE_TOKEN_COOKIE_NAME,
+          `${device.id}:${device.clientSecret}`,
+          baseCookieOpts
+        )
+      );
+      res.headers.append(
+        'Set-Cookie',
+        Cookies.serialize(SESSION_ID_COOKIE_NAME, session.id, baseCookieOpts)
+      );
+      return res;
+    } catch {
+      return c.html(
+        errorHtml({
+          title: 'Authentication Error',
+          message: 'Metorial could not authenticate you.'
+        })
+      );
+    }
   })
   .get('/oidc/callback', async c => {
     let code = c.req.query('code') || '';

--- a/src/ares/service/src/lib/ssoRedirect.test.ts
+++ b/src/ares/service/src/lib/ssoRedirect.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getSamlConnectionDefaultRedirectUrl } from './ssoRedirect';
+
+describe('getSamlConnectionDefaultRedirectUrl', () => {
+  it('binds the Jackson default redirect to its tenant and connection', () => {
+    let redirectUrl = new URL(
+      getSamlConnectionDefaultRedirectUrl({
+        callbackUrl: 'https://sso.example.com/sso/jxn/saml/callback',
+        tenantId: 'tenant_123',
+        connectionId: 'connection_123'
+      })
+    );
+
+    expect(redirectUrl.pathname).toBe('/sso/jxn/saml/callback');
+    expect(redirectUrl.searchParams.get('tenant_id')).toBe('tenant_123');
+    expect(redirectUrl.searchParams.get('connection_id')).toBe('connection_123');
+  });
+
+  it('replaces untrusted existing tenant context', () => {
+    let redirectUrl = new URL(
+      getSamlConnectionDefaultRedirectUrl({
+        callbackUrl:
+          'https://sso.example.com/sso/jxn/saml/callback?tenant_id=attacker&connection_id=attacker',
+        tenantId: 'tenant_123',
+        connectionId: 'connection_123'
+      })
+    );
+
+    expect(redirectUrl.searchParams.get('tenant_id')).toBe('tenant_123');
+    expect(redirectUrl.searchParams.get('connection_id')).toBe('connection_123');
+  });
+});

--- a/src/ares/service/src/lib/ssoRedirect.ts
+++ b/src/ares/service/src/lib/ssoRedirect.ts
@@ -1,0 +1,10 @@
+export let getSamlConnectionDefaultRedirectUrl = (d: {
+  callbackUrl: string;
+  tenantId: string;
+  connectionId: string;
+}) => {
+  let defaultRedirectUrl = new URL(d.callbackUrl);
+  defaultRedirectUrl.searchParams.set('tenant_id', d.tenantId);
+  defaultRedirectUrl.searchParams.set('connection_id', d.connectionId);
+  return defaultRedirectUrl.toString();
+};

--- a/src/ares/service/src/services/sso/connection.ts
+++ b/src/ares/service/src/services/sso/connection.ts
@@ -11,6 +11,7 @@ import type {
 import { db } from '../../db';
 import { getId } from '../../id';
 import { jackson } from '../../lib/jackson';
+import { getSamlConnectionDefaultRedirectUrl } from '../../lib/ssoRedirect';
 import { enqueueDisableSsoDirectoryUsers } from '../../queues/disableSsoDirectoryUsers';
 
 let ssoConnectionInclude = {
@@ -30,12 +31,18 @@ class SsoConnectionServiceImpl {
       samlMetadata: { type: 'xml'; payload: string } | { type: 'url'; url: string };
     };
   }) {
+    let connectionId = getId('ssoConnection');
+
     let con = await jackson.apiController.createSAMLConnection({
       product: 'metorial',
       tenant: d.tenant.id,
       name: d.input.name,
       redirectUrl: jackson.redirectUrl,
-      defaultRedirectUrl: jackson.defaultRedirectUrl.saml,
+      defaultRedirectUrl: getSamlConnectionDefaultRedirectUrl({
+        callbackUrl: jackson.defaultRedirectUrl.saml,
+        tenantId: d.tenant.id,
+        connectionId: connectionId.id
+      }),
       rawMetadata:
         d.input.samlMetadata.type === 'xml' ? d.input.samlMetadata.payload : undefined!,
       metadataUrl: d.input.samlMetadata.type === 'url' ? d.input.samlMetadata.url : undefined
@@ -50,7 +57,7 @@ class SsoConnectionServiceImpl {
 
     return await db.ssoConnection.create({
       data: {
-        ...getId('ssoConnection'),
+        ...connectionId,
         tenantOid: d.tenant.oid,
         internalId: con.clientID,
         internalClientId: con.clientID,

--- a/src/ares/service/src/services/sso/login.ts
+++ b/src/ares/service/src/services/sso/login.ts
@@ -1,0 +1,55 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import type {
+  App,
+  AuthDevice,
+  SsoConnection,
+  SsoTenant,
+  SsoUserProfile
+} from '../../../prisma/generated/client';
+import { validateRedirectUrl } from '../../lib/validateRedirectUrl';
+import { authService } from '../auth';
+import { deviceService } from '../device';
+
+class SsoLoginServiceImpl {
+  async completeLogin(d: {
+    tenant: SsoTenant;
+    connection: SsoConnection;
+    userProfile: SsoUserProfile;
+    app: App;
+    device: AuthDevice;
+    context: { ip: string; ua: string };
+    redirectUrl: string;
+  }) {
+    if (d.tenant.appOid !== d.app.oid && !d.tenant.isGlobal) {
+      throw new ServiceError(
+        badRequestError({ message: 'SSO tenant does not belong to this app' })
+      );
+    }
+
+    let authAttempt = await authService.authWithSso({
+      ssoUser: {
+        email: d.userProfile.email,
+        firstName: d.userProfile.firstName,
+        lastName: d.userProfile.lastName
+      },
+      ssoConnectionId: d.connection.id,
+      ssoUid: d.userProfile.uid,
+      ssoTenant: d.tenant,
+      ssoUserProfile: d.userProfile,
+      context: d.context,
+      redirectUrl: d.redirectUrl,
+      device: d.device,
+      app: d.app
+    });
+
+    validateRedirectUrl(authAttempt.redirectUrl, d.app.redirectDomains);
+
+    let session = await deviceService.exchangeAuthAttemptForSession({
+      authAttempt
+    });
+
+    return { authAttempt, session };
+  }
+}
+
+export let ssoLoginService = new SsoLoginServiceImpl();

--- a/src/metorial/apis/custom-portal/src/controllers/auth.ts
+++ b/src/metorial/apis/custom-portal/src/controllers/auth.ts
@@ -9,11 +9,11 @@ import {
 } from '../lib/cookies';
 import { portalPresenter, sessionPresenter } from '../presenters';
 import {
-  assertPortalAuthState,
   getPortalSsoAuthorizationCodeOrThrow,
   getPortalSessionFromCookie,
   issuePortalTokens
 } from '../lib/portal';
+import { assertPortalAuthStateOrAllowIdpInitiated } from '../lib/portalAuthState';
 
 export let authController = portalFromIdApp.controller({
   boot: portalFromIdApp
@@ -108,9 +108,9 @@ export let authController = portalFromIdApp.controller({
         code: ctx.input.code
       });
 
-      assertPortalAuthState({
+      assertPortalAuthStateOrAllowIdpInitiated({
         ctx,
-        portal: ctx.portal,
+        surfaceId: ctx.portal.surface.id,
         state: ctx.input.state
       });
 
@@ -118,7 +118,7 @@ export let authController = portalFromIdApp.controller({
         context: ctx.context,
         surface: ctx.portal.surface,
         code,
-        state: ctx.input.state!
+        state: ctx.input.state
       });
       clearPortalAuthStateCookie({
         ctx,

--- a/src/metorial/apis/custom-portal/src/lib/portal.test.ts
+++ b/src/metorial/apis/custom-portal/src/lib/portal.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { assertPortalAuthStateOrAllowIdpInitiated } from './portalAuthState';
+
+describe('assertPortalAuthStateOrAllowIdpInitiated', () => {
+  it('allows an IdP-initiated callback without state or a pending cookie', () => {
+    expect(
+      assertPortalAuthStateOrAllowIdpInitiated({
+        ctx: { getCookie: () => undefined },
+        surfaceId: 'surface_123'
+      })
+    ).toBe(false);
+  });
+
+  it('allows an IdP-initiated callback when a stale state cookie exists', () => {
+    expect(
+      assertPortalAuthStateOrAllowIdpInitiated({
+        ctx: { getCookie: () => 'pending-state' },
+        surfaceId: 'surface_123'
+      })
+    ).toBe(false);
+  });
+
+  it('continues to require an exact state match', () => {
+    expect(() =>
+      assertPortalAuthStateOrAllowIdpInitiated({
+        ctx: { getCookie: () => 'pending-state' },
+        surfaceId: 'surface_123',
+        state: 'other-state'
+      })
+    ).toThrow();
+  });
+});

--- a/src/metorial/apis/custom-portal/src/lib/portal.ts
+++ b/src/metorial/apis/custom-portal/src/lib/portal.ts
@@ -14,7 +14,6 @@ import {
 } from '@metorial/module-consumer';
 import {
   clearPortalSessionCookie,
-  getAuthStateCookieName,
   getSessionCookieName,
   setPortalSessionCookie
 } from './cookies';
@@ -117,29 +116,6 @@ export let getPortalSessionFromCookie = async (d: {
     }
 
     throw err;
-  }
-};
-
-export let getPortalAuthStateFromCookie = (d: {
-  ctx: Pick<ServiceRequest, 'getCookie'>;
-  portal: PortalWithSurface;
-}) => {
-  return d.ctx.getCookie(getAuthStateCookieName(d.portal.surface.id));
-};
-
-export let assertPortalAuthState = (d: {
-  ctx: Pick<ServiceRequest, 'getCookie'>;
-  portal: PortalWithSurface;
-  state?: string | null;
-}) => {
-  let expectedState = getPortalAuthStateFromCookie(d);
-
-  if (!d.state || !expectedState || d.state != expectedState) {
-    throw new ServiceError(
-      unauthorizedError({
-        message: 'Portal SSO state is invalid or has expired.'
-      })
-    );
   }
 };
 

--- a/src/metorial/apis/custom-portal/src/lib/portalAuthState.ts
+++ b/src/metorial/apis/custom-portal/src/lib/portalAuthState.ts
@@ -1,0 +1,25 @@
+import { ServiceError, unauthorizedError } from '@lowerdeck/error';
+import type { ServiceRequest } from '@lowerdeck/rpc-server';
+import { getAuthStateCookieName } from './cookies';
+
+export let assertPortalAuthStateOrAllowIdpInitiated = (d: {
+  ctx: Pick<ServiceRequest, 'getCookie'>;
+  surfaceId: string;
+  state?: string | null;
+}) => {
+  let expectedState = d.ctx.getCookie(getAuthStateCookieName(d.surfaceId));
+
+  if (d.state !== undefined && d.state !== null) {
+    if (!d.state || !expectedState || d.state != expectedState) {
+      throw new ServiceError(
+        unauthorizedError({
+          message: 'Portal SSO state is invalid or has expired.'
+        })
+      );
+    }
+
+    return true;
+  }
+
+  return false;
+};

--- a/src/metorial/modules/cargo-sync/src/queue.ts
+++ b/src/metorial/modules/cargo-sync/src/queue.ts
@@ -18,7 +18,7 @@ export let cargoSyncQueueProcessor = cargoSyncQueue.process(async data => {
 export let cargoSyncCron = createCron(
   {
     name: 'cargo/sync/cron',
-    cron: '0 16 * * *'
+    cron: '0 9 * * *'
   },
   async () => {
     let runId = cargoSyncRunId();

--- a/src/metorial/modules/consumer/src/services/consumers/consumerAuth.ts
+++ b/src/metorial/modules/consumer/src/services/consumers/consumerAuth.ts
@@ -383,11 +383,38 @@ class ConsumerAuthServiceImpl {
     context: Context;
     surface: ConsumerSurface;
     code: string;
-    state: string;
+    state?: string;
   }) {
     let consumerAuthTenant = await this.getConsumerAuthTenantOrThrow({
       surface: d.surface
     });
+
+    if (d.state === undefined) {
+      let { user, session: aresSession } = await consumerAresService.exchangeOAuthCode({
+        clientId: consumerAuthTenant.aresClientId,
+        code: d.code
+      });
+      let email = user.email;
+      let name = this.getAresUserName({ user });
+
+      await this.assertEmailCanAccessSurface({
+        surface: d.surface,
+        email
+      });
+
+      let { session } = await this.materializeAresConsumerSession({
+        context: d.context,
+        surface: d.surface,
+        consumerAuthTenant,
+        aresSessionId: aresSession.id,
+        aresUserId: user.id,
+        email,
+        name
+      });
+
+      return { session };
+    }
+
     let authExchange = await this.getAuthExchangeOrThrow({
       surface: d.surface,
       state: d.state
@@ -436,6 +463,10 @@ class ConsumerAuthServiceImpl {
       name = this.getAresUserName({
         user
       });
+    }
+
+    if (!aresSessionId || !aresUserId || !email || !name) {
+      throw new Error('Invalid Ares auth exchange');
     }
 
     await this.assertEmailCanAccessSurface({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches SAML/OAuth login, redirect binding, and relaxed portal state checks for IdP-initiated flows—security-sensitive authentication paths with new callback behavior.
> 
> **Overview**
> Adds **IdP-initiated SAML** completion on a new **GET** `/sso/jxn/saml/callback` path: exchange the Jackson `code`, resolve the connection (including legacy callbacks without `tenant_id`/`connection_id`), upsert identity, run shared **`ssoLoginService.completeLogin`**, set device/session cookies, and redirect with an OAuth `code`.
> 
> **Tenant-bound SAML redirects:** new SAML connections register a default redirect URL with trusted `tenant_id` and `connection_id` query params (`getSamlConnectionDefaultRedirectUrl`), and token exchange uses that URI when both are present.
> 
> **Shared login path:** SP-initiated SSO hooks and the SAML GET callback both call **`ssoLoginService.completeLogin`** instead of duplicating `authWithSso` + redirect validation + session exchange.
> 
> **Portal IdP-initiated SSO:** portal SSO completion allows missing `state` (no CSRF cookie required); when `state` is sent, validation is unchanged. **`authenticateWithAresCode`** exchanges the Ares code directly when `state` is omitted.
> 
> Also shifts the **cargo-sync** daily cron from 16:00 to 09:00 UTC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc3d828eb8c618afd8c7d34310eeb4f1e984f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->