### PR TITLE
Harden repository loading

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/scm/repos/preview.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/scm/repos/preview.ts
@@ -9,6 +9,7 @@ export type DashboardInstanceScmReposPreviewOutput = {
     name: string;
     identifier: string;
   }[];
+  nextCursor?: string | undefined;
 };
 
 export let mapDashboardInstanceScmReposPreviewOutput =
@@ -25,12 +26,15 @@ export let mapDashboardInstanceScmReposPreviewOutput =
           identifier: mtMap.objectField('identifier', mtMap.passthrough())
         })
       )
-    )
+    ),
+    nextCursor: mtMap.objectField('next_cursor', mtMap.passthrough())
   });
 
 export type DashboardInstanceScmReposPreviewBody = {
   installationId: string;
   externalAccountId?: string | undefined;
+  cursor?: string | undefined;
+  limit?: number | undefined;
 };
 
 export let mapDashboardInstanceScmReposPreviewBody =
@@ -39,6 +43,8 @@ export let mapDashboardInstanceScmReposPreviewBody =
     externalAccountId: mtMap.objectField(
       'external_account_id',
       mtMap.passthrough()
-    )
+    ),
+    cursor: mtMap.objectField('cursor', mtMap.passthrough()),
+    limit: mtMap.objectField('limit', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/scm/repos/preview.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/scm/repos/preview.ts
@@ -9,6 +9,7 @@ export type ManagementInstanceScmReposPreviewOutput = {
     name: string;
     identifier: string;
   }[];
+  nextCursor?: string | undefined;
 };
 
 export let mapManagementInstanceScmReposPreviewOutput =
@@ -25,12 +26,15 @@ export let mapManagementInstanceScmReposPreviewOutput =
           identifier: mtMap.objectField('identifier', mtMap.passthrough())
         })
       )
-    )
+    ),
+    nextCursor: mtMap.objectField('next_cursor', mtMap.passthrough())
   });
 
 export type ManagementInstanceScmReposPreviewBody = {
   installationId: string;
   externalAccountId?: string | undefined;
+  cursor?: string | undefined;
+  limit?: number | undefined;
 };
 
 export let mapManagementInstanceScmReposPreviewBody =
