### PR TITLE
Fix magic mcp setup for non-oauth configs

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/scenes/sessionTemplates/addProviderPanelFlow.tsx
@@ -895,7 +895,13 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
         }
       : null
   );
-  let toolItems = tools.data?.items ?? [];
+  let retainedToolItemsRef = useRef<NonNullable<typeof tools.data>['items']>([]);
+  let hasLoadedToolsRef = useRef(false);
+  if (tools.data) {
+    retainedToolItemsRef.current = tools.data.items;
+    hasLoadedToolsRef.current = true;
+  }
+  let toolItems = tools.data?.items ?? retainedToolItemsRef.current;
   let requiresProviderConfig =
     showConfigSection &&
     (p.forceConfigSectionVisible || provider.data?.type.config.status == 'enabled');
@@ -1093,7 +1099,10 @@ export let ProviderSetupSections = (p: ProviderSetupSectionsProps) => {
     };
   }, [requiresProviderConfig, requiresAuthConfig, showToolFilters, toolItems.length]);
 
-  if (provider.isLoading || (showToolFilters && !!providerVersionId && tools.isLoading)) {
+  if (
+    provider.isLoading ||
+    (showToolFilters && !!providerVersionId && tools.isLoading && !hasLoadedToolsRef.current)
+  ) {
     return <CenteredSpinner />;
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI loading-state change in the add-provider configure flow with no auth or API behavior changes.
> 
> **Overview**
> Fixes Magic MCP (and other) provider setup flows where switching or creating **non-OAuth** auth configs could blank the configure step.
> 
> In `ProviderSetupSections`, `useProviderTools` is keyed on `providerAuthMethodId`, so choosing an auth method triggers a refetch. The UI used to treat **any** tools loading state as a full-page spinner, which cleared config/auth sections mid-setup. The change **retains the last loaded tool list** in refs and only blocks on the spinner until tools have loaded **once**; subsequent refetches keep the existing sections visible while tools update in the background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fee2c3888ceceb5a150b1e331467d4c8ef962d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->