### PR TITLE
Aadd horizon channel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@metorial/oss",

--- a/src/metorial/multi-region/db.ts
+++ b/src/metorial/multi-region/db.ts
@@ -1,4 +1,4 @@
-export * from './src/cell';
 export * from './src/db';
 export * from './src/repositories/cell';
+export * from './src/repositories/horizon';
 export * from './src/repositories/token';

--- a/src/metorial/multi-region/prisma/migrations/20260724000000_add_horizon_rpc/migration.sql
+++ b/src/metorial/multi-region/prisma/migrations/20260724000000_add_horizon_rpc/migration.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "Horizon" (
+    "oid" SERIAL NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "endpointUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Horizon_pkey" PRIMARY KEY ("oid")
+);
+
+CREATE TABLE "HorizonToken" (
+    "oid" SERIAL NOT NULL,
+    "id" TEXT NOT NULL,
+    "horizonOid" INTEGER NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "HorizonToken_pkey" PRIMARY KEY ("oid")
+);
+
+CREATE UNIQUE INDEX "Horizon_identifier_key" ON "Horizon"("identifier");
+CREATE UNIQUE INDEX "HorizonToken_id_key" ON "HorizonToken"("id");
+CREATE INDEX "HorizonToken_horizonOid_expiresAt_idx" ON "HorizonToken"("horizonOid", "expiresAt");
+
+ALTER TABLE "HorizonToken"
+ADD CONSTRAINT "HorizonToken_horizonOid_fkey"
+FOREIGN KEY ("horizonOid") REFERENCES "Horizon"("oid") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/metorial/multi-region/prisma/schema/cell.prisma
+++ b/src/metorial/multi-region/prisma/schema/cell.prisma
@@ -73,3 +73,30 @@ model HyperplaneToken {
 
   @@index([hyperplaneOid, expiresAt])
 }
+
+model Horizon {
+  oid        Int    @id @default(autoincrement())
+  identifier String @unique
+
+  endpointUrl String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  tokens HorizonToken[]
+}
+
+model HorizonToken {
+  oid Int    @id @default(autoincrement())
+  id  String @unique @default(uuid())
+
+  horizonOid Int
+  horizon    Horizon @relation(fields: [horizonOid], references: [oid])
+
+  token     String
+  expiresAt DateTime
+
+  createdAt DateTime @default(now())
+
+  @@index([horizonOid, expiresAt])
+}

--- a/src/metorial/multi-region/src/db/index.ts
+++ b/src/metorial/multi-region/src/db/index.ts
@@ -2,7 +2,6 @@ import { Signer } from '@aws-sdk/rds-signer';
 import { PrismaPg } from '@prisma/adapter-pg';
 import type pg from 'pg';
 import { PrismaClient } from '../../prisma/generated/client.js';
