### PR TITLE
Cargo merge improvements

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_syncs.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/endpoints/dashboard_instance_skills_syncs.ts
@@ -1,15 +1,14 @@
-import {
-  BaseMetorialEndpoint,
-  MetorialEndpointManager
-} from '@metorial/util-endpoint';
+import { BaseMetorialEndpoint, MetorialEndpointManager } from '@metorial/util-endpoint';
 
 import {
   mapDashboardInstanceSkillsSyncsGetOutput,
   mapDashboardInstanceSkillsSyncsListOutput,
   mapDashboardInstanceSkillsSyncsListQuery,
+  mapDashboardInstanceSkillsSyncsRepositoryChecksOutput,
   type DashboardInstanceSkillsSyncsGetOutput,
   type DashboardInstanceSkillsSyncsListOutput,
-  type DashboardInstanceSkillsSyncsListQuery
+  type DashboardInstanceSkillsSyncsListQuery,
+  type DashboardInstanceSkillsSyncsRepositoryChecksOutput
 } from '../resources';
 
 /**
@@ -60,15 +59,11 @@ export class MetorialDashboardInstanceSkillsSyncsEndpoint {
     let request = {
       path,
 
-      query: query
-        ? mapDashboardInstanceSkillsSyncsListQuery.transformTo(query)
-        : undefined,
+      query: query ? mapDashboardInstanceSkillsSyncsListQuery.transformTo(query) : undefined,
       ...(opts?.headers ? { headers: opts.headers } : {})
     } as any;
 
-    return this._get(request).transform(
-      mapDashboardInstanceSkillsSyncsListOutput
-    );
+    return this._get(request).transform(mapDashboardInstanceSkillsSyncsListOutput);
   }
 
   /**
@@ -95,8 +90,33 @@ export class MetorialDashboardInstanceSkillsSyncsEndpoint {
       ...(opts?.headers ? { headers: opts.headers } : {})
     } as any;
 
-    return this._get(request).transform(
-      mapDashboardInstanceSkillsSyncsGetOutput
-    );
+    return this._get(request).transform(mapDashboardInstanceSkillsSyncsGetOutput);
+  }
+
+  /**
+   * @name Get skill sync repository checks
+   * @description Returns the latest repository checks and review requirements.
+   *
+   * @param `instanceId` - string
+   * @param `skillSyncId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceSkillsSyncsRepositoryChecksOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  repositoryChecks(
+    instanceId: string,
+    skillSyncId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceSkillsSyncsRepositoryChecksOutput> {
+    let path = `dashboard/instances/${instanceId}/skill-syncs/${skillSyncId}/repository-checks`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(mapDashboardInstanceSkillsSyncsRepositoryChecksOutput);
   }
 }

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/get.ts
@@ -3,14 +3,26 @@ import { mtMap } from '@metorial/util-resource-mapper';
 export type DashboardInstanceSkillsSyncsGetOutput = {
   object: 'skill.sync';
   id: string;
-  status: 'pending' | 'completed' | 'failed' | 'processing' | 'canceled';
+  status:
+    | 'pending'
+    | 'completed'
+    | 'failed'
+    | 'processing'
+    | 'waiting_for_review'
+    | 'canceled';
   skillMarketplaceId: string | null;
   skillPluginId: string | null;
   logs: { timestamp: Date; message: string }[];
   repositoryPropagations: {
     object: 'skill.sync_repository_propagation';
     id: string;
-    status: 'pending' | 'processing' | 'completed' | 'failed' | 'canceled';
+    status:
+      | 'pending'
+      | 'processing'
+      | 'waiting_for_review'
+      | 'completed'
+      | 'failed'
+      | 'canceled';
     repoId: string;
     branchName: string;
     prName: string;
@@ -32,10 +44,7 @@ export let mapDashboardInstanceSkillsSyncsGetOutput =
     object: mtMap.objectField('object', mtMap.passthrough()),
     id: mtMap.objectField('id', mtMap.passthrough()),
     status: mtMap.objectField('status', mtMap.passthrough()),
-    skillMarketplaceId: mtMap.objectField(
-      'skill_marketplace_id',
-      mtMap.passthrough()
-    ),
+    skillMarketplaceId: mtMap.objectField('skill_marketplace_id', mtMap.passthrough()),
     skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
     logs: mtMap.objectField(
       'logs',
@@ -56,14 +65,8 @@ export let mapDashboardInstanceSkillsSyncsGetOutput =
           repoId: mtMap.objectField('repo_id', mtMap.passthrough()),
           branchName: mtMap.objectField('branch_name', mtMap.passthrough()),
           prName: mtMap.objectField('pr_name', mtMap.passthrough()),
-          prDescription: mtMap.objectField(
-            'pr_description',
-            mtMap.passthrough()
-          ),
-          commitMessage: mtMap.objectField(
-            'commit_message',
-            mtMap.passthrough()
-          ),
+          prDescription: mtMap.objectField('pr_description', mtMap.passthrough()),
+          commitMessage: mtMap.objectField('commit_message', mtMap.passthrough()),
           errorMessage: mtMap.objectField('error_message', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date()),
@@ -76,4 +79,3 @@ export let mapDashboardInstanceSkillsSyncsGetOutput =
     startedAt: mtMap.objectField('started_at', mtMap.date()),
     completedAt: mtMap.objectField('completed_at', mtMap.date())
   });
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/index.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/index.ts
@@ -1,2 +1,3 @@
 export * from './get';
 export * from './list';
+export * from './repository-checks';

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/list.ts
@@ -4,14 +4,26 @@ export type DashboardInstanceSkillsSyncsListOutput = {
   items: {
     object: 'skill.sync';
     id: string;
-    status: 'pending' | 'completed' | 'failed' | 'processing' | 'canceled';
+    status:
+      | 'pending'
+      | 'completed'
+      | 'failed'
+      | 'processing'
+      | 'waiting_for_review'
+      | 'canceled';
     skillMarketplaceId: string | null;
     skillPluginId: string | null;
     logs: { timestamp: Date; message: string }[];
     repositoryPropagations: {
       object: 'skill.sync_repository_propagation';
       id: string;
-      status: 'pending' | 'processing' | 'completed' | 'failed' | 'canceled';
+      status:
+        | 'pending'
+        | 'processing'
+        | 'waiting_for_review'
+        | 'completed'
+        | 'failed'
+        | 'canceled';
       repoId: string;
       branchName: string;
       prName: string;
@@ -39,14 +51,8 @@ export let mapDashboardInstanceSkillsSyncsListOutput =
           object: mtMap.objectField('object', mtMap.passthrough()),
           id: mtMap.objectField('id', mtMap.passthrough()),
           status: mtMap.objectField('status', mtMap.passthrough()),
-          skillMarketplaceId: mtMap.objectField(
-            'skill_marketplace_id',
-            mtMap.passthrough()
-          ),
-          skillPluginId: mtMap.objectField(
-            'skill_plugin_id',
-            mtMap.passthrough()
-          ),
+          skillMarketplaceId: mtMap.objectField('skill_marketplace_id', mtMap.passthrough()),
+          skillPluginId: mtMap.objectField('skill_plugin_id', mtMap.passthrough()),
           logs: mtMap.objectField(
             'logs',
             mtMap.array(
@@ -64,23 +70,11 @@ export let mapDashboardInstanceSkillsSyncsListOutput =
                 id: mtMap.objectField('id', mtMap.passthrough()),
                 status: mtMap.objectField('status', mtMap.passthrough()),
                 repoId: mtMap.objectField('repo_id', mtMap.passthrough()),
-                branchName: mtMap.objectField(
-                  'branch_name',
-                  mtMap.passthrough()
-                ),
+                branchName: mtMap.objectField('branch_name', mtMap.passthrough()),
                 prName: mtMap.objectField('pr_name', mtMap.passthrough()),
-                prDescription: mtMap.objectField(
-                  'pr_description',
-                  mtMap.passthrough()
-                ),
-                commitMessage: mtMap.objectField(
-                  'commit_message',
-                  mtMap.passthrough()
-                ),
-                errorMessage: mtMap.objectField(
-                  'error_message',
-                  mtMap.passthrough()
-                ),
+                prDescription: mtMap.objectField('pr_description', mtMap.passthrough()),
+                commitMessage: mtMap.objectField('commit_message', mtMap.passthrough()),
+                errorMessage: mtMap.objectField('error_message', mtMap.passthrough()),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date()),
                 startedAt: mtMap.objectField('started_at', mtMap.date()),
@@ -97,10 +91,7 @@ export let mapDashboardInstanceSkillsSyncsListOutput =
     pagination: mtMap.objectField(
       'pagination',
       mtMap.object({
-        hasMoreBefore: mtMap.objectField(
-          'has_more_before',
-          mtMap.passthrough()
-        ),
+        hasMoreBefore: mtMap.objectField('has_more_before', mtMap.passthrough()),
         hasMoreAfter: mtMap.objectField('has_more_after', mtMap.passthrough())
       })
     )
@@ -121,8 +112,9 @@ export type DashboardInstanceSkillsSyncsListQuery = {
     | 'completed'
     | 'failed'
     | 'processing'
+    | 'waiting_for_review'
     | 'canceled'
-    | ('pending' | 'completed' | 'failed' | 'processing' | 'canceled')[]
+    | ('pending' | 'completed' | 'failed' | 'processing' | 'waiting_for_review' | 'canceled')[]
     | undefined;
   createdAt?: { gt?: Date | undefined; lt?: Date | undefined } | undefined;
 };
@@ -180,4 +172,3 @@ export let mapDashboardInstanceSkillsSyncsListQuery = mtMap.union([
     })
   )
 ]);
-

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/repository-checks.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/syncs/repository-checks.ts
@@ -1,0 +1,74 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceSkillsSyncsRepositoryChecksOutput = {
+  object: 'skill.sync_repository_checks';
+  items: {
+    object: 'skill.sync_repository_check';
+    propagationId: string;
+    repoId: string;
+    provider: 'github' | 'gitlab' | 'bitbucket' | null;
+    repositoryName: string;
+    repositoryUrl: string | null;
+    pullRequestUrl: string | null;
+    status:
+      | 'pending'
+      | 'processing'
+      | 'waiting_for_review'
+      | 'completed'
+      | 'failed'
+      | 'canceled';
+    originStatus: string | null;
+    blockers: string[];
+    checks: {
+      name: string;
+      status: string;
+      url: string | null;
+      summary: string | null;
+    }[];
+    reviewStatus: string | null;
+    requiredReviewCount: number | null;
+    approvedReviewCount: number | null;
+    mergeability: string | null;
+    lastCheckedAt: Date | null;
+    errorMessage: string | null;
+  }[];
+};
+
+export let mapDashboardInstanceSkillsSyncsRepositoryChecksOutput =
+  mtMap.object<DashboardInstanceSkillsSyncsRepositoryChecksOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    items: mtMap.objectField(
+      'items',
+      mtMap.array(
+        mtMap.object({
+          object: mtMap.objectField('object', mtMap.passthrough()),
+          propagationId: mtMap.objectField('propagation_id', mtMap.passthrough()),
+          repoId: mtMap.objectField('repo_id', mtMap.passthrough()),
+          provider: mtMap.objectField('provider', mtMap.passthrough()),
+          repositoryName: mtMap.objectField('repository_name', mtMap.passthrough()),
+          repositoryUrl: mtMap.objectField('repository_url', mtMap.passthrough()),
+          pullRequestUrl: mtMap.objectField('pull_request_url', mtMap.passthrough()),
+          status: mtMap.objectField('status', mtMap.passthrough()),
+          originStatus: mtMap.objectField('origin_status', mtMap.passthrough()),
+          blockers: mtMap.objectField('blockers', mtMap.array(mtMap.passthrough())),
+          checks: mtMap.objectField(
+            'checks',
+            mtMap.array(
+              mtMap.object({
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                url: mtMap.objectField('url', mtMap.passthrough()),
+                summary: mtMap.objectField('summary', mtMap.passthrough())
+              })
+            )
+          ),
+          reviewStatus: mtMap.objectField('review_status', mtMap.passthrough()),
+          requiredReviewCount: mtMap.objectField('required_review_count', mtMap.passthrough()),
+          approvedReviewCount: mtMap.objectField('approved_review_count', mtMap.passthrough()),
+          mergeability: mtMap.objectField('mergeability', mtMap.passthrough()),
+          lastCheckedAt: mtMap.objectField('last_checked_at', mtMap.date()),
+          errorMessage: mtMap.objectField('error_message', mtMap.passthrough())
+        })
+      )
+    )
+  });

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skillSyncs.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skillSyncs.tsx
@@ -9,6 +9,7 @@ import {
   useSkillMarketplaceRepositories,
   useSkillPluginRepositories,
   useSkillSync,
+  useSkillSyncRepositoryChecks,
   useSkillSyncs
 } from '@metorial/state';
 import {
@@ -24,25 +25,37 @@ import {
 import { ID, Table } from '@metorial/ui-product';
 import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useInterval } from 'react-use';
 import styled from 'styled-components';
 import { RouterPanel } from '../../scenes/routerPanel';
 
 type SkillSync = DashboardInstanceSkillsSyncsGetOutput;
 type SkillRepository = SkillMarketplaceRepository | SkillPluginRepository;
 type RepositoryPropagation = SkillSync['repositoryPropagations'][number];
+type RepositoryCheck = NonNullable<
+  ReturnType<typeof useSkillSyncRepositoryChecks>['data']
+>['items'][number];
 
 let statusColor = (status: SkillSync['status']): 'blue' | 'gray' | 'red' | 'orange' =>
   status === 'completed'
     ? 'blue'
     : status === 'failed' || status === 'canceled'
       ? 'red'
-      : status === 'pending' || status === 'processing'
+      : status === 'pending' || status === 'processing' || status === 'waiting_for_review'
         ? 'orange'
         : 'gray';
 
+let statusLabel = (status: SkillSync['status']) =>
+  ({
+    pending: 'Queued',
+    processing: 'Syncing',
+    waiting_for_review: 'Action required',
+    completed: 'Completed',
+    failed: 'Failed',
+    canceled: 'Canceled'
+  })[status] ?? status;
+
 let SkillSyncStatusBadge = ({ status }: { status: SkillSync['status'] }) => (
-  <Badge color={statusColor(status)}>{status}</Badge>
+  <Badge color={statusColor(status)}>{statusLabel(status)}</Badge>
 );
 
 let getRepositoryId = (repository: SkillRepository) => repository.repoId;
@@ -58,6 +71,12 @@ let getRepositoryLabel = (repository: SkillRepository) => {
     r.repository?.url?.match(/[:/]([^/:]+)\/[^/]+?$/)?.[1];
 
   return owner ? `${owner}/${name}` : name;
+};
+
+let getRepositoryUrl = (repository: SkillRepository) => {
+  let r = repository as any;
+  let url = r.repository?.url ?? r.url;
+  return typeof url === 'string' ? url : null;
 };
 
 let getErrorMessage = (value: unknown) => {
@@ -76,11 +95,14 @@ let getRepositoryError = (
 ) => {
   let r = repository as any;
   let p = propagation as any;
+  let propagationError = propagation && ['failed', 'canceled'].includes(propagation.status);
   return (
-    getErrorMessage(p?.error) ??
-    getErrorMessage(p?.lastError) ??
-    getErrorMessage(p?.syncError) ??
-    getErrorMessage(p?.errorMessage) ??
+    (propagationError
+      ? (getErrorMessage(p?.error) ??
+        getErrorMessage(p?.lastError) ??
+        getErrorMessage(p?.syncError) ??
+        getErrorMessage(p?.errorMessage))
+      : null) ??
     getErrorMessage(r?.error) ??
     getErrorMessage(r?.lastError) ??
     getErrorMessage(r?.syncError) ??
@@ -88,11 +110,136 @@ let getRepositoryError = (
   );
 };
 
-let RepositorySyncStatus = ({ propagation }: { propagation?: RepositoryPropagation }) =>
+let getPullRequestsUrl = (repositoryCheck: RepositoryCheck) => {
+  if (repositoryCheck.pullRequestUrl) return repositoryCheck.pullRequestUrl;
+  if (!repositoryCheck.repositoryUrl) return null;
+  let repositoryUrl = repositoryCheck.repositoryUrl
+    .replace(/\.git\/?$/, '')
+    .replace(/\/+$/, '');
+  if (repositoryCheck.provider === 'github') return `${repositoryUrl}/pulls`;
+  if (repositoryCheck.provider === 'gitlab') return `${repositoryUrl}/-/merge_requests`;
+  if (repositoryCheck.provider === 'bitbucket') return `${repositoryUrl}/pull-requests`;
+  return null;
+};
+
+let getRepositoryActionMessage = (repositoryCheck: RepositoryCheck) => {
+  let checksFailed = repositoryCheck.blockers.includes('checks_failed');
+  let reviewRequired = repositoryCheck.blockers.includes('reviews_required');
+  let reviewMessage =
+    repositoryCheck.reviewStatus === 'changes_requested'
+      ? 'Changes were requested. Update the pull request to continue.'
+      : repositoryCheck.requiredReviewCount != null &&
+          repositoryCheck.requiredReviewCount > 0 &&
+          repositoryCheck.approvedReviewCount != null
+        ? `Review required (${repositoryCheck.approvedReviewCount}/${repositoryCheck.requiredReviewCount} approvals).`
+        : 'Review required. Approve the pull request to continue.';
+  if (checksFailed && reviewRequired) {
+    return `Checks failed. ${reviewMessage}`;
+  }
+  if (checksFailed) {
+    return 'Checks failed. Fix or rerun them in the repository. We’ll continue automatically.';
+  }
+  if (reviewRequired) return reviewMessage;
+  if (repositoryCheck.blockers.includes('merge_conflict')) {
+    return 'This pull request has conflicts. Resolve them to continue.';
+  }
+  if (repositoryCheck.blockers.includes('merge_permission_required')) {
+    return 'The connected GitLab user can’t merge into this branch. Grant merge access to continue.';
+  }
+  if (repositoryCheck.blockers.includes('merge_blocked')) {
+    return 'Repository rules are blocking this pull request. Open it for details.';
+  }
+  if (repositoryCheck.blockers.includes('provider_unavailable')) {
+    return 'We couldn’t update the pull request. We’ll retry automatically.';
+  }
+  return repositoryCheck.errorMessage ?? 'Repository action is required to continue.';
+};
+
+let RepositoryAction = ({ repositoryCheck }: { repositoryCheck: RepositoryCheck }) => {
+  let actionableBlockers = [
+    'checks_failed',
+    'reviews_required',
+    'merge_conflict',
+    'merge_permission_required',
+    'merge_blocked',
+    'provider_unavailable'
+  ];
+  if (
+    repositoryCheck.status !== 'waiting_for_review' &&
+    !repositoryCheck.blockers.some(blocker => actionableBlockers.includes(blocker))
+  ) {
+    return null;
+  }
+  let pullRequestsUrl = getPullRequestsUrl(repositoryCheck);
+  let relevantChecks = repositoryCheck.checks.filter(check =>
+    ['failed', 'failure', 'pending', 'running', 'in_progress'].includes(check.status)
+  );
+  let visibleChecks = relevantChecks.slice(0, 5);
+
+  return (
+    <Callout color="orange">
+      <RepositoryActionContent>
+        <div>
+          <Text size="2" weight="strong">
+            {repositoryCheck.repositoryName}
+          </Text>
+          <Text size="2">{getRepositoryActionMessage(repositoryCheck)}</Text>
+          {visibleChecks.length > 0 && (
+            <CheckList>
+              {visibleChecks.map(check => (
+                <li key={`${check.name}:${check.status}`}>
+                  {check.url ? (
+                    <ExternalLink href={check.url} target="_blank" rel="noopener noreferrer">
+                      {check.name}
+                    </ExternalLink>
+                  ) : (
+                    check.name
+                  )}{' '}
+                  — {check.status}
+                </li>
+              ))}
+              {relevantChecks.length > visibleChecks.length && (
+                <li>{relevantChecks.length - visibleChecks.length} more checks</li>
+              )}
+            </CheckList>
+          )}
+        </div>
+        <RepositoryLinks>
+          {pullRequestsUrl && (
+            <ExternalLink href={pullRequestsUrl} target="_blank" rel="noopener noreferrer">
+              Open {repositoryCheck.provider === 'gitlab' ? 'merge request' : 'pull request'}
+            </ExternalLink>
+          )}
+          {repositoryCheck.repositoryUrl && (
+            <ExternalLink
+              href={repositoryCheck.repositoryUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open repository
+            </ExternalLink>
+          )}
+        </RepositoryLinks>
+      </RepositoryActionContent>
+    </Callout>
+  );
+};
+
+let RepositorySyncStatus = ({
+  propagation,
+  syncStatus
+}: {
+  propagation?: RepositoryPropagation;
+  syncStatus: SkillSync['status'];
+}) =>
   propagation ? (
     <SkillSyncStatusBadge status={propagation.status} />
   ) : (
-    <Badge color="gray">Not queued</Badge>
+    <Badge color="gray">
+      {['pending', 'processing', 'waiting_for_review'].includes(syncStatus)
+        ? 'Not queued'
+        : 'Skipped'}
+    </Badge>
   );
 
 export let SkillSyncsTable = ({
@@ -113,10 +260,6 @@ export let SkillSyncsTable = ({
       : null
   );
   let [_, setSearchParams] = useSearchParams();
-
-  useInterval(() => {
-    syncs.refetch();
-  }, 10_000);
 
   return (
     <>
@@ -174,12 +317,31 @@ let SyncDuration = ({ sync }: { sync: SkillSync }) => {
 let SkillSyncDetails = ({ syncId }: { syncId: string }) => {
   let instance = useCurrentInstance();
   let sync = useSkillSync(instance.data?.id, syncId);
+  let repositoryChecks = useSkillSyncRepositoryChecks(instance.data?.id, syncId);
+  let repositoryChecksRefetchRef = useRef(repositoryChecks.refetch);
+  repositoryChecksRefetchRef.current = repositoryChecks.refetch;
+  let wasActiveRef = useRef(false);
   let repos1 = useSkillMarketplaceRepositories(
     instance.data?.id,
     sync.data?.skillMarketplaceId
   );
   let repos2 = useSkillPluginRepositories(instance.data?.id, sync.data?.skillPluginId);
   let reposLoader = sync.data?.skillMarketplaceId ? repos1 : repos2;
+
+  useEffect(() => {
+    let active = Boolean(
+      sync.data?.status &&
+        ['pending', 'processing', 'waiting_for_review'].includes(sync.data.status)
+    );
+    if (!active) {
+      if (wasActiveRef.current) repositoryChecksRefetchRef.current();
+      wasActiveRef.current = false;
+      return;
+    }
+    wasActiveRef.current = true;
+    let id = setInterval(() => repositoryChecksRefetchRef.current(), 5_000);
+    return () => clearInterval(id);
+  }, [sync.data?.status]);
 
   return renderWithLoader({ sync })(({ sync }) => {
     let repositories = reposLoader.data?.items ?? [];
@@ -266,8 +428,22 @@ let SkillSyncDetails = ({ syncId }: { syncId: string }) => {
               data={[
                 ...repositoryRows.map(({ repository, propagation }) => ({
                   data: [
-                    getRepositoryLabel(repository),
-                    <RepositorySyncStatus propagation={propagation} />,
+                    getRepositoryUrl(repository) ? (
+                      <ExternalLink
+                        href={getRepositoryUrl(repository)!}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={event => event.stopPropagation()}
+                      >
+                        {getRepositoryLabel(repository)}
+                      </ExternalLink>
+                    ) : (
+                      getRepositoryLabel(repository)
+                    ),
+                    <RepositorySyncStatus
+                      propagation={propagation}
+                      syncStatus={sync.data.status}
+                    />,
                     propagation?.branchName ?? 'N/A',
                     propagation?.prName ?? 'N/A',
                     propagation?.completedAt ? (
@@ -292,6 +468,29 @@ let SkillSyncDetails = ({ syncId }: { syncId: string }) => {
                 }))
               ]}
             />
+
+            {repositoryChecks.error && (
+              <>
+                <Spacer height={10} />
+                <Text size="2" color="gray600">
+                  We couldn’t load repository checks. Syncing will continue in the background.
+                </Text>
+              </>
+            )}
+
+            {repositoryChecks.data?.items.length ? (
+              <>
+                <Spacer height={10} />
+                <RepositoryActions>
+                  {repositoryChecks.data.items.map(repositoryCheck => (
+                    <RepositoryAction
+                      key={repositoryCheck.propagationId}
+                      repositoryCheck={repositoryCheck}
+                    />
+                  ))}
+                </RepositoryActions>
+              </>
+            ) : null}
 
             {repositoryErrors.length > 0 && (
               <>
@@ -381,4 +580,42 @@ let LogTimestamp = styled.div`
 let LogMessage = styled.div`
   font-size: 13px;
   white-space: pre-wrap;
+`;
+
+let RepositoryActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+let RepositoryActionContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+`;
+
+let RepositoryLinks = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: flex-start;
+  gap: 12px;
+`;
+
+let ExternalLink = styled.a`
+  color: ${theme.colors.blue800};
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+let CheckList = styled.ul`
+  margin: 6px 0 0;
+  padding-left: 18px;
+  color: ${theme.colors.gray700};
+  font-size: 13px;
 `;

--- a/src/metorial-frontend/packages/state/src/skills/loaders/skillSyncs.ts
+++ b/src/metorial-frontend/packages/state/src/skills/loaders/skillSyncs.ts
@@ -43,7 +43,7 @@ export let useSkillSyncs = (
   );
 
   let hasActiveSyncs = data.data?.items.some(sync =>
-    ['pending', 'processing'].includes(sync.status)
+    ['pending', 'processing', 'waiting_for_review'].includes(sync.status)
   );
   let refetchRef = useRef(data.refetch);
   refetchRef.current = data.refetch;
@@ -68,9 +68,13 @@ export let useSkillSync = (
   instanceId: string | null | undefined,
   skillSyncId: string | null | undefined
 ) => {
-  let data = skillSyncLoader.use(instanceId && skillSyncId ? { instanceId, skillSyncId } : null);
+  let data = skillSyncLoader.use(
+    instanceId && skillSyncId ? { instanceId, skillSyncId } : null
+  );
 
-  let isActive = data.data?.status ? ['pending', 'processing'].includes(data.data.status) : false;
+  let isActive = data.data?.status
+    ? ['pending', 'processing', 'waiting_for_review'].includes(data.data.status)
+    : false;
   let refetchRef = useRef(data.refetch);
   refetchRef.current = data.refetch;
   useEffect(() => {
@@ -81,3 +85,19 @@ export let useSkillSync = (
 
   return data;
 };
+
+export let skillSyncRepositoryChecksLoader = createLoader({
+  name: 'skillSyncRepositoryChecks',
+  parents: [skillSyncLoader],
+  fetch: (i: { instanceId: string; skillSyncId: string }) =>
+    withAuth(sdk => sdk.skillSyncs.repositoryChecks(i.instanceId, i.skillSyncId)),
+  mutators: {}
+});
+
+export let useSkillSyncRepositoryChecks = (
+  instanceId: string | null | undefined,
+  skillSyncId: string | null | undefined
+) =>
+  skillSyncRepositoryChecksLoader.use(
+    instanceId && skillSyncId ? { instanceId, skillSyncId } : null
+  );

--- a/src/metorial/apis/core/src/controllers/instance/skills/skillSync.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skillSync.ts
@@ -9,7 +9,7 @@ import { checkAccess } from '../../../middleware/checkAccess';
 import { hasFlags } from '../../../middleware/hasFlags';
 import { instanceGroup } from '../../../middleware/instanceGroup';
 import { isDashboardGroup } from '../../../middleware/isDashboard';
-import { skillSyncPresenter } from '../../../presenters';
+import { skillSyncPresenter, skillSyncRepositoryChecksPresenter } from '../../../presenters';
 import { getSkillPluginAccess } from './skillPlugin';
 
 let readScopes = ['instance.skill:read'] as const;
@@ -19,6 +19,7 @@ let statusValidator = v.enumOf([
   'completed',
   'failed',
   'processing',
+  'waiting_for_review',
   'canceled'
 ]);
 
@@ -46,14 +47,21 @@ export let skillSyncGroup = instanceGroup
 export let skillSyncController = Controller.create(
   {
     name: 'Skill Syncs',
-    description: 'View skill plugin and marketplace syncs for an instance.'
+    description: 'View skill plugin and marketplace syncs for an instance.',
+    hideInDocs: true
   },
   {
     list: instanceGroup
-      .get(Path('/dashboard/instances/:instanceId/skill-syncs', 'dashboard.instance.skills.syncs.list'), {
-        name: 'List skill syncs',
-        description: 'Returns a paginated list of skill syncs.'
-      })
+      .get(
+        Path(
+          '/dashboard/instances/:instanceId/skill-syncs',
+          'dashboard.instance.skills.syncs.list'
+        ),
+        {
+          name: 'List skill syncs',
+          description: 'Returns a paginated list of skill syncs.'
+        }
+      )
       .use(hasFlags(['skills-enabled']))
       .use(isDashboardGroup())
       .use(checkAccess({ possibleScopes: [...readScopes] }))
@@ -81,9 +89,7 @@ export let skillSyncController = Controller.create(
         });
         let list = await paginator.run(ctx.query);
 
-        return Paginator.present(list, skillSync =>
-          skillSyncPresenter.present({ skillSync })
-        );
+        return Paginator.present(list, skillSync => skillSyncPresenter.present({ skillSync }));
       }),
 
     get: skillSyncGroup
@@ -99,6 +105,29 @@ export let skillSyncController = Controller.create(
       )
       .use(checkAccess({ possibleScopes: [...readScopes] }))
       .output(skillSyncPresenter)
-      .do(async ctx => skillSyncPresenter.present({ skillSync: ctx.skillSync }))
+      .do(async ctx => skillSyncPresenter.present({ skillSync: ctx.skillSync })),
+
+    repositoryChecks: skillSyncGroup
+      .get(
+        Path(
+          '/dashboard/instances/:instanceId/skill-syncs/:skillSyncId/repository-checks',
+          'dashboard.instance.skills.syncs.repositoryChecks'
+        ),
+        {
+          name: 'Get skill sync repository checks',
+          description: 'Returns the latest repository checks and review requirements.',
+          hideInDocs: true
+        }
+      )
+      .use(checkAccess({ possibleScopes: [...readScopes] }))
+      .output(skillSyncRepositoryChecksPresenter)
+      .do(async ctx => {
+        let repositoryChecks = await skillSyncService.getSkillSyncRepositoryChecks({
+          ...(await getSkillPluginAccess(ctx)),
+          skillSyncId: ctx.skillSync.id
+        });
+
+        return skillSyncRepositoryChecksPresenter.present({ repositoryChecks });
+      })
   }
 );

--- a/src/metorial/apis/core/src/presenters/implementation/skills/index.ts
+++ b/src/metorial/apis/core/src/presenters/implementation/skills/index.ts
@@ -13,6 +13,7 @@ export * from './skillPlugin';
 export * from './skillPluginRepository';
 export * from './skillPluginSkill';
 export * from './skillSync';
+export * from './skillSyncRepositoryCheck';
 export * from './skillGroup';
 export * from './skillGroupItem';
 export * from './skillItem';

--- a/src/metorial/apis/core/src/presenters/implementation/skills/skillSync.ts
+++ b/src/metorial/apis/core/src/presenters/implementation/skills/skillSync.ts
@@ -5,7 +5,14 @@ import { skillSyncType } from '../../types';
 let skillSyncRepositoryPropagationSchema = v.object({
   object: v.literal('skill.sync_repository_propagation'),
   id: v.string(),
-  status: v.enumOf(['pending', 'processing', 'completed', 'failed', 'canceled']),
+  status: v.enumOf([
+    'pending',
+    'processing',
+    'waiting_for_review',
+    'completed',
+    'failed',
+    'canceled'
+  ]),
   repo_id: v.string(),
   branch_name: v.string(),
   pr_name: v.string(),
@@ -25,10 +32,12 @@ export let v1SkillSyncPresenter = Presenter.create(skillSyncType)
     status: skillSync.status,
     skill_marketplace_id: skillSync.destination.skillMarketplace?.id ?? null,
     skill_plugin_id: skillSync.destination.skillPlugin?.id ?? null,
-    logs: (skillSync.logs as [number, string][]).map(([ts, msg]) => ({
-      timestamp: new Date(ts),
-      message: msg
-    })),
+    logs: [...(skillSync.logs as [number, string][])]
+      .sort(([left], [right]) => left - right)
+      .map(([ts, msg]) => ({
+        timestamp: new Date(ts),
+        message: msg
+      })),
     repository_propagations: skillSync.repositoryPropagations.map(propagation => ({
       object: 'skill.sync_repository_propagation' as const,
       id: propagation.id,
@@ -52,7 +61,14 @@ export let v1SkillSyncPresenter = Presenter.create(skillSyncType)
     v.object({
       object: v.literal('skill.sync'),
       id: v.string(),
-      status: v.enumOf(['pending', 'completed', 'failed', 'processing', 'canceled']),
+      status: v.enumOf([
+        'pending',
+        'completed',
+        'failed',
+        'processing',
+        'waiting_for_review',
+        'canceled'
+      ]),
       skill_marketplace_id: v.nullable(v.string()),
       skill_plugin_id: v.nullable(v.string()),
       logs: v.array(v.object({ timestamp: v.date(), message: v.string() })),

--- a/src/metorial/apis/core/src/presenters/implementation/skills/skillSyncRepositoryCheck.ts
+++ b/src/metorial/apis/core/src/presenters/implementation/skills/skillSyncRepositoryCheck.ts
@@ -1,0 +1,75 @@
+import { v } from '@lowerdeck/validation';
+import { Presenter } from '@metorial/presenter';
+import { skillSyncRepositoryChecksType } from '../../types';
+
+let repositoryCheckSchema = v.object({
+  object: v.literal('skill.sync_repository_check'),
+  propagation_id: v.string(),
+  repo_id: v.string(),
+  provider: v.nullable(v.enumOf(['github', 'gitlab', 'bitbucket'])),
+  repository_name: v.string(),
+  repository_url: v.nullable(v.string()),
+  pull_request_url: v.nullable(v.string()),
+  status: v.enumOf([
+    'pending',
+    'processing',
+    'waiting_for_review',
+    'completed',
+    'failed',
+    'canceled'
+  ]),
+  origin_status: v.nullable(v.string()),
+  blockers: v.array(v.string()),
+  checks: v.array(
+    v.object({
+      name: v.string(),
+      status: v.string(),
+      url: v.nullable(v.string()),
+      summary: v.nullable(v.string())
+    })
+  ),
+  review_status: v.nullable(v.string()),
+  required_review_count: v.nullable(v.number()),
+  approved_review_count: v.nullable(v.number()),
+  mergeability: v.nullable(v.string()),
+  last_checked_at: v.nullable(v.date()),
+  error_message: v.nullable(v.string())
+});
+
+export let v1SkillSyncRepositoryChecksPresenter = Presenter.create(
+  skillSyncRepositoryChecksType
+)
+  .presenter(async ({ repositoryChecks }) => ({
+    object: 'skill.sync_repository_checks' as const,
+    items: repositoryChecks.map(repositoryCheck => ({
+      object: 'skill.sync_repository_check' as const,
+      propagation_id: repositoryCheck.propagationId,
+      repo_id: repositoryCheck.repoId,
+      provider: repositoryCheck.provider,
+      repository_name: repositoryCheck.repositoryName,
+      repository_url: repositoryCheck.repositoryUrl,
+      pull_request_url: repositoryCheck.pullRequestUrl,
+      status: repositoryCheck.status,
+      origin_status: repositoryCheck.originStatus,
+      blockers: repositoryCheck.blockers,
+      checks: repositoryCheck.checks.map(check => ({
+        name: check.name,
+        status: check.status,
+        url: check.url,
+        summary: check.summary
+      })),
+      review_status: repositoryCheck.reviewStatus,
+      required_review_count: repositoryCheck.requiredReviewCount,
+      approved_review_count: repositoryCheck.approvedReviewCount,
+      mergeability: repositoryCheck.mergeability,
+      last_checked_at: repositoryCheck.lastCheckedAt,
+      error_message: repositoryCheck.errorMessage
+    }))
+  }))
+  .schema(
+    v.object({
+      object: v.literal('skill.sync_repository_checks'),
+      items: v.array(repositoryCheckSchema)
+    })
+  )
+  .build();

--- a/src/metorial/apis/core/src/presenters/index.ts
+++ b/src/metorial/apis/core/src/presenters/index.ts
@@ -211,6 +211,7 @@ import {
   v1SkillPluginSkillPresenter,
   v1SkillPresenter,
   v1SkillSyncPresenter,
+  v1SkillSyncRepositoryChecksPresenter,
   v1SkillTemplateItemPresenter,
   v1SkillTemplatePresenter,
   v1SkillVersionPresenter,
@@ -417,6 +418,7 @@ import {
   skillPluginSkillType,
   skillPluginType,
   skillSyncType,
+  skillSyncRepositoryChecksType,
   skillTemplateItemType,
   skillTemplateType,
   skillType,
@@ -755,6 +757,14 @@ export let skillSyncPresenter = declarePresenter(skillSyncType, {
   mt_2025_01_01_dashboard: v1SkillSyncPresenter,
   mt_2026_01_01_magnetar: v1SkillSyncPresenter
 });
+
+export let skillSyncRepositoryChecksPresenter = declarePresenter(
+  skillSyncRepositoryChecksType,
+  {
+    mt_2025_01_01_dashboard: v1SkillSyncRepositoryChecksPresenter,
+    mt_2026_01_01_magnetar: v1SkillSyncRepositoryChecksPresenter
+  }
+);
 
 export let skillParticipantPresenter = declarePresenter(skillParticipantType, {
   mt_2025_01_01_dashboard: v1SkillParticipantPresenter,

--- a/src/metorial/apis/core/src/presenters/types.ts
+++ b/src/metorial/apis/core/src/presenters/types.ts
@@ -216,6 +216,7 @@ import type {
   SkillGroupResource,
   SkillItemResource,
   SkillResource,
+  SkillSyncRepositoryCheck,
   SkillTemplateItemResource,
   SkillTemplateResource
 } from '@metorial/cargo-module-skill';
@@ -950,6 +951,10 @@ export let skillSyncType = PresentableType.create<{
     };
   }>;
 }>()('skillSync');
+
+export let skillSyncRepositoryChecksType = PresentableType.create<{
+  repositoryChecks: SkillSyncRepositoryCheck[];
+}>()('skillSyncRepositoryChecks');
 
 export let skillParticipantType = PresentableType.create<{
   skillParticipant: SkillParticipant & {

--- a/src/metorial/cargo/modules/skill/src/queues/index.ts
+++ b/src/metorial/cargo/modules/skill/src/queues/index.ts
@@ -25,6 +25,12 @@ import { searchQueues } from './search';
 import { skillDestinationSyncCleanupCron } from './sync/cleanup';
 import { syncCollectQueueProcessor } from './sync/collect';
 import { syncFinishQueueProcessor } from './sync/finish';
+import {
+  originChangeFanoutQueueProcessor,
+  originChangePollQueueProcessor,
+  originChangePollWatchdogCron,
+  originChangeRepairCron
+} from './sync/originChanges';
 import { syncProcessQueueProcessor } from './sync/process';
 import {
   syncPropagatePerformQueueProcessor,
@@ -48,6 +54,10 @@ export let skillQueueProcessor = combineQueueProcessors([
   syncPropagateStartQueueProcessor,
   syncPropagatePerformQueueProcessor,
   syncPropagateWaitQueueProcessor,
+  originChangeFanoutQueueProcessor,
+  originChangePollQueueProcessor,
+  originChangePollWatchdogCron,
+  originChangeRepairCron,
   syncFinishQueueProcessor,
   skillDestinationSyncCleanupCron,
   skillExportQueueProcessor,

--- a/src/metorial/cargo/modules/skill/src/queues/sync/_lib/logs.ts
+++ b/src/metorial/cargo/modules/skill/src/queues/sync/_lib/logs.ts
@@ -2,8 +2,6 @@ import { db } from '@metorial/db';
 
 export type SkillDestinationSyncLogEntry = [number, string];
 
-let logKey = (entry: SkillDestinationSyncLogEntry) => `${entry[0]}:${entry[1]}`;
-
 export let appendSkillDestinationSyncLog = async (
   skillDestinationSyncId: string,
   message: string
@@ -13,32 +11,6 @@ export let appendSkillDestinationSyncLog = async (
     data: {
       logs: {
         push: [Date.now(), message] satisfies SkillDestinationSyncLogEntry
-      }
-    }
-  });
-};
-
-export let appendSkillDestinationSyncLogs = async (d: {
-  skillDestinationSyncId: string;
-  logs: SkillDestinationSyncLogEntry[];
-}) => {
-  if (d.logs.length === 0) return;
-
-  let sync = await db.skillDestinationSync.findUnique({
-    where: { id: d.skillDestinationSyncId },
-    select: { logs: true }
-  });
-  if (!sync) return;
-
-  let existingKeys = new Set(sync.logs.map(logKey));
-  let newLogs = d.logs.filter(log => !existingKeys.has(logKey(log)));
-  if (newLogs.length === 0) return;
-
-  await db.skillDestinationSync.update({
-    where: { id: d.skillDestinationSyncId },
-    data: {
-      logs: {
-        set: [...sync.logs, ...newLogs]
       }
     }
   });

--- a/src/metorial/cargo/modules/skill/src/queues/sync/finish.ts
+++ b/src/metorial/cargo/modules/skill/src/queues/sync/finish.ts
@@ -16,11 +16,14 @@ export let syncFinishQueueProcessor = syncFinishQueue.process(async data => {
   let sync = await db.skillDestinationSync.findUnique({
     where: { id: data.skillDestinationSyncId }
   });
-  if (!sync || sync.status !== 'processing') return;
+  if (!sync || !['processing', 'waiting_for_review'].includes(sync.status)) return;
 
   let status = data.status ?? 'completed';
   let updated = await db.skillDestinationSync.updateMany({
-    where: { id: data.skillDestinationSyncId, status: 'processing' },
+    where: {
+      id: data.skillDestinationSyncId,
+      status: { in: ['processing', 'waiting_for_review'] }
+    },
     data: { status, completedAt: new Date() }
   });
   if (updated.count === 0) return;

--- a/src/metorial/cargo/modules/skill/src/queues/sync/originChanges.ts
+++ b/src/metorial/cargo/modules/skill/src/queues/sync/originChanges.ts
@@ -1,0 +1,246 @@
+import { generatePlainId } from '@lowerdeck/id';
+import { createCron } from '@metorial/cron';
+import { db } from '@metorial/db';
+import { createQueue } from '@metorial/queue';
+import { getOriginTenant, origin } from '../../internal/skillDestination';
+import { syncPropagateWaitQueue } from './propagate';
+
+let pollIntervalMs = 5_000;
+let pollLeaseMs = 30_000;
+let cursorPrefix = 'cargo-skill-origin-changes';
+
+let scheduleOriginChangePoll = async (delay = pollIntervalMs) => {
+  let bucket = Math.floor((Date.now() + delay) / pollIntervalMs);
+  await originChangePollQueue.add(
+    {},
+    {
+      delay,
+      id: `${cursorPrefix}:poll:${bucket}`
+    }
+  );
+};
+
+let enqueuePropagationReconciliation = async (originSyncId: string, jobId: string) => {
+  let propagations = await db.skillDestinationSyncRepositoryPropagation.findMany({
+    where: {
+      originSyncId,
+      status: { in: ['processing', 'waiting_for_review'] },
+      skillDestinationSync: {
+        status: { in: ['processing', 'waiting_for_review'] }
+      }
+    },
+    select: {
+      id: true,
+      skillDestinationSync: {
+        select: { id: true }
+      }
+    }
+  });
+  let bySyncId = new Map<string, string[]>();
+  for (let propagation of propagations) {
+    let ids = bySyncId.get(propagation.skillDestinationSync.id) ?? [];
+    ids.push(propagation.id);
+    bySyncId.set(propagation.skillDestinationSync.id, ids);
+  }
+
+  for (let [skillDestinationSyncId, pendingPropagationIds] of bySyncId) {
+    await syncPropagateWaitQueue.add(
+      {
+        skillDestinationSyncId,
+        pendingPropagationIds
+      },
+      { id: `${jobId}:${skillDestinationSyncId}` }
+    );
+  }
+};
+
+export let originChangeFanoutQueue = createQueue<{
+  notificationId: string;
+  originSyncId: string;
+}>({
+  name: 'cargo/skill/sync/origin-change/fanout',
+  workerOpts: { concurrency: 20 }
+});
+
+export let originChangeFanoutQueueProcessor = originChangeFanoutQueue.process(async data => {
+  await enqueuePropagationReconciliation(
+    data.originSyncId,
+    `${cursorPrefix}:notification:${data.notificationId}`
+  );
+});
+
+export let originChangePollQueue = createQueue<Record<string, never>>({
+  name: 'cargo/skill/sync/origin-change/poll',
+  workerOpts: { concurrency: 1 }
+});
+
+let pollOriginTenant = async (resourceTenantOid: bigint) => {
+  let originTenant = await getOriginTenant({
+    oid: resourceTenantOid,
+    id: 'origin-change-poll'
+  });
+  let consumer = `${cursorPrefix}:${originTenant.id}`;
+  let leaseId = generatePlainId(16);
+  let now = new Date();
+  let leaseUntil = new Date(now.getTime() + pollLeaseMs);
+
+  await db.skillOriginChangeNotificationCursor.upsert({
+    where: { consumer },
+    create: { consumer },
+    update: {}
+  });
+  let claimed = await db.skillOriginChangeNotificationCursor.updateMany({
+    where: {
+      consumer,
+      OR: [{ leaseUntil: null }, { leaseUntil: { lt: now } }]
+    },
+    data: { leaseId, leaseUntil }
+  });
+  if (claimed.count === 0) return;
+
+  try {
+    for (let page = 0; page < 5; page++) {
+      let cursor = await db.skillOriginChangeNotificationCursor.findUniqueOrThrow({
+        where: { consumer }
+      });
+      if (cursor.leaseId !== leaseId) return;
+
+      let result = await origin.changeNotification.poll({
+        tenantId: originTenant.id,
+        afterCursor: cursor.cursor ?? undefined,
+        limit: 100
+      });
+
+      for (let notification of result.items) {
+        if (
+          notification.type !== 'repository_sync_status_changed' ||
+          !notification.repositorySync
+        ) {
+          continue;
+        }
+        await originChangeFanoutQueue.add(
+          {
+            notificationId: notification.id,
+            originSyncId: notification.repositorySync.id
+          },
+          { id: `${cursorPrefix}:notification:${notification.id}` }
+        );
+      }
+
+      await db.skillOriginChangeNotificationCursor.updateMany({
+        where: { consumer, leaseId },
+        data: {
+          cursor: result.nextCursor ?? cursor.cursor,
+          leaseUntil: new Date(Date.now() + pollLeaseMs)
+        }
+      });
+
+      if (result.items.length < 100) break;
+    }
+  } finally {
+    await db.skillOriginChangeNotificationCursor.updateMany({
+      where: { consumer, leaseId },
+      data: { leaseId: null, leaseUntil: null }
+    });
+  }
+};
+
+export let originChangePollQueueProcessor = originChangePollQueue.process(async () => {
+  try {
+    let activeTenants = await db.skillDestinationSyncRepositoryPropagation.findMany({
+      where: {
+        status: { in: ['processing', 'waiting_for_review'] },
+        skillDestinationSync: {
+          status: { in: ['processing', 'waiting_for_review'] }
+        }
+      },
+      distinct: ['skillRepositoryOid'],
+      select: {
+        skillRepository: {
+          select: { resourceTenantOid: true }
+        }
+      }
+    });
+    let tenantOids = new Set(
+      activeTenants.map(propagation => propagation.skillRepository.resourceTenantOid)
+    );
+    for (let resourceTenantOid of tenantOids) {
+      try {
+        await pollOriginTenant(resourceTenantOid);
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            event: 'cargo_skill_origin_change_poll_failed',
+            level: 'error',
+            resourceTenantOid: resourceTenantOid.toString(),
+            error: error instanceof Error ? error.message : String(error)
+          })
+        );
+      }
+    }
+  } finally {
+    await scheduleOriginChangePoll();
+  }
+});
+
+export let originChangePollWatchdogCron = createCron(
+  {
+    name: 'cargo/skill/sync/origin-change/watchdog',
+    cron: '* * * * *'
+  },
+  async () => {
+    await scheduleOriginChangePoll(0);
+  }
+);
+
+export let originChangeRepairCron = createCron(
+  {
+    name: 'cargo/skill/sync/origin-change/repair',
+    cron: '*/15 * * * *'
+  },
+  async () => {
+    let propagations = await db.skillDestinationSyncRepositoryPropagation.findMany({
+      where: {
+        status: { in: ['processing', 'waiting_for_review'] },
+        originSyncId: { not: null },
+        skillDestinationSync: {
+          status: { in: ['processing', 'waiting_for_review'] }
+        }
+      },
+      orderBy: { updatedAt: 'asc' },
+      take: 500,
+      select: {
+        originSyncId: true
+      }
+    });
+
+    for (let originSyncId of new Set(
+      propagations.flatMap(propagation =>
+        propagation.originSyncId ? [propagation.originSyncId] : []
+      )
+    )) {
+      try {
+        await enqueuePropagationReconciliation(
+          originSyncId,
+          `${cursorPrefix}:repair:${originSyncId}:${Math.floor(Date.now() / 900_000)}`
+        );
+        await db.skillDestinationSyncRepositoryPropagation.updateMany({
+          where: {
+            originSyncId,
+            status: { in: ['processing', 'waiting_for_review'] }
+          },
+          data: { updatedAt: new Date() }
+        });
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            event: 'cargo_skill_origin_change_repair_failed',
+            level: 'error',
+            originSyncId,
+            error: error instanceof Error ? error.message : String(error)
+          })
+        );
+      }
+    }
+  }
+);

