### PR TITLE
Various control improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,4 +187,5 @@ bin
 
 env.json
 .control/
+HOST.md
 src/control/target/

--- a/control.toml
+++ b/control.toml
@@ -1,3 +1,3 @@
-# Workspace-wide preparation for standalone OSS checkouts.
+# Workspace-wide preparation (prisma generate/push and `bun run build`) is
+# handled by Control itself before package-local prepare commands.
 mode = "oss"
-prepare = ["bun run build"]

--- a/scripts/dev-tools/workspace/entrypoint.sh
+++ b/scripts/dev-tools/workspace/entrypoint.sh
@@ -30,15 +30,13 @@ setup_workspace() {
   fi
 
   enter_workspace
-  echo "Installing container dependencies"
-  bun install --verbose
-  echo "Building workspace packages"
-  bun run build
+  echo "Installing container dependencies. This will take a few minutes..."
+  bun install
   local manifest
   manifest="$(control_manifest)"
   echo "Building Control"
   cargo build --manifest-path "${manifest}"
-  echo "Running Control prepare tasks"
+  echo "Running Control prepare (prisma generate, prisma push, build, package prepare)"
   cargo run --quiet --manifest-path "${manifest}" -- prepare --no-docker
   printf '%s\n' "${version}" >"${marker}"
   echo "Workspace setup complete"

--- a/src/ares/service/control.toml
+++ b/src/ares/service/control.toml
@@ -2,11 +2,7 @@ name = "@metorial/ares"
 group = "oss"
 
 [dev]
-prepare = [
-  "bun run prisma:generate",
-  "bun run prisma:push",
-  "bun run frontend:build",
-]
+prepare = ["bun run frontend:build"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/cargo/service/control.toml
+++ b/src/cargo/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial-cargo/service"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/control/README.md
+++ b/src/control/README.md
@@ -57,7 +57,7 @@ mode = "both"
 # Strings are literals. `true` inherits the key from root env.json or the
 # process environment when present.
 [dev]
-prepare = ["bun run prisma:generate", "bun run frontend:build"]
+prepare = ["bun run frontend:build"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]
@@ -85,15 +85,14 @@ stop = true
 paths = ["dist", ".cache"]
 ```
 
-Workspace-wide setup (library builds, shared codegen) can use a root
-`control.toml` with only `mode` and top-level `prepare` — no `name`/`package`.
-Those manifests are always prepared, including when package/group filters are
-passed:
+Workspace-wide Prisma generation, schema push, and `bun run build` are always
+run by Control before package-local `prepare` commands (via the root
+`prisma:generate`, `prisma:push`, and `build` scripts, which use Turbo for
+caching). Root `control.toml` files may still declare `mode` so they participate
+in selection; they no longer need a `prepare = ["bun run build"]` entry.
 
-```toml
-mode = "enterprise"
-prepare = ["bun run build"]
-```
+Package-local `prepare` should only contain package-specific steps (for example
+`frontend:build` or `admin:build`), not Prisma or the global build.
 
 The repository's `name`/`group`/`dev` schema is preferred. An extended schema
 is also accepted for external projects: `[package]`, `[env]`,
@@ -106,35 +105,44 @@ Unix and `cmd.exe /D /S /C` on Windows.
 Literal, inherited, and default environment values support the strict
 `{{HOSTNAME}}` template. It resolves from `METORIAL_HOSTNAME` and unknown or
 unclosed templates are errors. Native development defaults it to `localhost`;
-Docker workspaces use their stable `<workspace>.localhost` hostname.
+Docker workspaces use their branch-derived `<branch>.localhost` hostname.
 
 Package and group arguments select manifests. With no selectors all manifests
 are used. Each generated Turbo mirror receives its manifest's isolated
 environment.
 
 `control dev` starts Compose projects, waits for declared databases, creates
-databases idempotently, writes package-local `.env` files, performs preparation
-in manifest order, and generates
-an isolated `.control/dev` Turbo workspace with one mirror package per run
-command. It then invokes Turbo directly with explicit filters. Ctrl-C
-terminates Turbo and performs configured Docker cleanup.
+databases idempotently, writes package-local `.env` files, then prepares the
+workspace in this order:
+
+1. `bun run prisma:generate` (Turbo, all packages)
+2. `bun run prisma:push` (Turbo, all packages)
+3. `bun run build` (Turbo via the root build script)
+4. package-local `control.toml` prepare commands
+
+It then generates an isolated `.control/dev` Turbo workspace with one mirror
+package per run command and invokes Turbo directly with explicit filters.
+Ctrl-C terminates Turbo and performs configured Docker cleanup. Because prepare
+pushes every Prisma schema, dependency services cover the full workspace even
+when only a subset of applications are started.
 
 For Postgres, database creation uses `docker compose exec` when `compose` and
 `service` are supplied, otherwise the local `pg_isready` and `psql` clients.
 MongoDB follows the same rule using `mongosh`; an empty database receives a
 `__control` collection so that it persists.
 
-`control prepare` writes selected package environment files and runs
-`control.toml` prepare commands without starting Turbo or any application
-processes. It starts declared dependencies unless `--no-docker` is passed.
+`control prepare` writes environment files and runs the same preparation
+sequence without starting Turbo or any application processes. It starts
+declared dependencies unless `--no-docker` is passed.
 
 `control workspace create BRANCH` creates a sibling worktree. Enterprise mode
 creates the enterprise worktree and a paired OSS worktree at its `oss/` path.
 It then starts a persistent Ubuntu development container and a private
-dependency stack. The first initialization runs `bun install`, `bun run build`,
-builds Control, and runs `control prepare --no-docker` inside the container.
-After setup it opens `/workspace` through VS Code's Dev Containers extension
-unless `--no-open` is passed. Application services are not started.
+dependency stack. The first initialization runs `bun install`, builds Control,
+and runs `control prepare --no-docker` inside the container (prisma generate,
+prisma push, build, and package prepare). After setup it opens `/workspace`
+through VS Code's Dev Containers extension unless `--no-open` is passed.
+Application services are not started.
 
 `control workspace list` prints linked worktrees for the repository (branch,
 path, and workspace identity when metadata is present).
@@ -176,13 +184,17 @@ editor and container see the same output. The source checkout's `env.json` is
 mounted read-only when a worktree does not provide its own override.
 
 A single global Traefik container owns the declared HTTP ports and routes each
-request by host header. A workspace named `feature-auth-1234abcd` therefore
-uses URLs such as:
+request by host header. A workspace for branch `feature/auth` therefore uses
+URLs such as:
 
 ```text
-http://feature-auth-1234abcd.localhost:4310
-http://feature-auth-1234abcd.localhost:4300
+http://feature-auth.localhost:4310
+http://feature-auth.localhost:4300
 ```
+
+On start, Control writes `HOST.md` at the workspace root (visible inside the
+container as `/workspace/HOST.md`) listing every exposed HTTP endpoint for that
+hostname, grouped by package.
 
 `.localhost` resolves without host-file changes on supported systems. Every
 HTTP listener that should be reachable from the host must have a

--- a/src/control/src/dev.rs
+++ b/src/control/src/dev.rs
@@ -28,10 +28,16 @@ pub async fn run(
     if selected.is_empty() {
         bail!("no control.toml manifests or run commands were selected");
     }
+    let all = manifest::select(&manifests, &[], &project.kind)?;
     let root_env = environment::root_environment(project)?;
     if dry_run {
         let packages = turbo::plan(&selected, &project.root, &root_env)?;
         println!("root: {}", project.root.display());
+        if !no_prepare {
+            println!("prepare: bun run prisma:generate");
+            println!("prepare: bun run prisma:push");
+            println!("prepare: bun run build");
+        }
         for loaded in &selected {
             let cwd = loaded.path.parent().unwrap_or(&project.root);
             for command in &loaded.manifest.prepare {
@@ -45,11 +51,14 @@ pub async fn run(
         return Ok(());
     }
 
+    // Prepare runs prisma:push for every package, so dependency services must
+    // cover the full workspace even when only a subset of apps will run.
+    let docker_manifests = if no_prepare { &selected } else { &all };
     let projects = if no_docker {
         Vec::new()
     } else {
         println!("Starting development services");
-        match docker::start(&project.root, &selected, &root_env).await {
+        match docker::start(&project.root, docker_manifests, &root_env).await {
             Ok(projects) => {
                 println!("Development services ready");
                 projects
@@ -63,7 +72,7 @@ pub async fn run(
         }
     };
 
-    let prepared = prepare_selected(project, &selected, &root_env, no_prepare).await;
+    let prepared = prepare_selected(project, &all, &selected, &root_env, no_prepare).await;
     if let Err(error) = prepared {
         docker::stop(&project.root, &projects, &root_env).await;
         if process::is_interrupted(&error) {
@@ -151,25 +160,30 @@ pub async fn run_prepare(
     if selected.is_empty() {
         bail!("no control.toml manifests were selected");
     }
+    let all = manifest::select(&manifests, &[], &project.kind)?;
     let root_env = environment::root_environment(project)?;
     if !no_docker {
         println!("Starting development services");
-        docker::start(&project.root, &selected, &root_env)
+        docker::start(&project.root, &all, &root_env)
             .await
             .wrap_err("Docker startup failed")?;
         println!("Development services ready");
     }
-    prepare_selected(project, &selected, &root_env, false).await
+    prepare_selected(project, &all, &selected, &root_env, false).await
 }
 
 async fn prepare_selected(
     project: &ProjectRoot,
-    manifests: &[&LoadedManifest],
+    all: &[&LoadedManifest],
+    selected: &[&LoadedManifest],
     env: &BTreeMap<String, String>,
     skip_commands: bool,
 ) -> Result<()> {
     let environment_spinner = spinner("Preparing development environment");
-    for loaded in manifests {
+    // Always write every package `.env` when preparing so turbo `prisma:push`
+    // can reach every schema; with `--no-prepare` only write selected ones.
+    let env_targets = if skip_commands { selected } else { all };
+    for loaded in env_targets {
         if environment::has_values(loaded) {
             environment::write_for_manifest(loaded, env)?;
         }
@@ -178,10 +192,32 @@ async fn prepare_selected(
     if skip_commands {
         return Ok(());
     }
-    prepare(&project.root, manifests, env).await
+    prepare_workspace(project, selected, env).await
 }
 
-async fn prepare(
+async fn prepare_workspace(
+    project: &ProjectRoot,
+    selected: &[&LoadedManifest],
+    env: &BTreeMap<String, String>,
+) -> Result<()> {
+    // Global turbo tasks (cached) before any package-local prepare commands.
+    for (label, command) in [
+        ("Generating Prisma clients", "bun run prisma:generate"),
+        ("Pushing Prisma schemas", "bun run prisma:push"),
+        ("Building packages", "bun run build"),
+    ] {
+        println!("{label}");
+        if let Err(error) = process::shell(command, &project.root, env).await {
+            if process::is_interrupted(&error) {
+                return Err(error);
+            }
+            return Err(error).wrap_err_with(|| format!("{command} failed"));
+        }
+    }
+    prepare_commands(&project.root, selected, env).await
+}
+
+async fn prepare_commands(
     root: &Path,
     manifests: &[&LoadedManifest],
     env: &BTreeMap<String, String>,

--- a/src/control/src/workspace.rs
+++ b/src/control/src/workspace.rs
@@ -1,7 +1,5 @@
 use std::{
-    collections::hash_map::DefaultHasher,
     fs,
-    hash::{Hash, Hasher},
     path::{Path, PathBuf},
 };
 
@@ -122,8 +120,8 @@ pub async fn create(project: &ProjectRoot, branch: &str, open_code: bool) -> Res
         write_metadata(
             &target,
             &WorkspaceMetadata {
-                id: workspace_id(&target, branch),
-                hostname: workspace_hostname(&target, branch),
+                id: workspace_id(branch),
+                hostname: workspace_hostname(branch),
                 branch: branch.into(),
                 source_root: project.root.clone(),
             },
@@ -273,8 +271,8 @@ pub async fn metadata(project: &ProjectRoot) -> Result<WorkspaceMetadata> {
     };
     let source_root = source_root(project).await?;
     let metadata = WorkspaceMetadata {
-        id: workspace_id(&project.root, &branch),
-        hostname: workspace_hostname(&project.root, &branch),
+        id: workspace_id(&branch),
+        hostname: workspace_hostname(&branch),
         branch,
         source_root,
     };
@@ -389,20 +387,19 @@ fn same_path(left: &Path, right: &Path) -> bool {
         == right.canonicalize().unwrap_or_else(|_| right.to_path_buf())
 }
 
-pub fn workspace_id(root: &Path, branch: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    root.canonicalize()
-        .unwrap_or_else(|_| root.to_path_buf())
-        .hash(&mut hasher);
+pub fn workspace_id(branch: &str) -> String {
     let mut slug = branch_slug(branch).to_ascii_lowercase().replace('_', "-");
     slug.truncate(45);
     let slug = slug.trim_matches('-');
-    let slug = if slug.is_empty() { "workspace" } else { slug };
-    format!("{}-{:08x}", slug, hasher.finish() as u32)
+    if slug.is_empty() {
+        "workspace".into()
+    } else {
+        slug.to_string()
+    }
 }
 
-pub fn workspace_hostname(root: &Path, branch: &str) -> String {
-    format!("{}.localhost", workspace_id(root, branch))
+pub fn workspace_hostname(branch: &str) -> String {
+    format!("{}.localhost", workspace_id(branch))
 }
 
 async fn add_worktree(repo: &Path, target: &Path, branch: &str) -> Result<bool> {
@@ -493,14 +490,8 @@ mod tests {
             workspace_path(Path::new("/code/metorial"), "feature/cli"),
             Path::new("/code/metorial-feature-cli")
         );
-        assert_eq!(
-            workspace_id(Path::new("/code/metorial"), "Feature/CLI"),
-            workspace_id(Path::new("/code/metorial"), "Feature/CLI")
-        );
-        assert!(
-            workspace_hostname(Path::new("/code/metorial"), "Feature/CLI")
-                .starts_with("feature-cli-")
-        );
+        assert_eq!(workspace_id("Feature/CLI"), "feature-cli");
+        assert_eq!(workspace_hostname("Feature/CLI"), "feature-cli.localhost");
     }
 
     #[test]

--- a/src/control/src/workspace_dev.rs
+++ b/src/control/src/workspace_dev.rs
@@ -68,7 +68,12 @@ pub async fn stop(project: &ProjectRoot, volumes: bool) -> Result<()> {
     {
         docker_run(
             &project.root,
-            vec!["stop".into(), "--time".into(), "20".into(), name.clone()],
+            vec![
+                "stop".into(),
+                "--timeout".into(),
+                "20".into(),
+                name.clone(),
+            ],
             &environment,
         )
         .await
@@ -230,8 +235,9 @@ async fn ensure_running(project: &ProjectRoot, rebuild: bool) -> Result<RunningW
     )
     .await
     .wrap_err("could not start workspace container")?;
+    write_hosts_file(project, &metadata, &selected)?;
     println!("workspace hostname: {}", metadata.hostname);
-    for port in ports {
+    for port in &ports {
         println!("  http://{}:{port}", metadata.hostname);
     }
     Ok(RunningWorkspace {
@@ -469,6 +475,63 @@ fn exposed_ports(manifests: &[&LoadedManifest]) -> BTreeSet<u16> {
         .collect()
 }
 
+fn manifest_name(loaded: &LoadedManifest) -> String {
+    loaded
+        .manifest
+        .package
+        .as_ref()
+        .map(|package| package.name.clone())
+        .unwrap_or_else(|| loaded.path.display().to_string())
+}
+
+fn hosts_markdown(metadata: &WorkspaceMetadata, manifests: &[&LoadedManifest]) -> String {
+    let mut entries = manifests
+        .iter()
+        .flat_map(|loaded| {
+            let name = manifest_name(loaded);
+            loaded
+                .manifest
+                .expose
+                .iter()
+                .map(move |exposure| (exposure.port, name.clone()))
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.0.cmp(&right.0).then(left.1.cmp(&right.1)));
+
+    let mut lines = vec![
+        "# Workspace hosts".into(),
+        String::new(),
+        format!("Hostname: `{}`", metadata.hostname),
+        String::new(),
+        "## Exposed HTTP endpoints".into(),
+        String::new(),
+    ];
+    if entries.is_empty() {
+        lines.push("_No `[[dev.expose]]` ports declared._".into());
+    } else {
+        for (port, name) in entries {
+            lines.push(format!(
+                "- `{name}` — http://{}:{port}",
+                metadata.hostname
+            ));
+        }
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+fn write_hosts_file(
+    project: &ProjectRoot,
+    metadata: &WorkspaceMetadata,
+    manifests: &[&LoadedManifest],
+) -> Result<()> {
+    let path = project.root.join("HOST.md");
+    fs::write(&path, hosts_markdown(metadata, manifests))
+        .into_diagnostic()
+        .wrap_err_with(|| format!("could not write {}", path.display()))?;
+    Ok(())
+}
+
 fn proxy_label_args(metadata: &WorkspaceMetadata, ports: &BTreeSet<u16>) -> Vec<String> {
     let mut args = Vec::new();
     for port in ports {
@@ -629,7 +692,7 @@ fn services_project(metadata: &WorkspaceMetadata) -> String {
 }
 
 fn container_name(metadata: &WorkspaceMetadata) -> String {
-    format!("control-ws-{}", metadata.id)
+    format!("metorial-ws-{}", metadata.id)
 }
 
 fn resolve_services_host() -> Result<String> {
@@ -721,11 +784,12 @@ async fn docker_quiet(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manifest::{Exposure, Manifest, Package};
 
     fn metadata() -> WorkspaceMetadata {
         WorkspaceMetadata {
-            id: "feature-auth-deadbeef".into(),
-            hostname: "feature-auth-deadbeef.localhost".into(),
+            id: "feature-auth".into(),
+            hostname: "feature-auth.localhost".into(),
             branch: "feature/auth".into(),
             source_root: "/code/metorial".into(),
         }
@@ -734,23 +798,56 @@ mod tests {
     #[test]
     fn generates_stable_resource_names_and_volumes() {
         let metadata = metadata();
-        assert_eq!(
-            container_name(&metadata),
-            "control-ws-feature-auth-deadbeef"
-        );
-        assert_eq!(
-            services_project(&metadata),
-            "control_ws_feature_auth_deadbeef"
-        );
+        assert_eq!(container_name(&metadata), "metorial-ws-feature-auth");
+        assert_eq!(services_project(&metadata), "control_ws_feature_auth");
         let volumes = workspace_volumes(&metadata);
-        assert!(volumes.contains(&"control-feature-auth-deadbeef-state".into()));
-        assert!(volumes.contains(&"control-feature-auth-deadbeef-vscode-server".into()));
+        assert!(volumes.contains(&"control-feature-auth-state".into()));
+        assert!(volumes.contains(&"control-feature-auth-vscode-server".into()));
+    }
+
+    #[test]
+    fn writes_hosts_markdown_from_workspace_hostname() {
+        let metadata = metadata();
+        let manifests = [
+            LoadedManifest {
+                path: "apps/dashboard/control.toml".into(),
+                manifest: Manifest {
+                    package: Some(Package {
+                        name: "@metorial/dashboard".into(),
+                        groups: vec![],
+                    }),
+                    expose: vec![Exposure { port: 4300 }],
+                    ..Default::default()
+                },
+            },
+            LoadedManifest {
+                path: "services/api/control.toml".into(),
+                manifest: Manifest {
+                    package: Some(Package {
+                        name: "@metorial/core-api".into(),
+                        groups: vec![],
+                    }),
+                    expose: vec![Exposure { port: 4310 }, Exposure { port: 4318 }],
+                    ..Default::default()
+                },
+            },
+        ];
+        let selected = manifests.iter().collect::<Vec<_>>();
+        let markdown = hosts_markdown(&metadata, &selected);
+        assert!(markdown.contains("Hostname: `feature-auth.localhost`"));
+        assert!(markdown.contains("- `@metorial/dashboard` — http://feature-auth.localhost:4300"));
+        assert!(markdown.contains("- `@metorial/core-api` — http://feature-auth.localhost:4310"));
+        assert!(markdown.contains("- `@metorial/core-api` — http://feature-auth.localhost:4318"));
+        assert!(
+            markdown.find("4300").unwrap() < markdown.find("4310").unwrap(),
+            "endpoints should be sorted by port"
+        );
     }
 
     #[test]
     fn encodes_vscode_attached_container_uri() {
-        let uri = vscode_uri("control-ws-test", "/workspace");
-        let descriptor = serde_json::json!({ "containerName": "control-ws-test" }).to_string();
+        let uri = vscode_uri("metorial-ws-test", "/workspace");
+        let descriptor = serde_json::json!({ "containerName": "metorial-ws-test" }).to_string();
         let hex = descriptor
             .as_bytes()
             .iter()

--- a/src/forge/service/control.toml
+++ b/src/forge/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/forge"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/function-bay/service/control.toml
+++ b/src/function-bay/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/function-bay"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/metorial/db/control.toml
+++ b/src/metorial/db/control.toml
@@ -1,9 +1,6 @@
 name = "@metorial/db"
 group = "oss"
 
-[dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
-
 [dev.env]
 METORIAL_ENV = "development"
 METORIAL_SOURCE = "oss"

--- a/src/metorial/multi-region/control.toml
+++ b/src/metorial/multi-region/control.toml
@@ -1,2 +1,0 @@
-# Always prepared: global-router and others import the generated Prisma client.
-prepare = ["bun run prisma:generate"]

--- a/src/nebula/service/control.toml
+++ b/src/nebula/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/nebula"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/origin/apps/service/control.toml
+++ b/src/origin/apps/service/control.toml
@@ -3,7 +3,6 @@ group = "oss"
 mode = "enterprise"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/relay/service/control.toml
+++ b/src/relay/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/relay"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/shuttle/service/control.toml
+++ b/src/shuttle/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/shuttle"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/signal/service/control.toml
+++ b/src/signal/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/signal"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/slates/apps/hub/control.toml
+++ b/src/slates/apps/hub/control.toml
@@ -2,11 +2,7 @@ name = "@metorial/slates"
 group = "oss"
 
 [dev]
-prepare = [
-  "bun run prisma:generate",
-  "bun run prisma:push",
-  "bun run admin:build",
-]
+prepare = ["bun run admin:build"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/subspace/db/control.toml
+++ b/src/subspace/db/control.toml
@@ -1,9 +1,6 @@
 name = "@metorial-subspace/db"
 group = "oss"
 
-[dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
-
 [dev.env]
 METORIAL_ENV = "development"
 METORIAL_SOURCE = "oss"

--- a/src/synthesis/service/control.toml
+++ b/src/synthesis/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/synthesis"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]

--- a/src/voyager/service/control.toml
+++ b/src/voyager/service/control.toml
@@ -2,7 +2,6 @@ name = "@metorial/voyager"
 group = "oss"
 
 [dev]
-prepare = ["bun run prisma:generate", "bun run prisma:push"]
 run = ["bun --watch ./src/server.ts"]
 
 [[dev.expose]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dev bootstrap order and always runs full-workspace Prisma push and Docker deps, which can surprise filtered `control dev` runs; workspace hostname/id changes may break bookmarks or scripts tied to old hashed names.
> 
> **Overview**
> **Control** now owns workspace-wide preparation: it always runs `bun run prisma:generate`, `prisma:push`, and `build` (Turbo) before any package-local `prepare` commands. Root `control.toml` no longer declares `prepare = ["bun run build"]`, and per-service manifests drop duplicated Prisma steps—only package-specific steps remain (e.g. `frontend:build`, `admin:build`).
> 
> For `control dev` / `prepare`, Docker dependency startup and `.env` generation use **all** manifests when prepare runs, so `prisma:push` can reach every schema even if you only start a subset of apps. Container bootstrap drops a redundant `bun run build` and relies on `control prepare --no-docker`.
> 
> Docker workspace IDs and Traefik hostnames are **branch-slug based** (e.g. `feature-auth.localhost`) instead of path-hashed suffixes; containers are named `metorial-ws-*`. On workspace start, Control writes **`HOST.md`** (gitignored) listing exposed HTTP endpoints for that hostname.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb4585a9b4e7ed39f32f69c61eb3c2034dbda66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->