### PR TITLE
Harden transient repo issues

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/syncs.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-marketplace/syncs.tsx
@@ -1,13 +1,42 @@
-import { useParams } from 'react-router-dom';
+import { Paths } from '@metorial/frontend-config';
+import {
+  useCurrentInstance,
+  useCurrentOrganization,
+  useCurrentProject
+} from '@metorial/state';
+import { Button, Spacer } from '@metorial/ui';
+import { RiArrowLeftLine } from '@remixicon/react';
+import { Link, useParams } from 'react-router-dom';
 import { SkillSyncsTable } from '../skillSyncs';
 
 export let SkillMarketplaceSyncsPage = () => {
   let { skillMarketplaceId } = useParams();
 
+  let instance = useCurrentInstance();
+  let organization = useCurrentOrganization();
+  let project = useCurrentProject();
+
   return (
-    <SkillSyncsTable
-      emptyMessage="No syncs found for this skill marketplace."
-      query={skillMarketplaceId ? { skillMarketplaceId, order: 'desc' } : null}
-    />
+    <>
+      <Link
+        to={Paths.instance.skillMarketplace(
+          organization.data,
+          project.data,
+          instance.data,
+          skillMarketplaceId
+        )}
+      >
+        <Button as="span" size="2" variant="outline" iconLeft={<RiArrowLeftLine />}>
+          Back to Overview
+        </Button>
+      </Link>
+
+      <Spacer height={15} />
+
+      <SkillSyncsTable
+        emptyMessage="No syncs found for this skill marketplace."
+        query={skillMarketplaceId ? { skillMarketplaceId, order: 'desc' } : null}
+      />
+    </>
   );
 };

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skill-plugin/_layout.tsx
@@ -117,14 +117,14 @@ export let SkillPluginLayout = () => {
                   label: 'Overview',
                   to: Paths.instance.skillPlugin(...pluginPathParams)
                 },
