### PR TITLE
Skill fixes

### DIFF
--- a/src/metorial/apis/core/src/controllers/instance/skills/skillGroupItemAccess.test.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skillGroupItemAccess.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  resolveResourceScopeForOwner: vi.fn(),
+  getSkillById: vi.fn(),
+  assertConsumerCanWriteSkill: vi.fn()
+}));
+
+vi.mock('@metorial/module-resource-tenant', () => ({
+  resolveResourceScopeForOwner: mocks.resolveResourceScopeForOwner
+}));
+
+vi.mock('@metorial/cargo-module-skill', () => ({
+  skillService: {
+    getSkillById: mocks.getSkillById
+  }
+}));
+
+vi.mock('@metorial/module-consumer', () => ({
+  consumerSkillService: {
+    assertConsumerCanWriteSkill: mocks.assertConsumerCanWriteSkill
+  }
+}));
+
+import { assertConsumerCanWriteSkillGroupItem } from './skillGroupItemAccess';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('assertConsumerCanWriteSkillGroupItem', () => {
+  it('lazily resolves the instance scope before checking consumer access', async () => {
+    let resourceTenant = { oid: 1n, id: 'rtn_1' };
+    let resourceGroup = { oid: 2n, id: 'rgr_1' };
+    let skill = { oid: 3n, id: 'skl_1' };
+    let consumerProfile = { oid: 4n, id: 'cpr_1' };
+
+    mocks.resolveResourceScopeForOwner.mockResolvedValue({
+      resourceTenant,
+      resourceGroup
+    });
+    mocks.getSkillById.mockResolvedValue(skill);
+
+    await assertConsumerCanWriteSkillGroupItem({
+      instance: { id: 'ins_1' } as any,
+      skillId: 'skl_1',
+      consumerProfile: consumerProfile as any
+    });
+
+    expect(mocks.resolveResourceScopeForOwner).toHaveBeenCalledWith({
+      type: 'instance',
+      instance: { id: 'ins_1' }
+    });
+    expect(mocks.getSkillById).toHaveBeenCalledWith({
+      resourceTenant,
+      resourceGroup,
+      skillId: 'skl_1',
+      allowDeleted: true,
+      consumerProfileOid: 4n
+    });
+    expect(mocks.assertConsumerCanWriteSkill).toHaveBeenCalledWith({
+      skill,
+      consumerProfile
+    });
+  });
+
+  it('does not provision a scope for non-consumer requests', async () => {
+    await assertConsumerCanWriteSkillGroupItem({
+      instance: { id: 'ins_1' } as any,
+      skillId: 'skl_1'
+    });
+
+    expect(mocks.resolveResourceScopeForOwner).not.toHaveBeenCalled();
+  });
+});

--- a/src/metorial/apis/core/src/controllers/instance/skills/skillGroupItemAccess.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skillGroupItemAccess.ts
@@ -1,6 +1,7 @@
-import { ConsumerGroup, ConsumerProfile, db, Instance } from '@metorial/db';
+import { ConsumerGroup, ConsumerProfile, Instance } from '@metorial/db';
 import { skillService } from '@metorial/cargo-module-skill';
 import { consumerSkillService } from '@metorial/module-consumer';
