### PR TITLE
Harden integration provider creation

### DIFF
--- a/src/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -637,35 +637,37 @@ class integrationInstanceProviderServiceImpl {
           }
         }
 
-        let integrationInstanceProvider = existing
-          ? await db.integrationInstanceProvider.update({
-              where: { oid: existing.oid },
-              data: {
-                status: 'active',
-                archivedAt: null,
-                isParentDeleted: false,
-                name: materialProvider.name,
-                description: materialProvider.description,
-                metadata: materialProvider.metadata,
-                integrationVersionOid: materialProvider.integration.currentVersion!.oid
-              }
-            })
-          : await db.integrationInstanceProvider.create({
-              data: {
-                ...getId('integrationInstanceProvider'),
-                status: 'active',
-                name: materialProvider.name,
-                description: materialProvider.description,
-                metadata: materialProvider.metadata,
-                integrationOid: d.integrationInstance.integrationOid,
-                integrationInstanceOid: d.integrationInstance.oid,
-                integrationProviderOid: integrationProvider.oid,
-                integrationVersionOid: materialProvider.integration.currentVersion!.oid,
-                tenantOid: d.tenant.oid,
-                solutionOid: d.solution.oid,
-                environmentOid: d.environment.oid
-              }
-            });
+        let integrationInstanceProvider = await db.integrationInstanceProvider.upsert({
+          where: {
+            integrationInstanceOid_integrationProviderOid: {
+              integrationInstanceOid: d.integrationInstance.oid,
+              integrationProviderOid: integrationProvider.oid
+            }
+          },
+          create: {
+            ...getId('integrationInstanceProvider'),
+            status: 'active',
+            name: materialProvider.name,
+            description: materialProvider.description,
+            metadata: materialProvider.metadata,
+            integrationOid: d.integrationInstance.integrationOid,
+            integrationInstanceOid: d.integrationInstance.oid,
+            integrationProviderOid: integrationProvider.oid,
+            integrationVersionOid: materialProvider.integration.currentVersion!.oid,
+            tenantOid: d.tenant.oid,
+            solutionOid: d.solution.oid,
+            environmentOid: d.environment.oid
+          },
+          update: {
+            status: 'active',
+            archivedAt: null,
+            isParentDeleted: false,
+            name: materialProvider.name,
+            description: materialProvider.description,
+            metadata: materialProvider.metadata,
+            integrationVersionOid: materialProvider.integration.currentVersion!.oid
+          }
+        });
 
         if (!isInheritedSharedConfig && d.input[idx]!.lockProviderResources) {
           let configUpdate = await db.providerConfig.updateMany({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core integration-instance provider persistence on a hot path; behavior should be equivalent but races now resolve via DB uniqueness instead of in-memory `existing` checks.
> 
> **Overview**
> **Hardens** how integration instance providers are created or refreshed inside `setIntegrationInstanceProviders` by replacing a separate “load existing → `update` or `create`” path with a single **`upsert`** on the `integrationInstanceOid` + `integrationProviderOid` unique key.
> 
> Create and update payloads match the prior behavior (activate, clear archive/parent-deleted flags, sync provider metadata and integration version on update). The main intent is to avoid duplicate rows or lost updates when concurrent calls attach the same provider to the same integration instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf9a0354d860c545a57dd45c931f418b2605a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->