### PR TITLE
Improve client name validation

### DIFF
--- a/src/metorial-frontend/scenes/skills/src/scenes/skillSettings.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillSettings.tsx
@@ -70,7 +70,7 @@ export let SkillSettingsScene = (p: {
 
   let discoveryForm = useForm({
     initialValues: {
-      clientName: skill.data?.clientName ?? '',
+      clientName: (skill.data?.clientName ?? '').toLowerCase().replace(/[^a-z0-9]/g, '-'),
       clientDescription: skill.data?.clientDescription ?? '',
       license: skill.data?.license ?? '',
       compatibility: skill.data?.compatibility ?? ''
@@ -78,7 +78,11 @@ export let SkillSettingsScene = (p: {
     updateInitialValues: true,
     onSubmit: async values => {
       await discoveryUpdateMutator.mutate({
-        clientName: values.clientName.trim(),
+        clientName:
+          values.clientName
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]/g, '-') || undefined,
         clientDescription: values.clientDescription.trim() || undefined,
         license: values.license.trim() || null,
         compatibility: values.compatibility.trim() || null
@@ -86,7 +90,11 @@ export let SkillSettingsScene = (p: {
     },
     schema: yup =>
       yup.object({
-        clientName: yup.string().trim().required('Client name is required'),
+        clientName: yup
+          .string()
+          .trim()
+          .required('Client name is required')
+          .matches(/^[a-z0-9-]+$/, 'Client name must only contain letters and numbers'),
         clientDescription: yup.string().ensure(),
         license: yup.string().ensure(),
         compatibility: yup.string().ensure()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only validation and normalization in skill settings; no auth or backend contract changes in this diff.
> 
> **Overview**
> Tightens **client name** handling on the skill **Discovery Settings** form so values exposed to clients follow a consistent slug-like format.
> 
> On load and save, `clientName` is lowercased and non-`a-z0-9` characters are replaced with hyphens; an empty result after normalization is sent as `undefined` on update. Form validation now requires the field and enforces `^[a-z0-9-]+$` via Yup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227920b67a9b40da84c50a479ce9e635837add90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->