+import { resolveResourceScopeForOwner } from '@metorial/module-resource-tenant';
 
 export let assertConsumerCanWriteSkillGroupItem = async (d: {
   instance: Instance;
@@ -10,16 +11,16 @@ export let assertConsumerCanWriteSkillGroupItem = async (d: {
 }) => {
   if (!d.consumerProfile) return;
 
-  let instance = await db.instance.findUniqueOrThrow({
-    where: { id: d.instance.id },
-    include: { resourceTenant: true, resourceGroup: true }
+  let scope = await resolveResourceScopeForOwner({
+    type: 'instance',
+    instance: {
+      id: d.instance.id
+    }
   });
-  if (!instance.resourceTenant || !instance.resourceGroup) {
-    throw new Error('Instance has no Cargo resource scope');
-  }
+
   let skill = await skillService.getSkillById({
-    resourceTenant: instance.resourceTenant,
-    resourceGroup: instance.resourceGroup,
+    resourceTenant: scope.resourceTenant,
+    resourceGroup: scope.resourceGroup,
     skillId: d.skillId,
     allowDeleted: true,
     consumerProfileOid: d.consumerProfile.oid

--- a/src/metorial/apis/core/src/lib/cargoAccess.test.ts
+++ b/src/metorial/apis/core/src/lib/cargoAccess.test.ts
@@ -1,20 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-let { findInstanceMock, upsertActorMock } = vi.hoisted(() => ({
-  findInstanceMock: vi.fn(),
+let { resolveResourceScopeMock, upsertActorMock } = vi.hoisted(() => ({
+  resolveResourceScopeMock: vi.fn(),
   upsertActorMock: vi.fn()
 }));
 
 vi.mock('@metorial/module-resource-tenant', () => ({
+  resolveResourceScopeForOwner: resolveResourceScopeMock,
   resourceActorService: {
     upsertActor: upsertActorMock
-  }
-}));
-vi.mock('@metorial/db', () => ({
-  db: {
-    instance: {
-      findUnique: findInstanceMock
-    }
   }
 }));
 
@@ -23,6 +17,10 @@ import {
   getInstanceCargoActorInput,
   hasInstanceConsumerAccess
 } from './cargoAccess';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('cargoAccess', () => {
   it('treats consumer-only requests as consumer-scoped', () => {
@@ -97,9 +95,9 @@ describe('cargoAccess', () => {
     });
   });
 
-  it('passes consumer access tags into native Cargo authorization', async () => {
+  it('lazily resolves the instance scope and passes consumer access tags', async () => {
     let accessTags = [{ accessTagOid: 3n }];
-    findInstanceMock.mockResolvedValue({
+    resolveResourceScopeMock.mockResolvedValue({
       resourceTenant: { oid: 4n, id: 'rtn_1' },
       resourceGroup: { oid: 5n, id: 'rgr_1' }
     });
@@ -120,6 +118,18 @@ describe('cargoAccess', () => {
       accessTags
     });
 
+    expect(resolveResourceScopeMock).toHaveBeenCalledWith({
+      type: 'instance',
+      instance: { id: 'ins_1' }
+    });
+    expect(upsertActorMock).toHaveBeenCalledWith({
+      resourceTenant: { oid: 4n, id: 'rtn_1' },
+      input: {
+        identifier: 'mte-con-con_1',
+        name: 'Portal Consumer',
+        consumerOid: 1n
+      }
+    });
     expect(access).toEqual({
       resourceTenant: { oid: 4n, id: 'rtn_1' },
       resourceGroup: { oid: 5n, id: 'rgr_1' },
@@ -128,6 +138,38 @@ describe('cargoAccess', () => {
       accessTags,
       defaultPermissions: undefined,
       overridePermissions: undefined
+    });
+  });
+
+  it('preserves full Cargo access for organization members', async () => {
+    resolveResourceScopeMock.mockResolvedValue({
+      resourceTenant: { oid: 4n, id: 'rtn_1' },
+      resourceGroup: { oid: 5n, id: 'rgr_1' }
+    });
+    upsertActorMock.mockResolvedValue({
+      oid: 6n,
+      id: 'rac_1'
+    });
+
+    let access = await getInstanceCargoAccess({
+      instance: { id: 'ins_1' },
+      member: {
+        actor: {
+          oid: 2n,
+          id: 'ora_1',
+          name: 'Organization Actor'
+        }
+      } as any
+    });
+
+    expect(access).toEqual({
+      resourceTenant: { oid: 4n, id: 'rtn_1' },
+      resourceGroup: { oid: 5n, id: 'rgr_1' },
+      actor: { oid: 6n, id: 'rac_1' },
+      actorId: 'rac_1',
+      accessTags: undefined,
+      defaultPermissions: ['content_read', 'content_write'],
+      overridePermissions: true
     });
   });
 });

--- a/src/metorial/apis/core/src/lib/cargoAccess.ts
+++ b/src/metorial/apis/core/src/lib/cargoAccess.ts
@@ -1,12 +1,9 @@
-import { badRequestError, ServiceError } from '@lowerdeck/error';
-import {
-  db,
-  type Consumer,
-  type OrganizationActor,
-  type OrganizationMember
-} from '@metorial/db';
+import { type Consumer, type OrganizationActor, type OrganizationMember } from '@metorial/db';
 import type { AnyAccessTagSelector } from '@metorial/module-access';
-import { resourceActorService } from '@metorial/module-resource-tenant';
+import {
+  resolveResourceScopeForOwner,
+  resourceActorService
+} from '@metorial/module-resource-tenant';
 
 let fullCargoAccessPermissions = ['content_read', 'content_write'] as const;
 
@@ -47,35 +44,24 @@ export let getInstanceCargoActorInput = (ctx: InstanceCargoAccessContext) => {
 };
 
 export let getInstanceCargoAccess = async (ctx: InstanceCargoAccessContext) => {
-  let instance = await db.instance.findUnique({
-    where: {
+  let scope = await resolveResourceScopeForOwner({
+    type: 'instance',
+    instance: {
       id: ctx.instance.id
-    },
-    include: {
-      resourceTenant: true,
-      resourceGroup: true
     }
   });
-
-  if (!instance?.resourceTenant || !instance.resourceGroup) {
-    throw new ServiceError(
-      badRequestError({
-        message: 'The instance is not linked to a Cargo resource scope'
-      })
-    );
-  }
 
   let actorInput = getInstanceCargoActorInput(ctx);
   let actor = actorInput
     ? await resourceActorService.upsertActor({
-        resourceTenant: instance.resourceTenant,
+        resourceTenant: scope.resourceTenant,
         input: actorInput
       })
     : undefined;
 
   return {
-    resourceTenant: instance.resourceTenant,
-    resourceGroup: instance.resourceGroup,
+    resourceTenant: scope.resourceTenant,
+    resourceGroup: scope.resourceGroup,
     actor,
     actorId: actor?.id,
     accessTags: hasInstanceConsumerAccess(ctx) ? ctx.accessTags : undefined,

--- a/src/metorial/cargo/modules/skill/src/services/resource.test.ts
+++ b/src/metorial/cargo/modules/skill/src/services/resource.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  findManySkillTemplates: vi.fn(),
+  hydrateSkillTemplateResources: vi.fn()
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    skillTemplate: {
+      findMany: mocks.findManySkillTemplates
+    }
+  }
+}));
+
+vi.mock('@metorial/module-subspace', () => ({
+  subspaceSkillService: {},
+  subspaceSkillItemService: {},
+  subspaceSkillTemplateItemService: {},
+  subspaceSkillTemplateService: {
+    hydrateResources: mocks.hydrateSkillTemplateResources
+  }
+}));
+
+import { skillResourceService } from './resource';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.findManySkillTemplates.mockResolvedValue([
+    {
+      id: 'skt_plain',
+      storeId: 'str_legacy',
+      storeTemplate: {
+        id: 'stt_plain'
+      },
+      instance: null
+    }
+  ]);
+});
+
+describe('skillResourceService.hydrateSkillTemplates', () => {
+  it('preserves the scoped backing store ID selected by the template service', async () => {
+    let [template] = await skillResourceService.hydrateSkillTemplates([
+      {
+        id: 'skt_plain',
+        storeTemplate: {
+          storeId: 'str_scoped'
+        }
+      }
+    ]);
+
+    expect(template.storeId).toBe('str_scoped');
+    expect(template.localSkillTemplate.storeId).toBe('str_scoped');
+  });
+
+  it('does not fall back to a legacy store when the scoped backing is unavailable', async () => {
+    let [template] = await skillResourceService.hydrateSkillTemplates([
+      {
+        id: 'skt_plain',
+        storeTemplate: {
+          storeId: undefined
+        }
+      }
+    ]);
+
+    expect(template.storeId).toBeNull();
+    expect(template.localSkillTemplate.storeId).toBeNull();
+  });
+
+  it('keeps the stored ID for unscoped hydration callers', async () => {
+    let [template] = await skillResourceService.hydrateSkillTemplates([
+      {
+        id: 'skt_plain'
+      }
+    ]);
+
+    expect(template.storeId).toBe('str_legacy');
+  });
+});

--- a/src/metorial/cargo/modules/skill/src/services/resource.ts
+++ b/src/metorial/cargo/modules/skill/src/services/resource.ts
@@ -96,6 +96,11 @@ export type SkillTemplateResource = Prisma.SkillTemplateGetPayload<{
   items: SkillTemplateItemResource[];
 };
 
+type SkillTemplateHydrationInput = {
+  id: string;
+  storeTemplate?: unknown;
+};
+
 class SkillResourceServiceImpl {
   async ensureDelegatedSkill(skill: { id: string }) {
     let record = await db.skill.findUnique({
@@ -375,7 +380,7 @@ class SkillResourceServiceImpl {
   }
 
   async hydrateSkillTemplates(
-    templates: Array<{ id: string }>
+    templates: SkillTemplateHydrationInput[]
   ): Promise<SkillTemplateResource[]> {
     if (!templates.length) return [];
     let records = await db.skillTemplate.findMany({
@@ -387,10 +392,13 @@ class SkillResourceServiceImpl {
     });
     let byId = new Map(records.map(template => [template.id, template]));
     let ordered = templates
-      .map(template => byId.get(template.id))
-      .filter((template): template is NonNullable<typeof template> => !!template);
+      .map(input => {
+        let template = byId.get(input.id);
+        return template ? { input, template } : null;
+      })
+      .filter((item): item is NonNullable<typeof item> => !!item);
     return await Promise.all(
-      ordered.map(async template => {
+      ordered.map(async ({ input, template }) => {
         let items: SkillTemplateItemResource[] = [];
         if (template.instance) {
           let [hydrated] = await subspaceSkillTemplateService.hydrateResources({
@@ -399,16 +407,31 @@ class SkillResourceServiceImpl {
           });
           items = hydrated?.items ?? [];
         }
-        return {
+        let scopedStoreTemplate =
+          input.storeTemplate && typeof input.storeTemplate === 'object'
+            ? (input.storeTemplate as { storeId?: string | null })
+            : undefined;
+        let hasScopedStoreId =
+          !!scopedStoreTemplate &&
+          Object.prototype.hasOwnProperty.call(scopedStoreTemplate, 'storeId');
+        let storeId = hasScopedStoreId
+          ? (scopedStoreTemplate?.storeId ?? null)
+          : template.storeId;
+        let localSkillTemplate = {
           ...template,
-          localSkillTemplate: template,
+          storeId
+        };
+
+        return {
+          ...localSkillTemplate,
+          localSkillTemplate,
           items
         };
       })
     );
   }
 
-  async hydrateSkillTemplate(template: { id: string }) {
+  async hydrateSkillTemplate(template: SkillTemplateHydrationInput) {
     return (await this.hydrateSkillTemplates([template]))[0]!;
   }
 }

--- a/src/metorial/cargo/modules/skill/src/services/skillTemplate.test.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillTemplate.test.ts
@@ -31,6 +31,10 @@ vi.mock('@metorial/cargo-config/id', () => ({
   }
 }));
 
+vi.mock('@lowerdeck/id', () => ({
+  generatePlainId: vi.fn(() => 'ABCDE')
+}));
+
 vi.mock('@metorial/cargo-module-search', () => ({
   voyager: {},
   voyagerIndex: {},
@@ -154,6 +158,7 @@ describe('skillTemplateService.createSkillTemplate', () => {
       expect.objectContaining({
         data: expect.objectContaining({
           id: 'skt_1',
+          slug: 'my-skill-template-abcde',
           storeId: 'str_1',
           storeTemplateId: 'stt_1'
         })

--- a/src/metorial/cargo/modules/skill/src/services/skillTemplate.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillTemplate.ts
@@ -1,6 +1,8 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
+import { slugify } from '@lowerdeck/slugify';
 import { snowflake } from '@metorial/cargo-config/id';
 import { voyager, voyagerIndex, voyagerSource } from '@metorial/cargo-module-search';
 import {
@@ -397,7 +399,9 @@ class SkillTemplateServiceImpl {
           oid: snowflake.nextId(),
           id: d.input.id,
           owner: d.resourceTenant ? 'tenant' : 'system',
-          slug: d.input.systemIdentifier ?? d.input.id,
+          slug:
+            d.input.systemIdentifier ??
+            `${slugify(d.input.name)}-${generatePlainId(5).toLowerCase()}`,
           name: d.input.name,
           description: d.input.description,
           metadata: d.input.metadata as any,

--- a/src/metorial/modules/resource-tenant/src/services/resourceActor.ts
+++ b/src/metorial/modules/resource-tenant/src/services/resourceActor.ts
@@ -16,6 +16,32 @@ class ResourceActorServiceImpl {
       };
     }
   ) {
+    if (!d.input.id) {
+      return await db.resourceActor.upsert({
+        where: {
+          resourceTenantOid_identifier: {
+            resourceTenantOid: d.resourceTenant.oid,
+            identifier: d.input.identifier
+          }
+        },
+        update: {
+          type: d.input.type,
+          name: d.input.name,
+          organizationActorOid: d.input.organizationActorOid,
+          consumerOid: d.input.consumerOid
+        },
+        create: {
+          id: await ID.generateId('resourceActor'),
+          resourceTenantOid: d.resourceTenant.oid,
+          identifier: d.input.identifier,
+          type: d.input.type ?? 'external',
+          name: d.input.name,
+          organizationActorOid: d.input.organizationActorOid,
+          consumerOid: d.input.consumerOid
+        }
+      });
+    }
+
     let existing = d.input.id
       ? await db.resourceActor.findFirst({
           where: {
@@ -23,12 +49,7 @@ class ResourceActorServiceImpl {
             OR: [{ id: d.input.id }, { identifier: d.input.identifier }]
           }
         })
-      : await db.resourceActor.findFirst({
-          where: {
-            resourceTenantOid: d.resourceTenant.oid,
-            identifier: d.input.identifier
-          }
-        });
+      : undefined;
 
     if (existing) {
       return await db.resourceActor.update({

--- a/src/metorial/modules/resource-tenant/test/services.test.ts
+++ b/src/metorial/modules/resource-tenant/test/services.test.ts
@@ -17,6 +17,7 @@ let mocks = vi.hoisted(() => ({
   },
   resourceActor: {
     create: vi.fn(),
+    upsert: vi.fn(),
     update: vi.fn(),
     findFirst: vi.fn()
   },
@@ -146,13 +147,13 @@ describe('resource tenant services', () => {
     });
   });
 
-  it('creates and looks up actors within their tenant', async () => {
-    mocks.resourceActor.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
+  it('atomically upserts and looks up actors within their tenant', async () => {
+    mocks.resourceActor.findFirst.mockResolvedValueOnce({
       oid: 3n,
       id: 'crg_ta_1'
     });
     mocks.generateId.mockResolvedValue('crg_ta_1');
-    mocks.resourceActor.create.mockResolvedValue({ oid: 3n, id: 'crg_ta_1' });
+    mocks.resourceActor.upsert.mockResolvedValue({ oid: 3n, id: 'crg_ta_1' });
 
     await resourceActorService.upsertActor({
       resourceTenant: { oid: 1n, id: 'crg_tn_1' },
@@ -166,8 +167,20 @@ describe('resource tenant services', () => {
       actorId: 'crg_ta_1'
     });
 
-    expect(mocks.resourceActor.create).toHaveBeenCalledWith({
-      data: {
+    expect(mocks.resourceActor.upsert).toHaveBeenCalledWith({
+      where: {
+        resourceTenantOid_identifier: {
+          resourceTenantOid: 1n,
+          identifier: 'actor-one'
+        }
+      },
+      update: {
+        type: undefined,
+        name: 'Actor One',
+        organizationActorOid: undefined,
+        consumerOid: undefined
+      },
+      create: {
         id: 'crg_ta_1',
         resourceTenantOid: 1n,
         identifier: 'actor-one',
@@ -181,6 +194,43 @@ describe('resource tenant services', () => {
       where: {
         resourceTenantOid: 1n,
         OR: [{ id: 'crg_ta_1' }, { identifier: 'crg_ta_1' }]
+      }
+    });
+  });
+
+  it('preserves explicit actor ID compatibility', async () => {
+    mocks.resourceActor.findFirst.mockResolvedValue({
+      oid: 3n,
+      id: 'crg_ta_1',
+      type: 'system'
+    });
+    mocks.resourceActor.update.mockResolvedValue({ oid: 3n, id: 'crg_ta_1' });
+
+    await resourceActorService.upsertActor({
+      resourceTenant: { oid: 1n, id: 'crg_tn_1' },
+      input: {
+        id: 'crg_ta_1',
+        identifier: 'actor-one',
+        name: 'Actor One'
+      }
+    });
+
+    expect(mocks.resourceActor.findFirst).toHaveBeenCalledWith({
+      where: {
+        resourceTenantOid: 1n,
+        OR: [{ id: 'crg_ta_1' }, { identifier: 'actor-one' }]
+      }
+    });
+    expect(mocks.resourceActor.update).toHaveBeenCalledWith({
+      where: {
+        id: 'crg_ta_1'
+      },
+      data: {
+        identifier: 'actor-one',
+        type: 'system',
+        name: 'Actor One',
+        organizationActorOid: undefined,
+        consumerOid: undefined
       }
     });
   });
@@ -216,5 +266,129 @@ describe('resource tenant services', () => {
     });
 
     expect(mocks.user.update).not.toHaveBeenCalled();
+  });
+
+  it('provisions and links a missing instance scope', async () => {
+    let resourceTenant = { oid: 1n, id: 'crg_tn_1' };
+    let resourceGroup = {
+      oid: 2n,
+      id: 'crg_en_1',
+      resourceTenant
+    };
+
+    mocks.instance.findUnique
+      .mockResolvedValueOnce({
+        resourceTenantOid: null,
+        resourceGroupOid: null
+      })
+      .mockResolvedValueOnce({
+        oid: 3n,
+        id: 'ins_1',
+        name: 'Production',
+        type: 'production',
+        projectOid: 4n,
+        project: {
+          oid: 4n,
+          name: 'Project One'
+        }
+      });
+    mocks.resourceTenant.upsert.mockResolvedValue(resourceTenant);
+    mocks.resourceGroup.findFirst.mockResolvedValue(null);
+    mocks.resourceGroup.upsert.mockResolvedValue(resourceGroup);
+    mocks.generateId.mockResolvedValueOnce('crg_tn_1').mockResolvedValueOnce('crg_en_1');
+
+    await expect(
+      resolveResourceScopeForOwner({
+        type: 'instance',
+        instance: { id: 'ins_1' }
+      })
+    ).resolves.toEqual({
+      resourceTenant,
+      resourceGroup
+    });
+
+    expect(mocks.resourceTenant.upsert).toHaveBeenCalledWith({
+      where: {
+        identifier: 'mte-pro-4'
+      },
+      update: {
+        name: 'Project One'
+      },
+      create: {
+        id: 'crg_tn_1',
+        identifier: 'mte-pro-4',
+        name: 'Project One'
+      }
+    });
+    expect(mocks.resourceGroup.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          resourceTenantOid_identifier: {
+            resourceTenantOid: 1n,
+            identifier: 'mte-ins-3'
+          }
+        }
+      })
+    );
+    expect(mocks.project.update).toHaveBeenCalledWith({
+      where: { oid: 4n },
+      data: { resourceTenantOid: 1n }
+    });
+    expect(mocks.instance.update).toHaveBeenCalledWith({
+      where: { oid: 3n },
+      data: {
+        resourceTenantOid: 1n,
+        resourceGroupOid: 2n
+      }
+    });
+  });
+
+  it('repairs a dangling instance scope link', async () => {
+    let resourceTenant = { oid: 10n, id: 'crg_tn_10' };
+    let resourceGroup = {
+      oid: 20n,
+      id: 'crg_en_20',
+      resourceTenant
+    };
+
+    mocks.instance.findUnique
+      .mockResolvedValueOnce({
+        resourceTenantOid: 90n,
+        resourceGroupOid: 91n
+      })
+      .mockResolvedValueOnce({
+        oid: 30n,
+        id: 'ins_30',
+        name: 'Development',
+        type: 'development',
+        projectOid: 40n,
+        project: {
+          oid: 40n,
+          name: 'Project Forty'
+        }
+      });
+    mocks.resourceTenant.findUnique.mockResolvedValue(null);
+    mocks.resourceGroup.findFirst.mockResolvedValue(null);
+    mocks.resourceTenant.upsert.mockResolvedValue(resourceTenant);
+    mocks.resourceGroup.upsert.mockResolvedValue(resourceGroup);
+    mocks.generateId.mockResolvedValueOnce('crg_tn_10').mockResolvedValueOnce('crg_en_20');
+
+    await expect(
+      resolveResourceScopeForOwner({
+        type: 'instance',
+        instance: { id: 'ins_30' }
+      })
+    ).resolves.toEqual({
+      resourceTenant,
+      resourceGroup
+    });
+
+    expect(mocks.instance.update).toHaveBeenCalledWith({
+      where: { oid: 30n },
+      data: {
+        resourceTenantOid: 10n,
+        resourceGroupOid: 20n
+      }
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authorization and Cargo scope resolution on instance requests, including automatic provisioning/repair of tenant links and concurrent actor upserts.
> 
> **Overview**
> Routes **instance Cargo access** and **consumer skill-group write checks** through `resolveResourceScopeForOwner` instead of loading `resourceTenant` / `resourceGroup` from the instance row, so missing or broken links can be **provisioned or repaired** on demand. Non-consumer paths skip scope resolution where appropriate.
> 
> **Resource actors** without an explicit `id` now use a **tenant+identifier upsert**; explicit `id` still uses find-then-update/create.
> 
> **Skill templates**: new slugs default to `slugify(name)-{shortId}` when there is no `systemIdentifier`. **Template hydration** honors a caller-provided scoped `storeTemplate.storeId` and stops falling back to the DB store when that scoped field is present but empty.
> 
> Tests cover lazy scope resolution, org-member Cargo permissions, scoped `storeId` hydration, instance scope provision/repair, and actor upsert behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c313809979cd033fd0f38d37424785922c7841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->