-import { env } from '../env';
 export * from '../../prisma/generated/client.js';
 
 let getPositiveInteger = (value: number | undefined, fallback: number) => {
@@ -14,27 +13,27 @@ let getPositiveInteger = (value: number | undefined, fallback: number) => {
 };
 
 let GLOBAL_DB_TRANSACTION_MAX_WAIT_MS = getPositiveInteger(
-  env.service.GLOBAL_DB_TRANSACTION_MAX_WAIT_MS,
+  Number(process.env.GLOBAL_DB_TRANSACTION_MAX_WAIT_MS),
   15_000
 );
 
 let GLOBAL_DB_TRANSACTION_TIMEOUT_MS = getPositiveInteger(
-  env.service.GLOBAL_DB_TRANSACTION_TIMEOUT_MS,
+  Number(process.env.GLOBAL_DB_TRANSACTION_TIMEOUT_MS),
   30_000
 );
 
 let GLOBAL_DB_KEEPALIVE_INTERVAL_MS = getPositiveInteger(
-  env.service.GLOBAL_DB_KEEPALIVE_INTERVAL_MS,
+  Number(process.env.GLOBAL_DB_KEEPALIVE_INTERVAL_MS),
   30_000
 );
 
 let GLOBAL_DB_POOL_IDLE_TIMEOUT_MS = getPositiveInteger(
-  env.service.GLOBAL_DB_POOL_IDLE_TIMEOUT_MS,
+  Number(process.env.GLOBAL_DB_POOL_IDLE_TIMEOUT_MS),
   5 * 60_000
 );
 
 let GLOBAL_DB_CONNECTION_TIMEOUT_MS = getPositiveInteger(
-  env.service.GLOBAL_DB_CONNECTION_TIMEOUT_MS,
+  Number(process.env.GLOBAL_DB_CONNECTION_TIMEOUT_MS),
   10_000
 );
 

--- a/src/metorial/multi-region/src/repositories/horizon.test.ts
+++ b/src/metorial/multi-region/src/repositories/horizon.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { upsert, findUnique } = vi.hoisted(() => ({
+  upsert: vi.fn(),
+  findUnique: vi.fn()
+}));
+
+vi.mock('../db', () => ({
+  globalDB: {
+    horizon: { upsert, findUnique }
+  }
+}));
+
+import { horizonRepository } from './horizon';
+
+describe('Horizon repository', () => {
+  beforeEach(() => {
+    upsert.mockReset();
+    findUnique.mockReset();
+  });
+
+  it('registers Horizon idempotently and updates its endpoint', async () => {
+    upsert.mockResolvedValueOnce({
+      oid: 1,
+      identifier: 'default',
+      endpointUrl: 'https://horizon.example/rpc'
+    });
+
+    await horizonRepository.registerHorizon({
+      identifier: 'default',
+      endpointUrl: 'https://horizon.example/rpc'
+    });
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { identifier: 'default' },
+      create: {
+        identifier: 'default',
+        endpointUrl: 'https://horizon.example/rpc'
+      },
+      update: { endpointUrl: 'https://horizon.example/rpc' }
+    });
+  });
+
+  it('looks up Horizon without touching the Cell model', async () => {
+    findUnique.mockResolvedValueOnce(null);
+
+    await expect(horizonRepository.getHorizon({ identifier: 'other' })).resolves.toBeNull();
+    expect(findUnique).toHaveBeenCalledWith({ where: { identifier: 'other' } });
+  });
+});

--- a/src/metorial/multi-region/src/repositories/horizon.ts
+++ b/src/metorial/multi-region/src/repositories/horizon.ts
@@ -1,0 +1,28 @@
+import { Service } from '@lowerdeck/service';
+import { globalDB } from '../db';
+
+class HorizonRepository {
+  async registerHorizon(d: { identifier: string; endpointUrl: string }) {
+    return await globalDB.horizon.upsert({
+      where: { identifier: d.identifier },
+      create: {
+        identifier: d.identifier,
+        endpointUrl: d.endpointUrl
+      },
+      update: {
+        endpointUrl: d.endpointUrl
+      }
+    });
+  }
+
+  async getHorizon(d: { identifier: string }) {
+    return await globalDB.horizon.findUnique({
+      where: { identifier: d.identifier }
+    });
+  }
+}
+
+export let horizonRepository = Service.create(
+  'horizonRepository',
+  () => new HorizonRepository()
+).build();

--- a/src/metorial/multi-region/src/repositories/horizonToken.test.ts
+++ b/src/metorial/multi-region/src/repositories/horizonToken.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { findFirst, findUniqueOrThrow, create } = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  findUniqueOrThrow: vi.fn(),
+  create: vi.fn()
+}));
+
+vi.mock('../db', () => ({
+  globalDB: {
+    horizon: { findUniqueOrThrow },
+    horizonToken: { findFirst, create }
+  }
+}));
+
+import { horizonTokenRepository } from './token';
+
+describe('Horizon token repository', () => {
+  beforeEach(() => {
+    findFirst.mockReset();
+    findUniqueOrThrow.mockReset();
+    create.mockReset();
+  });
+
+  it('isolates reusable token lookup by Horizon identifier and expiry', async () => {
+    let expiresAfter = new Date('2026-07-24T12:00:00.000Z');
+    findFirst.mockResolvedValueOnce(null);
+
+    await horizonTokenRepository.findReusableHorizonToken({
+      horizonIdentifier: 'default',
+      expiresAfter
+    });
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        horizon: { identifier: 'default' },
+        expiresAt: { gt: expiresAfter }
+      },
+      include: { horizon: true },
+      orderBy: { expiresAt: 'desc' }
+    });
+  });
+
+  it('creates a token only for an already registered Horizon', async () => {
+    findUniqueOrThrow.mockResolvedValueOnce({ oid: 42, identifier: 'default' });
+    create.mockImplementationOnce(async ({ data }) => ({ ...data, id: 'hzt_1' }));
+
+    let result = await horizonTokenRepository.createHorizonToken({
+      horizonIdentifier: 'default',
+      ttlMs: 60_000
+    });
+
+    expect(findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { identifier: 'default' }
+    });
+    expect(result.id).toBe('hzt_1');
+    expect(create.mock.calls[0]?.[0].data.horizonOid).toBe(42);
+  });
+});