-                {
-                  label: 'Preview',
-                  to: Paths.instance.skillPlugin(...pluginPathParams, 'editor')
-                },
-                {
-                  label: 'Syncs',
-                  to: Paths.instance.skillPlugin(...pluginPathParams, 'syncs')
-                },
+                // {
+                //   label: 'Preview',
+                //   to: Paths.instance.skillPlugin(...pluginPathParams, 'editor')
+                // },
+                // {
+                //   label: 'Syncs',
+                //   to: Paths.instance.skillPlugin(...pluginPathParams, 'syncs')
+                // },
                 {
                   label: 'Settings',
                   to: Paths.instance.skillPlugin(...pluginPathParams, 'settings')

--- a/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skillSyncs.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/slices/product/pages/(skills)/skillSyncs.tsx
@@ -126,7 +126,7 @@ let getPullRequestsUrl = (repositoryCheck: RepositoryCheck) => {
 let getRepositoryActionMessage = (repositoryCheck: RepositoryCheck) => {
   if (repositoryCheck.repositoryAccessMode === 'default_branch') {
     if (repositoryCheck.errorMessage) return repositoryCheck.errorMessage;
-    return `We couldn't reach the repository provider. We'll retry automatically.`;
+    return `We couldn't update the default branch. We'll retry automatically.`;
   }
   let checksFailed = repositoryCheck.blockers.includes('checks_failed');
   let reviewRequired = repositoryCheck.blockers.includes('reviews_required');

--- a/src/metorial/cargo/modules/skill/src/lib/repositorySyncStatus.test.ts
+++ b/src/metorial/cargo/modules/skill/src/lib/repositorySyncStatus.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRepositorySyncRetryMessage,
+  isRepositorySyncRetrying
+} from './repositorySyncStatus';
+
+describe('repository sync status', () => {
+  it('only treats scheduled provider failures as active retries', () => {
+    expect(
+      isRepositorySyncRetrying({
+        errorMessage: 'Provider unavailable',
+        nextPollAt: new Date()
+      })
+    ).toBe(true);
+    expect(
+      isRepositorySyncRetrying({ errorMessage: 'Terminal failure', nextPollAt: null })
+    ).toBe(false);
+    expect(isRepositorySyncRetrying({ errorMessage: null, nextPollAt: new Date() })).toBe(
+      false
+    );
+  });
+
+  it('uses mode-specific canonical retry messages', () => {
+    expect(getRepositorySyncRetryMessage('default_branch')).toBe(
+      `We couldn't update the default branch. We'll retry automatically.`
+    );
+    expect(getRepositorySyncRetryMessage('pull_request')).toBe(
+      `We couldn't update the pull request. We'll retry automatically.`
+    );
+  });
+});

--- a/src/metorial/cargo/modules/skill/src/lib/repositorySyncStatus.ts
+++ b/src/metorial/cargo/modules/skill/src/lib/repositorySyncStatus.ts
@@ -1,0 +1,11 @@
+export type RepositoryAccessMode = 'pull_request' | 'default_branch';
+
+export let isRepositorySyncRetrying = (sync: {
+  errorMessage?: string | null;
+  nextPollAt?: unknown;
+}) => Boolean(sync.errorMessage && sync.nextPollAt);
+
+export let getRepositorySyncRetryMessage = (mode: RepositoryAccessMode) =>
+  mode === 'default_branch'
+    ? `We couldn't update the default branch. We'll retry automatically.`
+    : `We couldn't update the pull request. We'll retry automatically.`;

--- a/src/metorial/cargo/modules/skill/src/queues/sync/propagate.ts
+++ b/src/metorial/cargo/modules/skill/src/queues/sync/propagate.ts
@@ -3,6 +3,10 @@ import { getId } from '@metorial/cargo-config/id';
 import { db, withTransaction } from '@metorial/db';
 import { createQueue, QueueRetryError } from '@metorial/queue';
 import { getOriginTenant, origin } from '../../internal/skillDestination';
+import {
+  getRepositorySyncRetryMessage,
+  isRepositorySyncRetrying
+} from '../../lib/repositorySyncStatus';
 import { createSkillSyncBranchName, normalizeSkillSyncBranchName } from './_lib/branchName';
 import { appendSkillDestinationSyncLog } from './_lib/logs';
 import { syncFinishQueue } from './finish';
@@ -423,7 +427,7 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
       if (updated.count > 0) {
         await appendSkillDestinationSyncLog(
           data.skillDestinationSyncId,
-          `Repository update failed for ${repositoryName}.`
+          `${repositoryName}: ${originSync.errorMessage ?? 'Repository update failed.'}`
         );
       }
       continue;
@@ -455,9 +459,9 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
       originSync.status === 'waiting_for_review'
         ? ('waiting_for_review' as const)
         : ('processing' as const);
-    let providerUnavailable = Boolean(originSync.errorMessage);
+    let providerUnavailable = isRepositorySyncRetrying(originSync);
     let nextErrorMessage = providerUnavailable
-      ? 'Repository update is temporarily unavailable.'
+      ? getRepositorySyncRetryMessage(propagation.repositoryAccessMode)
       : null;
     if (propagation.status !== nextStatus || propagation.errorMessage !== nextErrorMessage) {
       let updated = await db.skillDestinationSyncRepositoryPropagation.updateMany({
@@ -492,7 +496,7 @@ export let syncPropagateWaitQueueProcessor = syncPropagateWaitQueue.process(asyn
       if (providerUnavailable) {
         await appendSkillDestinationSyncLog(
           data.skillDestinationSyncId,
-          `${repositoryName}: Repository update was temporarily unavailable; retrying.`
+          `${repositoryName}: ${nextErrorMessage}`
         );
       } else if (propagation.errorMessage) {
         await appendSkillDestinationSyncLog(

--- a/src/metorial/cargo/modules/skill/src/services/skillSync.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillSync.ts
@@ -11,6 +11,7 @@ import type { ResourceScope } from '@metorial/module-resource-tenant';
 import type { Prisma, SkillDestinationSyncStatus } from '@metorial/db';
 import { db, withTransaction } from '@metorial/db';
 import { getOriginTenant, origin } from '../internal/skillDestination';
+import { isRepositorySyncRetrying } from '../lib/repositorySyncStatus';
 
 export let skillSyncInclude = {
   destination: {
@@ -239,6 +240,10 @@ class SkillSyncServiceImpl {
         | null
         | undefined;
       let isPullRequest = propagation.repositoryAccessMode === 'pull_request';
+      let providerUnavailable = Boolean(
+        (originSync && isRepositorySyncRetrying(originSync)) ||
+        (!originSync && (propagation.errorMessage || propagation.originSyncId))
+      );
       let blockers = [
         isPullRequest && snapshot?.checks?.state === 'pending' ? 'checks_pending' : null,
         isPullRequest && snapshot?.checks?.state === 'failed' ? 'checks_failed' : null,
@@ -257,9 +262,7 @@ class SkillSyncServiceImpl {
         snapshot?.mergeability?.reason !== 'merge_permission_required'
           ? 'merge_blocked'
           : null,
-        (originSync?.errorMessage ||
-          propagation.errorMessage ||
-          (propagation.originSyncId && !originSync)) &&
+        providerUnavailable &&
         ['processing', 'waiting_for_review'].includes(propagation.status)
           ? 'provider_unavailable'
           : null
@@ -292,9 +295,7 @@ class SkillSyncServiceImpl {
         approvedReviewCount: isPullRequest ? (snapshot?.review?.approvals ?? null) : null,
         mergeability: isPullRequest ? (snapshot?.mergeability?.state ?? null) : null,
         lastCheckedAt: snapshot?.observedAt ? new Date(snapshot.observedAt) : null,
-        errorMessage: isPullRequest
-          ? (propagation.errorMessage ?? originSync?.errorMessage ?? null)
-          : (originSync?.errorMessage ?? propagation.errorMessage ?? null)
+        errorMessage: propagation.errorMessage ?? originSync?.errorMessage ?? null
       };
     });
   }

--- a/src/origin/apps/code-bucket/internal/service/rpc.go
+++ b/src/origin/apps/code-bucket/internal/service/rpc.go
@@ -3,6 +3,9 @@ package service
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/metorial/metorial/services/code-bucket/gen/rpc"
@@ -16,6 +19,65 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+var (
+	providerHTTPStatusPattern = regexp.MustCompile(`(?i)\bstatus(?: code)?[\s:=()]+(\d{3})\b`)
+	providerJSONSecretPattern = regexp.MustCompile(`(?i)("(?:authorization|private-token|access[_-]?token|refresh[_-]?token)"\s*:\s*")[^"]*(")`)
+	providerSecretPattern     = regexp.MustCompile(`(?i)(authorization|private-token|access[_-]?token|refresh[_-]?token)\s*[:=]\s*[^,\s}"']+`)
+	providerBearerPattern     = regexp.MustCompile(`(?i)bearer\s+[a-z0-9._~+/-]+=*`)
+)
+
+func providerExportError(provider string, err error) error {
+	message := err.Error()
+	grpcCode := codes.Internal
+
+	if matches := providerHTTPStatusPattern.FindStringSubmatch(message); len(matches) == 2 {
+		if httpStatus, parseErr := strconv.Atoi(matches[1]); parseErr == nil {
+			switch {
+			case httpStatus == 400 || httpStatus == 422:
+				grpcCode = codes.InvalidArgument
+			case httpStatus == 401:
+				grpcCode = codes.Unauthenticated
+			case httpStatus == 403 && isProtectedBranchError(message):
+				grpcCode = codes.FailedPrecondition
+			case httpStatus == 403:
+				grpcCode = codes.PermissionDenied
+			case httpStatus == 404:
+				grpcCode = codes.NotFound
+			case httpStatus == 408 || httpStatus == 504:
+				grpcCode = codes.DeadlineExceeded
+			case httpStatus == 409:
+				grpcCode = codes.Aborted
+			case httpStatus == 429:
+				grpcCode = codes.ResourceExhausted
+			case httpStatus >= 500:
+				grpcCode = codes.Unavailable
+			}
+		}
+	}
+
+	return status.Errorf(grpcCode, "failed to upload to %s: %s", provider, sanitizeProviderError(message))
+}
+
+func isProtectedBranchError(message string) bool {
+	normalized := strings.ToLower(message)
+	return strings.Contains(normalized, "protected branch") ||
+		strings.Contains(normalized, "protected ref") ||
+		strings.Contains(normalized, "not allowed to push into this branch") ||
+		strings.Contains(normalized, "branch restriction") ||
+		strings.Contains(normalized, "pre-receive hook declined")
+}
+
+func sanitizeProviderError(message string) string {
+	const maxLength = 1000
+	message = providerJSONSecretPattern.ReplaceAllString(message, `$1[redacted]$2`)
+	message = providerSecretPattern.ReplaceAllString(message, `$1=[redacted]`)
+	message = providerBearerPattern.ReplaceAllString(message, "Bearer [redacted]")
+	if len(message) > maxLength {
+		return message[:maxLength] + "…"
+	}
+	return message
+}
 
 type RcpService struct {
 	rpc.UnimplementedCodeBucketServer
@@ -235,7 +297,7 @@ func (rs *RcpService) ExportBucketToGithub(ctx context.Context, req *rpc.ExportB
 			return nil
 		})
 	}); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to upload to GitHub: %v", err)
+		return nil, providerExportError("GitHub", err)
 	}
 
 	return &rpc.ExportBucketToGithubResponse{}, nil
@@ -269,7 +331,7 @@ func (rs *RcpService) ExportBucketToGitlab(ctx context.Context, req *rpc.ExportB
 			return nil
 		})
 	}); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to upload to GitLab: %v", err)
+		return nil, providerExportError("GitLab", err)
 	}
 
 	return &rpc.ExportBucketToGitlabResponse{}, nil
@@ -323,7 +385,7 @@ func (rs *RcpService) ExportBucketToBitbucketCloud(ctx context.Context, req *rpc
 		},
 	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to upload to Bitbucket Cloud: %v", err)
+		return nil, providerExportError("Bitbucket Cloud", err)
 	}
 	return &rpc.ExportBucketToBitbucketResponse{}, nil
 }
@@ -373,7 +435,7 @@ func (rs *RcpService) ExportBucketToBitbucketDataCenter(ctx context.Context, req
 		},
 	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to upload to Bitbucket Data Center: %v", err)
+		return nil, providerExportError("Bitbucket Data Center", err)
 	}
 	return &rpc.ExportBucketToBitbucketResponse{}, nil
 }