@@ -39,6 +43,8 @@ export let mapManagementInstanceScmReposPreviewBody =
     externalAccountId: mtMap.objectField(
       'external_account_id',
       mtMap.passthrough()
-    )
+    ),
+    cursor: mtMap.objectField('cursor', mtMap.passthrough()),
+    limit: mtMap.objectField('limit', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/scm/repos/preview.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/scm/repos/preview.ts
@@ -9,6 +9,7 @@ export type ScmReposPreviewOutput = {
     name: string;
     identifier: string;
   }[];
+  nextCursor?: string | undefined;
 };
 
 export let mapScmReposPreviewOutput = mtMap.object<ScmReposPreviewOutput>({
@@ -24,12 +25,15 @@ export let mapScmReposPreviewOutput = mtMap.object<ScmReposPreviewOutput>({
         identifier: mtMap.objectField('identifier', mtMap.passthrough())
       })
     )
-  )
+  ),
+  nextCursor: mtMap.objectField('next_cursor', mtMap.passthrough())
 });
 
 export type ScmReposPreviewBody = {
   installationId: string;
   externalAccountId?: string | undefined;
+  cursor?: string | undefined;
+  limit?: number | undefined;
 };
 
 export let mapScmReposPreviewBody = mtMap.object<ScmReposPreviewBody>({
@@ -37,6 +41,8 @@ export let mapScmReposPreviewBody = mtMap.object<ScmReposPreviewBody>({
   externalAccountId: mtMap.objectField(
     'external_account_id',
     mtMap.passthrough()
-  )
+  ),
+  cursor: mtMap.objectField('cursor', mtMap.passthrough()),
+  limit: mtMap.objectField('limit', mtMap.passthrough())
 });
 

--- a/src/metorial-frontend/packages/state/src/custom-provider/loaders/repos.ts
+++ b/src/metorial-frontend/packages/state/src/custom-provider/loaders/repos.ts
@@ -23,9 +23,7 @@ export let useScmInstallations = (
   query?: DashboardInstanceScmInstallationListQuery
 ) => {
   let data = usePaginator(pagination =>
-    scmInstallationsLoader.use(
-      instanceId ? { instanceId, ...pagination, ...query } : null
-    )
+    scmInstallationsLoader.use(instanceId ? { instanceId, ...pagination, ...query } : null)
   );
 
   return data;
@@ -119,12 +117,23 @@ export let useResolveScmRepository = scmInstallationsLoader.createExternalMutato
           installationAccounts.flatMap(({ installation, accounts }) =>
             accounts.map(async account => ({
               installation,
-              repositories: (
-                await sdk.scm.repos.preview(i.instanceId, {
-                  installationId: installation.id,
-                  externalAccountId: account.externalId
-                })
-              ).repos
+              repositories: await (async () => {
+                let cursor: string | undefined;
+                let repositories: Awaited<ReturnType<typeof sdk.scm.repos.preview>>['repos'] =
+                  [];
+
+                while (true) {
+                  let page = await sdk.scm.repos.preview(i.instanceId, {
+                    installationId: installation.id,
+                    externalAccountId: account.externalId,
+                    cursor,
+                    limit: 50
+                  });
+                  repositories.push(...page.repos);
+                  if (!page.nextCursor) return repositories;
+                  cursor = page.nextCursor;
+                }
+              })()
             }))
           )
         );
@@ -184,9 +193,7 @@ export let useScmAccounts = (
   instanceId: string | null | undefined,
   query?: DashboardInstanceScmAccountsPreviewBody
 ) => {
-  let data = scmAccountsLoader.use(
-    instanceId && query ? { instanceId, ...query } : null
-  );
+  let data = scmAccountsLoader.use(instanceId && query ? { instanceId, ...query } : null);
 
   return data;
 };
@@ -212,10 +219,7 @@ export let useScmConnections = (instanceId: string | null | undefined) => {
 };
 
 export let useCreateScmConnection = scmConnectionsLoader.createExternalMutator(
-  (i: {
-    instanceId: string;
-    redirectUrl?: string;
-  }) =>
+  (i: { instanceId: string; redirectUrl?: string }) =>
     withAuth(sdk =>
       sdk.scm.connections.create(i.instanceId, {
         redirectUrl: i.redirectUrl

--- a/src/metorial-frontend/packages/ui/src/popover/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/popover/index.tsx
@@ -1,7 +1,7 @@
 import * as RadixPopover from '@radix-ui/react-popover';
 import React, { useEffect, useState } from 'react';
 import { keyframes, styled } from 'styled-components';
-import { useZindex } from '../dialog/state';
+import { useDialogContext, useZindex } from '../dialog/state';
 import { theme } from '../theme';
 
 let fadeInTop = keyframes`
@@ -184,6 +184,7 @@ let Root = ({
   operationKey?: string;
 }) => {
   let [open, setOpen] = useState(false);
+  let dialog = useDialogContext();
 
   useEffect(() => {
     setOpen(false);
@@ -203,7 +204,7 @@ let Root = ({
     <RadixPopover.Root open={open} onOpenChange={setOpen}>
       <RadixPopover.Trigger asChild>{trigger}</RadixPopover.Trigger>
 
-      <RadixPopover.Portal>
+      <RadixPopover.Portal container={dialog?.contentRef?.current}>
         <Wrapper
           style={{ zIndex }}
           side={side}

--- a/src/metorial-frontend/scenes/scm/src/repositoryPicker.tsx
+++ b/src/metorial-frontend/scenes/scm/src/repositoryPicker.tsx
@@ -38,6 +38,7 @@ import styled from 'styled-components';
 import {
   type ScmAccountSelection,
   type ScmInstallation,
+  type ScmRepositoryPreview,
   filterScmRepositories,
   formatScmProvider,
   getInstallationName,
@@ -136,8 +137,9 @@ let AccountMeta = styled.div`
 
 let AccountMenu = styled.div`
   width: min(600px, calc(100vw - 50px));
-  max-height: min(540px, calc(100vh - 180px));
-  overflow: auto;
+  max-height: min(540px, var(--radix-popover-content-available-height));
+  overflow-y: auto;
+  overscroll-behavior: contain;
 `;
 
 let AccountMenuTitle = styled.div`
@@ -485,6 +487,8 @@ export let ScmRepositoryPicker = (p: ScmRepositoryPickerProps) => {
   let [selectedAccount, setSelectedAccount] = useState<ScmAccountSelection | null>(null);
   let [accountMenuKey, setAccountMenuKey] = useState('initial');
   let [search, setSearch] = useState('');
+  let [previewCursor, setPreviewCursor] = useState<string | undefined>();
+  let [loadedRepos, setLoadedRepos] = useState<ScmRepositoryPreview[]>([]);
   let [view, setView] = useState<'repositories' | 'create'>('repositories');
   let [createName, setCreateName] = useState('');
   let [createVisibility, setCreateVisibility] = useState<'private' | 'public'>('private');
@@ -508,20 +512,46 @@ export let ScmRepositoryPicker = (p: ScmRepositoryPickerProps) => {
     selectedAccount
       ? {
           installationId: selectedAccount.installationId,
-          externalAccountId: selectedAccount.externalAccountId
+          externalAccountId: selectedAccount.externalAccountId,
+          cursor: previewCursor
         }
       : undefined
   );
 
+  useEffect(() => {
+    setPreviewCursor(undefined);
+    setLoadedRepos([]);
+  }, [selectedAccount?.installationId, selectedAccount?.externalAccountId]);
+
+  useEffect(() => {
+    let repoPage = repos.data;
+    if (!repoPage) return;
+    setLoadedRepos(current =>
+      previewCursor
+        ? [
+            ...current,
+            ...repoPage.repos.filter(
+              repo => !current.some(item => item.externalId == repo.externalId)
+            )
+          ]
+        : repoPage.repos
+    );
+  }, [repos.data, previewCursor]);
+
+  useEffect(() => {
+    if (!repos.data?.nextCursor || repos.isLoading) return;
+    setPreviewCursor(repos.data.nextCursor);
+  }, [repos.data?.nextCursor, repos.isLoading]);
+
   let filteredRepos = useMemo(
     () =>
       filterScmRepositories(
-        repos.data?.repos ?? [],
+        loadedRepos,
         search,
         p.excludedExternalRepoIds ?? [],
         p.excludedRepositoryIdentifiers ?? []
       ),
-    [repos.data?.repos, search, p.excludedExternalRepoIds, p.excludedRepositoryIdentifiers]
+    [loadedRepos, search, p.excludedExternalRepoIds, p.excludedRepositoryIdentifiers]
   );
   let publicRepository = useMemo(
     () =>
@@ -806,6 +836,8 @@ export let ScmRepositoryPicker = (p: ScmRepositoryPickerProps) => {
                             onSelect={account => {
                               setSelectedAccount(account);
                               setSearch('');
+                              setPreviewCursor(undefined);
+                              setLoadedRepos([]);
                               setAccountMenuKey(
                                 `${account.installationId}:${account.externalAccountId}`
                               );
@@ -920,84 +952,87 @@ export let ScmRepositoryPicker = (p: ScmRepositoryPickerProps) => {
               </EmptyState>
             )}
 
-            {selectedAccount
-              ? renderWithLoader(
-                  { repos },
-                  { spaceTop: 30 }
-                )(({ repos }) => (
-                  <>
-                    {(!publicRepository || filteredRepos.length > 0) && (
-                      <>
-                        <ResultMeta>
-                          <Text size="1" color="gray600">
-                            {filteredRepos.length}{' '}
-                            {filteredRepos.length == 1 ? 'repository' : 'repositories'}
-                          </Text>
-                          <Text size="1" color="gray600">
-                            {formatScmProvider(selectedAccount.provider)}
-                          </Text>
-                        </ResultMeta>
+            {selectedAccount ? (
+              repos.isLoading && loadedRepos.length == 0 ? (
+                <>
+                  <Spacer height={20} />
+                  <Text size="2" color="gray600">
+                    Loading repositories…
+                  </Text>
+                </>
+              ) : (
+                <>
+                  {(!publicRepository || filteredRepos.length > 0) && (
+                    <>
+                      <ResultMeta>
+                        <Text size="1" color="gray600">
+                          {filteredRepos.length}{' '}
+                          {filteredRepos.length == 1 ? 'repository' : 'repositories'}
+                        </Text>
+                        <Text size="1" color="gray600">
+                          {formatScmProvider(selectedAccount.provider)}
+                        </Text>
+                      </ResultMeta>
 
-                        <RepoList>
-                          {filteredRepos.map(repository => {
-                            let selected = repository.externalId == p.selectedExternalRepoId;
-                            return (
-                              <RepoItem
-                                key={repository.externalId}
-                                type="button"
-                                $selected={selected}
-                                disabled={createRepo.isLoading}
-                                onClick={() => selectRepository(repository.externalId)}
+                      <RepoList>
+                        {filteredRepos.map(repository => {
+                          let selected = repository.externalId == p.selectedExternalRepoId;
+                          return (
+                            <RepoItem
+                              key={repository.externalId}
+                              type="button"
+                              $selected={selected}
+                              disabled={createRepo.isLoading}
+                              onClick={() => selectRepository(repository.externalId)}
+                            >
+                              <RepoIcon>
+                                <RiGitRepositoryLine size={18} />
+                              </RepoIcon>
+                              <div style={{ minWidth: 0 }}>
+                                <RepoTitle>{repository.identifier}</RepoTitle>
+                                <RepoMeta>
+                                  {formatScmProvider(repository.provider)} · {repository.name}
+                                </RepoMeta>
+                              </div>
+                              <Button
+                                as="div"
+                                size="2"
+                                variant={selected ? 'solid' : 'outline'}
+                                success={selected}
+                                loading={
+                                  !!(
+                                    createRepo.isLoading &&
+                                    createRepo.input &&
+                                    'externalRepoId' in createRepo.input &&
+                                    createRepo.input.externalRepoId == repository.externalId
+                                  )
+                                }
                               >
-                                <RepoIcon>
-                                  <RiGitRepositoryLine size={18} />
-                                </RepoIcon>
-                                <div style={{ minWidth: 0 }}>
-                                  <RepoTitle>{repository.identifier}</RepoTitle>
-                                  <RepoMeta>
-                                    {formatScmProvider(repository.provider)} ·{' '}
-                                    {repository.name}
-                                  </RepoMeta>
-                                </div>
-                                <Button
-                                  as="div"
-                                  size="2"
-                                  variant={selected ? 'solid' : 'outline'}
-                                  success={selected}
-                                  loading={
-                                    !!(
-                                      createRepo.isLoading &&
-                                      createRepo.input &&
-                                      'externalRepoId' in createRepo.input &&
-                                      createRepo.input.externalRepoId == repository.externalId
-                                    )
-                                  }
-                                >
-                                  {selected ? 'Selected' : 'Select'}
-                                </Button>
-                              </RepoItem>
-                            );
-                          })}
+                                {selected ? 'Selected' : 'Select'}
+                              </Button>
+                            </RepoItem>
+                          );
+                        })}
 
-                          {!filteredRepos.length && (
-                            <EmptyState>
-                              <Text size="2" weight="strong">
-                                No repositories found
-                              </Text>
-                              <Spacer size={4} />
-                              <Text size="2" color="gray600">
-                                {search
-                                  ? 'Try another search or switch to a different account.'
-                                  : 'This account has no available repositories.'}
-                              </Text>
-                            </EmptyState>
-                          )}
-                        </RepoList>
-                      </>
-                    )}
-                  </>
-                ))
-              : null}
+                        {!filteredRepos.length && (
+                          <EmptyState>
+                            <Text size="2" weight="strong">
+                              No repositories found
+                            </Text>
+                            <Spacer size={4} />
+                            <Text size="2" color="gray600">
+                              {search
+                                ? 'Try another search or switch to a different account.'
+                                : 'This account has no available repositories.'}
+                            </Text>
+                          </EmptyState>
+                        )}
+                      </RepoList>
+                    </>
+                  )}
+                </>
+              )
+            ) : null}
 
             <createInstallation.RenderError />
             <createProvider.RenderError />

--- a/src/metorial/apis/core/src/controllers/instance/scm/repos.ts
+++ b/src/metorial/apis/core/src/controllers/instance/scm/repos.ts
@@ -98,6 +98,13 @@ export let scmReposController = Controller.create(
           installation_id: v.string({ description: 'SCM installation ID' }),
           external_account_id: v.optional(
             v.string({ description: 'Filter by external account ID' })
+          ),
+          cursor: v.optional(v.string({ description: 'Cursor from a previous repository preview page' })),
+          limit: v.optional(
+            v.number({
+              description: 'Maximum number of repositories to return (defaults to 50)',
+              modifiers: [v.minValue(1), v.maxValue(100)]
+            })
           )
         })
       )
@@ -106,7 +113,9 @@ export let scmReposController = Controller.create(
         let repoPreviews = await subspaceScmRepositoryService.listRepositoryPreviews({
           instance: ctx.instance,
           scmConnectionId: ctx.body.installation_id,
-          externalAccountId: ctx.body.external_account_id
+          externalAccountId: ctx.body.external_account_id,
+          cursor: ctx.body.cursor,
+          limit: ctx.body.limit
         });
 
         return scmRepoPreviewPresenter.present({

--- a/src/metorial/apis/core/src/presenters/implementation/scm/repos.ts
+++ b/src/metorial/apis/core/src/presenters/implementation/scm/repos.ts
@@ -6,14 +6,16 @@ export let v1ScmRepoPreviewPresenter = Presenter.create(scmRepoPreviewType)
   .presenter(async ({ repoPreviews }) => ({
     object: 'scm.repository.list#preview' as const,
 
-    repos: repoPreviews.map(r => ({
+    repos: repoPreviews.repositories.map(r => ({
       object: 'scm.repository.item#preview' as const,
 
       provider: r.provider,
       external_id: r.externalId,
       name: r.name,
       identifier: r.identifier
-    }))
+    })),
+
+    next_cursor: repoPreviews.nextCursor ?? undefined
   }))
   .schema(
     v.object({
@@ -30,6 +32,9 @@ export let v1ScmRepoPreviewPresenter = Presenter.create(scmRepoPreviewType)
           name: v.string({ description: 'Repository name' }),
           identifier: v.string({ description: 'Repository identifier (e.g. full name)' })
         })
+      ),
+      next_cursor: v.optional(
+        v.string({ description: 'Cursor for the next repository preview page' })
       )
     })
   )

--- a/src/origin/apps/service/src/controllers/scmRepository.ts
+++ b/src/origin/apps/service/src/controllers/scmRepository.ts
@@ -55,7 +55,13 @@ export let scmRepositoryController = app.controller({
       v.object({
         tenantId: v.string(),
         scmInstallationId: v.string(),
-        externalAccountId: v.optional(v.string())
+        externalAccountId: v.optional(v.string()),
+        cursor: v.optional(v.string()),
+        limit: v.optional(
+          v.number({
+            modifiers: [v.minValue(1), v.maxValue(100)]
+          })
+        )
       })
     )
     .do(async ctx => {
@@ -64,13 +70,16 @@ export let scmRepositoryController = app.controller({
         scmInstallationId: ctx.input.scmInstallationId
       });
 
-      let repos = await scmRepoService.listRepositoryPreviews({
+      let result = await scmRepoService.listRepositoryPreviews({
         installation,
-        externalAccountId: ctx.input.externalAccountId ?? installation.externalAccountId
+        externalAccountId: ctx.input.externalAccountId ?? installation.externalAccountId,
+        cursor: ctx.input.cursor,
+        limit: ctx.input.limit
       });
 
       return {
-        repositories: repos.map(scmRepoPreviewPresenter)
+        repositories: result.repositories.map(scmRepoPreviewPresenter),
+        nextCursor: result.nextCursor
       };
     }),
 

--- a/src/origin/apps/service/src/endpoints.ts
+++ b/src/origin/apps/service/src/endpoints.ts
@@ -9,12 +9,14 @@ await scmBackendService.ensureDefaultBackends();
 
 let originServer = Bun.serve({
   fetch: originApi,
-  port: 52090
+  port: 52090,
+  idleTimeout: 250
 });
 
 let scmServer = Bun.serve({
   fetch: scmController.fetch,
-  port: 52093
+  port: 52093,
+  idleTimeout: 60
 });
 
 console.log(`Origin controller running on http://localhost:${originServer.port}`);

--- a/src/origin/apps/service/src/lib/bitbucket.ts
+++ b/src/origin/apps/service/src/lib/bitbucket.ts
@@ -258,6 +258,42 @@ export class BitbucketClient {
     return repos.map(repo => this.normalizeDataCenterRepository(repo));
   }
 
+  async listRepositoryPage(i: {
+    accountSlug?: string;
+    cursor?: string;
+    limit: number;
+  }): Promise<{ repositories: BitbucketRepository[]; nextCursor?: string }> {
+    if (!isDataCenter(this.backend)) {
+      let path = i.cursor ?? (i.accountSlug
+        ? `repositories/${encodeURIComponent(i.accountSlug)}`
+        : 'repositories');
+      let page = await this.request<{ values: any[]; next?: string }>(path, {
+        query: i.cursor ? undefined : { pagelen: i.limit, role: 'member' }
+      });
+      return {
+        repositories: page.values.map(repo => this.normalizeCloudRepository(repo)),
+        nextCursor: page.next
+      };
+    }
+
+    let start = i.cursor ? Number(i.cursor) : 0;
+    if (!Number.isInteger(start) || start < 0) {
+      throw new ServiceError(badRequestError({ message: 'Invalid Bitbucket repository cursor' }));
+    }
+    let path = i.accountSlug
+      ? `projects/${encodeURIComponent(i.accountSlug)}/repos`
+      : 'repos';
+    let page = await this.request<{
+      values: any[];
+      isLastPage: boolean;
+      nextPageStart?: number;
+    }>(path, { query: { limit: i.limit, start } });
+    return {
+      repositories: page.values.map(repo => this.normalizeDataCenterRepository(repo)),
+      nextCursor: page.isLastPage || page.nextPageStart == null ? undefined : String(page.nextPageStart)
+    };
+  }
+
   async getRepository(owner: string, repo: string): Promise<BitbucketRepository> {
     if (!isDataCenter(this.backend)) {
       let result = await this.request<any>(

--- a/src/origin/apps/service/src/lib/scmProviderError.test.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.test.ts
@@ -1,8 +1,21 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  captureException: vi.fn()
+}));
+
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({ captureException: mocks.captureException })
+}));
+
 import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
 
 describe('SCM provider errors', () => {
+  beforeEach(() => {
+    mocks.captureException.mockClear();
+  });
+
   it.each([
     [{ status: 401 }, 401, 'unauthorized'],
     [{ cause: { response: { status: 401 } } }, 401, 'unauthorized'],
@@ -35,5 +48,17 @@ describe('SCM provider errors', () => {
     let mapped = wrapScmProviderError('github', providerError, 'load repositories');
 
     expect(mapped.parent).toBe(providerError);
+  });
+
+  it('does not report expected provider 4xx responses to Sentry', () => {
+    wrapScmProviderError('gitlab', { response: { status: 400 } }, 'refresh the OAuth token');
+
+    expect(mocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports unexpected provider failures to Sentry as Errors', () => {
+    wrapScmProviderError('gitlab', { response: { status: 500 } }, 'refresh the OAuth token');
+
+    expect(mocks.captureException).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/src/origin/apps/service/src/lib/scmProviderError.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.ts
@@ -32,10 +32,14 @@ export let wrapScmProviderError = (
 ): ServiceError<any> => {
   if (isServiceError(error)) return error;
 
-  console.error(`SCM provider error (${provider}):`, error);
-  Sentry.captureException(error);
-
   let status = getScmProviderErrorStatus(error);
+  console.error(`SCM provider error (${provider}, status: ${status ?? 'unknown'})`);
+  if (status == null || status >= 500) {
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(`SCM provider request failed (${provider})`)
+    );
+  }
+
   let prefix = `${providerName(provider)} could not ${operation}`;
   let mapped =
     status === 400 || status === 422

--- a/src/origin/apps/service/src/services/scmRepo.ts
+++ b/src/origin/apps/service/src/services/scmRepo.ts
@@ -224,25 +224,29 @@ class scmRepoServiceImpl {
 
       // Existing clients can still supply the installation's user ID. New account previews
       // supply the actual personal namespace ID required by GitLab's project APIs.
-      let page = providerCursor ? Number(providerCursor) : 1;
-      if (!Number.isInteger(page) || page < 1) {
+      let idAfter = providerCursor ? Number(providerCursor) : undefined;
+      if (idAfter !== undefined && (!Number.isInteger(idAfter) || idAfter < 1)) {
         throw new ServiceError(badRequestError({ message: 'Invalid repository preview cursor' }));
       }
       let projects: any[];
+      let nextProviderCursor: string | undefined;
       if (
         !i.externalAccountId ||
         i.externalAccountId == personalNamespaceId ||
         i.externalAccountId == i.installation.externalAccountId
       ) {
         projects = await withScmProviderError('gitlab', 'list user projects', () =>
-          gitlab.Users.allProjects(user.id, { perPage: limit, page })
+          gitlab.Users.allProjects(user.id, { perPage: limit, idAfter, maxPages: 1 })
         );
+        nextProviderCursor = projects.length === limit ? String(projects.at(-1)?.id) : undefined;
       } else {
         // List projects for a specific group
         let groupId = getGitLabNamespaceId(i.externalAccountId);
+        let page = providerCursor ? Number(providerCursor) : 1;
         projects = await withScmProviderError('gitlab', 'list group projects', () =>
           gitlab.Groups.allProjects(groupId, { perPage: limit, page })
         );
+        nextProviderCursor = projects.length === limit ? String(page + 1) : undefined;
       }
 
       let hostname = new URL(i.installation.backend.webUrl).hostname;
@@ -267,7 +271,7 @@ class scmRepoServiceImpl {
           }) satisfies ScmRepoPreview
         ),
         nextCursor: encodeRepositoryPreviewCursor(
-          projects.length === limit ? String(page + 1) : undefined,
+          nextProviderCursor,
           i.externalAccountId
         )
       };

--- a/src/origin/apps/service/src/services/scmRepo.ts
+++ b/src/origin/apps/service/src/services/scmRepo.ts
@@ -27,6 +27,41 @@ import { createRepoWebhookQueue } from '../queues/scm/createRepoWebhook';
 import { createHandleRepoPushQueue } from '../queues/scm/handleRepoPush';
 import type { ScmAccountPreview, ScmRepoPreview } from '../types';
 
+let defaultRepositoryPreviewLimit = 50;
+
+let decodeRepositoryPreviewCursor = (
+  cursor: string | undefined,
+  externalAccountId: string | undefined
+) => {
+  if (!cursor) return undefined;
+
+  try {
+    let value = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+    if (
+      typeof value?.providerCursor != 'string' ||
+      value.externalAccountId !== (externalAccountId ?? null)
+    ) {
+      throw new Error('Invalid cursor');
+    }
+    return value.providerCursor;
+  } catch {
+    throw new ServiceError(badRequestError({ message: 'Invalid repository preview cursor' }));
+  }
+};
+
+let encodeRepositoryPreviewCursor = (
+  providerCursor: string | undefined,
+  externalAccountId: string | undefined
+) => {
+  if (!providerCursor) return null;
+  return Buffer.from(
+    JSON.stringify({
+      providerCursor,
+      externalAccountId: externalAccountId ?? null
+    })
+  ).toString('base64url');
+};
+
 let getGitLabPersonalNamespaceIdForUser = async (gitlab: any, user: any) => {
   let namespaces = await withScmProviderError<any[]>(
     'gitlab',
@@ -117,7 +152,12 @@ class scmRepoServiceImpl {
   async listRepositoryPreviews(i: {
     installation: ScmInstallation & { backend: ScmBackend };
     externalAccountId?: string;
+    cursor?: string;
+    limit?: number;
   }) {
+    let limit = Math.min(Math.max(i.limit ?? defaultRepositoryPreviewLimit, 1), 100);
+    let providerCursor = decodeRepositoryPreviewCursor(i.cursor, i.externalAccountId);
+
     if (i.installation.provider == 'github') {
       if (!i.installation.externalInstallationId) {
         throw new ServiceError(badRequestError({ message: 'Installation ID not found' }));
@@ -127,35 +167,28 @@ class scmRepoServiceImpl {
         i.installation.backend
       );
 
-      // For GitHub Apps, use the installation repositories endpoint
-      // This lists all repositories the installation has access to
-      let allRepos: any[] = [];
-      let page = 1;
-
-      while (true) {
-        let response = await withScmProviderError(
-          'github',
-          'list installation repositories',
-          () =>
-            octokit.request('GET /installation/repositories', {
-              per_page: 100,
-              page
-            })
-        );
-
-        allRepos.push(...response.data.repositories);
-
-        if (response.data.repositories.length < 100) break;
-        page++;
+      let page = providerCursor ? Number(providerCursor) : 1;
+      if (!Number.isInteger(page) || page < 1) {
+        throw new ServiceError(badRequestError({ message: 'Invalid repository preview cursor' }));
       }
+      let response = await withScmProviderError(
+        'github',
+        'list installation repositories',
+        () =>
+          octokit.request('GET /installation/repositories', {
+            per_page: limit,
+            page
+          })
+      );
 
       // Filter by externalAccountId if provided (to support account-specific filtering in UI)
       let filteredRepos = i.externalAccountId
-        ? allRepos.filter(r => r.owner.id.toString() === i.externalAccountId)
-        : allRepos;
+        ? response.data.repositories.filter(r => r.owner.id.toString() === i.externalAccountId)
+        : response.data.repositories;
 
-      return filteredRepos.map(
-        r =>
+      return {
+        repositories: filteredRepos.map(
+          r =>
           ({
             provider: i.installation.provider,
             name: r.name,
@@ -171,13 +204,17 @@ class scmRepoServiceImpl {
               provider: i.installation.provider
             }
           }) satisfies ScmRepoPreview
-      );
+        ),
+        nextCursor: encodeRepositoryPreviewCursor(
+          response.data.repositories.length === limit ? String(page + 1) : undefined,
+          i.externalAccountId
+        )
+      };
     }
 
     if (i.installation.provider == 'gitlab') {
       let gitlab = await createGitLabClientWithInstallation(i.installation);
 
-      let allProjects: any[] = [];
       let user = await withScmProviderError('gitlab', 'load the authenticated user', () =>
         gitlab.Users.showCurrentUser()
       );
@@ -187,26 +224,32 @@ class scmRepoServiceImpl {
 
       // Existing clients can still supply the installation's user ID. New account previews
       // supply the actual personal namespace ID required by GitLab's project APIs.
+      let page = providerCursor ? Number(providerCursor) : 1;
+      if (!Number.isInteger(page) || page < 1) {
+        throw new ServiceError(badRequestError({ message: 'Invalid repository preview cursor' }));
+      }
+      let projects: any[];
       if (
         !i.externalAccountId ||
         i.externalAccountId == personalNamespaceId ||
         i.externalAccountId == i.installation.externalAccountId
       ) {
-        allProjects = await withScmProviderError('gitlab', 'list user projects', () =>
-          gitlab.Users.allProjects(user.id, { perPage: 100 })
+        projects = await withScmProviderError('gitlab', 'list user projects', () =>
+          gitlab.Users.allProjects(user.id, { perPage: limit, page })
         );
       } else {
         // List projects for a specific group
         let groupId = getGitLabNamespaceId(i.externalAccountId);
-        allProjects = await withScmProviderError('gitlab', 'list group projects', () =>
-          gitlab.Groups.allProjects(groupId, { perPage: 100 })
+        projects = await withScmProviderError('gitlab', 'list group projects', () =>
+          gitlab.Groups.allProjects(groupId, { perPage: limit, page })
         );
       }
 
       let hostname = new URL(i.installation.backend.webUrl).hostname;
 
-      return allProjects.map(
-        (p: any) =>
+      return {
+        repositories: projects.map(
+          (p: any) =>
           ({
             provider: i.installation.provider,
             name: p.name,
@@ -222,7 +265,12 @@ class scmRepoServiceImpl {
               provider: i.installation.provider
             }
           }) satisfies ScmRepoPreview
-      );
+        ),
+        nextCursor: encodeRepositoryPreviewCursor(
+          projects.length === limit ? String(page + 1) : undefined,
+          i.externalAccountId
+        )
+      };
     }
 
     if (i.installation.provider == 'bitbucket') {
@@ -231,12 +279,17 @@ class scmRepoServiceImpl {
       let selected = i.externalAccountId
         ? accounts.find(account => account.id === i.externalAccountId)
         : undefined;
-      let repos = await withScmProviderError('bitbucket', 'list repositories', () =>
-        client.listRepositories(selected?.slug)
+      let page = await withScmProviderError('bitbucket', 'list repositories', () =>
+        client.listRepositoryPage({
+          accountSlug: selected?.slug,
+          cursor: providerCursor,
+          limit
+        })
       );
       let hostname = new URL(i.installation.backend.webUrl).hostname;
-      return repos.map(
-        repo =>
+      return {
+        repositories: page.repositories.map(
+          repo =>
           ({
             provider: i.installation.provider,
             name: repo.name,
@@ -252,7 +305,9 @@ class scmRepoServiceImpl {
               provider: i.installation.provider
             }
           }) satisfies ScmRepoPreview
-      );
+        ),
+        nextCursor: encodeRepositoryPreviewCursor(page.nextCursor, i.externalAccountId)
+      };
     }
 
     throw new ServiceError(badRequestError({ message: 'Unsupported provider' }));

--- a/src/subspace/apps/controller/src/controllers/scmRepository.ts
+++ b/src/subspace/apps/controller/src/controllers/scmRepository.ts
@@ -97,7 +97,13 @@ export let scmRepositoryController = app.controller({
         tenantId: v.string(),
         environmentId: v.string(),
         scmConnectionId: v.string(),
-        externalAccountId: v.optional(v.string())
+        externalAccountId: v.optional(v.string()),
+        cursor: v.optional(v.string()),
+        limit: v.optional(
+          v.number({
+            modifiers: [v.minValue(1), v.maxValue(100)]
+          })
+        )
       })
     )
     .do(async ctx => {
@@ -105,11 +111,16 @@ export let scmRepositoryController = app.controller({
         tenant: ctx.tenant,
         input: {
           scmConnectionId: ctx.input.scmConnectionId,
-          externalAccountId: ctx.input.externalAccountId
+          externalAccountId: ctx.input.externalAccountId,
+          cursor: ctx.input.cursor,
+          limit: ctx.input.limit
         }
       });
 
-      return items.repositories.map(item => scmRepositoryPreviewPresenter(item));
+      return {
+        repositories: items.repositories.map(item => scmRepositoryPreviewPresenter(item)),
+        nextCursor: items.nextCursor
+      };
     }),
 
   createRepository: tenantApp

--- a/src/subspace/modules/custom-provider/src/services/scmRepository.ts
+++ b/src/subspace/modules/custom-provider/src/services/scmRepository.ts
@@ -145,17 +145,22 @@ class scmRepositoryServiceImpl {
     input: {
       scmConnectionId: string;
       externalAccountId?: string;
+      cursor?: string;
+      limit?: number;
     };
-  }): Promise<{ repositories: ScmRepositoryPreview[] }> {
+  }): Promise<{ repositories: ScmRepositoryPreview[]; nextCursor: string | null }> {
     let tenant = await getTenantForOrigin(d.tenant);
     let result = await origin.scmRepository.listRepositoryPreviews({
       tenantId: tenant.id,
       scmInstallationId: d.input.scmConnectionId,
-      externalAccountId: d.input.externalAccountId
+      externalAccountId: d.input.externalAccountId,
+      cursor: d.input.cursor,
+      limit: d.input.limit
     });
 
     return {
-      repositories: result.repositories.map(normalizeScmRepositoryPreview)
+      repositories: result.repositories.map(normalizeScmRepositoryPreview),
+      nextCursor: result.nextCursor
     };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches SCM preview APIs and provider pagination across GitHub/GitLab/Bitbucket; behavior changes for large repo lists but scope is limited to preview/resolve flows.
> 
> **Overview**
> **SCM repository preview** is now **cursor-paginated** end-to-end (`cursor`, `limit`, `next_cursor`) instead of loading every repo from GitHub, GitLab, and Bitbucket in one shot. Origin maps provider-specific paging into encoded cursors; the dashboard SDK types and API presenters were updated to match.
> 
> The **repository picker** and **resolve-by-identifier** flow accumulate preview pages (50 at a time) so large accounts still load fully without blocking on a single huge upstream call. The picker shows an initial loading state while the first page is empty.
> 
> **UI fixes:** popovers inside modals render into the dialog container; the account menu respects Radix available height with contained scrolling.
> 
> **Ops:** expected SCM provider **4xx** errors no longer go to Sentry (only 5xx/unknown); Origin/SCM Bun servers get higher **idleTimeout** for long preview chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8eaa2af2d36f1e4064814c2b0abd794d0925987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->