--- a/src/metorial/cargo/modules/skill/src/queues/sync/propagate.ts
+++ b/src/metorial/cargo/modules/skill/src/queues/sync/propagate.ts
@@ -4,11 +4,7 @@ import { db, withTransaction } from '@metorial/db';
 import { createQueue, QueueRetryError } from '@metorial/queue';
 import { getOriginTenant, origin } from '../../internal/skillDestination';
 import { createSkillSyncBranchName, normalizeSkillSyncBranchName } from './_lib/branchName';
-import {
-  appendSkillDestinationSyncLog,
-  appendSkillDestinationSyncLogs,
-  type SkillDestinationSyncLogEntry
-} from './_lib/logs';
+import { appendSkillDestinationSyncLog } from './_lib/logs';
 import { syncFinishQueue } from './finish';
 
 let getPublicErrorMessage = (error: unknown) => {
@@ -53,23 +49,6 @@ let failSync = async (d: { skillDestinationSyncId: string; error: unknown }) => 
 let formatRepositoryName = (
   repository?: { externalOwner: string; externalName: string } | null
 ) => (repository ? `${repository.externalOwner}/${repository.externalName}` : 'repository');
-
-let normalizeOriginLogs = (logs: unknown, prefix: string): SkillDestinationSyncLogEntry[] => {
-  if (!Array.isArray(logs)) return [];
-
-  return logs.flatMap(log => {
-    if (
-      Array.isArray(log) &&
-      typeof log[0] === 'number' &&
-      Number.isFinite(log[0]) &&
-      typeof log[1] === 'string'
-    ) {
-      return [[log[0], `${prefix}: ${log[1]}`] satisfies SkillDestinationSyncLogEntry];
-    }
-
-    return [];
-  });
-};
 
 export let syncPropagateStartQueue = createQueue<{
   skillDestinationSyncId: string;
@@ -333,7 +312,7 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
       destination: true
     }
   });