--- a/src/metorial/multi-region/src/repositories/index.ts
+++ b/src/metorial/multi-region/src/repositories/index.ts
@@ -1,4 +1,5 @@
 export * from './cell';
+export * from './horizon';
 export * from './oauth';
 export * from './oauthJwk';
 export * from './token';

--- a/src/metorial/multi-region/src/repositories/token.ts
+++ b/src/metorial/multi-region/src/repositories/token.ts
@@ -113,3 +113,55 @@ export let hyperplaneTokenRepository = Service.create(
   'hyperplaneTokenRepository',
   () => new HyperplaneTokenRepository()
 ).build();
+
+class HorizonTokenRepository {
+  async findReusableHorizonToken(d: { horizonIdentifier: string; expiresAfter?: Date }) {
+    return await globalDB.horizonToken.findFirst({
+      where: {
+        horizon: { identifier: d.horizonIdentifier },
+        expiresAt: d.expiresAfter ? { gt: d.expiresAfter } : { gt: new Date() }
+      },
+      include: {
+        horizon: true
+      },
+      orderBy: {
+        expiresAt: 'desc'
+      }
+    });
+  }
+
+  async getHorizonToken(d: { horizonIdentifier: string; horizonTokenId: string }) {
+    return await globalDB.horizonToken.findFirst({
+      where: {
+        id: d.horizonTokenId,
+        horizon: { identifier: d.horizonIdentifier }
+      },
+      include: {
+        horizon: true
+      }
+    });
+  }
+
+  async createHorizonToken(d: { horizonIdentifier: string; ttlMs: number }) {
+    let expiresAt = new Date(Date.now() + d.ttlMs);
+    let horizon = await globalDB.horizon.findUniqueOrThrow({
+      where: { identifier: d.horizonIdentifier }
+    });
+
+    return await globalDB.horizonToken.create({
+      data: {
+        horizonOid: horizon.oid,
+        token: crypto.randomUUID(),
+        expiresAt
+      },
+      include: {
+        horizon: true
+      }
+    });
+  }
+}
+
+export let horizonTokenRepository = Service.create(
+  'horizonTokenRepository',
+  () => new HorizonTokenRepository()
+).build();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a migration and token issuance paths in the global DB; behavior is modeled on Hyperplane tokens but still touches shared infrastructure and env-based DB config.
> 
> **Overview**
> Introduces a **Horizon** channel in the global multi-region DB: registered instances get a unique identifier and optional RPC `endpointUrl`, with **HorizonToken** rows for short-lived auth tokens (mirroring the existing Hyperplane token pattern).
> 
> Adds `horizonRepository` (idempotent register + lookup) and `horizonTokenRepository` (find reusable token by horizon + expiry, get by id, create with TTL only after the Horizon exists). New Prisma models, SQL migration, package exports, and unit tests cover registration and token behavior.
> 
> **Global DB client tuning** now reads `GLOBAL_DB_*` timeout/pool settings from `process.env` instead of the removed `env.service` import. The public `db` barrel drops a direct `./src/cell` re-export in favor of repository exports including Horizon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aca829567c4de0bad04e46f1ed39f7a1efb0fc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->