--- a/src/origin/apps/code-bucket/internal/service/rpc_test.go
+++ b/src/origin/apps/code-bucket/internal/service/rpc_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestProviderExportErrorMapsProviderFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		message  string
+		code     codes.Code
+	}{
+		{
+			name:     "gitlab protected branch",
+			provider: "GitLab",
+			message:  `failed to create commit (status 403): {"message":"You are not allowed to push into this branch"}`,
+			code:     codes.FailedPrecondition,
+		},
+		{
+			name:     "github permission denied",
+			provider: "GitHub",
+			message:  `update reference failed (status 403): {"message":"Resource not accessible by integration"}`,
+			code:     codes.PermissionDenied,
+		},
+		{
+			name:     "bitbucket rate limited",
+			provider: "Bitbucket Cloud",
+			message:  `Bitbucket source upload failed (status 429): retry later`,
+			code:     codes.ResourceExhausted,
+		},
+		{
+			name:     "provider unavailable",
+			provider: "GitLab",
+			message:  `failed to create commit (status 503): service unavailable`,
+			code:     codes.Unavailable,
+		},
+		{
+			name:     "unknown failure",
+			provider: "Bitbucket Data Center",
+			message:  `unexpected git transport failure`,
+			code:     codes.Internal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := providerExportError(tt.provider, errors.New(tt.message))
+			if got := status.Code(err); got != tt.code {
+				t.Fatalf("expected gRPC code %s, got %s", tt.code, got)
+			}
+			if !strings.Contains(status.Convert(err).Message(), tt.provider) {
+				t.Fatalf("expected provider context in error: %v", err)
+			}
+		})
+	}
+}
+
+func TestProviderExportErrorSanitizesCredentials(t *testing.T) {
+	err := providerExportError(
+		"GitLab",
+		errors.New(`request failed (status 401): {"access_token":"secret"} authorization=other-secret Bearer abc.def`),
+	)
+	message := status.Convert(err).Message()
+
+	if strings.Contains(message, "secret") || strings.Contains(message, "abc.def") {
+		t.Fatalf("expected credentials to be redacted: %s", message)
+	}
+	if !strings.Contains(message, "[redacted]") {
+		t.Fatalf("expected redaction marker: %s", message)
+	}
+}

