### PR TITLE
Harden protoguad alert creation

### DIFF
--- a/src/subspace/modules/monitor/src/queues/schemaChange/index.test.ts
+++ b/src/subspace/modules/monitor/src/queues/schemaChange/index.test.ts
@@ -7,9 +7,8 @@ let monitorFindMany = vi.fn();
 let monitorUpdate = vi.fn();
 let notificationFindUnique = vi.fn();
 let notificationFindMany = vi.fn();
-let monitorAlertFindUnique = vi.fn();
-let monitorAlertCreate = vi.fn();
-let monitorAlertUpdate = vi.fn();
+let monitorAlertCreateMany = vi.fn();
+let monitorAlertUpdateMany = vi.fn();
 let monitorAlertEventCreate = vi.fn();
 
 let db = {
@@ -23,9 +22,8 @@ let db = {
     findMany: notificationFindMany
   },
   monitorAlert: {
-    findUnique: monitorAlertFindUnique,
-    create: monitorAlertCreate,
-    update: monitorAlertUpdate
+    createMany: monitorAlertCreateMany,
+    updateMany: monitorAlertUpdateMany
   },
   monitorAlertEvent: {
     create: monitorAlertEventCreate
@@ -101,9 +99,8 @@ describe('schema change alert queues', () => {
     monitorUpdate.mockReset();
     notificationFindUnique.mockReset();
     notificationFindMany.mockReset();
-    monitorAlertFindUnique.mockReset();
-    monitorAlertCreate.mockReset();
-    monitorAlertUpdate.mockReset();
+    monitorAlertCreateMany.mockReset();
+    monitorAlertUpdateMany.mockReset();
     monitorAlertEventCreate.mockReset();
   });
 
@@ -148,8 +145,7 @@ describe('schema change alert queues', () => {
 
     monitorFindUnique.mockResolvedValue(baseMonitor);
     notificationFindUnique.mockResolvedValue(baseNotification);
-    monitorAlertFindUnique.mockResolvedValue(null);
-    monitorAlertCreate.mockResolvedValue({ oid: BigInt(11) });
+    monitorAlertCreateMany.mockResolvedValue({ count: 1 });
 
     await queues['sub/mon/schema/alert/single'].processor({
       monitorId: 'monitor_1',
@@ -157,18 +153,19 @@ describe('schema change alert queues', () => {
       status: 'ignored'
     });
 
-    expect(monitorAlertCreate).toHaveBeenCalledWith({
+    expect(monitorAlertCreateMany).toHaveBeenCalledWith({
       data: expect.objectContaining({
         status: 'ignored',
         monitorOid: baseMonitor.oid,
         specificationChangeNotificationOid: baseNotification.oid,
         createdAt: baseNotification.createdAt
-      })
+      }),
+      skipDuplicates: true
     });
     expect(monitorAlertEventCreate).toHaveBeenCalledWith({
       data: expect.objectContaining({
         type: 'created',
-        monitorAlertOid: BigInt(11),
+        monitorAlertOid: BigInt(100),
         createdAt: baseNotification.createdAt
       })
     });
@@ -192,10 +189,7 @@ describe('schema change alert queues', () => {
 
     monitorFindUnique.mockResolvedValue(monitor);
     notificationFindUnique.mockResolvedValue(baseNotification);
-    monitorAlertFindUnique.mockResolvedValue({
-      oid: BigInt(12),
-      status: 'pending'
-    });
+    monitorAlertCreateMany.mockResolvedValue({ count: 0 });
 
     await queues['sub/mon/schema/alert/single'].processor({
       monitorId: 'monitor_1',
@@ -203,8 +197,8 @@ describe('schema change alert queues', () => {
       status: 'ignored'
     });
 
-    expect(monitorAlertUpdate).not.toHaveBeenCalled();
-    expect(monitorAlertCreate).not.toHaveBeenCalled();
+    expect(monitorAlertUpdateMany).not.toHaveBeenCalled();
+    expect(monitorAlertEventCreate).not.toHaveBeenCalled();
     expect(monitorUpdate).toHaveBeenCalledWith({
       where: { oid: baseMonitor.oid },
       data: {
@@ -212,5 +206,33 @@ describe('schema change alert queues', () => {
         lastAlertAt: monitor.lastAlertAt
       }
     });
+  });
+
+  it('upgrades an existing ignored alert without creating another event', async () => {
+    await import('./index');
+
+    monitorFindUnique.mockResolvedValue(baseMonitor);
+    notificationFindUnique.mockResolvedValue(baseNotification);
+    monitorAlertCreateMany.mockResolvedValue({ count: 0 });
+    monitorAlertUpdateMany.mockResolvedValue({ count: 1 });
+
+    await queues['sub/mon/schema/alert/single'].processor({
+      monitorId: 'monitor_1',
+      notificationId: 'notification_1',
+      status: 'pending'
+    });
+
+    expect(monitorAlertUpdateMany).toHaveBeenCalledWith({
+      where: {
+        monitorOid: baseMonitor.oid,
+        specificationChangeNotificationOid: baseNotification.oid,
+        status: 'ignored'
+      },
+      data: {
+        status: 'pending',
+        resolvedAt: null
+      }
+    });
+    expect(monitorAlertEventCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/subspace/modules/monitor/src/queues/schemaChange/index.ts
+++ b/src/subspace/modules/monitor/src/queues/schemaChange/index.ts
@@ -95,37 +95,10 @@ let createSchemaChangeAlert = async (d: {
   status: MonitorAlertStatus;
 }) =>
   await withTransaction(async tx => {
-    let existing = await tx.monitorAlert.findUnique({
-      where: {
-        monitorOid_specificationChangeNotificationOid: {
-          monitorOid: d.monitor.oid,
-          specificationChangeNotificationOid: d.notification.oid
-        }
-      }
-    });
-
-    if (existing) {
-      if (existing.status === 'ignored' && d.status === 'pending') {
-        await tx.monitorAlert.update({
-          where: { oid: existing.oid },
-          data: {
-            status: 'pending',
-            resolvedAt: null
-          }
-        });
-      }
-
-      await updateMonitorAlertWindow({
-        db: tx,
-        monitor: d.monitor,
-        timestamp: d.notification.createdAt
-      });
-      return;
-    }
-
-    let alert = await tx.monitorAlert.create({
+    let alertId = getId('monitorAlert');
+    let createResult = await tx.monitorAlert.createMany({
       data: {
-        ...getId('monitorAlert'),
+        ...alertId,
         status: d.status,
         monitorOid: d.monitor.oid,
         specificationChangeNotificationOid: d.notification.oid,
@@ -133,17 +106,34 @@ let createSchemaChangeAlert = async (d: {
         environmentOid: d.monitor.environmentOid,
         solutionOid: d.monitor.solutionOid,
         createdAt: d.notification.createdAt
-      }
+      },
+      skipDuplicates: true
     });
 
-    await tx.monitorAlertEvent.create({
-      data: {
-        ...getId('monitorAlertEvent'),
-        type: 'created',
-        monitorAlertOid: alert.oid,
-        createdAt: d.notification.createdAt
-      }
-    });
+    if (createResult.count === 0 && d.status === 'pending') {
+      await tx.monitorAlert.updateMany({
+        where: {
+          monitorOid: d.monitor.oid,
+          specificationChangeNotificationOid: d.notification.oid,
+          status: 'ignored'
+        },
+        data: {
+          status: 'pending',
+          resolvedAt: null
+        }
+      });
+    }
+
+    if (createResult.count === 1) {
+      await tx.monitorAlertEvent.create({
+        data: {
+          ...getId('monitorAlertEvent'),
+          type: 'created',
+          monitorAlertOid: alertId.oid,
+          createdAt: d.notification.createdAt
+        }
+      });
+    }
 
     await updateMonitorAlertWindow({
       db: tx,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes transactional alert persistence and event emission for schema-change monitors; incorrect duplicate handling could miss alerts or duplicate events, but scope is limited to the monitor queue path with updated tests.
> 
> **Overview**
> **Schema-change monitor alert creation** is refactored to be idempotent under concurrent queue workers instead of relying on a read-then-write `findUnique` / `create` / `update` flow.
> 
> `createSchemaChangeAlert` now inserts via **`createMany` with `skipDuplicates: true`**, pre-assigns alert IDs with `getId`, and only emits a **`created` monitor alert event when the insert actually succeeds** (`count === 1`). When the insert is skipped and the job wants **`pending`**, it runs **`updateMany`** to promote an existing **`ignored`** row to **`pending`** (clearing `resolvedAt`) without adding another event. Duplicate **`ignored`** backfill jobs no longer touch existing alerts or events; monitor first/last alert windows still update.
> 
> Tests are aligned with **`createMany` / `updateMany`** mocks and cover the ignored→pending upgrade path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd16625e3e232007d52894e4b21be3c831302f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->