### PR TITLE
Add more telemetry and timeout validation

### DIFF
--- a/src/metorial/modules/subspace/src/services/adminProviderTelemetry.ts
+++ b/src/metorial/modules/subspace/src/services/adminProviderTelemetry.ts
@@ -11,6 +11,7 @@ export let subspaceAdminProviderTelemetryService = createSubspacePublicService(
     'listErrorGroups',
     'getErrorGroup',
     'listRuns',
+    'listToolCalls',
     'getRunLogs',
     'listAuthLogs',
     'listProviderVersionDeployments',

--- a/src/slates/apps/registry/src/lib/slatePackage/manifest.test.ts
+++ b/src/slates/apps/registry/src/lib/slatePackage/manifest.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import { normalizeSlatePackage } from './manifest';
+
+let createEntries = (slateJson: Record<string, unknown>) => [
+  {
+    path: 'slate.json',
+    buffer: Buffer.from(JSON.stringify(slateJson))
+  },
+  {
+    path: 'package.json',
+    buffer: Buffer.from(
+      JSON.stringify({
+        name: '@npm/weather-package',
+        version: '1.2.3',
+        description: 'Weather slate'
+      })
+    )
+  }
+];
+
+let normalizeWithTimeout = (timeout?: unknown) =>
+  normalizeSlatePackage({
+    entries: createEntries({
+      name: '@demo/weather',
+      ...(timeout !== undefined ? { timeout } : {})
+    }),
+    identifier: {
+      scopeIdentifier: 'demo',
+      slateIdentifier: 'weather'
+    }
+  });
+
+describe('slate.json timeout validation', () => {
+  it('accepts a manifest without a timeout', () => {
+    expect(normalizeWithTimeout().manifest.timeout).toBeUndefined();
+  });
+
+  it('accepts timeouts within the Lambda limit', () => {
+    expect(normalizeWithTimeout(1).manifest.timeout).toBe(1);
+    expect(normalizeWithTimeout(120).manifest.timeout).toBe(120);
+    expect(normalizeWithTimeout(900).manifest.timeout).toBe(900);
+  });
+
+  it('rejects timeouts above the 900 second Lambda maximum', () => {
+    expect(() => normalizeWithTimeout(901)).toThrow();
+    expect(() => normalizeWithTimeout(1500)).toThrow();
+  });
+
+  it('rejects zero and negative timeouts', () => {
+    expect(() => normalizeWithTimeout(0)).toThrow();
+    expect(() => normalizeWithTimeout(-15)).toThrow();
+  });
+
+  it('rejects non-integer timeouts', () => {
+    expect(() => normalizeWithTimeout(12.5)).toThrow();
+  });
+});

--- a/src/slates/apps/registry/src/lib/slatePackage/manifest.ts
+++ b/src/slates/apps/registry/src/lib/slatePackage/manifest.ts
@@ -16,13 +16,28 @@ export type NormalizedSlatePackage = {
   isPrebuilt?: boolean;
 };
 
+// AWS Lambda caps function timeouts at 900 seconds and Function Bay passes the
+// value through unclamped, so out-of-range manifests must be rejected at publish
+// time instead of failing the deployment later.
+let timeoutValidation = v.optional(
+  v.number({
+    modifiers: [
+      v.integer({ message: 'Timeout must be a whole number of seconds.' }),
+      v.minValue(1, { message: 'Timeout must be at least 1 second.' }),
+      v.maxValue(900, {
+        message: 'Timeout must be at most 900 seconds (the AWS Lambda maximum).'
+      })
+    ]
+  })
+);
+
 let rawSlateJsonValidation = v.object({
   name: v.string(),
   description: v.optional(v.string()),
   categories: v.optional(v.array(v.string())),
   skills: v.optional(v.array(v.string())),
   logoUrl: v.optional(v.string()),
-  timeout: v.optional(v.number({}))
+  timeout: timeoutValidation
 });
 
 let packageJsonValidation = v.object({
@@ -68,7 +83,7 @@ export let slateJsonValidation = v.object({
   categories: v.optional(v.array(v.string())),
   skills: v.optional(v.array(v.string())),
   logoUrl: v.optional(v.string()),
-  timeout: v.optional(v.number({}))
+  timeout: timeoutValidation
 });
 
 let parseJsonFile = <T>(d: {

--- a/src/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
+++ b/src/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
@@ -1,6 +1,6 @@
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { db } from '@metorial-subspace/db';
+import { db, type Prisma } from '@metorial-subspace/db';
 import { providerService } from '@metorial-subspace/module-catalog';
 import {
   adminProviderTelemetryErrorGroupService,
@@ -554,7 +554,22 @@ let presentAdminRun = (run: any) => ({
   completed_at: run.completedAt
 });
 
-let presentAdminToolCall = (message: any) => ({
+let adminToolCallInclude = {
+  session: { select: { id: true } },
+  sessionProvider: { include: { provider: true } },
+  providerRun: { include: { providerVersion: true } },
+  toolCall: { include: { tool: true } },
+  error: { include: { group: true } },
+  tenant: true,
+  environment: true
+} satisfies Prisma.SessionMessageInclude;
+
+type AdminToolCallMessage = Omit<
+  Prisma.SessionMessageGetPayload<{ include: typeof adminToolCallInclude }>,
+  'input' | 'output'
+>;
+
+let presentAdminToolCall = (message: AdminToolCallMessage) => ({
   object: 'admin.tool_call',
   id: message.id,
   status: message.status,
@@ -1045,15 +1060,7 @@ export let adminProviderTelemetryController = app.controller({
                   createdAt: { gte: scope.from, lte: scope.to }
                 },
                 omit: { input: true, output: true },
-                include: {
-                  session: { select: { id: true } },
-                  sessionProvider: { include: { provider: true } },
-                  providerRun: { include: { providerVersion: true } },
-                  toolCall: { include: { tool: true } },
-                  error: { include: { group: true } },
-                  tenant: true,
-                  environment: true
-                }
+                include: adminToolCallInclude
               })
           ),
         { defaultOrder: 'desc' }

--- a/src/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
+++ b/src/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
@@ -1044,6 +1044,7 @@ export let adminProviderTelemetryController = app.controller({
                 where: {
                   methodOrToolKey: toolKeys.length ? { in: toolKeys } : { not: null },
                   sessionProviderOid: { not: null },
+                  OR: [{ toolCall: { isNot: null } }, { source: 'client' }],
                   status: ctx.input.statuses ? { in: ctx.input.statuses } : undefined,
                   failureReason: ctx.input.failureReasons
                     ? { in: ctx.input.failureReasons }

--- a/src/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
+++ b/src/subspace/apps/controller/src/controllers/adminProviderTelemetry.ts
@@ -554,6 +554,65 @@ let presentAdminRun = (run: any) => ({
   completed_at: run.completedAt
 });
 
+let presentAdminToolCall = (message: any) => ({
+  object: 'admin.tool_call',
+  id: message.id,
+  status: message.status,
+  failure_reason: message.failureReason,
+  source: message.source,
+  tool_key: message.toolCall?.toolKey ?? message.methodOrToolKey ?? null,
+  tool: message.toolCall?.tool
+    ? {
+        id: message.toolCall.tool.id,
+        key: message.toolCall.tool.key,
+        name: message.toolCall.tool.name
+      }
+    : null,
+  is_tool_resolved: !!message.toolCall,
+  error: message.error
+    ? {
+        id: message.error.id,
+        type: message.error.type,
+        code: message.error.code,
+        message: message.error.message,
+        group_id: message.error.group?.id ?? null
+      }
+    : null,
+  provider: message.sessionProvider?.provider
+    ? {
+        id: message.sessionProvider.provider.id,
+        name: message.sessionProvider.provider.name,
+        slug: message.sessionProvider.provider.slug
+      }
+    : null,
+  provider_version: message.providerRun?.providerVersion
+    ? {
+        id: message.providerRun.providerVersion.id,
+        tag: message.providerRun.providerVersion.tag,
+        name: message.providerRun.providerVersion.name
+      }
+    : null,
+  provider_run_id: message.providerRun?.id ?? null,
+  tenant: {
+    id: message.tenant.id,
+    name: message.tenant.name,
+    identifier: message.tenant.identifier
+  },
+  environment: {
+    id: message.environment.id,
+    name: message.environment.name,
+    identifier: message.environment.identifier
+  },
+  tenant_id: message.tenant.id,
+  environment_id: message.environment.id,
+  session_id: message.session.id,
+  created_at: message.createdAt,
+  completed_at: message.completedAt,
+  duration_ms: message.completedAt
+    ? message.completedAt.getTime() - message.createdAt.getTime()
+    : null
+});
+
 let SESSION_TRACE_LIMITS = {
   messages: 100,
   runs: 30,
@@ -926,6 +985,82 @@ export let adminProviderTelemetryController = app.controller({
 
       let list = await paginator.run(ctx.input);
       return Paginator.presentLight(list, presentAdminRun);
+    }),
+
+  listToolCalls: app
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          ...telemetryScopeValidator,
+          toolKeys: v.optional(v.array(v.string())),
+          statuses: v.optional(
+            v.array(v.enumOf(['waiting_for_response', 'failed', 'succeeded']))
+          ),
+          failureReasons: v.optional(
+            v.array(v.enumOf(['timeout', 'provider_error', 'system_error', 'none']))
+          ),
+          sources: v.optional(v.array(v.enumOf(['client', 'provider']))),
+          providerVersionIds: v.optional(v.array(v.string()))
+        })
+      )
+    )
+    .do(async ctx => {
+      let scope = await resolveTelemetryScope(ctx.input);
+      if (scope.isEmpty) return emptyList();
+
+      let toolKeys = uniqueStrings(ctx.input.toolKeys ?? []);
+      if (ctx.input.toolKeys && toolKeys.length === 0) return emptyList();
+
+      let providerVersions = ctx.input.providerVersionIds?.length
+        ? await db.providerVersion.findMany({
+            where: { id: { in: ctx.input.providerVersionIds } },
+            select: { oid: true }
+          })
+        : undefined;
+
+      let paginator = Paginator.create(
+        ({ prisma }) =>
+          prisma(
+            async opts =>
+              await db.sessionMessage.findMany({
+                ...opts,
+                orderBy: createdAtOrder(ctx.input.order),
+                where: {
+                  methodOrToolKey: toolKeys.length ? { in: toolKeys } : { not: null },
+                  sessionProviderOid: { not: null },
+                  status: ctx.input.statuses ? { in: ctx.input.statuses } : undefined,
+                  failureReason: ctx.input.failureReasons
+                    ? { in: ctx.input.failureReasons }
+                    : undefined,
+                  source: ctx.input.sources ? { in: ctx.input.sources } : undefined,
+                  tenantOid: oidFilter(scope.tenantOids),
+                  environmentOid: oidFilter(scope.environmentOids),
+                  sessionProvider: scope.provider
+                    ? { providerOid: scope.provider.oid }
+                    : undefined,
+                  providerRun: providerVersions
+                    ? { providerVersionOid: { in: providerVersions.map(v => v.oid) } }
+                    : undefined,
+                  createdAt: { gte: scope.from, lte: scope.to }
+                },
+                omit: { input: true, output: true },
+                include: {
+                  session: { select: { id: true } },
+                  sessionProvider: { include: { provider: true } },
+                  providerRun: { include: { providerVersion: true } },
+                  toolCall: { include: { tool: true } },
+                  error: { include: { group: true } },
+                  tenant: true,
+                  environment: true
+                }
+              })
+          ),
+        { defaultOrder: 'desc' }
+      );
+
+      let list = await paginator.run(ctx.input);
+      return Paginator.presentLight(list, presentAdminToolCall);
     }),
 
   getRunLogs: app

--- a/src/subspace/db/prisma/schema/session/message.prisma
+++ b/src/subspace/db/prisma/schema/session/message.prisma
@@ -105,6 +105,7 @@ model SessionMessage {
   @@index([status])
   @@index([type])
   @@index([source])
+  @@index([methodOrToolKey, createdAt])
 }
 
 model SessionMessageStorageBucket {


### PR DESCRIPTION
Add more telemetry and timeout validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New admin telemetry queries over session messages and a schema index affect observability paths and DB load; slate timeout validation is bounded publish-time behavior with clear failure modes.
> 
> **Overview**
> Adds **admin provider telemetry** support for paginated **tool-call** listings scoped like other telemetry APIs, with filters on tool keys, status, failure reason, source, and provider version. Results are returned as `admin.tool_call` records (metadata only—**input/output omitted**) and wired through the subspace admin telemetry service.
> 
> **Slate publish** now validates optional `timeout` as a whole number between **1 and 900 seconds** (AWS Lambda max) in both `slate.json` and normalized manifest paths, with unit tests covering valid, missing, and invalid values.
> 
> A **`SessionMessage` index on `(methodOrToolKey, createdAt)`** backs the new listing queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ff54ff589a747121e25189bebf9ee61b522904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->