--- a/src/origin/apps/service/src/lib/scmProviderError.test.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.test.ts
@@ -13,6 +13,7 @@ import {
   formatScmProviderError,
   getScmProviderErrorDetails,
   getScmProviderLogDetails,
+  isRetryableScmProviderError,
   withScmProviderError,
   wrapScmProviderError
 } from './scmProviderError';
@@ -40,7 +41,9 @@ describe('SCM provider errors', () => {
   });
 
   it('preserves existing ServiceErrors', async () => {
-    let serviceError = new ServiceError(badRequestError({ message: 'Known validation error' }));
+    let serviceError = new ServiceError(
+      badRequestError({ message: 'Known validation error' })
+    );
 
     await expect(
       withScmProviderError('github', 'create repository', async () => {
@@ -131,6 +134,51 @@ describe('SCM provider errors', () => {
       requestId: 'request-123',
       classification: 'invalid_request'
     });
+  });
+
+  it.each([
+    [
+      'gitlab',
+      `failed to upload to GitLab: failed to create commit (status 403): {"message":"403 Forbidden - You are not allowed to push into this branch"}`,
+      'protected_branch'
+    ],
+    [
+      'github',
+      `failed to upload to GitHub: update reference failed (status 403): {"message":"Resource not accessible by integration"}`,
+      'permission_denied'
+    ],
+    [
+      'bitbucket',
+      `failed to upload to Bitbucket Cloud: source upload failed (status 403): branch restriction rejected the push`,
+      'protected_branch'
+    ]
+  ])('classifies %s code-bucket 403 details', (_provider, details, classification) => {
+    let error = Object.assign(new Error(`/rpc.CodeBucket/Export INTERNAL: ${details}`), {
+      code: 13,
+      details
+    });
+
+    expect(getScmProviderErrorDetails(error)).toMatchObject({
+      status: 403,
+      description: details,
+      classification
+    });
+    expect(isRetryableScmProviderError(error)).toBe(false);
+  });
+
+  it('uses semantic gRPC codes when no HTTP status is available', () => {
+    expect(
+      getScmProviderErrorDetails({
+        code: 7,
+        details: 'The integration cannot write to this repository.'
+      }).classification
+    ).toBe('permission_denied');
+    expect(
+      isRetryableScmProviderError({
+        code: 14,
+        details: 'The repository provider is unavailable.'
+      })
+    ).toBe(true);
   });
 
   it('formats detailed diagnostics without JavaScript stacks or credentials', () => {

--- a/src/origin/apps/service/src/lib/scmProviderError.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.ts
@@ -11,22 +11,36 @@ import {
   unauthorizedError
 } from '@lowerdeck/error';
 import { getSentry } from '@lowerdeck/sentry';
+import { status as grpcStatus } from '@grpc/grpc-js';
 
 let Sentry = getSentry();
 
 type ScmProvider = 'github' | 'gitlab' | 'bitbucket';
 
+let getEmbeddedHttpStatus = (value: unknown) => {
+  if (typeof value !== 'string') return undefined;
+  let match = value.match(/\bstatus(?: code)?[\s:=()]+(\d{3})\b/i);
+  if (!match) return undefined;
+
+  let status = Number(match[1]);
+  return Number.isInteger(status) ? status : undefined;
+};
+
 export let getScmProviderErrorStatus = (error: any): number | undefined =>
   error?.status ??
   error?.response?.status ??
   error?.cause?.response?.status ??
-  error?.cause?.response?.statusCode;
+  error?.cause?.response?.statusCode ??
+  getEmbeddedHttpStatus(error?.details) ??
+  getEmbeddedHttpStatus(error instanceof Error ? error.message : error);
 
 let getHeader = (headers: any, name: string) => {
   if (!headers) return undefined;
   if (typeof headers.get === 'function') return headers.get(name) ?? undefined;
 
-  let entry = Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  let entry = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase()
+  );
   return typeof entry?.[1] === 'string' ? entry[1] : undefined;
 };
 
@@ -49,7 +63,10 @@ let sanitizeText = (value: unknown, maxLength = 1000): string | undefined => {
       /("(?:authorization|private-token|access[_-]?token|refresh[_-]?token)"\s*:\s*")[^"]*"/gi,
       '$1[redacted]"'
     )
-    .replace(/(authorization|private-token|access[_-]?token|refresh[_-]?token)\s*[:=]\s*[^,\s}"']+/gi, '$1=[redacted]')
+    .replace(
+      /(authorization|private-token|access[_-]?token|refresh[_-]?token)\s*[:=]\s*[^,\s}"']+/gi,
+      '$1=[redacted]'
+    )
     .replace(/bearer\s+[a-z0-9._~+/-]+=*/gi, 'Bearer [redacted]')
     .trim();
 
@@ -61,6 +78,7 @@ let getDescription = (error: any) => {
   let candidates = [
     error?.cause?.description,
     error?.description,
+    error?.details,
     error?.response?.data?.message,
     error?.response?.data?.error,
     error?.cause?.response?.data?.message,
@@ -110,12 +128,20 @@ export type ScmProviderErrorDetails = {
     | 'network_failure';
 };
 
-let classifyScmProviderError = (status: number | undefined, description: string | undefined) => {
+let classifyScmProviderError = (
+  status: number | undefined,
+  description: string | undefined,
+  grpcCode?: number
+) => {
   let normalized = description?.toLowerCase() ?? '';
   if (
     normalized.includes('protected branch') ||
     normalized.includes('protected ref') ||
-    normalized.includes('is protected')
+    normalized.includes('is protected') ||
+    normalized.includes('was protected') ||
+    normalized.includes('not allowed to push into this branch') ||
+    normalized.includes('branch restriction') ||
+    normalized.includes('pre-receive hook declined')
   ) {
     return 'protected_branch' as const;
   }
@@ -130,6 +156,22 @@ let classifyScmProviderError = (status: number | undefined, description: string 
   if (status === 408 || status === 504) return 'timeout' as const;
   if (status === 400 || status === 422) return 'invalid_request' as const;
   if (status != null && status >= 500) return 'upstream_failure' as const;
+
+  if (grpcCode === grpcStatus.UNAUTHENTICATED) return 'authentication_failed' as const;
+  if (grpcCode === grpcStatus.PERMISSION_DENIED) return 'permission_denied' as const;
+  if (grpcCode === grpcStatus.NOT_FOUND) return 'resource_not_found' as const;
+  if (grpcCode === grpcStatus.ABORTED || grpcCode === grpcStatus.ALREADY_EXISTS) {
+    return 'conflict' as const;
+  }
+  if (grpcCode === grpcStatus.RESOURCE_EXHAUSTED) return 'rate_limited' as const;
+  if (grpcCode === grpcStatus.DEADLINE_EXCEEDED) return 'timeout' as const;
+  if (
+    grpcCode === grpcStatus.INVALID_ARGUMENT ||
+    grpcCode === grpcStatus.FAILED_PRECONDITION
+  ) {
+    return 'invalid_request' as const;
+  }
+  if (grpcCode === grpcStatus.UNAVAILABLE) return 'upstream_failure' as const;
   return 'network_failure' as const;
 };
 
@@ -137,8 +179,7 @@ export let getScmProviderErrorDetails = (error: unknown): ScmProviderErrorDetail
   let value = error as any;
   let request = getRequest(value);
   let response = getResponse(value);
-  let method =
-    typeof request?.method === 'string' ? request.method.toUpperCase() : undefined;
+  let method = typeof request?.method === 'string' ? request.method.toUpperCase() : undefined;
   let status = getScmProviderErrorStatus(value);
   let description = getDescription(value);
 
@@ -150,13 +191,19 @@ export let getScmProviderErrorDetails = (error: unknown): ScmProviderErrorDetail
     requestId:
       getHeader(response?.headers, 'x-request-id') ??
       getHeader(response?.headers, 'x-gitlab-meta'),
-    classification: classifyScmProviderError(status, description)
+    classification: classifyScmProviderError(
+      status,
+      description,
+      typeof value?.code === 'number' ? value.code : undefined
+    )
   };
 };
 
 export let isRetryableScmProviderError = (error: unknown) => {
-  let status = getScmProviderErrorStatus(error);
-  return status == null || status === 408 || status === 429 || status >= 500;
+  let classification = getScmProviderErrorDetails(error).classification;
+  return ['network_failure', 'rate_limited', 'timeout', 'upstream_failure'].includes(
+    classification
+  );
 };
 
 let providerName = (provider: ScmProvider) =>
@@ -196,7 +243,8 @@ export let formatScmProviderError = (d: {
 };
 
 let publicErrorReason = (classification: ScmProviderErrorDetails['classification']) => {
-  if (classification === 'protected_branch') return 'a protected branch rule blocked the request';
+  if (classification === 'protected_branch')
+    return 'a protected branch rule blocked the request';
   if (classification === 'missing_branch') return 'the requested branch was not found';
   if (classification === 'permission_denied') return 'the integration lacks permission';
   if (classification === 'authentication_failed') return 'authentication failed';

--- a/src/origin/apps/service/src/queues/scm/repositorySync/_lib.test.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/_lib.test.ts
@@ -19,7 +19,11 @@ vi.mock('../../../services/repositorySyncState', () => ({
   transitionRepositorySyncState: mocks.updateState
 }));
 
-import { logRepositorySyncQueueError, markRepositorySyncFailed } from './_lib';
+import {
+  logRepositorySyncQueueError,
+  markRepositorySyncFailed,
+  shouldRetryRepositorySyncContents
+} from './_lib';
 
 describe('repository sync failure diagnostics', () => {
   beforeEach(() => {
@@ -102,5 +106,64 @@ describe('repository sync failure diagnostics', () => {
           'Direct push was blocked by repository rules. Use pull requests or allow writes to the default branch.'
       })
     );
+  });
+
+  it('stores protected-branch guidance for code-bucket gRPC failures', async () => {
+    mocks.findUnique.mockResolvedValue({
+      status: 'syncing_contents',
+      repositoryAccessMode: 'default_branch'
+    });
+    let details =
+      'failed to upload to GitLab: failed to create commit (status 403): {"message":"403 Forbidden - You are not allowed to push into this branch"}';
+    let error = Object.assign(
+      new Error(`/rpc.rpc.CodeBucket/ExportBucketToGitlab INTERNAL: ${details}`),
+      {
+        code: 13,
+        details
+      }
+    );
+
+    await markRepositorySyncFailed('sync_direct_grpc', error);
+
+    expect(mocks.updateState).toHaveBeenCalledWith(
+      'sync_direct_grpc',
+      'syncing_contents',
+      expect.objectContaining({
+        status: 'failed',
+        errorMessage:
+          'Direct push was blocked by repository rules. Use pull requests or allow writes to the default branch.'
+      })
+    );
+  });
+
+  it('does not retry permanent code-bucket failures', () => {
+    let permanentError = {
+      code: 7,
+      details:
+        'failed to upload to GitLab: failed to create commit (status 403): not allowed to push'
+    };
+
+    expect(
+      shouldRetryRepositorySyncContents({
+        repositoryAccessMode: 'default_branch',
+        status: 'syncing_contents',
+        attemptCount: 0,
+        error: permanentError
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    { code: 14, details: 'provider unavailable' },
+    { status: 409, description: 'branch changed' }
+  ])('retries transient and conflict failures', error => {
+    expect(
+      shouldRetryRepositorySyncContents({
+        repositoryAccessMode: 'default_branch',
+        status: 'syncing_contents',
+        attemptCount: 0,
+        error
+      })
+    ).toBe(true);
   });
 });

--- a/src/origin/apps/service/src/queues/scm/repositorySync/_lib.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/_lib.ts
@@ -1,7 +1,8 @@
 import { db } from '../../../db';
 import {
   getScmProviderErrorDetails,
-  getScmProviderLogDetails
+  getScmProviderLogDetails,
+  isRetryableScmProviderError
 } from '../../../lib/scmProviderError';
 import {
   isTerminalRepositorySyncStatus,
@@ -9,6 +10,24 @@ import {
 } from '../../../services/repositorySyncState';
 
 export type RepositorySyncLogEntry = [number, string];
+
+export let shouldRetryRepositorySyncContents = (d: {
+  repositoryAccessMode: string;
+  status: string;
+  attemptCount: number;
+  error: unknown;
+}) => {
+  if (
+    d.repositoryAccessMode !== 'default_branch' ||
+    d.status !== 'syncing_contents' ||
+    d.attemptCount >= 3
+  ) {
+    return false;
+  }
+
+  let classification = getScmProviderErrorDetails(d.error).classification;
+  return classification === 'conflict' || isRetryableScmProviderError(d.error);
+};
 
 export let logRepositorySyncQueueEvent = (
   stage: string,

--- a/src/origin/apps/service/src/queues/scm/repositorySync/syncContents.ts
+++ b/src/origin/apps/service/src/queues/scm/repositorySync/syncContents.ts
@@ -5,17 +5,15 @@ import {
   cleanupRepositorySyncBranchIfNoChanges,
   getRepositorySyncBranchSha
 } from '../../../lib/scmRepositorySyncProvider';
-import {
-  getScmProviderErrorDetails,
-  isRetryableScmProviderError
-} from '../../../lib/scmProviderError';
+import { getScmProviderErrorDetails } from '../../../lib/scmProviderError';
 import { codeBucketService } from '../../../services';
 import { transitionRepositorySyncState } from '../../../services/repositorySyncState';
 import {
   appendRepositorySyncLog,
   logRepositorySyncQueueError,
   logRepositorySyncQueueEvent,
-  markRepositorySyncFailed
+  markRepositorySyncFailed,
+  shouldRetryRepositorySyncContents
 } from './_lib';
 import { createPrRepositorySyncQueue } from './createPr';
 
@@ -180,10 +178,13 @@ export let syncContentsRepositorySyncQueueProcessor = syncContentsRepositorySync
       });
       let providerError = getScmProviderErrorDetails(e);
       let shouldRetry =
-        failedSync?.repositoryAccessMode === 'default_branch' &&
-        failedSync.status === 'syncing_contents' &&
-        failedSync.attemptCount < 3 &&
-        (isRetryableScmProviderError(e) || providerError.classification === 'conflict');
+        failedSync &&
+        shouldRetryRepositorySyncContents({
+          repositoryAccessMode: failedSync.repositoryAccessMode,
+          status: failedSync.status,
+          attemptCount: failedSync.attemptCount,
+          error: e
+        });
       if (failedSync && shouldRetry) {
         let delay = Math.min(60_000, 2_000 * 2 ** failedSync.attemptCount);
         await transitionRepositorySyncState(failedSync.id, 'syncing_contents', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches repository sync queues, SCM error classification, and code-bucket export paths—incorrect retry or classification could cause stuck syncs or missed auto-retries, but changes are well covered by new tests.
> 
> **Overview**
> **Repository sync reliability** now distinguishes **scheduled retries** (`errorMessage` + `nextPollAt`) from terminal failures via shared `repositorySyncStatus` helpers in cargo; propagation and API repository checks use mode-specific user messages and only surface `provider_unavailable` during active retries.
> 
> **Origin SCM handling** maps code-bucket gRPC export failures to semantic codes (including protected-branch → non-retryable), redacts secrets in error text, and classifies/retryability from HTTP status embedded in messages or gRPC codes. Default-branch content sync retries are centralized in `shouldRetryRepositorySyncContents` (transient/conflict only, max 3 attempts).
> 
> **Dashboard**: skill marketplace syncs get a back link to overview; skill plugin **Preview** and **Syncs** tabs are hidden; sync UI copy aligns with default-branch vs pull-request retry wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9958e705a8977ecb5e3115f326aa8be1d59355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->