### PR TITLE
Fix control startup

### DIFF
--- a/src/control/README.md
+++ b/src/control/README.md
@@ -31,7 +31,9 @@ target/release/control dev backend
 target/release/control env
 target/release/control cleanup --dry-run
 target/release/control docker stop
-target/release/control workspace feature/my-change
+target/release/control workspace create feature/my-change
+target/release/control workspace list
+target/release/control workspace remove feature/my-change
 target/release/control workspace dev
 ```
 
@@ -111,13 +113,17 @@ For Postgres, database creation uses `docker compose exec` when `compose` and
 MongoDB follows the same rule using `mongosh`; an empty database receives a
 `__control` collection so that it persists.
 
-`control workspace` creates a sibling worktree. Enterprise mode creates the
-enterprise worktree and a paired OSS worktree at its `oss/` path. Failures are
-rolled back best-effort. The command then attempts to open the path using
-`code`, unless `--no-open` is passed.
+`control workspace create BRANCH` creates a sibling worktree. Enterprise mode
+creates the enterprise worktree and a paired OSS worktree at its `oss/` path.
+Failures are rolled back best-effort. After creation it runs `bun install` and
+builds the workspace's Control binary, then attempts to open the path using
+`code`, unless `--no-open` is passed. The original `control workspace BRANCH`
+syntax remains supported.
 
-The explicit form is `control workspace create BRANCH`; the original
-`control workspace BRANCH` syntax remains supported.
+`control workspace list` prints linked worktrees for the repository (branch,
+path, and workspace identity when metadata is present).
+`control workspace remove BRANCH` removes the matching worktree, including the
+paired OSS worktree in enterprise mode.
 
 ## Docker workspaces
 

--- a/src/control/src/dev.rs
+++ b/src/control/src/dev.rs
@@ -48,14 +48,13 @@ pub async fn run(
     let projects = if no_docker {
         Vec::new()
     } else {
-        let services_spinner = spinner("Waiting for development services");
+        println!("Starting development services");
         match docker::start(&project.root, &selected, &root_env).await {
             Ok(projects) => {
-                services_spinner.finish_with_message("Development services ready");
+                println!("Development services ready");
                 projects
             }
             Err(error) => {
-                services_spinner.finish_and_clear();
                 if process::is_interrupted(&error) {
                     return Ok(());
                 }

--- a/src/control/src/docker.rs
+++ b/src/control/src/docker.rs
@@ -29,7 +29,7 @@ pub async fn start(
             "60".into(),
         ]);
         args.extend(services.iter().cloned());
-        if let Err(error) = process::run_quiet("docker", &args, root, environment).await {
+        if let Err(error) = process::run("docker", &args, root, environment).await {
             stop(root, &projects[..=index], environment).await;
             return Err(error);
         }

--- a/src/control/src/environment.rs
+++ b/src/control/src/environment.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, env, fs, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 use miette::{IntoDiagnostic, Result, WrapErr, bail};
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
@@ -227,15 +231,7 @@ pub fn write_for_manifest(
     let path = directory.join(".env");
     let temporary = directory.join(".env.control.tmp");
     let values = all_for_manifest(loaded, root_values)?;
-    let mut contents = values
-        .iter()
-        .map(|(key, value)| format!("{key}=\"{}\"", escape_dotenv(value)))
-        .collect::<Vec<_>>()
-        .join("\n");
-    contents.push('\n');
-    fs::write(&temporary, contents)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("could not write {}", temporary.display()))?;
+    write_dotenv(&temporary, &values)?;
     if path.exists() {
         fs::remove_file(&path)
             .into_diagnostic()
@@ -245,6 +241,37 @@ pub fn write_for_manifest(
         .into_diagnostic()
         .wrap_err_with(|| format!("could not install {}", path.display()))?;
     Ok(path)
+}
+
+pub fn write_dotenv(path: &Path, values: &BTreeMap<String, String>) -> Result<()> {
+    let mut contents = values
+        .iter()
+        .map(|(key, value)| format!("{key}={}", format_dotenv_value(value)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    contents.push('\n');
+    fs::write(path, contents)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("could not write {}", path.display()))
+}
+
+fn format_dotenv_value(value: &str) -> String {
+    // Bun's `--env-file` does not unescape `\"` inside double-quoted values, so
+    // JSON (and anything else with `"`) must use single quotes to round-trip.
+    let needs_quotes = value.is_empty()
+        || value.bytes().any(|byte| {
+            matches!(
+                byte,
+                b' ' | b'\t' | b'\n' | b'\r' | b'#' | b'=' | b'"' | b'\'' | b'`' | b'$'
+            )
+        });
+    if !needs_quotes {
+        return value.to_string();
+    }
+    if !value.contains('\'') && !value.contains('\n') && !value.contains('\r') {
+        return format!("'{value}'");
+    }
+    format!("\"{}\"", escape_dotenv(value))
 }
 
 fn escape_dotenv(value: &str) -> String {
@@ -326,7 +353,20 @@ mod tests {
         .unwrap();
         let loaded = load(&temp.path().join("control.toml")).unwrap();
         let path = write_for_manifest(&loaded, &BTreeMap::new()).unwrap();
-        assert_eq!(fs::read_to_string(path).unwrap(), "LITERAL=\"a\\\"b\"\n");
+        assert_eq!(fs::read_to_string(path).unwrap(), "LITERAL='a\"b'\n");
+    }
+
+    #[test]
+    fn writes_json_env_values_with_single_quotes_for_bun() {
+        let json = r#"{"local1":{"federationApi":"http://localhost:4321"}}"#;
+        let values = BTreeMap::from([("VITE_FEDERATION_INSTANCES".into(), json.into())]);
+        let temp = tempdir().unwrap();
+        let path = temp.path().join(".env");
+        write_dotenv(&path, &values).unwrap();
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            format!("VITE_FEDERATION_INSTANCES='{json}'\n")
+        );
     }
 
     #[test]