-  if (!sync || sync.status !== 'processing') return;
+  if (!sync || !['processing', 'waiting_for_review'].includes(sync.status)) return;
 
   let propagations = await db.skillDestinationSyncRepositoryPropagation.findMany({
     where: {
@@ -376,74 +355,192 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
     originRepositories.repositories.map(repository => [repository.id, repository])
   );
 
-  let pendingPropagationIds: string[] = [];
-  let copiedLogs: SkillDestinationSyncLogEntry[] = [];
-  let failed = false;
-
   for (let propagation of propagations) {
-    if (!propagation.originSyncId) {
-      pendingPropagationIds.push(propagation.id);
-      continue;
-    }
+    if (!propagation.originSyncId) continue;
 
     let originSync = originSyncById.get(propagation.originSyncId);
-    if (!originSync) {
-      pendingPropagationIds.push(propagation.id);
-      continue;
-    }
+    if (!originSync) continue;
 
     let repositoryName = formatRepositoryName(
       originRepositoryById.get(propagation.skillRepository.repoId)
     );
-    copiedLogs.push(...normalizeOriginLogs(originSync.logs, repositoryName));
-
     if (
       originSync.status === 'merged' ||
       originSync.status === 'complete_unmerged' ||
       originSync.status === 'complete_no_changes'
     ) {
-      await db.skillDestinationSyncRepositoryPropagation.update({
-        where: { oid: propagation.oid },
+      let updated = await db.skillDestinationSyncRepositoryPropagation.updateMany({
+        where: {
+          oid: propagation.oid,
+          status: { in: ['processing', 'waiting_for_review'] }
+        },
         data: {
           status: 'completed',
           completedAt: new Date()
         }
       });
-      await appendSkillDestinationSyncLog(
-        data.skillDestinationSyncId,
-        `Repository update completed for ${repositoryName}.`
-      );
+      if (updated.count > 0) {
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `Repository update completed for ${repositoryName}.`
+        );
+      }
       continue;
     }
 
-    if (originSync.status === 'failed' || originSync.status === 'cancelled') {
-      failed = true;
-      await db.skillDestinationSyncRepositoryPropagation.update({
-        where: { oid: propagation.oid },
+    if (originSync.status === 'failed') {
+      let updated = await db.skillDestinationSyncRepositoryPropagation.updateMany({
+        where: {
+          oid: propagation.oid,
+          status: { in: ['processing', 'waiting_for_review'] }
+        },
         data: {
           status: 'failed',
           errorMessage: originSync.errorMessage ?? `Origin sync ${originSync.status}`,
           completedAt: new Date()
         }
       });
-      await appendSkillDestinationSyncLog(
-        data.skillDestinationSyncId,
-        `Repository update failed for ${repositoryName}.`
-      );
+      if (updated.count > 0) {
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `Repository update failed for ${repositoryName}.`
+        );
+      }
       continue;
     }
 
-    pendingPropagationIds.push(propagation.id);
+    if (originSync.status === 'cancelled') {
+      let updated = await db.skillDestinationSyncRepositoryPropagation.updateMany({
+        where: {
+          oid: propagation.oid,
+          status: { in: ['processing', 'waiting_for_review'] }
+        },
+        data: {
+          status: 'canceled',
+          errorMessage: originSync.errorMessage,
+          completedAt: new Date()
+        }
+      });
+      if (updated.count > 0) {
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `Repository update canceled for ${repositoryName}.`
+        );
+      }
+      continue;
+    }
+
+    let nextStatus =
+      originSync.status === 'waiting_for_review'
+        ? ('waiting_for_review' as const)
+        : ('processing' as const);
+    let providerUnavailable = Boolean(originSync.errorMessage);
+    let nextErrorMessage = providerUnavailable
+      ? 'Repository update is temporarily unavailable.'
+      : null;
+    if (propagation.status !== nextStatus || propagation.errorMessage !== nextErrorMessage) {
+      let updated = await db.skillDestinationSyncRepositoryPropagation.updateMany({
+        where: {
+          oid: propagation.oid,
+          status: propagation.status,
+          errorMessage: propagation.errorMessage
+        },
+        data: {
+          status: nextStatus,
+          errorMessage: nextErrorMessage
+        }
+      });
+      if (updated.count === 0) continue;
+
+      console.log(
+        JSON.stringify({
+          event: 'cargo_skill_repository_sync_reconciled',
+          level: providerUnavailable ? 'warn' : 'info',
+          skillDestinationSyncId: data.skillDestinationSyncId,
+          propagationId: propagation.id,
+          repository: repositoryName,
+          provider: originRepositoryById.get(propagation.skillRepository.repoId)?.provider,
+          originSyncId: originSync.id,
+          originStatus: originSync.status,
+          previousStatus: propagation.status,
+          status: nextStatus,
+          originError: originSync.errorMessage
+        })
+      );
+
+      if (providerUnavailable) {
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `${repositoryName}: Repository update was temporarily unavailable; retrying.`
+        );
+      } else if (propagation.errorMessage) {
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `${repositoryName}: Repository status is available again.`
+        );
+      } else if (nextStatus === 'waiting_for_review') {
+        let snapshot = originSync.statusSnapshot as
+          | {
+              checks?: {
+                state?: string;
+                items?: { name?: string; status?: string }[];
+              };
+              review?: { state?: string };
+              mergeability?: { state?: string; reason?: string };
+            }
+          | null
+          | undefined;
+        let checksFailed = snapshot?.checks?.state === 'failed';
+        let failedChecks = (snapshot?.checks?.items ?? [])
+          .filter(check => check.status === 'failed')
+          .flatMap(check => (check.name ? [check.name] : []))
+          .slice(0, 3);
+        let reviewRequired = ['pending', 'changes_requested'].includes(
+          snapshot?.review?.state ?? ''
+        );
+        let hasConflict = snapshot?.mergeability?.state === 'conflicting';
+        let mergePermissionRequired =
+          snapshot?.mergeability?.reason === 'merge_permission_required';
+        let failedChecksMessage = failedChecks.length
+          ? `Checks failed: ${failedChecks.join(', ')}.`
+          : 'Repository checks failed.';
+        let message =
+          checksFailed && reviewRequired
+            ? `${failedChecksMessage} Review is required.`
+            : checksFailed
+              ? failedChecksMessage
+              : mergePermissionRequired
+                ? 'The connected GitLab user does not have permission to merge.'
+                : hasConflict
+                  ? 'Pull request has merge conflicts.'
+                  : reviewRequired
+                    ? snapshot?.review?.state === 'changes_requested'
+                      ? 'Review changes were requested.'
+                      : 'Review required.'
+                    : 'Repository action required.';
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `${repositoryName}: ${message}`
+        );
+      } else {
+        await appendSkillDestinationSyncLog(
+          data.skillDestinationSyncId,
+          `${repositoryName}: Repository requirements changed; continuing sync.`
+        );
+      }
+    }
   }
 
-  await appendSkillDestinationSyncLogs({
-    skillDestinationSyncId: data.skillDestinationSyncId,
-    logs: copiedLogs
+  let allPropagations = await db.skillDestinationSyncRepositoryPropagation.findMany({
+    where: { skillDestinationSyncOid: sync.oid },
+    select: { status: true }
   });
-
-  if (failed) {
+  if (allPropagations.some(propagation => propagation.status === 'failed')) {
     await db.skillDestinationSync.updateMany({
-      where: { oid: sync.oid, status: 'processing' },
+      where: {
+        oid: sync.oid,
+        status: { in: ['processing', 'waiting_for_review'] }
+      },
       data: {
         status: 'failed',
         completedAt: new Date()
@@ -452,17 +549,37 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
     return;
   }
 
-  if (pendingPropagationIds.length === 0) {
+  if (
+    allPropagations.length > 0 &&
+    allPropagations.every(propagation => propagation.status === 'completed')
+  ) {
     await syncFinishQueue.add({
       skillDestinationSyncId: data.skillDestinationSyncId
     });
-  } else {
-    await syncPropagateWaitQueue.add(
-      {
-        skillDestinationSyncId: data.skillDestinationSyncId,
-        pendingPropagationIds
-      },
-      { delay: 60_000 }
-    );
+    return;
   }
+
+  if (
+    allPropagations.length > 0 &&
+    allPropagations.every(propagation =>
+      ['completed', 'canceled'].includes(propagation.status)
+    )
+  ) {
+    await syncFinishQueue.add({
+      skillDestinationSyncId: data.skillDestinationSyncId,
+      status: 'canceled'
+    });
+    return;
+  }
+
+  let status = allPropagations.some(propagation => propagation.status === 'waiting_for_review')
+    ? ('waiting_for_review' as const)
+    : ('processing' as const);
+  await db.skillDestinationSync.updateMany({
+    where: {
+      oid: sync.oid,
+      status: { in: ['processing', 'waiting_for_review'] }
+    },
+    data: { status }
+  });
 });

--- a/src/metorial/cargo/modules/skill/src/services/skillMarketplace.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillMarketplace.ts
@@ -31,7 +31,7 @@ export let skillMarketplaceInclude = {
       syncs: {
         where: {
           status: {
-            in: ['pending', 'processing']
+            in: ['pending', 'processing', 'waiting_for_review']
           }
         }
       }

--- a/src/metorial/cargo/modules/skill/src/services/skillPlugin.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillPlugin.ts
@@ -51,7 +51,7 @@ export let skillPluginInclude = {
       syncs: {
         where: {
           status: {
-            in: ['pending', 'processing']
+            in: ['pending', 'processing', 'waiting_for_review']
           }
         }
       }

--- a/src/metorial/cargo/modules/skill/src/services/skillSync.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillSync.ts
@@ -10,6 +10,7 @@ import {
 import type { ResourceScope } from '@metorial/module-resource-tenant';
 import type { Prisma, SkillDestinationSyncStatus } from '@metorial/db';
 import { db, withTransaction } from '@metorial/db';
+import { getOriginTenant, origin } from '../internal/skillDestination';
 
 export let skillSyncInclude = {
   destination: {
@@ -45,6 +46,30 @@ export type SkillSyncRecord = Prisma.SkillDestinationSyncGetPayload<{
 }>;
 
 export type SkillSyncStatusFilter = SkillDestinationSyncStatus;
+
+export type SkillSyncRepositoryCheck = {
+  propagationId: string;
+  repoId: string;
+  provider: 'github' | 'gitlab' | 'bitbucket' | null;
+  repositoryName: string;
+  repositoryUrl: string | null;
+  pullRequestUrl: string | null;
+  status: SkillSyncRecord['repositoryPropagations'][number]['status'];
+  originStatus: string | null;
+  blockers: string[];
+  checks: {
+    name: string;
+    status: string;
+    url: string | null;
+    summary: string | null;
+  }[];
+  reviewStatus: string | null;
+  requiredReviewCount: number | null;
+  approvedReviewCount: number | null;
+  mergeability: string | null;
+  lastCheckedAt: Date | null;
+  errorMessage: string | null;
+};
 
 class SkillSyncServiceImpl {
   private async getSkillSyncRecord(
@@ -139,6 +164,126 @@ class SkillSyncServiceImpl {
     }
   ) {
     return await this.getSkillSyncRecord(d);
+  }
+
+  async getSkillSyncRepositoryChecks(
+    d: ResourceScope & {
+      skillSyncId: string;
+    }
+  ): Promise<SkillSyncRepositoryCheck[]> {
+    let skillSync = await this.getSkillSyncRecord(d);
+    let originSyncIds = skillSync.repositoryPropagations.flatMap(propagation =>
+      propagation.originSyncId ? [propagation.originSyncId] : []
+    );
+    let repoIds = skillSync.repositoryPropagations.map(
+      propagation => propagation.skillRepository.repoId
+    );
+    let resourceTenantOid =
+      skillSync.destination.skillMarketplace?.resourceTenantOid ??
+      skillSync.destination.skillPlugin?.resourceTenantOid;
+
+    if (!resourceTenantOid) return [];
+
+    let originTenant = await getOriginTenant({
+      oid: resourceTenantOid,
+      id: skillSync.destination.id
+    });
+    let [originSyncs, repositories] = await Promise.all([
+      originSyncIds.length
+        ? origin.scmRepositorySync.getMany({
+            tenantId: originTenant.id,
+            scmRepositorySyncIds: originSyncIds
+          })
+        : Promise.resolve({ syncs: [] }),
+      repoIds.length
+        ? origin.scmRepository.getMany({
+            tenantId: originTenant.id,
+            scmRepositoryIds: repoIds
+          })
+        : Promise.resolve({ repositories: [] })
+    ]);
+    let originSyncById = new Map(originSyncs.syncs.map(sync => [sync.id, sync]));
+    let repositoryById = new Map(
+      repositories.repositories.map(repository => [repository.id, repository])
+    );
+
+    return skillSync.repositoryPropagations.map(propagation => {
+      let originSync = propagation.originSyncId
+        ? originSyncById.get(propagation.originSyncId)
+        : undefined;
+      let repository = repositoryById.get(propagation.skillRepository.repoId);
+      let snapshot = originSync?.statusSnapshot as
+        | {
+            observedAt?: string | Date;
+            checks?: {
+              state?: string;
+              items?: {
+                name?: string;
+                status?: string;
+                url?: string | null;
+                summary?: string | null;
+              }[];
+            };
+            review?: {
+              state?: string;
+              approvals?: number | null;
+              requiredApprovals?: number | null;
+            };
+            mergeability?: {
+              state?: string;
+              reason?: string;
+            };
+          }
+        | null
+        | undefined;
+      let blockers = [
+        snapshot?.checks?.state === 'pending' ? 'checks_pending' : null,
+        snapshot?.checks?.state === 'failed' ? 'checks_failed' : null,
+        ['pending', 'changes_requested'].includes(snapshot?.review?.state ?? '')
+          ? 'reviews_required'
+          : null,
+        snapshot?.mergeability?.state === 'conflicting' ? 'merge_conflict' : null,
+        snapshot?.mergeability?.reason === 'merge_permission_required'
+          ? 'merge_permission_required'
+          : null,
+        snapshot?.mergeability?.state === 'blocked' &&
+        snapshot?.mergeability?.reason !== 'merge_permission_required'
+          ? 'merge_blocked'
+          : null,
+        (originSync?.errorMessage ||
+          propagation.errorMessage ||
+          (propagation.originSyncId && !originSync)) &&
+        ['processing', 'waiting_for_review'].includes(propagation.status)
+          ? 'provider_unavailable'
+          : null
+      ].filter((blocker): blocker is string => blocker != null);
+
+      return {
+        propagationId: propagation.id,
+        repoId: propagation.skillRepository.repoId,
+        provider: repository?.provider ?? null,
+        repositoryName: repository
+          ? `${repository.externalOwner}/${repository.externalName}`
+          : propagation.skillRepository.repoId,
+        repositoryUrl: repository?.externalUrl ?? null,
+        pullRequestUrl: originSync?.providerPrUrl ?? null,
+        status: propagation.status,
+        originStatus: originSync?.status ?? null,
+        blockers,
+        checks: (snapshot?.checks?.items ?? []).map(check => ({
+          name: check.name ?? 'Repository check',
+          status: check.status ?? 'unknown',
+          url: check.url ?? null,
+          summary: check.summary ?? null
+        })),
+        reviewStatus: snapshot?.review?.state ?? null,
+        requiredReviewCount: snapshot?.review?.requiredApprovals ?? null,
+        approvedReviewCount: snapshot?.review?.approvals ?? null,
+        mergeability: snapshot?.mergeability?.state ?? null,
+        lastCheckedAt: snapshot?.observedAt ? new Date(snapshot.observedAt) : null,
+        errorMessage: propagation.errorMessage ?? originSync?.errorMessage ?? null
+      };
+    });
   }
 }
 

--- a/src/metorial/db/control.toml
+++ b/src/metorial/db/control.toml
@@ -58,26 +58,6 @@ EXTERNAL_MULTI_REGION_ENDPOINT = "http://localhost:4323"
 INTERNAL_MULTI_REGION_ENDPOINT = "http://localhost:4323"
 
 [dev.db.main]
-name = "metorial-oss"
+name = "metorial-enterprise"
 engine = "postgres"
 env = "DATABASE_URL"
-
-[dev.db.subspace]
-name = "subspace"
-engine = "postgres"
-env = "SUBSPACE_DATABASE_URL"
-
-[dev.db.cargo]
-name = "cargo"
-engine = "postgres"
-env = "CARGO_DATABASE_URL"
-
-[dev.db.global]
-name = "metorial-oss-global"
-engine = "postgres"
-env = "GLOBAL_DATABASE_URL"
-
-[dev.db.usage]
-name = "metorial-usage"
-engine = "mongodb"
-env = "USAGE_MONGO_URL"

--- a/src/metorial/db/prisma/schema/skill/skillDestination.prisma
+++ b/src/metorial/db/prisma/schema/skill/skillDestination.prisma
@@ -49,12 +49,14 @@ enum SkillDestinationSyncStatus {
   completed
   failed
   processing
+  waiting_for_review
   canceled
 }
 
 enum SkillDestinationSyncRepositoryPropagationStatus {
   pending
   processing
+  waiting_for_review
   completed
   failed
   canceled
@@ -111,4 +113,18 @@ model SkillDestinationSyncRepositoryPropagation {
   @@unique([skillDestinationSyncOid, skillRepositoryOid])
   @@index([status])
   @@index([originSyncId])
+}
+
+model SkillOriginChangeNotificationCursor {
+  consumer String @id
+
+  cursor String?
+
+  leaseId    String?
+  leaseUntil DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@index([leaseUntil])
 }

--- a/src/origin/apps/service/prisma/schema/changeNotification.prisma
+++ b/src/origin/apps/service/prisma/schema/changeNotification.prisma
@@ -1,5 +1,6 @@
 enum ChangeNotificationType {
   repo_push
+  repository_sync_status_changed
 }
 
 model ChangeNotification {
@@ -17,5 +18,12 @@ model ChangeNotification {
   repoPushOid BigInt?
   repoPush    ScmRepositoryPush? @relation(fields: [repoPushOid], references: [oid])
 
+  repositorySyncOid BigInt?
+  repositorySync    ScmRepositorySync? @relation("RepositorySyncChangeNotifications", fields: [repositorySyncOid], references: [oid], onDelete: SetNull)
+
+  materialHash String?
+
   createdAt DateTime @default(now())
+
+  @@index([tenantOid, oid])
 }

--- a/src/origin/apps/service/prisma/schema/scm.prisma
+++ b/src/origin/apps/service/prisma/schema/scm.prisma
@@ -10,6 +10,7 @@ enum ScmRepositorySyncStatus {
   syncing_contents
   creating_pr
   waiting_for_ci
+  waiting_for_review
   merging
   merged
   failed
@@ -110,6 +111,8 @@ model ScmRepositorySync {
 
   errorMessage String?
   ciState      String?
+  /// [RepositorySyncStatusSnapshot]
+  statusSnapshot Json?
   attemptCount Int     @default(0)
 
   /// [SyncLogEntry]
@@ -128,6 +131,8 @@ model ScmRepositorySync {
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)
 
+  changeNotifications ChangeNotification[] @relation("RepositorySyncChangeNotifications")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -135,6 +140,7 @@ model ScmRepositorySync {
   @@index([repoOid])
   @@index([codeBucketOid])
   @@index([status])
+  @@index([status, nextPollAt])
 }
 
 model ScmInstallation {

--- a/src/origin/apps/service/src/controllers/changeNotification.ts
+++ b/src/origin/apps/service/src/controllers/changeNotification.ts
@@ -3,6 +3,7 @@ import { v } from '@lowerdeck/validation';
 import { changeNotificationPresenter } from '../presenters/changeNotification';
 import { changeNotificationService } from '../services';
 import { app } from './_app';
+import { tenantApp } from './tenant';
 
 export let changeNotificationApp = app.use(async ctx => {
   let changeNotificationId = ctx.body.changeNotificationId;
@@ -43,5 +44,26 @@ export let changeNotificationController = app.controller({
         changeNotificationId: v.string()
       })
     )
-    .do(async ctx => changeNotificationPresenter(ctx.changeNotification))
+    .do(async ctx => changeNotificationPresenter(ctx.changeNotification)),
+
+  poll: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        afterCursor: v.optional(v.string()),
+        limit: v.optional(v.number({ modifiers: [v.integer(), v.positive()] }))
+      })
+    )
+    .do(async ctx => {
+      let result = await changeNotificationService.pollChangeNotifications({
+        tenantOid: ctx.tenant.oid,
+        afterCursor: ctx.input.afterCursor,
+        limit: ctx.input.limit ?? 100
+      });
+      return {
+        items: result.notifications.map(changeNotificationPresenter),
+        nextCursor: result.nextCursor
+      };
+    })
 });

--- a/src/origin/apps/service/src/controllers/scmRepositorySync.ts
+++ b/src/origin/apps/service/src/controllers/scmRepositorySync.ts
@@ -22,5 +22,21 @@ export let scmRepositorySyncController = app.controller({
       return {
         syncs: syncs.map(scmRepositorySyncPresenter)
       };
+    }),
+
+  checkStatus: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        scmRepositorySyncId: v.string()
+      })
+    )
+    .do(async ctx => {
+      let sync = await scmRepositorySyncService.checkScmRepositorySyncStatus({
+        tenant: ctx.tenant,
+        id: ctx.input.scmRepositorySyncId
+      });
+      return scmRepositorySyncPresenter(sync);
     })
 });

--- a/src/origin/apps/service/src/db.ts
+++ b/src/origin/apps/service/src/db.ts
@@ -14,5 +14,38 @@ declare global {
       content: string;
     }[];
     type SyncLogEntry = [number, string];
+    type RepositorySyncStatusSnapshot = {
+      version: 1;
+      provider: 'github' | 'gitlab' | 'bitbucket';
+      pullRequest: {
+        id: string;
+        url: string;
+        state: 'open' | 'merged' | 'closed';
+      };
+      checks: {
+        state: 'pending' | 'success' | 'failed' | 'unknown';
+        total: number;
+        successful: number;
+        pending: number;
+        failed: number;
+        items: {
+          name: string;
+          status: 'pending' | 'success' | 'failed' | 'unknown';
+          url: string | null;
+          summary: string | null;
+        }[];
+      };
+      review: {
+        state: 'pending' | 'approved' | 'changes_requested' | 'not_required' | 'unknown';
+        approvals: number;
+        changesRequested: number;
+        requiredApprovals?: number;
+      };
+      mergeability: {
+        state: 'mergeable' | 'blocked' | 'conflicting' | 'checking' | 'unknown';
+        reason?: string;
+      };
+      observedAt: string;
+    };
   }
 }

--- a/src/origin/apps/service/src/lib/bitbucket.ts
+++ b/src/origin/apps/service/src/lib/bitbucket.ts
@@ -39,6 +39,12 @@ export type BitbucketPullRequest = {
   version?: number;
 };
 
+export type BitbucketPullRequestStatus = BitbucketPullRequest & {
+  approvals: number;
+  changesRequested: number;
+  mergeability: 'mergeable' | 'blocked' | 'conflicting' | 'unknown';
+};
+
 let tokenRefreshes = new Map<bigint, Promise<BitbucketCredentials>>();
 
 let isDataCenter = (backend: ScmBackend) => backend.type === 'bitbucket_data_center';
@@ -264,9 +270,9 @@ export class BitbucketClient {
     limit: number;
   }): Promise<{ repositories: BitbucketRepository[]; nextCursor?: string }> {
     if (!isDataCenter(this.backend)) {
-      let path = i.cursor ?? (i.accountSlug
-        ? `repositories/${encodeURIComponent(i.accountSlug)}`
-        : 'repositories');
+      let path =
+        i.cursor ??
+        (i.accountSlug ? `repositories/${encodeURIComponent(i.accountSlug)}` : 'repositories');
       let page = await this.request<{ values: any[]; next?: string }>(path, {
         query: i.cursor ? undefined : { pagelen: i.limit, role: 'member' }
       });
@@ -278,11 +284,11 @@ export class BitbucketClient {
 
     let start = i.cursor ? Number(i.cursor) : 0;
     if (!Number.isInteger(start) || start < 0) {
-      throw new ServiceError(badRequestError({ message: 'Invalid Bitbucket repository cursor' }));
+      throw new ServiceError(
+        badRequestError({ message: 'Invalid Bitbucket repository cursor' })
+      );
     }
-    let path = i.accountSlug
-      ? `projects/${encodeURIComponent(i.accountSlug)}/repos`
-      : 'repos';
+    let path = i.accountSlug ? `projects/${encodeURIComponent(i.accountSlug)}/repos` : 'repos';
     let page = await this.request<{
       values: any[];
       isLastPage: boolean;
@@ -290,7 +296,8 @@ export class BitbucketClient {
     }>(path, { query: { limit: i.limit, start } });
     return {
       repositories: page.values.map(repo => this.normalizeDataCenterRepository(repo)),
-      nextCursor: page.isLastPage || page.nextPageStart == null ? undefined : String(page.nextPageStart)
+      nextCursor:
+        page.isLastPage || page.nextPageStart == null ? undefined : String(page.nextPageStart)
     };
   }
 
@@ -367,7 +374,17 @@ export class BitbucketClient {
             url: i.url,
             active: true,
             secret: i.secret,
-            events: ['repo:push']
+            events: [
+              'repo:push',
+              'pullrequest:created',
+              'pullrequest:updated',
+              'pullrequest:approved',
+              'pullrequest:unapproved',
+              'pullrequest:fulfilled',
+              'pullrequest:rejected',
+              'repo:commit_status_created',
+              'repo:commit_status_updated'
+            ]
           }
         }
       );
@@ -382,7 +399,14 @@ export class BitbucketClient {
           url: i.url,
           active: true,
           secret: i.secret,
-          events: ['repo:refs_changed']
+          events: [
+            'repo:refs_changed',
+            'pr:opened',
+            'pr:modified',
+            'pr:reviewer:approved',
+            'pr:merged',
+            'pr:declined'
+          ]
         }
       }
     );
@@ -411,6 +435,50 @@ export class BitbucketClient {
       ? `repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks/${encodeURIComponent(webhookId)}`
       : `projects/${encodeURIComponent(owner)}/repos/${encodeURIComponent(repo)}/webhooks/${encodeURIComponent(webhookId)}`;
     await this.request(path, { method: 'DELETE' });
+  }
+
+  async updateWebhook(i: {
+    repositoryId: string;
+    webhookId: string;
+    url: string;
+    secret: string;
+  }) {
+    let [owner, repo] = i.repositoryId.split('/');
+    if (!owner || !repo) throw new Error('Invalid Bitbucket repository ID');
+    let dataCenter = isDataCenter(this.backend);
+    let path = !dataCenter
+      ? `repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks/${encodeURIComponent(i.webhookId)}`
+      : `projects/${encodeURIComponent(owner)}/repos/${encodeURIComponent(repo)}/webhooks/${encodeURIComponent(i.webhookId)}`;
+    await this.request(path, {
+      method: 'PUT',
+      body: {
+        description: 'Metorial repository sync',
+        name: 'Metorial repository sync',
+        url: i.url,
+        active: true,
+        secret: i.secret,
+        events: !dataCenter
+          ? [
+              'repo:push',
+              'pullrequest:created',
+              'pullrequest:updated',
+              'pullrequest:approved',
+              'pullrequest:unapproved',
+              'pullrequest:fulfilled',
+              'pullrequest:rejected',
+              'repo:commit_status_created',
+              'repo:commit_status_updated'
+            ]
+          : [
+              'repo:refs_changed',
+              'pr:opened',
+              'pr:modified',
+              'pr:reviewer:approved',
+              'pr:merged',
+              'pr:declined'
+            ]
+      }
+    });
   }
 
   async getBranch(repositoryId: string, branch: string) {
@@ -609,10 +677,70 @@ export class BitbucketClient {
     };
   }
 
-  async getCiState(
+  async getPullRequestStatus(
+    repositoryId: string,
+    id: string
+  ): Promise<BitbucketPullRequestStatus> {
+    let [owner, repo] = repositoryId.split('/');
+    if (!owner || !repo) throw new Error('Invalid Bitbucket repository ID');
+    let dataCenter = isDataCenter(this.backend);
+    let path = !dataCenter
+      ? `repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pullrequests/${encodeURIComponent(id)}`
+      : `projects/${encodeURIComponent(owner)}/repos/${encodeURIComponent(repo)}/pull-requests/${encodeURIComponent(id)}`;
+    let pr = await this.request<any>(path);
+    let participants = pr.participants ?? pr.reviewers ?? [];
+    let properties = pr.properties ?? {};
+    let conflicted =
+      properties.mergeResult?.outcome === 'CONFLICTED' ||
+      properties.conflicted === true ||
+      (pr.merge_commit == null && pr.reason === 'CONFLICTING');
+    let blocked =
+      properties.mergeResult?.outcome === 'VETOED' ||
+      properties.openTaskCount > 0 ||
+      pr.task_count > 0;
+
+    return {
+      id: pr.id.toString(),
+      url: !dataCenter ? pr.links.html.href : pr.links.self[0].href,
+      state: pr.state,
+      mergeSha: pr.merge_commit?.hash ?? properties.mergeCommit?.id,
+      version: pr.version,
+      approvals: participants.filter((participant: any) => participant.approved === true)
+        .length,
+      changesRequested: participants.filter(
+        (participant: any) =>
+          participant.status === 'NEEDS_WORK' || participant.state === 'changes_requested'
+      ).length,
+      mergeability: conflicted ? 'conflicting' : blocked ? 'blocked' : 'unknown'
+    };
+  }
+
+  async declinePullRequest(repositoryId: string, id: string) {
+    let existing = await this.getPullRequest(repositoryId, id);
+    if (!['OPEN'].includes(existing.state.toUpperCase())) return;
+    let [owner, repo] = repositoryId.split('/');
+    if (!owner || !repo) throw new Error('Invalid Bitbucket repository ID');
+    let path = !isDataCenter(this.backend)
+      ? `repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pullrequests/${encodeURIComponent(id)}/decline`
+      : `projects/${encodeURIComponent(owner)}/repos/${encodeURIComponent(repo)}/pull-requests/${encodeURIComponent(id)}/decline`;
+    await this.request(path, {
+      method: 'POST',
+      query: isDataCenter(this.backend) ? { version: existing.version } : undefined,
+      body: {}
+    });
+  }
+
+  async getCiChecks(
     repositoryId: string,
     commit: string
-  ): Promise<'pending' | 'success' | 'failed'> {
+  ): Promise<
+    {
+      name: string;
+      status: 'pending' | 'success' | 'failed' | 'unknown';
+      url: string | null;
+      summary: string | null;
+    }[]
+  > {
     let [owner, repo] = repositoryId.split('/');
     if (!owner || !repo) throw new Error('Invalid Bitbucket repository ID');
     let statuses: any[];
@@ -625,15 +753,30 @@ export class BitbucketClient {
         `${trimSlash(this.backend.webUrl)}/rest/build-status/1.0/commits/${encodeURIComponent(commit)}`
       );
     }
-    if (statuses.length === 0) return 'success';
-    let states = statuses.map(status => String(status.state ?? status.status).toUpperCase());
-    if (states.some(state => ['FAILED', 'ERROR', 'STOPPED', 'CANCELLED'].includes(state))) {
-      return 'failed';
+    return statuses.map(status => {
+      let state = String(status.state ?? status.status).toUpperCase();
+      return {
+        name: String(status.name ?? status.key ?? 'Build check'),
+        status: ['FAILED', 'ERROR', 'STOPPED', 'CANCELLED'].includes(state)
+          ? 'failed'
+          : ['SUCCESSFUL', 'SUCCESS', 'COMPLETED'].includes(state)
+            ? 'success'
+            : ['INPROGRESS', 'IN_PROGRESS', 'PENDING'].includes(state)
+              ? 'pending'
+              : 'unknown',
+        url: typeof status.url === 'string' ? status.url : null,
+        summary: typeof status.description === 'string' ? status.description : null
+      };
+    });
+  }
+
+  async getCiState(repositoryId: string, commit: string) {
+    let checks = await this.getCiChecks(repositoryId, commit);
+    if (checks.some(check => check.status === 'failed')) return 'failed' as const;
+    if (checks.some(check => ['pending', 'unknown'].includes(check.status))) {
+      return 'pending' as const;
     }
-    if (states.some(state => !['SUCCESSFUL', 'SUCCESS', 'COMPLETED'].includes(state))) {
-      return 'pending';
-    }
-    return 'success';
+    return 'success' as const;
   }
 
   async mergePullRequest(repositoryId: string, id: string): Promise<BitbucketPullRequest> {

--- a/src/origin/apps/service/src/lib/gitlab.ts
+++ b/src/origin/apps/service/src/lib/gitlab.ts
@@ -4,7 +4,6 @@ import type { ScmBackend, ScmInstallation } from '../../prisma/generated/client'
 import { db } from '../db';
 import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
 
-type GitLabClient = InstanceType<typeof Gitlab>;
 type GitLabInstallation = ScmInstallation & { backend: ScmBackend };
 type GitLabCredentials = {
   accessToken: string;
@@ -14,7 +13,7 @@ type GitLabCredentials = {
 
 let tokenRefreshes = new Map<bigint, Promise<GitLabCredentials>>();
 
-export let createGitLabClient = (backend?: ScmBackend): GitLabClient => {
+export let createGitLabClient = (backend?: ScmBackend) => {
   let host = backend?.webUrl ?? 'https://gitlab.com';
   let oauthToken = undefined; // Will be set when we have a token
 
@@ -24,10 +23,7 @@ export let createGitLabClient = (backend?: ScmBackend): GitLabClient => {
   });
 };
 
-export let createGitLabClientWithToken = (
-  token: string,
-  backend?: ScmBackend
-): GitLabClient => {
+export let createGitLabClientWithToken = (token: string, backend?: ScmBackend) => {
   let host = backend?.webUrl ?? 'https://gitlab.com';
 
   return new Gitlab({
@@ -150,9 +146,7 @@ export let refreshGitLabAccessToken = async (i: {
   };
 };
 
-export let createGitLabClientWithInstallation = async (
-  installation: GitLabInstallation
-): Promise<GitLabClient> => {
+export let createGitLabClientWithInstallation = async (installation: GitLabInstallation) => {
   let accessToken = await getGitLabAccessTokenWithInstallation(installation);
   return createGitLabClientWithToken(accessToken, installation.backend);
 };

--- a/src/origin/apps/service/src/lib/scmRepositorySyncProvider.test.ts
+++ b/src/origin/apps/service/src/lib/scmRepositorySyncProvider.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGitLabClientWithInstallation } from './gitlab';
 import {
+  closeRepositorySyncPullRequest,
   createRepositorySyncBranch,
   getRepositorySyncCiState,
+  getRepositorySyncStatusSnapshot,
   mergeRepositorySyncPullRequest
 } from './scmRepositorySyncProvider';
 
@@ -22,6 +24,7 @@ let createSync = (overrides: Record<string, unknown> = {}) =>
     branchName: 'metorial/sync-marketplace-8',
     baseBranch: 'main',
     providerPrId: '42',
+    providerPrUrl: 'https://gitlab.example/project/-/merge_requests/42',
     repo: {
       id: 'repo_123',
       provider: 'gitlab',
@@ -64,11 +67,19 @@ describe('GitLab repository sync', () => {
         create: vi.fn()
       },
       MergeRequests: {
+        edit: vi.fn(),
         merge: vi.fn(),
-        show: vi.fn()
+        show: vi.fn().mockResolvedValue({
+          state: 'opened',
+          sha: 'source_sha'
+        })
       },
       Pipelines: {
         all: vi.fn()
+      },
+      MergeRequestApprovals: {
+        showConfiguration: vi.fn(),
+        showApprovalState: vi.fn()
       }
     };
     createGitLabClient.mockReset();
@@ -234,6 +245,7 @@ describe('GitLab repository sync', () => {
     });
 
     expect(gitlab.MergeRequests.merge).toHaveBeenCalledWith(123, 42, {
+      sha: 'source_sha',
       shouldRemoveSourceBranch: true
     });
     expect(gitlab.Branches.remove).not.toHaveBeenCalled();
@@ -259,16 +271,107 @@ describe('GitLab repository sync', () => {
     await expect(getRepositorySyncCiState(createSync())).resolves.toBe('success');
   });
 
+  it('normalizes GitLab checks, approvals, and mergeability into a provider-neutral snapshot', async () => {
+    gitlab.Pipelines.all.mockResolvedValue([{ id: 1, status: 'success' }]);
+    gitlab.MergeRequests.show.mockResolvedValue({
+      state: 'opened',
+      detailed_merge_status: 'not_approved'
+    });
+    gitlab.MergeRequestApprovals.showConfiguration.mockResolvedValue({
+      approvals_required: 2,
+      approved_by: [{ user: { id: 1 } }]
+    });
+    gitlab.MergeRequestApprovals.showApprovalState.mockResolvedValue({
+      rules: [{ approvals_required: 2, approved: false, approved_by: [{ id: 1 }] }]
+    });
+
+    await expect(getRepositorySyncStatusSnapshot(createSync())).resolves.toMatchObject({
+      version: 1,
+      provider: 'gitlab',
+      pullRequest: { id: '42', state: 'open' },
+      checks: {
+        state: 'success',
+        total: 1,
+        successful: 1,
+        pending: 0,
+        failed: 0,
+        items: [
+          {
+            name: 'Pipeline 1',
+            status: 'success',
+            url: null,
+            summary: 'Pipeline is success.'
+          }
+        ]
+      },
+      review: { state: 'pending', approvals: 1, requiredApprovals: 2 },
+      mergeability: { state: 'blocked', reason: 'not_approved' }
+    });
+    expect(gitlab.MergeRequestApprovals.showConfiguration).toHaveBeenCalledWith(123, {
+      mergerequestIId: 42
+    });
+    expect(gitlab.MergeRequestApprovals.showApprovalState).toHaveBeenCalledWith(123, 42);
+  });
+
+  it('keeps a GitLab pipeline waiting for manual jobs in a pending state', async () => {
+    gitlab.Pipelines.all.mockResolvedValue([{ id: 1, status: 'manual' }]);
+    gitlab.MergeRequests.show.mockResolvedValue({
+      state: 'opened',
+      detailed_merge_status: 'mergeable'
+    });
+
+    await expect(getRepositorySyncStatusSnapshot(createSync())).resolves.toMatchObject({
+      checks: {
+        state: 'pending',
+        pending: 1,
+        items: [{ status: 'pending', summary: 'Pipeline is manual.' }]
+      }
+    });
+  });
+
+  it('retries transient GitLab approval API failures instead of merging blindly', async () => {
+    gitlab.Pipelines.all.mockResolvedValue([{ id: 1, status: 'success' }]);
+    gitlab.MergeRequests.show.mockResolvedValue({
+      state: 'opened',
+      detailed_merge_status: 'mergeable'
+    });
+    gitlab.MergeRequestApprovals.showConfiguration.mockRejectedValue({
+      cause: { response: { statusCode: 500 } }
+    });
+
+    await expect(getRepositorySyncStatusSnapshot(createSync())).rejects.toMatchObject({
+      cause: { response: { statusCode: 500 } }
+    });
+  });
+
   it('treats a 405 as success when GitLab already merged the merge request', async () => {
     gitlab.MergeRequests.merge.mockRejectedValue({ cause: { response: { statusCode: 405 } } });
-    gitlab.MergeRequests.show.mockResolvedValue({
-      state: 'merged',
-      merge_commit_sha: 'merge_sha'
-    });
+    gitlab.MergeRequests.show
+      .mockResolvedValueOnce({ state: 'opened', sha: 'source_sha' })
+      .mockResolvedValueOnce({
+        state: 'merged',
+        merge_commit_sha: 'merge_sha'
+      });
 
     await expect(mergeRepositorySyncPullRequest(createSync())).resolves.toEqual({
       mergeSha: 'merge_sha'
     });
+  });
+
+  it('closes a superseded open GitLab merge request', async () => {
+    gitlab.MergeRequests.show.mockResolvedValue({ state: 'opened' });
+
+    await expect(closeRepositorySyncPullRequest(createSync())).resolves.toBe('closed');
+    expect(gitlab.MergeRequests.edit).toHaveBeenCalledWith(123, 42, {
+      stateEvent: 'close'
+    });
+  });
+
+  it('preserves a superseded merge request that was already merged', async () => {
+    gitlab.MergeRequests.show.mockResolvedValue({ state: 'merged' });
+
+    await expect(closeRepositorySyncPullRequest(createSync())).resolves.toBe('merged');
+    expect(gitlab.MergeRequests.edit).not.toHaveBeenCalled();
   });
 
   it('propagates merge failures', async () => {
@@ -276,5 +379,15 @@ describe('GitLab repository sync', () => {
     gitlab.MergeRequests.merge.mockRejectedValue(error);
 
     await expect(mergeRepositorySyncPullRequest(createSync())).rejects.toBe(error);
+  });
+
+  it('marks GitLab merge permission failures as actionable', async () => {
+    let error = Object.assign(new Error('401 Unauthorized'), { status: 401 });
+    gitlab.MergeRequests.merge.mockRejectedValue(error);
+
+    await expect(mergeRepositorySyncPullRequest(createSync())).rejects.toBe(error);
+    expect((error as { scmMergePermissionDenied?: boolean }).scmMergePermissionDenied).toBe(
+      true
+    );
   });
 });

--- a/src/origin/apps/service/src/lib/scmRepositorySyncProvider.ts
+++ b/src/origin/apps/service/src/lib/scmRepositorySyncProvider.ts
@@ -14,6 +14,7 @@ import {
   isRetryableScmProviderError,
   wrapScmProviderError
 } from './scmProviderError';
+import type { RepositorySyncStatusSnapshot } from '../services/repositorySyncState';
 
 type SyncWithRepo = ScmRepositorySync & {
   repo: ScmRepository & {
@@ -24,6 +25,7 @@ type SyncWithRepo = ScmRepositorySync & {
 };
 
 export type RepositorySyncCiState = 'pending' | 'success' | 'failed';
+export type { RepositorySyncStatusSnapshot } from '../services/repositorySyncState';
 
 let getGitHubClient = async (repo: SyncWithRepo['repo']) => {
   if (!repo.installation.externalInstallationId) {
@@ -37,10 +39,47 @@ let getGitHubClient = async (repo: SyncWithRepo['repo']) => {
 };
 
 let getGitLabClient = async (repo: SyncWithRepo['repo']) =>
-  (await createGitLabClientWithInstallation(repo.installation)) as any;
+  createGitLabClientWithInstallation(repo.installation);
+
+type GitLabClient = Awaited<ReturnType<typeof getGitLabClient>>;
+
+type GitLabMergeRequestStatus = {
+  state: string;
+  detailed_merge_status?: string;
+  detailedMergeStatus?: string;
+  merge_status?: string;
+  merge_error?: string | null;
+  has_conflicts?: boolean;
+  blocking_discussions_resolved?: boolean;
+  draft?: boolean;
+  merge_commit_sha?: string | null;
+  squash_commit_sha?: string | null;
+  sha?: string | null;
+  diff_refs?: { head_sha?: string | null };
+};
+
+let getGitLabMergeRequest = async (
+  gitlab: GitLabClient,
+  projectId: number,
+  mergeRequestIid: number
+): Promise<GitLabMergeRequestStatus> =>
+  (await gitlab.MergeRequests.show(projectId, mergeRequestIid, {
+    withMergeStatusRecheck: true
+  } as NonNullable<Parameters<GitLabClient['MergeRequests']['show']>[2]> & {
+    withMergeStatusRecheck: boolean;
+  })) as unknown as GitLabMergeRequestStatus;
 
 let getBitbucketClient = async (repo: SyncWithRepo['repo']) =>
   createBitbucketClientWithInstallation(repo.installation);
+
+let collectGitHubPages = async <T>(loadPage: (page: number) => Promise<T[]>) => {
+  let items: T[] = [];
+  for (let page = 1; ; page++) {
+    let next = await loadPage(page);
+    items.push(...next);
+    if (next.length < 100) return items;
+  }
+};
 
 let isGitHubEmptyRepositoryError = (e: any) =>
   e.status === 409 &&
@@ -70,7 +109,7 @@ let logGitLabSyncDebug = (message: string, d: Record<string, unknown>) => {
 };
 
 let logGitLabSyncError = (message: string, e: any, d: Record<string, unknown>) => {
-  console.error(
+  console.log(
     JSON.stringify({
       event: 'gitlab_repository_sync',
       level: 'error',
@@ -84,7 +123,8 @@ let logGitLabSyncError = (message: string, e: any, d: Record<string, unknown>) =
 let normalizeGitLabBranch = (value: unknown) => {
   if (typeof value !== 'string') return undefined;
   let normalized = value.trim();
-  if (!normalized || ['null', 'undefined'].includes(normalized.toLowerCase())) return undefined;
+  if (!normalized || ['null', 'undefined'].includes(normalized.toLowerCase()))
+    return undefined;
   return normalized;
 };
 
@@ -155,7 +195,9 @@ let initializeEmptyGitLabRepository = async (d: {
   context: Record<string, unknown>;
   onLog?: (message: string) => Promise<void>;
 }) => {
-  await d.onLog?.(`GitLab repository is empty; initializing default branch "${d.branchName}".`);
+  await d.onLog?.(
+    `GitLab repository is empty; initializing default branch "${d.branchName}".`
+  );
   logGitLabSyncDebug('initializing empty repository', {
     ...d.context,
     baseBranch: d.branchName
@@ -173,7 +215,9 @@ let initializeEmptyGitLabRepository = async (d: {
     } catch (error) {
       let branch = await getGitLabBranchOrNull(d.gitlab, d.projectId, d.branchName);
       if (branch) {
-        await d.onLog?.(`GitLab default branch "${d.branchName}" was initialized concurrently.`);
+        await d.onLog?.(
+          `GitLab default branch "${d.branchName}" was initialized concurrently.`
+        );
         return branch;
       }
 
@@ -541,8 +585,7 @@ export let createRepositorySyncBranch = async (
     }
 
     let liveBaseBranch = getGitLabProjectDefaultBranch(project);
-    let baseBranchName =
-      liveBaseBranch ?? normalizeGitLabBranch(sync.baseBranch) ?? 'main';
+    let baseBranchName = liveBaseBranch ?? normalizeGitLabBranch(sync.baseBranch) ?? 'main';
     let baseBranch;
 
     if (!liveBaseBranch) {
@@ -1065,9 +1108,439 @@ export let createRepositorySyncPullRequest = async (
   throw new ServiceError(badRequestError({ message: 'Unsupported repository provider' }));
 };
 
+export let closeRepositorySyncPullRequest = async (sync: SyncWithRepo) => {
+  if (!sync.providerPrId) return 'missing' as const;
+
+  if (sync.repo.provider === 'github') {
+    let octokit = await getGitHubClient(sync.repo);
+    try {
+      let pr = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+        owner: sync.repo.externalOwner,
+        repo: sync.repo.externalName,
+        pull_number: parseInt(sync.providerPrId)
+      });
+      if (pr.data.merged) return 'merged' as const;
+      if (pr.data.state !== 'open') return 'already_closed' as const;
+      await octokit.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
+        owner: sync.repo.externalOwner,
+        repo: sync.repo.externalName,
+        pull_number: parseInt(sync.providerPrId),
+        state: 'closed'
+      });
+      return 'closed' as const;
+    } catch (error) {
+      if (getScmProviderErrorStatus(error) !== 404) throw error;
+      return 'missing' as const;
+    }
+  }
+
+  if (sync.repo.provider === 'gitlab') {
+    let gitlab = await getGitLabClient(sync.repo);
+    let projectId = parseInt(sync.repo.externalId);
+    try {
+      let mergeRequest = await gitlab.MergeRequests.show(
+        projectId,
+        parseInt(sync.providerPrId)
+      );
+      if (mergeRequest.state === 'merged') return 'merged' as const;
+      if (mergeRequest.state !== 'opened') return 'already_closed' as const;
+      await gitlab.MergeRequests.edit(projectId, parseInt(sync.providerPrId), {
+        stateEvent: 'close'
+      });
+      return 'closed' as const;
+    } catch (error) {
+      if (getScmProviderErrorStatus(error) !== 404) throw error;
+      return 'missing' as const;
+    }
+  }
+
+  if (sync.repo.provider === 'bitbucket') {
+    let client = await getBitbucketClient(sync.repo);
+    try {
+      let pullRequest = await client.getPullRequestStatus(
+        sync.repo.externalId,
+        sync.providerPrId
+      );
+      let state = pullRequest.state.toUpperCase();
+      if (['MERGED', 'FULFILLED'].includes(state)) return 'merged' as const;
+      if (state !== 'OPEN') return 'already_closed' as const;
+      await client.declinePullRequest(sync.repo.externalId, sync.providerPrId);
+      return 'closed' as const;
+    } catch (error) {
+      if (getScmProviderErrorStatus(error) !== 404) throw error;
+      return 'missing' as const;
+    }
+  }
+
+  throw new ServiceError(badRequestError({ message: 'Unsupported repository provider' }));
+};
+
+export let getRepositorySyncStatusSnapshot = async (
+  sync: SyncWithRepo,
+  options?: { allowMissingPullRequestMetadata?: boolean }
+): Promise<RepositorySyncStatusSnapshot> => {
+  if (!sync.providerPrId || !sync.providerPrUrl) {
+    if (options?.allowMissingPullRequestMetadata) {
+      sync = {
+        ...sync,
+        providerPrId: sync.providerPrId ?? '0',
+        providerPrUrl: sync.providerPrUrl ?? ''
+      };
+    } else {
+      throw new ServiceError(
+        badRequestError({ message: 'Pull request has not been created' })
+      );
+    }
+  }
+
+  let providerPrId = sync.providerPrId!;
+  let providerPrUrl = sync.providerPrUrl!;
+  let observedAt = new Date().toISOString();
+
+  if (sync.repo.provider === 'github') {
+    let octokit = await getGitHubClient(sync.repo);
+    let [pr, statusItems, runItems, reviewItems] = await Promise.all([
+      octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+        owner: sync.repo.externalOwner,
+        repo: sync.repo.externalName,
+        pull_number: parseInt(providerPrId)
+      }),
+      collectGitHubPages<any>(async page => {
+        let response = await octokit.request(
+          'GET /repos/{owner}/{repo}/commits/{ref}/status',
+          {
+            owner: sync.repo.externalOwner,
+            repo: sync.repo.externalName,
+            ref: sync.branchName,
+            per_page: 100,
+            page
+          }
+        );
+        return response.data.statuses ?? [];
+      }),
+      collectGitHubPages<any>(async page => {
+        let response = await octokit.request(
+          'GET /repos/{owner}/{repo}/commits/{ref}/check-runs',
+          {
+            owner: sync.repo.externalOwner,
+            repo: sync.repo.externalName,
+            ref: sync.branchName,
+            per_page: 100,
+            page
+          } as any
+        );
+        return response.data.check_runs ?? [];
+      }),
+      collectGitHubPages<any>(async page => {
+        let response = await octokit.request(
+          'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews',
+          {
+            owner: sync.repo.externalOwner,
+            repo: sync.repo.externalName,
+            pull_number: parseInt(providerPrId),
+            per_page: 100,
+            page
+          }
+        );
+        return response.data as any[];
+      })
+    ]);
+    let checkItems: RepositorySyncStatusSnapshot['checks']['items'] = [
+      ...statusItems.map((item: any) => ({
+        name: item.context ?? 'Commit status',
+        status: ['failure', 'error'].includes(item.state)
+          ? ('failed' as const)
+          : item.state === 'success'
+            ? ('success' as const)
+            : item.state === 'pending'
+              ? ('pending' as const)
+              : ('unknown' as const),
+        url: item.target_url ?? null,
+        summary: item.description ?? null
+      })),
+      ...runItems.map((item: any) => ({
+        name: item.name ?? 'Check run',
+        status: [
+          'failure',
+          'timed_out',
+          'cancelled',
+          'action_required',
+          'startup_failure'
+        ].includes(item.conclusion)
+          ? ('failed' as const)
+          : item.status === 'completed'
+            ? ('success' as const)
+            : ('pending' as const),
+        url: item.details_url ?? item.html_url ?? null,
+        summary: item.output?.summary ?? null
+      }))
+    ];
+    let checkStates = checkItems.map(item => item.status);
+    let failed = checkStates.filter(state => state === 'failed').length;
+    let pending = checkStates.filter(state => state === 'pending').length;
+    let successful = checkStates.filter(state => state === 'success').length;
+    let latestReviews = new Map<string, string>();
+    for (let review of reviewItems) {
+      let reviewer = review.user?.id?.toString();
+      if (reviewer) latestReviews.set(reviewer, String(review.state).toUpperCase());
+    }
+    let approvals = [...latestReviews.values()].filter(state => state === 'APPROVED').length;
+    let changesRequested = [...latestReviews.values()].filter(
+      state => state === 'CHANGES_REQUESTED'
+    ).length;
+    let requiredApprovals: number | undefined;
+    try {
+      let protection = await octokit.request(
+        'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews',
+        {
+          owner: sync.repo.externalOwner,
+          repo: sync.repo.externalName,
+          branch: sync.baseBranch
+        }
+      );
+      requiredApprovals = protection.data.required_approving_review_count;
+    } catch (error) {
+      if (![403, 404].includes(getScmProviderErrorStatus(error) ?? 0)) throw error;
+    }
+    let mergeableState = (pr.data as any).mergeable_state;
+    let mergeability: RepositorySyncStatusSnapshot['mergeability'] =
+      pr.data.mergeable == null
+        ? { state: 'checking', reason: mergeableState }
+        : pr.data.mergeable === false
+          ? { state: 'conflicting', reason: mergeableState }
+          : ['blocked', 'draft'].includes(mergeableState)
+            ? { state: 'blocked', reason: mergeableState }
+            : { state: 'mergeable', reason: mergeableState };
+
+    return {
+      version: 1,
+      provider: 'github',
+      pullRequest: {
+        id: providerPrId,
+        url: providerPrUrl,
+        state: pr.data.merged ? 'merged' : pr.data.state === 'open' ? 'open' : 'closed',
+        mergeSha: pr.data.merge_commit_sha ?? null
+      },
+      checks: {
+        state: failed ? 'failed' : pending ? 'pending' : 'success',
+        total: checkStates.length,
+        successful,
+        pending,
+        failed,
+        items: checkItems
+      },
+      review: {
+        state: changesRequested
+          ? 'changes_requested'
+          : requiredApprovals != null && approvals < requiredApprovals
+            ? 'pending'
+            : approvals
+              ? 'approved'
+              : mergeability.state === 'blocked' && mergeableState === 'blocked'
+                ? 'pending'
+                : 'not_required',
+        approvals,
+        changesRequested,
+        requiredApprovals
+      },
+      mergeability,
+      observedAt
+    };
+  }
+
+  if (sync.repo.provider === 'gitlab') {
+    let gitlab = await getGitLabClient(sync.repo);
+    let projectId = parseInt(sync.repo.externalId);
+    let [mergeRequest, pipelines] = await Promise.all([
+      getGitLabMergeRequest(gitlab, projectId, parseInt(providerPrId)),
+      gitlab.Pipelines.all(projectId, { ref: sync.branchName, perPage: 1 })
+    ]);
+    let pipeline = pipelines[0];
+    let pipelineState = typeof pipeline?.status === 'string' ? pipeline.status : undefined;
+    let failed = ['failed', 'canceled'].includes(pipelineState ?? '') ? 1 : 0;
+    let pending =
+      pipeline &&
+      !['success', 'skipped', 'failed', 'canceled'].includes(pipelineState ?? '')
+        ? 1
+        : 0;
+    let successful = pipeline && !failed && !pending ? 1 : 0;
+    let checkItems: RepositorySyncStatusSnapshot['checks']['items'] = pipeline
+      ? [
+          {
+            name:
+              typeof pipeline.name === 'string' ? pipeline.name : `Pipeline ${pipeline.id}`,
+            status: failed ? 'failed' : pending ? 'pending' : 'success',
+            url: pipeline.web_url ?? null,
+            summary: pipelineState ? `Pipeline is ${pipelineState}.` : null
+          }
+        ]
+      : [];
+    let detailed =
+      mergeRequest.detailed_merge_status ?? mergeRequest.detailedMergeStatus ?? 'unknown';
+    let approvals = 0;
+    let approvalsRequired = 0;
+    let approvalRulesPending = false;
+    try {
+      let approval = await gitlab.MergeRequestApprovals.showConfiguration(projectId, {
+        mergerequestIId: parseInt(providerPrId)
+      });
+      approvals = approval?.approved_by?.length ?? 0;
+      approvalsRequired = approval?.approvals_required ?? 0;
+    } catch (error) {
+      if (![403, 404].includes(getScmProviderErrorStatus(error) ?? 0)) throw error;
+      // Approval APIs are unavailable on some GitLab editions.
+    }
+    try {
+      let approvalState = await gitlab.MergeRequestApprovals.showApprovalState(
+        projectId,
+        parseInt(providerPrId)
+      );
+      let rules = (Array.isArray(approvalState?.rules) ? approvalState.rules : []) as {
+        approvals_required?: number;
+        approved?: boolean;
+        approved_by?: unknown[];
+      }[];
+      approvalRulesPending = rules.some(
+        rule => (rule.approvals_required ?? 0) > 0 && rule.approved !== true
+      );
+      approvalsRequired = Math.max(
+        approvalsRequired,
+        ...rules.map(rule => rule.approvals_required ?? 0)
+      );
+      approvals = Math.max(
+        approvals,
+        ...rules.map(rule => (Array.isArray(rule.approved_by) ? rule.approved_by.length : 0))
+      );
+    } catch (error) {
+      if (![403, 404].includes(getScmProviderErrorStatus(error) ?? 0)) throw error;
+      // Approval-state APIs are unavailable on some GitLab editions.
+    }
+    let reviewState: RepositorySyncStatusSnapshot['review']['state'] =
+      approvalRulesPending || approvalsRequired > approvals || detailed === 'not_approved'
+        ? 'pending'
+        : approvals
+          ? 'approved'
+          : 'not_required';
+    let mergeability: RepositorySyncStatusSnapshot['mergeability'] = [
+      'unchecked',
+      'checking',
+      'preparing',
+      'approvals_syncing',
+      'unknown'
+    ].includes(detailed)
+      ? { state: 'checking', reason: detailed }
+      : ['conflict', 'cannot_be_merged', 'need_rebase'].includes(detailed)
+        ? { state: 'conflicting', reason: detailed }
+        : detailed === 'mergeable'
+          ? { state: 'mergeable', reason: detailed }
+          : { state: 'blocked', reason: detailed };
+
+    return {
+      version: 1,
+      provider: 'gitlab',
+      pullRequest: {
+        id: providerPrId,
+        url: providerPrUrl,
+        state:
+          mergeRequest.state === 'merged'
+            ? 'merged'
+            : mergeRequest.state === 'opened'
+              ? 'open'
+              : 'closed',
+        mergeSha:
+          mergeRequest.merge_commit_sha ?? mergeRequest.squash_commit_sha ?? null
+      },
+      checks: {
+        state: failed ? 'failed' : pending ? 'pending' : 'success',
+        total: pipeline ? 1 : 0,
+        successful,
+        pending,
+        failed,
+        items: checkItems
+      },
+      review: {
+        state: reviewState,
+        approvals,
+        changesRequested: 0,
+        requiredApprovals: approvalsRequired
+      },
+      mergeability,
+      observedAt
+    };
+  }
+
+  if (sync.repo.provider === 'bitbucket') {
+    let client = await getBitbucketClient(sync.repo);
+    let [branchSha, pr] = await Promise.all([
+      client.getBranch(sync.repo.externalId, sync.branchName),
+      client.getPullRequestStatus(sync.repo.externalId, providerPrId)
+    ]);
+    let checkItems = await client.getCiChecks(sync.repo.externalId, branchSha);
+    let failed = checkItems.filter(check => check.status === 'failed').length;
+    let pending = checkItems.filter(check =>
+      ['pending', 'unknown'].includes(check.status)
+    ).length;
+    let successful = checkItems.filter(check => check.status === 'success').length;
+    let ciState: RepositorySyncStatusSnapshot['checks']['state'] = failed
+      ? 'failed'
+      : pending
+        ? 'pending'
+        : 'success';
+    let state = pr.state.toUpperCase();
+    return {
+      version: 1,
+      provider: 'bitbucket',
+      pullRequest: {
+        id: providerPrId,
+        url: providerPrUrl,
+        state: ['MERGED', 'FULFILLED'].includes(state)
+          ? 'merged'
+          : state === 'OPEN'
+            ? 'open'
+            : 'closed',
+        mergeSha: pr.mergeSha ?? null
+      },
+      checks: {
+        state: ciState,
+        total: checkItems.length,
+        successful,
+        pending,
+        failed,
+        items: checkItems
+      },
+      review: {
+        state: pr.changesRequested
+          ? 'changes_requested'
+          : pr.approvals
+            ? 'approved'
+            : 'unknown',
+        approvals: pr.approvals,
+        changesRequested: pr.changesRequested
+      },
+      mergeability: { state: pr.mergeability },
+      observedAt
+    };
+  }
+
+  throw new ServiceError(badRequestError({ message: 'Unsupported repository provider' }));
+};
+
 export let getRepositorySyncCiState = async (
   sync: SyncWithRepo
 ): Promise<RepositorySyncCiState> => {
+  let snapshot = await getRepositorySyncStatusSnapshot(sync, {
+    allowMissingPullRequestMetadata: true
+  });
+  if (snapshot.checks.state === 'failed' || snapshot.mergeability.state === 'conflicting')
+    return 'failed';
+  if (
+    snapshot.checks.state === 'pending' ||
+    snapshot.checks.state === 'unknown' ||
+    ['checking', 'blocked', 'unknown'].includes(snapshot.mergeability.state)
+  )
+    return 'pending';
+  return 'success';
+  /*
   if (sync.repo.provider === 'github') {
     let octokit = await getGitHubClient(sync.repo);
 
@@ -1162,12 +1635,10 @@ export let getRepositorySyncCiState = async (
           ref: sync.branchName,
           perPage: 1
         }),
-        gitlab.MergeRequests.show(
+        getGitLabMergeRequest(
+          gitlab,
           parseInt(sync.repo.externalId),
-          parseInt(sync.providerPrId!),
-          {
-            withMergeStatusRecheck: true
-          }
+          parseInt(sync.providerPrId!)
         )
       ]);
     } catch (e: any) {
@@ -1237,6 +1708,7 @@ export let getRepositorySyncCiState = async (
   }
 
   throw new ServiceError(badRequestError({ message: 'Unsupported repository provider' }));
+  */
 };
 
 export let mergeRepositorySyncPullRequest = async (
@@ -1338,11 +1810,29 @@ export let mergeRepositorySyncPullRequest = async (
 
   if (sync.repo.provider === 'gitlab') {
     let gitlab = await getGitLabClient(sync.repo);
+    let mergeRequestBeforeMerge = await getGitLabMergeRequest(
+      gitlab,
+      parseInt(sync.repo.externalId),
+      parseInt(sync.providerPrId)
+    );
+    if (mergeRequestBeforeMerge.state === 'merged') {
+      return {
+        mergeSha:
+          mergeRequestBeforeMerge.merge_commit_sha ??
+          mergeRequestBeforeMerge.squash_commit_sha ??
+          undefined
+      };
+    }
+    let sourceSha = mergeRequestBeforeMerge.sha ?? mergeRequestBeforeMerge.diff_refs?.head_sha;
+    if (!sourceSha) {
+      throw new Error('GitLab did not return the merge request source SHA');
+    }
     logGitLabSyncDebug('merging merge request', {
       syncId: sync.id,
       repoId: sync.repo.id,
       projectId: sync.repo.externalId,
-      providerPrId: sync.providerPrId
+      providerPrId: sync.providerPrId,
+      sourceSha
     });
 
     let merge;
@@ -1350,24 +1840,76 @@ export let mergeRepositorySyncPullRequest = async (
       merge = await gitlab.MergeRequests.merge(
         parseInt(sync.repo.externalId),
         parseInt(sync.providerPrId),
-        { shouldRemoveSourceBranch: sync.branchName !== sync.baseBranch }
+        {
+          sha: sourceSha,
+          shouldRemoveSourceBranch: sync.branchName !== sync.baseBranch
+        }
       );
     } catch (e: any) {
+      let authenticatedUser:
+        | { id: number | string | undefined; username: string | undefined }
+        | undefined;
+      let authenticatedUserError;
+      try {
+        let user = await gitlab.Users.showCurrentUser();
+        authenticatedUser = {
+          id: user.id,
+          username: user.username
+        };
+      } catch (identityError) {
+        authenticatedUserError = getScmProviderErrorDetails(identityError);
+      }
+
+      let mergeRequest: GitLabMergeRequestStatus | undefined;
+      let mergeRequestError;
+      try {
+        mergeRequest = await getGitLabMergeRequest(
+          gitlab,
+          parseInt(sync.repo.externalId),
+          parseInt(sync.providerPrId)
+        );
+      } catch (statusError) {
+        mergeRequestError = getScmProviderErrorDetails(statusError);
+      }
+
       logGitLabSyncError('failed to merge merge request', e, {
         syncId: sync.id,
         repoId: sync.repo.id,
         projectId: sync.repo.externalId,
-        providerPrId: sync.providerPrId
+        providerPrId: sync.providerPrId,
+        authenticatedUser,
+        authenticatedUserError,
+        mergeRequest: mergeRequest
+          ? {
+              state: mergeRequest.state,
+              detailedMergeStatus:
+                mergeRequest.detailed_merge_status ?? mergeRequest.detailedMergeStatus,
+              mergeStatus: mergeRequest.merge_status,
+              mergeError: mergeRequest.merge_error,
+              hasConflicts: mergeRequest.has_conflicts,
+              blockingDiscussionsResolved: mergeRequest.blocking_discussions_resolved,
+              draft: mergeRequest.draft
+            }
+          : undefined,
+        mergeRequestError
       });
 
-      if (getScmProviderErrorStatus(e) === 405) {
-        let mergeRequest = await gitlab.MergeRequests.show(
-          parseInt(sync.repo.externalId),
-          parseInt(sync.providerPrId)
-        );
-        if (mergeRequest.state === 'merged') {
-          return { mergeSha: mergeRequest.merge_commit_sha ?? mergeRequest.squash_commit_sha };
-        }
+      if (mergeRequest?.state === 'merged') {
+        return {
+          mergeSha:
+            mergeRequest.merge_commit_sha ?? mergeRequest.squash_commit_sha ?? undefined
+        };
+      }
+
+      if (
+        e &&
+        typeof e === 'object' &&
+        [401, 403].includes(getScmProviderErrorStatus(e) ?? 0)
+      ) {
+        Object.defineProperty(e, 'scmMergePermissionDenied', {
+          value: true,
+          enumerable: false
+        });
       }
 
       throw e;

--- a/src/origin/apps/service/src/presenters/changeNotification.ts
+++ b/src/origin/apps/service/src/presenters/changeNotification.ts
@@ -3,15 +3,18 @@ import type {
   ScmAccount,
   ScmRepository,
   ScmRepositoryPush,
+  ScmRepositorySync,
   Tenant
 } from '../../prisma/generated/client';
 import { repositoryPresenter } from './repository';
 import { scmRepositoryPushPresenter } from './scmRepositoryPush';
+import { scmRepositorySyncPresenter } from './scmRepositorySync';
 
 export let changeNotificationPresenter = (
   notification: ChangeNotification & {
     repo: ScmRepository & { account: ScmAccount };
     repoPush: ScmRepositoryPush | null;
+    repositorySync: ScmRepositorySync | null;
     tenant: Tenant;
   }
 ) => ({
@@ -26,6 +29,9 @@ export let changeNotificationPresenter = (
         ...notification.repoPush,
         repo: notification.repo
       })
+    : undefined,
+  repositorySync: notification.repositorySync
+    ? scmRepositorySyncPresenter(notification.repositorySync)
     : undefined,
 
   tenantId: notification.tenant.id,

--- a/src/origin/apps/service/src/presenters/scmRepositorySync.ts
+++ b/src/origin/apps/service/src/presenters/scmRepositorySync.ts
@@ -1,4 +1,5 @@
 import type { ScmRepositorySync } from '../../prisma/generated/client';
+import type { RepositorySyncStatusSnapshot } from '../services/repositorySyncState';
 
 export let scmRepositorySyncPresenter = (sync: ScmRepositorySync) => ({
   object: 'origin#repository_sync' as const,
@@ -19,6 +20,7 @@ export let scmRepositorySyncPresenter = (sync: ScmRepositorySync) => ({
 
   errorMessage: sync.errorMessage,
   ciState: sync.ciState,
+  statusSnapshot: sync.statusSnapshot as RepositorySyncStatusSnapshot | null,
   attemptCount: sync.attemptCount,
   logs: sync.logs,
 

--- a/src/origin/apps/service/src/queues/scm/createRepoWebhook.ts
+++ b/src/origin/apps/service/src/queues/scm/createRepoWebhook.ts
@@ -6,6 +6,7 @@ import { ID } from '../../id';
 import { createBitbucketClientWithInstallation } from '../../lib/bitbucket';
 import { createGitHubInstallationClient } from '../../lib/githubApp';
 import { createGitLabClientWithInstallation } from '../../lib/gitlab';
+import { getScmProviderErrorStatus } from '../../lib/scmProviderError';
 
 export let createRepoWebhookQueue = createQueue<{ repoId: string }>({
   name: 'ori/rep/wh-cr',
@@ -82,7 +83,55 @@ export let createRepoWebhookQueueProcessor = createRepoWebhookQueue.process(asyn
   let existingWebhook = await db.scmRepositoryWebhook.findUnique({
     where: { repoOid: repo.oid }
   });
-  if (existingWebhook) return;
+  if (existingWebhook) {
+    try {
+      if (repo.provider === 'github') {
+        if (!repo.installation.externalInstallationId) throw new Error('Installation ID not found');
+        let octokit = await createGitHubInstallationClient(
+          repo.installation.externalInstallationId,
+          repo.installation.backend
+        );
+        await octokit.request('PATCH /repos/{owner}/{repo}/hooks/{hook_id}', {
+          owner: repo.externalOwner,
+          repo: repo.externalName,
+          hook_id: parseInt(existingWebhook.externalId),
+          active: true,
+          config: {
+            url: `${env.service.ORIGIN_SERVICE_PUBLIC_URL}/origin/webhook-ingest/gh/${existingWebhook.id}`,
+            content_type: 'json',
+            secret: existingWebhook.signingSecret,
+            insecure_ssl: '0'
+          },
+          events: ['push', 'status', 'check_run', 'check_suite', 'pull_request', 'pull_request_review']
+        });
+      } else if (repo.provider === 'gitlab') {
+        let gitlab = await createGitLabClientWithInstallation(repo.installation);
+        await gitlab.ProjectHooks.edit(
+          parseInt(repo.externalId),
+          parseInt(existingWebhook.externalId),
+          `${env.service.ORIGIN_SERVICE_PUBLIC_URL}/origin/webhook-ingest/gl/${existingWebhook.id}`,
+          {
+            pushEvents: true,
+            mergeRequestsEvents: true,
+            pipelineEvents: true,
+            token: existingWebhook.signingSecret
+          }
+        );
+      } else {
+        let client = await createBitbucketClientWithInstallation(repo.installation);
+        await client.updateWebhook({
+          repositoryId: repo.externalId,
+          webhookId: existingWebhook.externalId,
+          url: `${env.service.ORIGIN_SERVICE_PUBLIC_URL}/origin/webhook-ingest/bb/${existingWebhook.id}`,
+          secret: existingWebhook.signingSecret
+        });
+      }
+      return;
+    } catch (error) {
+      if (getScmProviderErrorStatus(error) !== 404) throw error;
+      await db.scmRepositoryWebhook.delete({ where: { oid: existingWebhook.oid } });
+    }
+  }
 
   if (isLocalOrPrivateWebhookUrl(env.service.ORIGIN_SERVICE_PUBLIC_URL)) {
     console.warn(
@@ -114,7 +163,7 @@ export let createRepoWebhookQueueProcessor = createRepoWebhookQueue.process(asyn
           secret,
           insecure_ssl: '0'
         },
-        events: ['push'],
+        events: ['push', 'status', 'check_run', 'check_suite', 'pull_request', 'pull_request_review'],
         active: true
       });
 
@@ -152,6 +201,8 @@ export let createRepoWebhookQueueProcessor = createRepoWebhookQueue.process(asyn
         `${env.service.ORIGIN_SERVICE_PUBLIC_URL}/origin/webhook-ingest/gl/${webhookId}`,
         {
           pushEvents: true,
+          mergeRequestsEvents: true,
+          pipelineEvents: true,
           token: secret
         }
       );

--- a/src/origin/apps/service/src/queues/scm/index.ts
+++ b/src/origin/apps/service/src/queues/scm/index.ts
@@ -2,9 +2,11 @@ import { combineQueueProcessors } from '@lowerdeck/queue';
 import { createRepoWebhookQueueProcessor } from './createRepoWebhook';
 import { createHandleRepoPushQueueProcessor } from './handleRepoPush';
 import { repositorySyncQueueProcessor } from './repositorySync';
+import { reconcileRepoWebhooksProcessor } from './reconcileRepoWebhooks';
 
 export let scmQueueProcessor = combineQueueProcessors([
   createHandleRepoPushQueueProcessor,
   createRepoWebhookQueueProcessor,
-  repositorySyncQueueProcessor
+  repositorySyncQueueProcessor,
+  reconcileRepoWebhooksProcessor
 ]);

--- a/src/origin/apps/service/src/queues/scm/reconcileRepoWebhooks.ts
+++ b/src/origin/apps/service/src/queues/scm/reconcileRepoWebhooks.ts
@@ -1,0 +1,32 @@
+import { createCron } from '@lowerdeck/cron';
+import { db } from '../../db';
+import { env } from '../../env';
+import { createRepoWebhookQueue } from './createRepoWebhook';
+
+export let reconcileRepoWebhooksProcessor = createCron(
+  {
+    name: 'ori/rep/wh-reconcile',
+    cron: '17 */6 * * *',
+    redisUrl: env.service.REDIS_URL
+  },
+  async () => {
+    let bucket = Math.floor(Date.now() / (6 * 60 * 60_000));
+    let cursor: bigint | undefined;
+    while (true) {
+      let repos = await db.scmRepository.findMany({
+        where: cursor == null ? undefined : { oid: { gt: cursor } },
+        select: { oid: true, id: true },
+        orderBy: { oid: 'asc' },
+        take: 1_000
+      });
+      for (let repo of repos) {
+        await createRepoWebhookQueue.add(
+          { repoId: repo.id },
+          { id: `${repo.id}:reconcile:${bucket}` }
+        );
+      }
+      if (repos.length < 1_000) return;
+      cursor = repos[repos.length - 1]!.oid;
+    }
+  }
+);

--- a/src/origin/apps/service/src/queues/scm/repositorySync/_lib.test.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/_lib.test.ts
@@ -1,15 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mocks = vi.hoisted(() => ({
-  updateMany: vi.fn()
+  updateMany: vi.fn(),
+  findUnique: vi.fn(),
+  updateState: vi.fn()
 }));
 
 vi.mock('../../../db', () => ({
   db: {
     scmRepositorySync: {
-      updateMany: mocks.updateMany
+      updateMany: mocks.updateMany,
+      findUnique: mocks.findUnique
     }
   }
+}));
+vi.mock('../../../services/repositorySyncState', () => ({
+  isTerminalRepositorySyncStatus: () => false,
+  transitionRepositorySyncState: mocks.updateState
 }));
 
 import { logRepositorySyncQueueError, markRepositorySyncFailed } from './_lib';
@@ -18,6 +25,10 @@ describe('repository sync failure diagnostics', () => {
   beforeEach(() => {
     mocks.updateMany.mockReset();
     mocks.updateMany.mockResolvedValue({ count: 1 });
+    mocks.findUnique.mockReset();
+    mocks.findUnique.mockResolvedValue({ status: 'waiting_for_ci' });
+    mocks.updateState.mockReset();
+    mocks.updateState.mockResolvedValue({});
     vi.restoreAllMocks();
   });
 
@@ -36,15 +47,15 @@ describe('repository sync failure diagnostics', () => {
 
     await markRepositorySyncFailed('sync_123', error);
 
-    expect(mocks.updateMany).toHaveBeenCalledWith(
+    expect(mocks.updateState).toHaveBeenCalledWith(
+      'sync_123',
+      'waiting_for_ci',
       expect.objectContaining({
-        data: expect.objectContaining({
-          status: 'failed',
-          errorMessage: 'GitLab could not create the update branch: the request was rejected.'
-        })
+        status: 'failed',
+        errorMessage: 'GitLab could not create the update branch: the request was rejected.'
       })
     );
-    expect(JSON.stringify(mocks.updateMany.mock.calls)).not.toContain('internal.js');
+    expect(JSON.stringify(mocks.updateState.mock.calls)).not.toContain('internal.js');
   });
 
   it('logs structured provider details without serializing the stack', () => {

--- a/src/origin/apps/service/src/queues/scm/repositorySync/_lib.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/_lib.ts
@@ -1,5 +1,9 @@
 import { db } from '../../../db';
 import { getScmProviderLogDetails } from '../../../lib/scmProviderError';
+import {
+  isTerminalRepositorySyncStatus,
+  transitionRepositorySyncState
+} from '../../../services/repositorySyncState';
 
 export type RepositorySyncLogEntry = [number, string];
 
@@ -76,21 +80,15 @@ export let getRepositorySyncErrorMessage = (error: unknown) => {
 export let markRepositorySyncFailed = async (syncId: string, error: unknown) => {
   let message = getRepositorySyncErrorMessage(error);
 
-  await db.scmRepositorySync.updateMany({
-    where: {
-      id: syncId,
-      status: {
-        notIn: ['merged', 'failed', 'cancelled', 'complete_unmerged', 'complete_no_changes']
-      }
-    },
-    data: {
-      status: 'failed',
-      errorMessage: message,
-      completedAt: new Date(),
-      attemptCount: { increment: 1 },
-      logs: {
-        push: [Date.now(), 'Repository update failed.'] satisfies RepositorySyncLogEntry
-      }
+  let sync = await db.scmRepositorySync.findUnique({ where: { id: syncId } });
+  if (!sync || isTerminalRepositorySyncStatus(sync.status)) return;
+  await transitionRepositorySyncState(syncId, sync.status, {
+    status: 'failed',
+    errorMessage: message,
+    completedAt: new Date(),
+    attemptCount: { increment: 1 },
+    logs: {
+      push: [Date.now(), 'Repository update failed.'] satisfies RepositorySyncLogEntry
     }
   });
 };

--- a/src/origin/apps/service/src/queues/scm/repositorySync/createBranch.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/createBranch.ts
@@ -2,6 +2,7 @@ import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
 import { createRepositorySyncBranch } from '../../../lib/scmRepositorySyncProvider';
+import { transitionRepositorySyncState } from '../../../services/repositorySyncState';
 import {
   appendRepositorySyncLog,
   logRepositorySyncQueueError,
@@ -76,19 +77,15 @@ export let createBranchRepositorySyncQueueProcessor = createBranchRepositorySync
       });
 
       let baseBranch = branchResult?.baseBranch ?? sync.baseBranch;
-      await db.$transaction([
-        db.scmRepository.update({
-          where: { oid: sync.repo.oid },
-          data: { defaultBranch: baseBranch }
-        }),
-        db.scmRepositorySync.update({
-          where: { oid: sync.oid },
-          data: {
-            baseBranch,
-            status: 'syncing_contents'
-          }
-        })
-      ]);
+      await db.scmRepository.update({
+        where: { oid: sync.repo.oid },
+        data: { defaultBranch: baseBranch }
+      });
+      let updated = await transitionRepositorySyncState(sync.id, 'creating_branch', {
+        baseBranch,
+        status: 'syncing_contents'
+      });
+      if (!updated) return;
       logRepositorySyncQueueEvent('createBranch', 'transitioned sync to syncing_contents', {
         syncId: sync.id
       });

--- a/src/origin/apps/service/src/queues/scm/repositorySync/createPr.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/createPr.ts
@@ -1,7 +1,11 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
-import { createRepositorySyncPullRequest } from '../../../lib/scmRepositorySyncProvider';
+import {
+  closeRepositorySyncPullRequest,
+  createRepositorySyncPullRequest
+} from '../../../lib/scmRepositorySyncProvider';
+import { transitionRepositorySyncState } from '../../../services/repositorySyncState';
 import {
   appendRepositorySyncLog,
   logRepositorySyncQueueError,
@@ -53,6 +57,60 @@ export let createPrRepositorySyncQueueProcessor = createPrRepositorySyncQueue.pr
         return;
       }
 
+      let newer = await db.scmRepositorySync.findFirst({
+        where: {
+          repoOid: sync.repoOid,
+          codeBucketOid: sync.codeBucketOid,
+          oid: { gt: sync.oid }
+        },
+        select: { id: true }
+      });
+      if (newer) {
+        await transitionRepositorySyncState(sync.id, 'creating_pr', {
+          status: 'cancelled',
+          completedAt: new Date(),
+          errorMessage: 'Superseded by a newer repository sync before pull request creation'
+        });
+        return;
+      }
+
+      let older = await db.scmRepositorySync.findMany({
+        where: {
+          repoOid: sync.repoOid,
+          codeBucketOid: sync.codeBucketOid,
+          baseBranch: sync.baseBranch,
+          oid: { lt: sync.oid },
+          providerPrId: { not: null },
+          status: { notIn: ['merged', 'cancelled', 'complete_no_changes'] }
+        },
+        include: {
+          repo: {
+            include: {
+              installation: {
+                include: { backend: true }
+              }
+            }
+          }
+        },
+        orderBy: { oid: 'desc' }
+      });
+      for (let previous of older) {
+        let outcome = await closeRepositorySyncPullRequest(previous);
+        if (outcome === 'merged') {
+          await transitionRepositorySyncState(previous.id, previous.status, {
+            status: 'merged',
+            completedAt: new Date(),
+            errorMessage: null
+          });
+        } else {
+          await transitionRepositorySyncState(previous.id, previous.status, {
+            status: 'cancelled',
+            completedAt: new Date(),
+            errorMessage: 'Superseded by a newer Metorial repository sync'
+          });
+        }
+      }
+
       logRepositorySyncQueueEvent('createPr', 'creating provider pull request', {
         syncId: sync.id,
         repoId: sync.repo.id,
@@ -75,15 +133,12 @@ export let createPrRepositorySyncQueueProcessor = createPrRepositorySyncQueue.pr
       });
 
       if (!sync.enableAutoMerge) {
-        await db.scmRepositorySync.update({
-          where: { oid: sync.oid },
-          data: {
-            status: 'complete_unmerged',
-            providerPrId: pr.providerPrId,
-            providerPrUrl: pr.providerPrUrl,
-            completedAt: new Date()
-          }
+        let updated = await transitionRepositorySyncState(sync.id, 'creating_pr', {
+          status: 'waiting_for_review',
+          providerPrId: pr.providerPrId,
+          providerPrUrl: pr.providerPrUrl
         });
+        if (!updated) return;
         await appendRepositorySyncLog(
           sync.id,
           'Repository update is ready for manual review.'
@@ -95,14 +150,12 @@ export let createPrRepositorySyncQueueProcessor = createPrRepositorySyncQueue.pr
         return;
       }
 
-      await db.scmRepositorySync.update({
-        where: { oid: sync.oid },
-        data: {
-          status: 'waiting_for_ci',
-          providerPrId: pr.providerPrId,
-          providerPrUrl: pr.providerPrUrl
-        }
+      let updated = await transitionRepositorySyncState(sync.id, 'creating_pr', {
+        status: 'waiting_for_ci',
+        providerPrId: pr.providerPrId,
+        providerPrUrl: pr.providerPrUrl
       });
+      if (!updated) return;
       await appendRepositorySyncLog(sync.id, 'Waiting for checks to pass.');
       logRepositorySyncQueueEvent('createPr', 'transitioned sync to waiting_for_ci', {
         syncId: sync.id,

--- a/src/origin/apps/service/src/queues/scm/repositorySync/index.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/index.ts
@@ -5,6 +5,7 @@ import { mergeRepositorySyncQueueProcessor } from './merge';
 import { startRepositorySyncQueueProcessor } from './start';
 import { syncContentsRepositorySyncQueueProcessor } from './syncContents';
 import { waitForCiRepositorySyncQueueProcessor } from './waitForCi';
+import { recoverRepositorySyncProcessor } from './recover';
 
 export let repositorySyncQueueProcessor = combineQueueProcessors([
   startRepositorySyncQueueProcessor,
@@ -12,5 +13,6 @@ export let repositorySyncQueueProcessor = combineQueueProcessors([
   syncContentsRepositorySyncQueueProcessor,
   createPrRepositorySyncQueueProcessor,
   waitForCiRepositorySyncQueueProcessor,
-  mergeRepositorySyncQueueProcessor
+  mergeRepositorySyncQueueProcessor,
+  recoverRepositorySyncProcessor
 ]);

--- a/src/origin/apps/service/src/queues/scm/repositorySync/merge.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/merge.ts
@@ -1,12 +1,24 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
-import { mergeRepositorySyncPullRequest } from '../../../lib/scmRepositorySyncProvider';
+import {
+  getScmProviderErrorDetails,
+  getScmProviderErrorStatus
+} from '../../../lib/scmProviderError';
+import {
+  getRepositorySyncStatusSnapshot,
+  mergeRepositorySyncPullRequest
+} from '../../../lib/scmRepositorySyncProvider';
+import {
+  classifyRepositorySyncSnapshot,
+  type RepositorySyncStatusSnapshot,
+  transitionRepositorySyncState
+} from '../../../services/repositorySyncState';
 import {
   appendRepositorySyncLog,
+  getRepositorySyncErrorMessage,
   logRepositorySyncQueueError,
-  logRepositorySyncQueueEvent,
-  markRepositorySyncFailed
+  logRepositorySyncQueueEvent
 } from './_lib';
 
 export let mergeRepositorySyncQueue = createQueue<{ syncId: string }>({
@@ -20,7 +32,22 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
       syncId: data.syncId,
       expectedStatus: 'merging'
     });
-
+    let claimed = await db.scmRepositorySync.updateMany({
+      where: {
+        id: data.syncId,
+        status: 'merging',
+        OR: [{ nextPollAt: null }, { nextPollAt: { lte: new Date() } }]
+      },
+      data: {
+        nextPollAt: new Date(Date.now() + 5 * 60_000)
+      }
+    });
+    if (claimed.count === 0) {
+      logRepositorySyncQueueEvent('merge', 'skipped sync because it is already claimed', {
+        syncId: data.syncId
+      });
+      return;
+    }
     let sync = await db.scmRepositorySync.findFirst({
       where: {
         id: data.syncId,
@@ -51,6 +78,47 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
       return;
     }
 
+    let snapshot = await getRepositorySyncStatusSnapshot(sync);
+    if (snapshot.pullRequest.state === 'merged') {
+      await transitionRepositorySyncState(sync.id, 'merging', {
+        status: 'merged',
+        statusSnapshot: snapshot,
+        providerMergeSha: snapshot.pullRequest.mergeSha ?? sync.providerMergeSha,
+        completedAt: new Date(),
+        attemptCount: 0,
+        nextPollAt: null
+      });
+      return;
+    }
+    if (snapshot.pullRequest.state === 'closed') {
+      await transitionRepositorySyncState(sync.id, 'merging', {
+        status: 'cancelled',
+        statusSnapshot: snapshot,
+        completedAt: new Date(),
+        nextPollAt: null,
+        errorMessage: 'Pull request was closed before it could be merged'
+      });
+      return;
+    }
+    let status = classifyRepositorySyncSnapshot(snapshot, true);
+    if (status !== 'merging') {
+      let delay = 30_000;
+      let updated = await transitionRepositorySyncState(sync.id, 'merging', {
+        status,
+        statusSnapshot: snapshot,
+        lastPolledAt: new Date(),
+        attemptCount: 0,
+        nextPollAt: new Date(Date.now() + delay)
+      });
+      if (!updated) return;
+      let { waitForCiRepositorySyncQueue } = await import('./waitForCi');
+      await waitForCiRepositorySyncQueue.add(
+        { syncId: sync.id },
+        { delay, id: `${sync.id}:merge-recheck` }
+      );
+      return;
+    }
+
     logRepositorySyncQueueEvent('merge', 'merging provider pull request', {
       syncId: sync.id,
       repoId: sync.repo.id,
@@ -59,9 +127,7 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
       repo: sync.repo.externalName,
       providerPrId: sync.providerPrId
     });
-    await appendRepositorySyncLog(sync.id, 'Merging the pull request.');
     let merge = await mergeRepositorySyncPullRequest(sync);
-    await appendRepositorySyncLog(sync.id, 'Pull request merged.');
     logRepositorySyncQueueEvent('merge', 'provider pull request merged', {
       syncId: sync.id,
       repoId: sync.repo.id,
@@ -69,14 +135,14 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
       mergeSha: merge.mergeSha
     });
 
-    await db.scmRepositorySync.update({
-      where: { oid: sync.oid },
-      data: {
-        status: 'merged',
-        providerMergeSha: merge.mergeSha,
-        completedAt: new Date()
-      }
+    let updated = await transitionRepositorySyncState(sync.id, 'merging', {
+      status: 'merged',
+      providerMergeSha: merge.mergeSha,
+      completedAt: new Date(),
+      attemptCount: 0,
+      nextPollAt: null
     });
+    if (!updated) return;
     await appendRepositorySyncLog(sync.id, 'Repository update completed.');
     logRepositorySyncQueueEvent('merge', 'marked sync merged', {
       syncId: sync.id,
@@ -86,6 +152,83 @@ export let mergeRepositorySyncQueueProcessor = mergeRepositorySyncQueue.process(
     logRepositorySyncQueueError('merge', 'failed while processing queue item', e, {
       syncId: data.syncId
     });
-    await markRepositorySyncFailed(data.syncId, e);
+    let current = await db.scmRepositorySync.findUnique({ where: { id: data.syncId } });
+    if (current?.status === 'merging') {
+      let previousSnapshot = current.statusSnapshot as RepositorySyncStatusSnapshot | null;
+      let providerError = getScmProviderErrorDetails(e);
+      let mergePermissionRequired = Boolean(
+        (e as { scmMergePermissionDenied?: boolean })?.scmMergePermissionDenied
+      );
+      let providerReportedBlocker =
+        previousSnapshot?.review.state === 'pending' ||
+        previousSnapshot?.review.state === 'changes_requested' ||
+        previousSnapshot?.mergeability.state === 'blocked' ||
+        previousSnapshot?.mergeability.state === 'conflicting' ||
+        providerError.classification === 'protected_branch';
+      let mergeBlocked =
+        mergePermissionRequired ||
+        ([405, 409, 422].includes(getScmProviderErrorStatus(e) ?? 0) &&
+          providerReportedBlocker);
+      let delay = mergeBlocked
+        ? 60_000
+        : Math.min(20_000 * 2 ** Math.min(current.attemptCount, 10), 15 * 60_000);
+      let statusSnapshot =
+        mergeBlocked && previousSnapshot
+          ? {
+              ...previousSnapshot,
+              mergeability: {
+                state: 'blocked' as const,
+                reason: mergePermissionRequired
+                  ? 'merge_permission_required'
+                  : 'merge_rejected'
+              },
+              observedAt: new Date().toISOString()
+            }
+          : previousSnapshot;
+      console.log(
+        JSON.stringify({
+          event: 'repository_sync_merge_retry',
+          level: 'error',
+          syncId: current.id,
+          repoOid: current.repoOid.toString(),
+          providerPrId: current.providerPrId,
+          mergeBlocked,
+          mergePermissionRequired,
+          retryInMs: delay,
+          providerError,
+          observedStatus: previousSnapshot
+            ? {
+                checks: previousSnapshot.checks.state,
+                review: previousSnapshot.review.state,
+                mergeability: previousSnapshot.mergeability
+              }
+            : null
+        })
+      );
+      let updated = await transitionRepositorySyncState(data.syncId, 'merging', {
+        status: mergeBlocked ? 'waiting_for_review' : 'waiting_for_ci',
+        ...(statusSnapshot ? { statusSnapshot } : {}),
+        errorMessage: mergeBlocked ? null : getRepositorySyncErrorMessage(e),
+        nextPollAt: new Date(Date.now() + delay),
+        attemptCount: { increment: 1 }
+      });
+      if (!updated) return;
+      let retryMessage = mergeBlocked
+        ? mergePermissionRequired
+          ? 'The connected GitLab user does not have permission to merge.'
+          : 'Repository rules are blocking the merge.'
+        : 'Automatic merge was unavailable; retrying.';
+      let alreadyLogged = Array.isArray(current.logs)
+        ? current.logs.some(log => Array.isArray(log) && log[1] === retryMessage)
+        : false;
+      if (!alreadyLogged) {
+        await appendRepositorySyncLog(data.syncId, retryMessage);
+      }
+      let { waitForCiRepositorySyncQueue } = await import('./waitForCi');
+      await waitForCiRepositorySyncQueue.add(
+        { syncId: data.syncId },
+        { delay, id: `${data.syncId}:merge-retry:${current.attemptCount + 1}` }
+      );
+    }
   }
 });

--- a/src/origin/apps/service/src/queues/scm/repositorySync/recover.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/recover.ts
@@ -1,0 +1,83 @@
+import { createCron } from '@lowerdeck/cron';
+import { db } from '../../../db';
+import { env } from '../../../env';
+import { createBranchRepositorySyncQueue } from './createBranch';
+import { createPrRepositorySyncQueue } from './createPr';
+import { mergeRepositorySyncQueue } from './merge';
+import { startRepositorySyncQueue } from './start';
+import { syncContentsRepositorySyncQueue } from './syncContents';
+import { waitForCiRepositorySyncQueue } from './waitForCi';
+
+export let recoverRepositorySyncProcessor = createCron(
+  {
+    name: 'ori/rep-sync/recover',
+    cron: '* * * * *',
+    redisUrl: env.service.REDIS_URL
+  },
+  async () => {
+    let now = new Date();
+    let stale = new Date(now.getTime() - 5 * 60_000);
+    let syncs = await db.scmRepositorySync.findMany({
+      where: {
+        OR: [
+          {
+            status: { in: ['waiting_for_ci', 'waiting_for_review'] },
+            OR: [{ nextPollAt: null }, { nextPollAt: { lte: now } }]
+          },
+          {
+            status: {
+              in: ['pending', 'creating_branch', 'syncing_contents', 'creating_pr', 'merging']
+            },
+            updatedAt: { lte: stale }
+          }
+        ]
+      },
+      select: { id: true, status: true },
+      orderBy: { updatedAt: 'asc' },
+      take: 500
+    });
+
+    let bucket = Math.floor(now.getTime() / 60_000);
+    for (let sync of syncs) {
+      let options = { id: `${sync.id}:recovery:${sync.status}:${bucket}` };
+      if (sync.status === 'pending') await startRepositorySyncQueue.add({ syncId: sync.id }, options);
+      else if (sync.status === 'creating_branch')
+        await createBranchRepositorySyncQueue.add({ syncId: sync.id }, options);
+      else if (sync.status === 'syncing_contents')
+        await syncContentsRepositorySyncQueue.add({ syncId: sync.id }, options);
+      else if (sync.status === 'creating_pr')
+        await createPrRepositorySyncQueue.add({ syncId: sync.id }, options);
+      else if (sync.status === 'merging')
+        await mergeRepositorySyncQueue.add({ syncId: sync.id }, options);
+      else await waitForCiRepositorySyncQueue.add({ syncId: sync.id }, options);
+    }
+  }
+);
+
+export let accelerateRepositorySyncsForProviderEvent = async (d: {
+  repoOid: bigint;
+  providerPrId?: string;
+  idempotencyKey: string;
+}) => {
+  let syncs = await db.scmRepositorySync.findMany({
+    where: {
+      repoOid: d.repoOid,
+      status: { in: ['waiting_for_ci', 'waiting_for_review', 'merging'] },
+      ...(d.providerPrId && { providerPrId: d.providerPrId })
+    },
+    select: { id: true, status: true }
+  });
+  for (let sync of syncs) {
+    if (sync.status === 'merging') {
+      await mergeRepositorySyncQueue.add(
+        { syncId: sync.id },
+        { id: `${sync.id}:webhook:${d.idempotencyKey}` }
+      );
+    } else {
+      await waitForCiRepositorySyncQueue.add(
+        { syncId: sync.id },
+        { id: `${sync.id}:webhook:${d.idempotencyKey}` }
+      );
+    }
+  }
+};

--- a/src/origin/apps/service/src/queues/scm/repositorySync/start.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/start.ts
@@ -1,6 +1,7 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
+import { transitionRepositorySyncState } from '../../../services/repositorySyncState';
 import {
   appendRepositorySyncLog,
   logRepositorySyncQueueError,
@@ -21,17 +22,14 @@ export let startRepositorySyncQueueProcessor = startRepositorySyncQueue.process(
       expectedStatus: 'pending'
     });
 
-    let updated = await db.scmRepositorySync.updateMany({
+    let existing = await db.scmRepositorySync.findFirst({
       where: {
         id: data.syncId,
         status: 'pending'
-      },
-      data: {
-        status: 'creating_branch'
       }
     });
 
-    if (updated.count === 0) {
+    if (!existing) {
       logRepositorySyncQueueEvent(
         'start',
         'skipped sync because expected status was not present',
@@ -42,6 +40,10 @@ export let startRepositorySyncQueueProcessor = startRepositorySyncQueue.process(
       );
       return;
     }
+    let updated = await transitionRepositorySyncState(data.syncId, 'pending', {
+      status: 'creating_branch'
+    });
+    if (!updated) return;
 
     await appendRepositorySyncLog(data.syncId, 'Starting repository update.');
 

--- a/src/origin/apps/service/src/queues/scm/repositorySync/syncContents.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/syncContents.ts
@@ -3,6 +3,7 @@ import { db } from '../../../db';
 import { env } from '../../../env';
 import { cleanupRepositorySyncBranchIfNoChanges } from '../../../lib/scmRepositorySyncProvider';
 import { codeBucketService } from '../../../services';
+import { transitionRepositorySyncState } from '../../../services/repositorySyncState';
 import {
   appendRepositorySyncLog,
   logRepositorySyncQueueError,
@@ -85,14 +86,12 @@ export let syncContentsRepositorySyncQueueProcessor = syncContentsRepositorySync
 
       let branchChanges = await cleanupRepositorySyncBranchIfNoChanges(sync);
       if (!branchChanges.hasChanges) {
-        await db.scmRepositorySync.update({
-          where: { oid: sync.oid },
-          data: {
-            status: 'complete_no_changes',
-            errorMessage: null,
-            completedAt: new Date()
-          }
+        let updated = await transitionRepositorySyncState(sync.id, 'syncing_contents', {
+          status: 'complete_no_changes',
+          errorMessage: null,
+          completedAt: new Date()
         });
+        if (!updated) return;
 
         await appendRepositorySyncLog(sync.id, 'No file changes were needed.');
         logRepositorySyncQueueEvent('syncContents', 'completed sync with no changes', {
@@ -116,12 +115,10 @@ export let syncContentsRepositorySyncQueueProcessor = syncContentsRepositorySync
       });
 
       await appendRepositorySyncLog(sync.id, 'File changes are ready for review.');
-      await db.scmRepositorySync.update({
-        where: { oid: sync.oid },
-        data: {
-          status: 'creating_pr'
-        }
+      let updated = await transitionRepositorySyncState(sync.id, 'syncing_contents', {
+        status: 'creating_pr'
       });
+      if (!updated) return;
       logRepositorySyncQueueEvent('syncContents', 'transitioned sync to creating_pr', {
         syncId: sync.id
       });

--- a/src/origin/apps/service/src/queues/scm/repositorySync/waitForCi.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/waitForCi.ts
@@ -1,12 +1,13 @@
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../../db';
 import { env } from '../../../env';
-import { getRepositorySyncCiState } from '../../../lib/scmRepositorySyncProvider';
+import { getRepositorySyncStatusSnapshot } from '../../../lib/scmRepositorySyncProvider';
+import { transitionRepositorySyncState } from '../../../services/repositorySyncState';
 import {
   appendRepositorySyncLog,
+  getRepositorySyncErrorMessage,
   logRepositorySyncQueueError,
-  logRepositorySyncQueueEvent,
-  markRepositorySyncFailed
+  logRepositorySyncQueueEvent
 } from './_lib';
 import { mergeRepositorySyncQueue } from './merge';
 
@@ -28,7 +29,7 @@ export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.
       let sync = await db.scmRepositorySync.findFirst({
         where: {
           id: data.syncId,
-          status: 'waiting_for_ci'
+          status: { in: ['waiting_for_ci', 'waiting_for_review'] }
         },
         include: {
           repo: {
@@ -64,26 +65,67 @@ export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.
         branchName: sync.branchName,
         providerPrId: sync.providerPrId
       });
-      let ciState = await getRepositorySyncCiState(sync);
+      let snapshot = await getRepositorySyncStatusSnapshot(sync);
+      let previousSnapshot = sync.statusSnapshot as {
+        checks?: { state?: string };
+        review?: { state?: string };
+        mergeability?: { state?: string };
+      } | null;
+      let ciState = snapshot.checks.state;
       let now = new Date();
       logRepositorySyncQueueEvent('waitForCi', 'provider CI state loaded', {
         syncId: sync.id,
         ciState
       });
 
-      if (ciState === 'pending') {
-        let delay = index < 10 ? 20_000 : index < 100 ? 60_000 : 1000_000;
+      if (snapshot.pullRequest.state === 'merged') {
+        let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+          status: 'merged',
+          statusSnapshot: snapshot,
+          providerMergeSha: snapshot.pullRequest.mergeSha ?? sync.providerMergeSha,
+          ciState,
+          lastPolledAt: now,
+          attemptCount: 0,
+          nextPollAt: null,
+          completedAt: now
+        });
+        if (!updated) return;
+        return;
+      }
+
+      if (snapshot.pullRequest.state === 'closed') {
+        let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+          status: 'cancelled',
+          statusSnapshot: snapshot,
+          ciState,
+          lastPolledAt: now,
+          attemptCount: 0,
+          nextPollAt: null,
+          completedAt: now,
+          errorMessage: 'Pull request was closed before it could be merged'
+        });
+        if (!updated) return;
+        return;
+      }
+
+      if (
+        ciState === 'pending' ||
+        ciState === 'unknown' ||
+        snapshot.mergeability.state === 'checking' ||
+        (snapshot.mergeability.state === 'unknown' && snapshot.provider !== 'bitbucket')
+      ) {
+        let delay = index < 10 ? 20_000 : index < 100 ? 60_000 : 15 * 60_000;
         let nextPollAt = new Date(now.getTime() + delay);
 
-        await db.scmRepositorySync.update({
-          where: { oid: sync.oid },
-          data: {
-            ciState,
-            lastPolledAt: now,
-            nextPollAt
-          }
+        let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+          status: 'waiting_for_ci',
+          statusSnapshot: snapshot,
+          ciState,
+          lastPolledAt: now,
+          nextPollAt,
+          errorMessage: null
         });
-        await appendRepositorySyncLog(sync.id, 'Checks are still running.');
+        if (!updated) return;
 
         await waitForCiRepositorySyncQueue.add(
           { syncId: data.syncId, index: index + 1 },
@@ -97,33 +139,114 @@ export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.
       }
 
       if (ciState === 'failed') {
-        await db.scmRepositorySync.update({
-          where: { oid: sync.oid },
-          data: {
-            status: 'failed',
-            ciState,
-            lastPolledAt: now,
-            completedAt: now,
-            errorMessage: 'Repository checks failed'
-          }
+        let delay = index < 10 ? 20_000 : index < 100 ? 60_000 : 15 * 60_000;
+        let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+          status: 'waiting_for_review',
+          statusSnapshot: snapshot,
+          ciState,
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + delay),
+          completedAt: null,
+          errorMessage: null
         });
-        await appendRepositorySyncLog(sync.id, 'Checks failed.');
-        logRepositorySyncQueueEvent('waitForCi', 'CI failed; marked sync failed', {
+        if (!updated) return;
+        if (
+          sync.status !== 'waiting_for_review' ||
+          previousSnapshot?.checks?.state !== 'failed'
+        ) {
+          await appendRepositorySyncLog(sync.id, 'Checks failed; waiting for updates.');
+        }
+        await waitForCiRepositorySyncQueue.add(
+          { syncId: data.syncId, index: index + 1 },
+          { delay, id: `${data.syncId}:checks:${index + 1}` }
+        );
+        logRepositorySyncQueueEvent('waitForCi', 'CI failed; waiting for updates', {
           syncId: sync.id,
           ciState
         });
         return;
       }
 
-      await db.scmRepositorySync.update({
-        where: { oid: sync.oid },
-        data: {
-          status: 'merging',
+      if (
+        snapshot.review.state === 'pending' ||
+        snapshot.review.state === 'changes_requested' ||
+        snapshot.mergeability.state === 'blocked'
+      ) {
+        let delay = index < 10 ? 20_000 : 60_000;
+        let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+          status: 'waiting_for_review',
+          statusSnapshot: snapshot,
           ciState,
           lastPolledAt: now,
-          nextPollAt: null
+          nextPollAt: new Date(now.getTime() + delay),
+          errorMessage: null
+        });
+        if (!updated) return;
+        if (
+          sync.status !== 'waiting_for_review' ||
+          previousSnapshot?.review?.state !== snapshot.review.state ||
+          previousSnapshot?.mergeability?.state !== snapshot.mergeability.state
+        ) {
+          await appendRepositorySyncLog(
+            sync.id,
+            snapshot.review.state === 'changes_requested'
+              ? 'Review changes were requested.'
+              : 'Waiting for repository review requirements.'
+          );
         }
+        await waitForCiRepositorySyncQueue.add(
+          { syncId: data.syncId, index: index + 1 },
+          { delay, id: `${data.syncId}:review:${index + 1}` }
+        );
+        return;
+      }
+
+      if (snapshot.mergeability.state === 'conflicting') {
+        let delay = index < 10 ? 20_000 : 60_000;
+        let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+          status: 'waiting_for_review',
+          statusSnapshot: snapshot,
+          ciState,
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + delay),
+          completedAt: null,
+          errorMessage: null
+        });
+        if (!updated) return;
+        if (
+          sync.status !== 'waiting_for_review' ||
+          previousSnapshot?.mergeability?.state !== 'conflicting'
+        ) {
+          await appendRepositorySyncLog(sync.id, 'Pull request has merge conflicts.');
+        }
+        await waitForCiRepositorySyncQueue.add(
+          { syncId: data.syncId, index: index + 1 },
+          { delay, id: `${data.syncId}:conflict:${index + 1}` }
+        );
+        return;
+      }
+
+      if (!sync.enableAutoMerge) {
+        let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+          status: 'waiting_for_review',
+          statusSnapshot: snapshot,
+          ciState,
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + 60_000)
+        });
+        if (!updated) return;
+        return;
+      }
+
+      let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+        status: 'merging',
+        statusSnapshot: snapshot,
+        ciState,
+        lastPolledAt: now,
+        nextPollAt: null,
+        errorMessage: null
       });
+      if (!updated) return;
       await appendRepositorySyncLog(sync.id, 'Checks passed.');
       logRepositorySyncQueueEvent('waitForCi', 'CI succeeded; transitioned sync to merging', {
         syncId: sync.id,
@@ -138,7 +261,20 @@ export let waitForCiRepositorySyncQueueProcessor = waitForCiRepositorySyncQueue.
       logRepositorySyncQueueError('waitForCi', 'failed while processing queue item', e, {
         syncId: data.syncId
       });
-      await markRepositorySyncFailed(data.syncId, e);
+      let current = await db.scmRepositorySync.findUnique({ where: { id: data.syncId } });
+      if (current && ['waiting_for_ci', 'waiting_for_review'].includes(current.status)) {
+        let delay = Math.min(60_000 * 2 ** Math.min(current.attemptCount, 10), 15 * 60_000);
+        let updated = await transitionRepositorySyncState(data.syncId, current.status, {
+          attemptCount: { increment: 1 },
+          errorMessage: getRepositorySyncErrorMessage(e),
+          nextPollAt: new Date(Date.now() + delay)
+        });
+        if (!updated) return;
+        await waitForCiRepositorySyncQueue.add(
+          { syncId: data.syncId, index: data.index },
+          { delay, id: `${data.syncId}:retry:${current.attemptCount + 1}` }
+        );
+      }
     }
   }
 );

--- a/src/origin/apps/service/src/services/changeNotification.ts
+++ b/src/origin/apps/service/src/services/changeNotification.ts
@@ -1,4 +1,4 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { db } from '../db';
@@ -12,6 +12,7 @@ class ChangeNotificationServiceImpl {
       include: {
         repo: { include: { account: true } },
         repoPush: { include: { repo: true } },
+        repositorySync: true,
         tenant: true
       }
     });
@@ -32,12 +33,48 @@ class ChangeNotificationServiceImpl {
           include: {
             repo: { include: { account: true } },
             repoPush: { include: { repo: true } },
+            repositorySync: true,
             tenant: true
           },
           orderBy: opts.orderBy?.length ? opts.orderBy : [{ createdAt: 'desc' }]
         })
       )
     );
+  }
+
+  async pollChangeNotifications(d: {
+    tenantOid: bigint;
+    afterCursor?: string;
+    limit: number;
+  }) {
+    if (d.afterCursor && !/^\d+$/.test(d.afterCursor)) {
+      throw new ServiceError(
+        badRequestError({ message: 'Invalid change notification cursor' })
+      );
+    }
+    let after = d.afterCursor ? BigInt(d.afterCursor) : undefined;
+    let notifications = await db.changeNotification.findMany({
+      where: {
+        tenantOid: d.tenantOid,
+        type: 'repository_sync_status_changed',
+        ...(after != null && { oid: { gt: after } })
+      },
+      include: {
+        repo: { include: { account: true } },
+        repoPush: { include: { repo: true } },
+        repositorySync: true,
+        tenant: true
+      },
+      orderBy: { oid: 'asc' },
+      take: Math.min(Math.max(d.limit, 1), 100)
+    });
+    return {
+      notifications,
+      nextCursor:
+        notifications.length > 0
+          ? notifications[notifications.length - 1]!.oid.toString()
+          : d.afterCursor
+    };
   }
 }
 

--- a/src/origin/apps/service/src/services/index.ts
+++ b/src/origin/apps/service/src/services/index.ts
@@ -8,4 +8,5 @@ export * from './scmInstallationSession';
 export * from './scmRepo';
 export * from './scmRepoPush';
 export * from './scmRepositorySync';
+export * from './repositorySyncState';
 export * from './tenant';

--- a/src/origin/apps/service/src/services/repositorySyncState.test.ts
+++ b/src/origin/apps/service/src/services/repositorySyncState.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyRepositorySyncSnapshot,
+  type RepositorySyncStatusSnapshot
+} from './repositorySyncState';
+
+let snapshot = (
+  overrides: Partial<RepositorySyncStatusSnapshot> = {}
+): RepositorySyncStatusSnapshot => ({
+  version: 1,
+  provider: 'github',
+  pullRequest: { id: '1', url: 'https://example.test/pr/1', state: 'open' },
+  checks: {
+    state: 'success',
+    total: 1,
+    successful: 1,
+    pending: 0,
+    failed: 0,
+    items: []
+  },
+  review: { state: 'not_required', approvals: 0, changesRequested: 0 },
+  mergeability: { state: 'mergeable' },
+  observedAt: new Date(0).toISOString(),
+  ...overrides
+});
+
+describe('repository sync snapshot classification', () => {
+  it('waits for review after checks pass when approval blocks merging', () => {
+    expect(
+      classifyRepositorySyncSnapshot(
+        snapshot({
+          review: { state: 'pending', approvals: 0, changesRequested: 0 },
+          mergeability: { state: 'blocked', reason: 'approval_required' }
+        }),
+        true
+      )
+    ).toBe('waiting_for_review');
+  });
+
+  it('does not merge while provider mergeability is unknown', () => {
+    expect(
+      classifyRepositorySyncSnapshot(snapshot({ mergeability: { state: 'unknown' } }), true)
+    ).toBe('waiting_for_ci');
+  });
+
+  it('lets Bitbucket make the definitive merge decision after checks pass', () => {
+    expect(
+      classifyRepositorySyncSnapshot(
+        snapshot({
+          provider: 'bitbucket',
+          review: { state: 'unknown', approvals: 0, changesRequested: 0 },
+          mergeability: { state: 'unknown' }
+        }),
+        true
+      )
+    ).toBe('merging');
+  });
+
+  it('only enters merging for a mergeable auto-merge sync', () => {
+    expect(classifyRepositorySyncSnapshot(snapshot(), true)).toBe('merging');
+    expect(classifyRepositorySyncSnapshot(snapshot(), false)).toBe('waiting_for_review');
+  });
+
+  it('normalizes closed and merged provider states to terminal statuses', () => {
+    expect(
+      classifyRepositorySyncSnapshot(
+        snapshot({ pullRequest: { id: '1', url: 'x', state: 'merged' } }),
+        true
+      )
+    ).toBe('merged');
+    expect(
+      classifyRepositorySyncSnapshot(
+        snapshot({ pullRequest: { id: '1', url: 'x', state: 'closed' } }),
+        true
+      )
+    ).toBe('cancelled');
+  });
+
+  it('keeps failed checks and conflicts recoverable', () => {
+    expect(
+      classifyRepositorySyncSnapshot(
+        snapshot({
+          checks: {
+            state: 'failed',
+            total: 1,
+            successful: 0,
+            pending: 0,
+            failed: 1,
+            items: []
+          }
+        }),
+        true
+      )
+    ).toBe('waiting_for_review');
+    expect(
+      classifyRepositorySyncSnapshot(
+        snapshot({ mergeability: { state: 'conflicting', reason: 'conflict' } }),
+        true
+      )
+    ).toBe('waiting_for_review');
+  });
+});

--- a/src/origin/apps/service/src/services/repositorySyncState.ts
+++ b/src/origin/apps/service/src/services/repositorySyncState.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'crypto';
+import type { Prisma, ScmRepositorySyncStatus } from '../../prisma/generated/client';
+import { db } from '../db';
+import { getId } from '../id';
+
+export type RepositorySyncStatusSnapshot = {
+  version: 1;
+  provider: 'github' | 'gitlab' | 'bitbucket';
+  pullRequest: {
+    id: string;
+    url: string;
+    state: 'open' | 'merged' | 'closed';
+    mergeSha?: string | null;
+  };
+  checks: {
+    state: 'pending' | 'success' | 'failed' | 'unknown';
+    total: number;
+    successful: number;
+    pending: number;
+    failed: number;
+    items: {
+      name: string;
+      status: 'pending' | 'success' | 'failed' | 'unknown';
+      url: string | null;
+      summary: string | null;
+    }[];
+  };
+  review: {
+    state: 'pending' | 'approved' | 'changes_requested' | 'not_required' | 'unknown';
+    approvals: number;
+    changesRequested: number;
+    requiredApprovals?: number;
+  };
+  mergeability: {
+    state: 'mergeable' | 'blocked' | 'conflicting' | 'checking' | 'unknown';
+    reason?: string;
+  };
+  observedAt: string;
+};
+
+let stableSnapshot = (snapshot: RepositorySyncStatusSnapshot | null | undefined) => {
+  if (!snapshot) return null;
+  let { observedAt: _, ...material } = snapshot;
+  return material;
+};
+
+let materialHash = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+let updateRepositorySyncStateInTransaction = async (
+  syncId: string,
+  data: Prisma.ScmRepositorySyncUpdateInput,
+  expectedStatus: ScmRepositorySyncStatus
+) =>
+  db.$transaction(async tx => {
+    let before = await tx.scmRepositorySync.findUniqueOrThrow({ where: { id: syncId } });
+    let result = await tx.scmRepositorySync.updateMany({
+      where: { oid: before.oid, status: expectedStatus },
+      data
+    });
+    if (result.count === 0) return null;
+    let updated = await tx.scmRepositorySync.findUniqueOrThrow({
+      where: { oid: before.oid }
+    });
+
+    let beforeMaterial = {
+      status: before.status,
+      snapshot: stableSnapshot(before.statusSnapshot as RepositorySyncStatusSnapshot | null),
+      providerPrId: before.providerPrId,
+      providerPrUrl: before.providerPrUrl,
+      providerMergeSha: before.providerMergeSha,
+      errorMessage: before.errorMessage,
+      completedAt: before.completedAt?.toISOString() ?? null
+    };
+    let afterMaterial = {
+      status: updated.status,
+      snapshot: stableSnapshot(updated.statusSnapshot as RepositorySyncStatusSnapshot | null),
+      providerPrId: updated.providerPrId,
+      providerPrUrl: updated.providerPrUrl,
+      providerMergeSha: updated.providerMergeSha,
+      errorMessage: updated.errorMessage,
+      completedAt: updated.completedAt?.toISOString() ?? null
+    };
+
+    if (JSON.stringify(beforeMaterial) !== JSON.stringify(afterMaterial)) {
+      let hash = materialHash(afterMaterial);
+      await tx.changeNotification.create({
+        data: {
+          ...getId('changeNotification'),
+          type: 'repository_sync_status_changed',
+          tenantOid: updated.tenantOid,
+          repoOid: updated.repoOid,
+          repositorySyncOid: updated.oid,
+          materialHash: hash
+        }
+      });
+    }
+
+    return updated;
+  });
+
+export let transitionRepositorySyncState = (
+  syncId: string,
+  expectedStatus: ScmRepositorySyncStatus,
+  data: Prisma.ScmRepositorySyncUpdateInput
+) => updateRepositorySyncStateInTransaction(syncId, data, expectedStatus);
+
+export let isTerminalRepositorySyncStatus = (status: ScmRepositorySyncStatus) =>
+  ['merged', 'failed', 'cancelled', 'complete_unmerged', 'complete_no_changes'].includes(
+    status
+  );
+
+export let classifyRepositorySyncSnapshot = (
+  snapshot: RepositorySyncStatusSnapshot,
+  enableAutoMerge: boolean
+): ScmRepositorySyncStatus => {
+  if (snapshot.pullRequest.state === 'merged') return 'merged';
+  if (snapshot.pullRequest.state === 'closed') return 'cancelled';
+  if (snapshot.checks.state === 'failed' || snapshot.mergeability.state === 'conflicting')
+    return 'waiting_for_review';
+  if (
+    snapshot.review.state === 'pending' ||
+    snapshot.review.state === 'changes_requested' ||
+    snapshot.mergeability.state === 'blocked'
+  )
+    return 'waiting_for_review';
+  if (
+    snapshot.checks.state === 'pending' ||
+    snapshot.checks.state === 'unknown' ||
+    snapshot.mergeability.state === 'checking' ||
+    (snapshot.mergeability.state === 'unknown' && snapshot.provider !== 'bitbucket')
+  )
+    return 'waiting_for_ci';
+  return enableAutoMerge ? 'merging' : 'waiting_for_review';
+};

--- a/src/origin/apps/service/src/services/scmRepo.ts
+++ b/src/origin/apps/service/src/services/scmRepo.ts
@@ -25,6 +25,7 @@ import {
 } from '../lib/scmProviderError';
 import { createRepoWebhookQueue } from '../queues/scm/createRepoWebhook';
 import { createHandleRepoPushQueue } from '../queues/scm/handleRepoPush';
+import { accelerateRepositorySyncsForProviderEvent } from '../queues/scm/repositorySync/recover';
 import type { ScmAccountPreview, ScmRepoPreview } from '../types';
 
 let defaultRepositoryPreviewLimit = 50;
@@ -956,37 +957,55 @@ class scmRepoServiceImpl {
     };
 
     if (webhook.repo.provider == 'github') {
-      await db.scmRepositoryWebhookReceivedEvent.create({
-        data: {
-          webhookOid: webhook.oid,
-          eventType: i.eventType,
-          payload: i.payload,
-          idempotencyKey: i.idempotencyKey
-        }
-      });
-
       let branchName = event.ref?.replace('refs/heads/', '');
-
-      if (i.eventType == 'push') {
-        let push = await db.scmRepositoryPush.create({
-          data: {
-            ...getId('scmRepositoryPush'),
-            repoOid: webhook.repo.oid,
-            tenantOid: webhook.repo.tenantOid,
-
-            sha: event.after,
-            branchName,
-
-            pusherEmail: event.pusher.email,
-            pusherName: event.pusher.name,
-
-            senderIdentifier: `github.com/${event.sender.login}`,
-            commitMessage: event.commits?.[0]?.message || null
-          }
+      let push: { id: string } | undefined;
+      try {
+        push = await db.$transaction(async tx => {
+          let received = await tx.scmRepositoryWebhookReceivedEvent.create({
+            data: {
+              webhookOid: webhook.oid,
+              eventType: i.eventType,
+              payload: i.payload,
+              idempotencyKey: i.idempotencyKey
+            }
+          });
+          if (i.eventType != 'push') return undefined;
+          return tx.scmRepositoryPush.create({
+            data: {
+              ...getId('scmRepositoryPush'),
+              repoOid: webhook.repo.oid,
+              tenantOid: webhook.repo.tenantOid,
+              webhookReceivedEventOid: received.oid,
+              sha: event.after,
+              branchName,
+              pusherEmail: event.pusher.email,
+              pusherName: event.pusher.name,
+              senderIdentifier: `github.com/${event.sender.login}`,
+              commitMessage: event.commits?.[0]?.message || null
+            },
+            select: { id: true }
+          });
         });
-
-        await createHandleRepoPushQueue.add({ pushId: push.id });
+      } catch (error) {
+        if ((error as { code?: string }).code !== 'P2002') throw error;
+        let received = await db.scmRepositoryWebhookReceivedEvent.findUniqueOrThrow({
+          where: {
+            webhookOid_idempotencyKey: {
+              webhookOid: webhook.oid,
+              idempotencyKey: i.idempotencyKey
+            }
+          },
+          include: { pushes: { select: { id: true }, take: 1 } }
+        });
+        push = received.pushes[0];
       }
+      if (push) await createHandleRepoPushQueue.add({ pushId: push.id }, { id: push.id });
+      let providerPrId = String((event as any).pull_request?.number ?? (event as any).number ?? '');
+      await accelerateRepositorySyncsForProviderEvent({
+        repoOid: webhook.repo.oid,
+        providerPrId: providerPrId || undefined,
+        idempotencyKey: i.idempotencyKey
+      });
 
       return;
     }
@@ -1038,39 +1057,59 @@ class scmRepoServiceImpl {
     };
 
     if (webhook.repo.provider == 'gitlab') {
-      await db.scmRepositoryWebhookReceivedEvent.create({
-        data: {
-          webhookOid: webhook.oid,
-          eventType: i.eventType,
-          payload: i.payload,
-          idempotencyKey: i.idempotencyKey
-        }
-      });
-
       let branchName = event.ref?.replace('refs/heads/', '');
-
-      if (i.eventType == 'Push Hook') {
-        let hostname = new URL(webhook.repo.installation.backend.webUrl).hostname;
-
-        let push = await db.scmRepositoryPush.create({
-          data: {
-            ...getId('scmRepositoryPush'),
-            repoOid: webhook.repo.oid,
-            tenantOid: webhook.repo.tenantOid,
-
-            sha: event.after,
-            branchName,
-
-            pusherEmail: event.user_email,
-            pusherName: event.user_name,
-
-            senderIdentifier: `${hostname}/${event.user_username}`,
-            commitMessage: event.commits?.[0]?.message || null
-          }
+      let push: { id: string } | undefined;
+      try {
+        push = await db.$transaction(async tx => {
+          let received = await tx.scmRepositoryWebhookReceivedEvent.create({
+            data: {
+              webhookOid: webhook.oid,
+              eventType: i.eventType,
+              payload: i.payload,
+              idempotencyKey: i.idempotencyKey
+            }
+          });
+          if (i.eventType != 'Push Hook') return undefined;
+          let hostname = new URL(webhook.repo.installation.backend.webUrl).hostname;
+          return tx.scmRepositoryPush.create({
+            data: {
+              ...getId('scmRepositoryPush'),
+              repoOid: webhook.repo.oid,
+              tenantOid: webhook.repo.tenantOid,
+              webhookReceivedEventOid: received.oid,
+              sha: event.after,
+              branchName,
+              pusherEmail: event.user_email,
+              pusherName: event.user_name,
+              senderIdentifier: `${hostname}/${event.user_username}`,
+              commitMessage: event.commits?.[0]?.message || null
+            },
+            select: { id: true }
+          });
         });
-
-        await createHandleRepoPushQueue.add({ pushId: push.id });
+      } catch (error) {
+        if ((error as { code?: string }).code !== 'P2002') throw error;
+        let received = await db.scmRepositoryWebhookReceivedEvent.findUniqueOrThrow({
+          where: {
+            webhookOid_idempotencyKey: {
+              webhookOid: webhook.oid,
+              idempotencyKey: i.idempotencyKey
+            }
+          },
+          include: { pushes: { select: { id: true }, take: 1 } }
+        });
+        push = received.pushes[0];
       }
+      if (push) await createHandleRepoPushQueue.add({ pushId: push.id }, { id: push.id });
+      let providerPrId =
+        event.object_kind === 'merge_request'
+          ? String((event as any).object_attributes?.iid ?? '')
+          : '';
+      await accelerateRepositorySyncsForProviderEvent({
+        repoOid: webhook.repo.oid,
+        providerPrId: providerPrId || undefined,
+        idempotencyKey: i.idempotencyKey
+      });
     }
   }
 
@@ -1188,6 +1227,12 @@ class scmRepoServiceImpl {
         data: { webhookDispatchedAt: new Date() }
       });
     }
+    let providerPrId = String(event.pullrequest?.id ?? event.pullRequest?.id ?? '');
+    await accelerateRepositorySyncsForProviderEvent({
+      repoOid: webhook.repo.oid,
+      providerPrId: providerPrId || undefined,
+      idempotencyKey: i.idempotencyKey
+    });
   }
 
   async createPushForCurrentCommitOnDefaultBranch(i: {

--- a/src/origin/apps/service/src/services/scmRepositorySync.ts
+++ b/src/origin/apps/service/src/services/scmRepositorySync.ts
@@ -4,6 +4,13 @@ import type { CodeBucket, ScmRepository, Tenant } from '../../prisma/generated/c
 import { db } from '../db';
 import { getId } from '../id';
 import { startRepositorySyncQueue } from '../queues/scm/repositorySync/start';
+import { mergeRepositorySyncQueue } from '../queues/scm/repositorySync/merge';
+import { waitForCiRepositorySyncQueue } from '../queues/scm/repositorySync/waitForCi';
+import { getRepositorySyncStatusSnapshot } from '../lib/scmRepositorySyncProvider';
+import {
+  classifyRepositorySyncSnapshot,
+  transitionRepositorySyncState
+} from './repositorySyncState';
 
 class scmRepositorySyncServiceImpl {
   async getScmRepositorySyncById(d: { tenant: Tenant; id: string }) {
@@ -50,7 +57,9 @@ class scmRepositorySyncServiceImpl {
     }
 
     if (d.repo.tenantOid !== d.tenant.oid || d.codeBucket.tenantOid !== d.tenant.oid) {
-      throw new ServiceError(badRequestError({ message: 'Repository and code bucket must belong to the tenant' }));
+      throw new ServiceError(
+        badRequestError({ message: 'Repository and code bucket must belong to the tenant' })
+      );
     }
 
     let sync = await db.scmRepositorySync.create({
@@ -70,6 +79,64 @@ class scmRepositorySyncServiceImpl {
     await startRepositorySyncQueue.add({ syncId: sync.id });
 
     return sync;
+  }
+
+  async checkScmRepositorySyncStatus(d: { tenant: Tenant; id: string }) {
+    let sync = await db.scmRepositorySync.findFirst({
+      where: { id: d.id, tenantOid: d.tenant.oid },
+      include: {
+        repo: {
+          include: {
+            installation: {
+              include: { backend: true }
+            }
+          }
+        }
+      }
+    });
+    if (!sync) throw new ServiceError(notFoundError('scmRepositorySync'));
+    if (!sync.providerPrId || !sync.providerPrUrl) return sync;
+
+    let snapshot = await getRepositorySyncStatusSnapshot(sync);
+    let now = new Date();
+    let status = classifyRepositorySyncSnapshot(snapshot, sync.enableAutoMerge);
+
+    let completed = [
+      'merged',
+      'cancelled',
+      'complete_unmerged',
+      'complete_no_changes'
+    ].includes(status);
+    let updated = await transitionRepositorySyncState(sync.id, sync.status, {
+      status,
+      statusSnapshot: snapshot,
+      ...(status === 'merged'
+        ? { providerMergeSha: snapshot.pullRequest.mergeSha ?? sync.providerMergeSha }
+        : {}),
+      ciState: snapshot.checks.state,
+      lastPolledAt: now,
+      attemptCount: 0,
+      nextPollAt: completed ? null : new Date(now.getTime() + 30_000),
+      completedAt: completed ? (sync.completedAt ?? now) : null,
+      errorMessage:
+        status === 'cancelled' ? 'Pull request was closed before it could be merged' : null
+    });
+    if (!updated) {
+      return db.scmRepositorySync.findUniqueOrThrow({ where: { id: sync.id } });
+    }
+
+    if (status === 'merging' && sync.enableAutoMerge) {
+      await mergeRepositorySyncQueue.add(
+        { syncId: sync.id },
+        { id: `${sync.id}:rpc-merge:${now.getTime()}` }
+      );
+    } else if (!completed && sync.enableAutoMerge) {
+      await waitForCiRepositorySyncQueue.add(
+        { syncId: sync.id },
+        { id: `${sync.id}:rpc-check:${now.getTime()}` }
+      );
+    }
+    return updated;
   }
 }
 

--- a/src/origin/clients/origin/src/index.ts
+++ b/src/origin/clients/origin/src/index.ts
@@ -1,5 +1,7 @@
 import { createClient } from '@lowerdeck/rpc-client';
 import type { OriginClient } from '../../../apps/service/src/controllers';
+export type { OriginClient } from '../../../apps/service/src/controllers';
+export type { RepositorySyncStatusSnapshot } from '../../../apps/service/src/services/repositorySyncState';
 
 type ClientOpts = Parameters<typeof createClient>[0];
 

--- a/src/subspace/apps/controller/src/server.ts
+++ b/src/subspace/apps/controller/src/server.ts
@@ -1,67 +1,15 @@
 import { createRequire } from 'module';
 
 // Provide CommonJS `require` in ESM runtime for bundled deps.
-let require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).require = require;
 
 async function main() {
   await import('./init');
   await import('./instrument');
-
-  // Claim both ports before loading the heavy controller / connection graphs.
-  // A long import window under `bun --watch` can otherwise race a restart into
-  // EADDRINUSE on 52070 or 52072.
-  let apiFetch: ((request: Request) => Response | Promise<Response>) | null = null;
-  let server = Bun.serve({
-    hostname: '0.0.0.0',
-    port: 52070,
-    fetch: request =>
-      apiFetch ? apiFetch(request) : new Response('Starting', { status: 503 })
-  });
-  console.log(`Service running on http://localhost:${server.port}`);
-
-  let connection:
-    | {
-        fetch: (request: Request, server: any) => Response | Promise<Response>;
-        websocket: {
-          open?: (ws: any) => void;
-          message?: (ws: any, message: any) => void;
-          close?: (ws: any, code?: number, reason?: string) => void;
-          drain?: (ws: any) => void;
-          error?: (ws: any, error: Error) => void;
-        };
-      }
-    | null = null;
-
-  Bun.serve({
-    hostname: '0.0.0.0',
-    port: 52072,
-    idleTimeout: 0,
-    fetch: (request, bunServer) =>
-      connection
-        ? connection.fetch(request, bunServer)
-        : new Response('Starting', { status: 503 }),
-    websocket: {
-      open: ws => connection?.websocket.open?.(ws),
-      message: (ws, message) => connection?.websocket.message?.(ws, message),
-      close: (ws, code, reason) => connection?.websocket.close?.(ws, code, reason),
-      drain: ws => connection?.websocket.drain?.(ws),
-      error: (ws, error) => connection?.websocket.error?.(ws, error)
-    }
-  });
-  console.log('Connection service running on http://localhost:52072');
-
-  let [{ startControllerApi }, { startConnectionServer }] = await Promise.all([
-    import('./endpoints'),
-    import('./connection/server')
-  ]);
-  let [api, startedConnection] = await Promise.all([
-    startControllerApi(),
-    startConnectionServer()
-  ]);
-  apiFetch = api;
-  connection = startedConnection;
+  await import('./endpoints');
+  await import('./connection/server');
 }
 
 main().catch(error => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large changes to skill sync and Origin repository-sync state machines, SCM webhooks, and merge automation across GitHub/GitLab/Bitbucket; regressions could stall or mis-report syncs.
> 
> **Overview**
> Skill destination syncs can now sit in **`waiting_for_review`** while Git PRs need human action (failed checks, reviews, conflicts, merge rules) instead of failing or spinning blindly. Cargo reconciles propagations from Origin sync status snapshots, and new **origin-change poll/fanout/repair** queues react to `repository_sync_status_changed` notifications instead of relying only on long fixed-interval waits.
> 
> **Dashboard & API:** Adds **`GET …/skill-syncs/:id/repository-checks`** (SDK + `useSkillSyncRepositoryChecks`) exposing blockers, CI checks, and review counts. The skill syncs UI shows friendlier status labels, repository action callouts with PR/repo links, and polls checks while a sync is active.
> 
> **Origin:** Introduces provider-neutral **`statusSnapshot`** on repository syncs, **`waiting_for_review`** SCM status, state transitions via **`transitionRepositorySyncState`** with deduped change notifications, expanded GitHub/GitLab/Bitbucket webhooks (PR/CI/pipeline), webhook reconcile cron, recovery cron, and smarter wait-for-CI/merge retry paths (including superseded PR closure and GitLab merge permission handling).
> 
> Also sorts skill sync logs chronologically in the presenter and treats **`waiting_for_review`** as an in-progress sync for marketplace/plugin “active sync” queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abf437accdddf7fa6ce759d032532ea1cc897a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->