--- a/src/control/src/main.rs
+++ b/src/control/src/main.rs
@@ -31,6 +31,7 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Start selected development services.
+    #[command(visible_alias = "start")]
     Dev {
         /// Package names or group names. All packages are selected when omitted.
         selectors: Vec<String>,
@@ -90,6 +91,12 @@ enum WorkspaceCommand {
         /// Do not open the resulting workspace with VS Code/Cursor's `code` command.
         #[arg(long)]
         no_open: bool,
+    },
+    /// List branch workspaces for this repository.
+    List,
+    /// Remove a branch workspace worktree.
+    Remove {
+        branch: String,
     },
     /// Run this workspace in its Docker development container.
     Dev {
@@ -195,6 +202,25 @@ async fn main() -> Result<()> {
                 workspace::create(&project, &branch, !no_open).await?;
                 Ok(())
             }
+            (Some(WorkspaceCommand::List), None) => {
+                let workspaces = workspace::list(&project).await?;
+                if workspaces.is_empty() {
+                    println!("no workspaces");
+                    return Ok(());
+                }
+                for entry in workspaces {
+                    match (&entry.id, &entry.hostname) {
+                        (Some(id), Some(hostname)) => {
+                            println!("{}\t{}\t{}\t{}", entry.branch, entry.path.display(), id, hostname)
+                        }
+                        _ => println!("{}\t{}", entry.branch, entry.path.display()),
+                    }
+                }
+                Ok(())
+            }
+            (Some(WorkspaceCommand::Remove { branch }), None) => {
+                workspace::remove(&project, &branch).await
+            }
             (
                 Some(WorkspaceCommand::Dev {
                     selectors,
@@ -265,6 +291,48 @@ mod tests {
                 no_open: true,
                 command: None,
             } if branch == "feature/control"
+        ));
+
+        let create =
+            Cli::try_parse_from(["control", "workspace", "create", "feature/cli"]).unwrap();
+        assert!(matches!(
+            create.command,
+            Commands::Workspace {
+                command: Some(WorkspaceCommand::Create { branch, no_open: false }),
+                ..
+            } if branch == "feature/cli"
+        ));
+
+        let list = Cli::try_parse_from(["control", "workspace", "list"]).unwrap();
+        assert!(matches!(
+            list.command,
+            Commands::Workspace {
+                command: Some(WorkspaceCommand::List),
+                ..
+            }
+        ));
+
+        let remove =
+            Cli::try_parse_from(["control", "workspace", "remove", "feature/cli"]).unwrap();
+        assert!(matches!(
+            remove.command,
+            Commands::Workspace {
+                command: Some(WorkspaceCommand::Remove { branch }),
+                ..
+            } if branch == "feature/cli"
+        ));
+    }
+
+    #[test]
+    fn start_is_an_alias_for_dev() {
+        let start = Cli::try_parse_from(["control", "start", "--no-docker", "backend"]).unwrap();
+        assert!(matches!(
+            start.command,
+            Commands::Dev {
+                no_docker: true,
+                selectors,
+                ..
+            } if selectors == ["backend"]
         ));
     }
 }

--- a/src/control/src/manifest.rs
+++ b/src/control/src/manifest.rs
@@ -289,8 +289,14 @@ fn normalize(manifest: &mut Manifest, path: &Path) -> Result<()> {
             .into_iter()
             .enumerate()
         {
+            // Primary script is "dev" so mirrors are named `api`, not `api-run-1`.
+            let key = if index == 0 {
+                "dev".into()
+            } else {
+                format!("{}", index + 1)
+            };
             manifest.run.insert(
-                format!("run-{}", index + 1),
+                key,
                 Run {
                     command,
                     cwd: None,
@@ -572,6 +578,7 @@ mod tests {
         let loaded = load(&path).unwrap();
         assert_eq!(loaded.manifest.package.unwrap().name, "@metorial/api");
         assert_eq!(loaded.manifest.run.len(), 1);
+        assert!(loaded.manifest.run.contains_key("dev"));
         assert_eq!(loaded.manifest.expose, vec![Exposure { port: 4310 }]);
         assert_eq!(loaded.manifest.postgres["DATABASE_URL"].port, 35432);
     }

--- a/src/control/src/process.rs
+++ b/src/control/src/process.rs
@@ -56,7 +56,10 @@ pub async fn run_quiet(
 ) -> Result<()> {
     let mut command = command(program, args, cwd, env);
     isolate(&mut command);
+    // Null stdin: isolate() creates a new process group, so an inherited TTY
+    // causes SIGTTIN (docker compose exec stops and control hangs forever).
     let child = command
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)

--- a/src/control/src/turbo.rs
+++ b/src/control/src/turbo.rs
@@ -176,7 +176,7 @@ pub fn generate(workspace: &Path, packages: &[TurboPackage]) -> Result<()> {
                     .collect(),
             },
         );
-        write_environment(&directory.join(".env"), &package.environment)?;
+        environment::write_dotenv(&directory.join(".env"), &package.environment)?;
         write_runner(&directory.join("run.mjs"), &package.cwd, &package.command)?;
     }
     write_json(
@@ -200,27 +200,6 @@ pub fn generate(workspace: &Path, packages: &[TurboPackage]) -> Result<()> {
 
 fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
     let mut text = serde_json::to_string_pretty(value).into_diagnostic()?;
-    text.push('\n');
-    fs::write(path, text)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("could not write {}", path.display()))
-}
-
-fn write_environment(path: &Path, values: &BTreeMap<String, String>) -> Result<()> {
-    let mut text = values
-        .iter()
-        .map(|(key, value)| {
-            format!(
-                "{key}=\"{}\"",
-                value
-                    .replace('\\', "\\\\")
-                    .replace('"', "\\\"")
-                    .replace('\r', "\\r")
-                    .replace('\n', "\\n")
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
     text.push('\n');
     fs::write(path, text)
         .into_diagnostic()
@@ -265,7 +244,12 @@ fn turbo_package_name(package_name: &str, run_name: &str) -> String {
     let package_name = package_name
         .strip_prefix("metorial-")
         .unwrap_or(&package_name);
-    sanitize(&format!("{package_name}-{run_name}"))
+    let run_name = sanitize(run_name);
+    if run_name.is_empty() || run_name == "dev" {
+        package_name.to_string()
+    } else {
+        sanitize(&format!("{package_name}-{run_name}"))
+    }
 }
 
 pub fn filters(packages: &[TurboPackage]) -> Vec<String> {
@@ -318,5 +302,24 @@ mod tests {
                 .unwrap()
                 .contains("sensitive")
         );
+    }
+
+    #[test]
+    fn repository_schema_mirrors_omit_run_suffix() {
+        let temp = tempdir().unwrap();
+        let manifest = temp.path().join("control.toml");
+        fs::write(temp.path().join("package.json"), "{}").unwrap();
+        fs::write(
+            &manifest,
+            "name='@metorial/api'\n[dev]\nrun=['bun dev']",
+        )
+        .unwrap();
+        let loaded = load(&manifest).unwrap();
+        let packages = plan(&[&loaded], temp.path(), &BTreeMap::new()).unwrap();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "api");
+        let workspace = temp.path().join(".control/dev");
+        generate(&workspace, &packages).unwrap();
+        assert!(workspace.join("packages/api/package.json").is_file());
     }
 }

--- a/src/control/src/workspace.rs
+++ b/src/control/src/workspace.rs
@@ -22,6 +22,14 @@ pub struct WorkspaceMetadata {
     pub source_root: PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListedWorkspace {
+    pub branch: String,
+    pub path: PathBuf,
+    pub id: Option<String>,
+    pub hostname: Option<String>,
+}
+
 pub fn validate_branch(branch: &str) -> Result<()> {
     if branch.is_empty()
         || branch.starts_with('-')
@@ -120,6 +128,7 @@ pub async fn create(project: &ProjectRoot, branch: &str, open_code: bool) -> Res
         },
     )?;
     println!("created workspace {}", target.display());
+    prepare_workspace(project, &target).await?;
     if open_code {
         match Command::new("code").arg(&target).status() {
             Ok(status) if status.success() => {}
@@ -130,15 +139,106 @@ pub async fn create(project: &ProjectRoot, branch: &str, open_code: bool) -> Res
     Ok(target)
 }
 
+async fn prepare_workspace(project: &ProjectRoot, target: &Path) -> Result<()> {
+    println!("Installing dependencies");
+    process::run("bun", &["install".into()], target, &Default::default())
+        .await
+        .wrap_err_with(|| format!("bun install failed in {}", target.display()))?;
+
+    let control_manifest = match project.kind {
+        RootKind::Enterprise => target.join("oss/src/control/Cargo.toml"),
+        RootKind::Standalone => target.join("src/control/Cargo.toml"),
+    };
+    println!("Building control");
+    process::run(
+        "cargo",
+        &[
+            "build".into(),
+            "--manifest-path".into(),
+            control_manifest.to_string_lossy().into(),
+        ],
+        target,
+        &Default::default(),
+    )
+    .await
+    .wrap_err_with(|| {
+        format!(
+            "could not build control from {}",
+            control_manifest.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub async fn list(project: &ProjectRoot) -> Result<Vec<ListedWorkspace>> {
+    let source = source_root(project).await?;
+    let mut workspaces = Vec::new();
+    for worktree in list_worktrees(&project.root).await? {
+        if same_path(&worktree.path, &source) {
+            continue;
+        }
+        let Some(branch) = worktree.branch else {
+            continue;
+        };
+        let metadata = read_metadata_file(&worktree.path).ok().flatten();
+        workspaces.push(ListedWorkspace {
+            branch,
+            path: worktree.path,
+            id: metadata.as_ref().map(|metadata| metadata.id.clone()),
+            hostname: metadata.as_ref().map(|metadata| metadata.hostname.clone()),
+        });
+    }
+    workspaces.sort_by(|left, right| left.branch.cmp(&right.branch));
+    Ok(workspaces)
+}
+
+pub async fn remove(project: &ProjectRoot, branch: &str) -> Result<()> {
+    validate_branch(branch)?;
+    let source = source_root(project).await?;
+    let worktree = list_worktrees(&project.root)
+        .await?
+        .into_iter()
+        .find(|worktree| worktree.branch.as_deref() == Some(branch))
+        .ok_or_else(|| miette::miette!("no workspace found for branch {branch:?}"))?;
+
+    if same_path(&worktree.path, &source) {
+        bail!("cannot remove the source checkout");
+    }
+
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    if same_path(&worktree.path, &cwd) || cwd.starts_with(&worktree.path) {
+        bail!(
+            "cannot remove the workspace you are currently in; run from the source checkout at {}",
+            source.display()
+        );
+    }
+
+    if project.kind == RootKind::Enterprise || source.join("oss/package.json").is_file() {
+        let oss_repo = if project.kind == RootKind::Enterprise {
+            project.oss.clone()
+        } else {
+            source.join("oss")
+        };
+        let target_oss = worktree.path.join("oss");
+        if target_oss.exists() {
+            remove_worktree(&oss_repo, &target_oss)
+                .await
+                .wrap_err_with(|| {
+                    format!("could not remove OSS worktree {}", target_oss.display())
+                })?;
+        }
+    }
+
+    remove_worktree(&source, &worktree.path)
+        .await
+        .wrap_err_with(|| format!("could not remove worktree {}", worktree.path.display()))?;
+    println!("removed workspace {}", worktree.path.display());
+    Ok(())
+}
+
 pub async fn metadata(project: &ProjectRoot) -> Result<WorkspaceMetadata> {
-    let path = metadata_path(&project.root);
-    if path.is_file() {
-        let contents = fs::read_to_string(&path)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("could not read {}", path.display()))?;
-        return serde_json::from_str(&contents)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("invalid {}", path.display()));
+    if let Some(metadata) = read_metadata_file(&project.root)? {
+        return Ok(metadata);
     }
 
     let branch = process::output("git", &["branch", "--show-current"], &project.root)
@@ -154,25 +254,7 @@ pub async fn metadata(project: &ProjectRoot) -> Result<WorkspaceMetadata> {
     } else {
         branch
     };
-    let common_git = process::output("git", &["rev-parse", "--git-common-dir"], &project.root)
-        .await
-        .ok()
-        .map(PathBuf::from)
-        .map(|path| {
-            if path.is_absolute() {
-                path
-            } else {
-                project.root.join(path)
-            }
-        })
-        .and_then(|path| path.canonicalize().ok());
-    let source_root = common_git
-        .as_deref()
-        .filter(|path| path.file_name().and_then(|name| name.to_str()) == Some(".git"))
-        .and_then(Path::parent)
-        .filter(|path| path.join("package.json").is_file())
-        .unwrap_or(&project.root)
-        .to_path_buf();
+    let source_root = source_root(project).await?;
     let metadata = WorkspaceMetadata {
         id: workspace_id(&project.root, &branch),
         hostname: workspace_hostname(&project.root, &branch),
@@ -198,6 +280,96 @@ fn write_metadata(root: &Path, metadata: &WorkspaceMetadata) -> Result<()> {
     fs::write(&path, contents)
         .into_diagnostic()
         .wrap_err_with(|| format!("could not write {}", path.display()))
+}
+
+fn read_metadata_file(root: &Path) -> Result<Option<WorkspaceMetadata>> {
+    let path = metadata_path(root);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let contents = fs::read_to_string(&path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("could not read {}", path.display()))?;
+    let metadata = serde_json::from_str(&contents)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("invalid {}", path.display()))?;
+    Ok(Some(metadata))
+}
+
+async fn source_root(project: &ProjectRoot) -> Result<PathBuf> {
+    if let Some(metadata) = read_metadata_file(&project.root)? {
+        return Ok(metadata.source_root);
+    }
+
+    let common_git = process::output("git", &["rev-parse", "--git-common-dir"], &project.root)
+        .await
+        .ok()
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                project.root.join(path)
+            }
+        })
+        .and_then(|path| path.canonicalize().ok());
+    Ok(common_git
+        .as_deref()
+        .filter(|path| path.file_name().and_then(|name| name.to_str()) == Some(".git"))
+        .and_then(Path::parent)
+        .filter(|path| path.join("package.json").is_file())
+        .unwrap_or(&project.root)
+        .to_path_buf())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitWorktree {
+    path: PathBuf,
+    branch: Option<String>,
+}
+
+async fn list_worktrees(repo: &Path) -> Result<Vec<GitWorktree>> {
+    let output = process::output("git", &["worktree", "list", "--porcelain"], repo)
+        .await
+        .wrap_err_with(|| format!("could not list worktrees for {}", repo.display()))?;
+    Ok(parse_worktree_list(&output))
+}
+
+fn parse_worktree_list(output: &str) -> Vec<GitWorktree> {
+    let mut worktrees = Vec::new();
+    let mut path: Option<PathBuf> = None;
+    let mut branch: Option<String> = None;
+
+    for line in output.lines().chain(std::iter::once("")) {
+        if line.is_empty() {
+            if let Some(path) = path.take() {
+                worktrees.push(GitWorktree {
+                    path,
+                    branch: branch.take(),
+                });
+            } else {
+                branch = None;
+            }
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("worktree ") {
+            if let Some(path) = path.take() {
+                worktrees.push(GitWorktree {
+                    path,
+                    branch: branch.take(),
+                });
+            }
+            path = Some(PathBuf::from(value));
+        } else if let Some(value) = line.strip_prefix("branch refs/heads/") {
+            branch = Some(value.to_string());
+        }
+    }
+    worktrees
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    left.canonicalize().unwrap_or_else(|_| left.to_path_buf())
+        == right.canonicalize().unwrap_or_else(|_| right.to_path_buf())
 }
 
 pub fn workspace_id(root: &Path, branch: &str) -> String {
@@ -311,6 +483,40 @@ mod tests {
         assert!(
             workspace_hostname(Path::new("/code/metorial"), "Feature/CLI")
                 .starts_with("feature-cli-")
+        );
+    }
+
+    #[test]
+    fn parses_porcelain_worktree_list() {
+        let worktrees = parse_worktree_list(
+            "worktree /code/metorial\n\
+             HEAD abc\n\
+             branch refs/heads/dev\n\
+             \n\
+             worktree /code/metorial-feature-cli\n\
+             HEAD def\n\
+             branch refs/heads/feature/cli\n\
+             \n\
+             worktree /tmp/detached\n\
+             HEAD ghi\n\
+             detached\n",
+        );
+        assert_eq!(
+            worktrees,
+            vec![
+                GitWorktree {
+                    path: PathBuf::from("/code/metorial"),
+                    branch: Some("dev".into()),
+                },
+                GitWorktree {
+                    path: PathBuf::from("/code/metorial-feature-cli"),
+                    branch: Some("feature/cli".into()),
+                },
+                GitWorktree {
+                    path: PathBuf::from("/tmp/detached"),
+                    branch: None,
+                },
+            ]
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches dev startup (Docker, process spawning), env file format consumed by Bun, and git worktree lifecycle; behavior changes are intentional but could affect existing workflows relying on old mirror names or .env quoting.
> 
> **Overview**
> **Fixes `control dev` hanging or stalling during Docker startup** by streaming `docker compose up` output instead of running it quietly, dropping the services spinner for plain status lines, and giving **null stdin** to quiet subprocesses so inherited TTY + process groups no longer trigger SIGTTIN on `docker compose exec`.
> 
> **`.env` generation** is centralized in `write_dotenv` with quoting tuned for Bun’s `--env-file` (single quotes for JSON and embedded `"`), shared by manifest writes and Turbo mirror packages.
> 
> **CLI:** `control start` aliases `dev`; **`workspace list`** and **`workspace remove`** manage branch worktrees (enterprise paired OSS removal included). **`workspace create`** now runs **`bun install`** and builds the workspace **Control** binary before optionally opening the editor.
> 
> **Turbo mirrors:** repository `[dev].run` maps the first script to run key **`dev`**, so generated package names are e.g. **`api`** instead of **`api-run-1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76025c990deb90c143d097bdc08073416a20717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->