### PR TITLE
Harden queue startup

### DIFF
--- a/src/lowerdeck/packages/cron/src/index.ts
+++ b/src/lowerdeck/packages/cron/src/index.ts
@@ -26,34 +26,41 @@ export let createCron = (
   let connection = parseRedisUrl(opts.redisUrl);
   if (process.env.QUEUE_DEBUG_LOGGING)
     console.log('Creating cron with connection', opts.redisUrl, connection);
-  let queue = new Queue(`Cr0N_${opts.name}`, {
-    connection,
-    defaultJobOptions: {
-      removeOnComplete: true,
-      removeOnFail: {
-        age: 60 * 60 * 24 // 1 day
-      }
-    }
-  });
 
   return {
     start: async () => {
       log(`Starting cron job ${opts.name} to run every ${opts.cron} using bullmq`);
 
-      await queue.upsertJobScheduler(
-        'cron',
-        {
-          pattern: opts.cron
-        },
-        {
-          opts: {
-            removeDependencyOnFailure: true,
-            removeOnComplete: true,
-            removeOnFail: true,
-            keepLogs: 0
+      // Delay Redis connection creation until startup reaches this processor.
+      let queue = new Queue(`Cr0N_${opts.name}`, {
+        connection,
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: {
+            age: 60 * 60 * 24 // 1 day
           }
         }
-      );
+      });
+
+      try {
+        await queue.upsertJobScheduler(
+          'cron',
+          {
+            pattern: opts.cron
+          },
+          {
+            opts: {
+              removeDependencyOnFailure: true,
+              removeOnComplete: true,
+              removeOnFail: true,
+              keepLogs: 0
+            }
+          }
+        );
+      } catch (error) {
+        await queue.close();
+        throw error;
+      }
 
       let worker = new Worker(
         queue.name,
@@ -83,12 +90,32 @@ export let createCron = (
         },
         {
           connection,
-          concurrency: 1
+          concurrency: 1,
+          autorun: false
         }
       );
 
+      try {
+        await worker.waitUntilReady();
+      } catch (error) {
+        await Promise.allSettled([worker.close(true), queue.close()]);
+        throw error;
+      }
+      void worker.run().catch(error => {
+        Sentry.captureException(error, {
+          tags: {
+            cronName: opts.name,
+            cronOperation: 'run'
+          }
+        });
+        console.error(`Cron ${opts.name} stopped unexpectedly`, error);
+      });
+
       return {
-        close: worker.close.bind(worker)
+        close: async () => {
+          await worker.close();
+          await queue.close();
+        }
       };
     }
   };

--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  queueConstructed: vi.fn(),
+  queueAdd: vi.fn(),
+  workerConstructed: vi.fn(),
+  workerWaitUntilReady: vi.fn(),
+  workerRun: vi.fn(),
+  workerClose: vi.fn()
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class Queue {
+    constructor() {
+      mocks.queueConstructed();
+    }
+
+    add = mocks.queueAdd;
+    addBulk = vi.fn();
+  },
+  QueueEvents: class QueueEvents {},
+  Worker: class Worker {
+    constructor() {
+      mocks.workerConstructed();
+    }
+
+    waitUntilReady = mocks.workerWaitUntilReady;
+    run = mocks.workerRun;
+    close = mocks.workerClose;
+  }
+}));
+
+import { createBullMqQueue } from './bullmq';
+
+describe('createBullMqQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.queueAdd.mockResolvedValue({});
+    mocks.workerWaitUntilReady.mockResolvedValue(undefined);
+    mocks.workerRun.mockResolvedValue(undefined);
+    mocks.workerClose.mockResolvedValue(undefined);
+  });
+
+  it('does not create a producer connection until the queue publishes', async () => {
+    let queue = createBullMqQueue({
+      name: 'lazy-producer',
+      redisUrl: 'redis://localhost:6379'
+    });
+
+    expect(mocks.queueConstructed).not.toHaveBeenCalled();
+    await queue.add({ value: true });
+    expect(mocks.queueConstructed).toHaveBeenCalledOnce();
+  });
+
+  it('waits for the worker connection before reporting the processor as started', async () => {
+    let ready = Promise.withResolvers<void>();
+    mocks.workerWaitUntilReady.mockReturnValue(ready.promise);
+
+    let processor = createBullMqQueue({
+      name: 'ready-worker',
+      redisUrl: 'redis://localhost:6379'
+    }).process(async () => {});
+    let starting = processor.start();
+
+    await vi.waitFor(() => expect(mocks.workerConstructed).toHaveBeenCalledOnce());
+    expect(mocks.workerRun).not.toHaveBeenCalled();
+
+    ready.resolve();
+    await starting;
+    expect(mocks.workerRun).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
@@ -16,11 +16,7 @@ import {
   SpanStatusCode,
   trace
 } from '@lowerdeck/telemetry';
-import {
-  Queue,
-  QueueEvents,
-  Worker,
-} from 'bullmq';
+import { Queue, QueueEvents, Worker } from 'bullmq';
 import type { DeduplicationOptions, JobsOptions, QueueOptions, WorkerOptions } from 'bullmq';
 import { QueueRetryError } from '../lib/queueRetryError';
 import type { IQueue } from '../types';
@@ -132,22 +128,27 @@ export let createBullMqQueue = <JobData>(
   if (process.env.QUEUE_DEBUG_LOGGING)
     console.log('Creating queue with connection', opts.name, opts.redisUrl, redisOpts);
 
-  let queue = new Queue<JobData>(opts.name, {
-    ...opts.queueOpts,
-    connection: redisOpts,
-    defaultJobOptions: {
-      removeOnComplete: true,
-      removeOnFail: {
-        age: 60 * 60 * 24 // 1 day
-      },
-      backoff: {
-        type: 'custom'
-      },
-      attempts: 25,
-      keepLogs: 10,
-      ...opts.jobOpts
-    }
-  });
+  // Worker-only processes define hundreds of queues. Constructing every producer Queue
+  // eagerly opens a Redis connection even when that process never publishes to it.
+  let useQueue = memo(
+    () =>
+      new Queue<JobData>(opts.name, {
+        ...opts.queueOpts,
+        connection: redisOpts,
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: {
+            age: 60 * 60 * 24 // 1 day
+          },
+          backoff: {
+            type: 'custom'
+          },
+          attempts: 25,
+          keepLogs: 10,
+          ...opts.jobOpts
+        }
+      })
+  );
 
   let useQueueEvents = memo(() => new QueueEvents(opts.name, { connection: redisOpts }));
 
@@ -172,7 +173,7 @@ export let createBullMqQueue = <JobData>(
           }
         },
         async () =>
-          await queue.addBulk(
+          await useQueue().addBulk(
             payloads.map(
               payload =>
                 ({
@@ -208,7 +209,7 @@ export let createBullMqQueue = <JobData>(
             operation: 'publish'
           },
           async () =>
-            await queue.add(
+            await useQueue().add(
               'j' as any,
               {
                 payload: SuperJson.serialize(payload),
@@ -320,6 +321,7 @@ export let createBullMqQueue = <JobData>(
               concurrency: 50,
               ...opts.workerOpts,
               connection: redisOpts,
+              autorun: false,
 
               settings: {
                 ...opts.workerOpts?.settings,
@@ -336,6 +338,24 @@ export let createBullMqQueue = <JobData>(
               }
             }
           );
+
+          // Do not let the processor-composition layer move on to the next queue until
+          // this worker has an established Redis connection.
+          try {
+            await worker.waitUntilReady();
+          } catch (error) {
+            await worker.close(true);
+            throw error;
+          }
+          void worker.run().catch(error => {
+            Sentry.captureException(error, {
+              tags: {
+                queueName: opts.name,
+                queueOperation: 'run'
+              }
+            });
+            console.error(`Queue ${opts.name} stopped unexpectedly`, error);
+          });
 
           return {
             close: () => worker.close()

--- a/src/lowerdeck/packages/queue/src/index.test.ts
+++ b/src/lowerdeck/packages/queue/src/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { combineQueueProcessors } from './index';
+import type { IQueueProcessor } from './types';
+
+let deferred = () => {
+  let resolve!: () => void;
+  let promise = new Promise<void>(res => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+};
+
+describe('combineQueueProcessors', () => {
+  it('waits for each processor before starting the next one', async () => {
+    let firstStarted = deferred();
+    let starts: string[] = [];
+    let processor = (name: string, wait?: Promise<void>): IQueueProcessor => ({
+      start: async () => {
+        starts.push(name);
+        await wait;
+      }
+    });
+
+    let starting = combineQueueProcessors([
+      processor('first', firstStarted.promise),
+      processor('second')
+    ]).start();
+
+    await vi.waitFor(() => expect(starts).toEqual(['first']));
+    firstStarted.resolve();
+    await starting;
+
+    expect(starts).toEqual(['first', 'second']);
+  });
+
+  it('closes processors that started before a later processor fails', async () => {
+    let closeFirst = vi.fn();
+    let closeSecond = vi.fn();
+    let failure = new Error('failed to start');
+
+    let combined = combineQueueProcessors([
+      { start: async () => ({ close: closeFirst }) },
+      { start: async () => ({ close: closeSecond }) },
+      {
+        start: async () => {
+          throw failure;
+        }
+      }
+    ]);
+
+    await expect(combined.start()).rejects.toBe(failure);
+    expect(closeSecond).toHaveBeenCalledOnce();
+    expect(closeFirst).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lowerdeck/packages/queue/src/index.ts
+++ b/src/lowerdeck/packages/queue/src/index.ts
@@ -29,7 +29,23 @@ export let createQueue = <JobData>(opts: { driver?: 'bullmq' } & BullMqCreateOpt
 export let combineQueueProcessors = (opts: IQueueProcessor[]): IQueueProcessor => {
   return {
     start: async () => {
-      let processors = await Promise.all(opts.map(x => x.start()));
+      let processors: Awaited<ReturnType<IQueueProcessor['start']>>[] = [];
+
+      // Processor trees can contain hundreds of BullMQ workers. Starting the tree with
+      // Promise.all creates a Redis connection storm and immediately drains every queue
+      // at once. Waiting for each child also makes nested processor groups naturally
+      // bounded without a global semaphore or deadlocks.
+      try {
+        for (let processor of opts) {
+          processors.push(await processor.start());
+        }
+      } catch (error) {
+        // A partially started worker must not remain alive without a health endpoint.
+        await Promise.allSettled(
+          processors.reverse().map(async processor => await processor?.close?.())
+        );
+        throw error;
+      }
 
       return {
         close: async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core worker startup and connection lifecycle for all BullMQ queues and crons; misbehavior could delay job processing or leave partial startup, though rollback and tests mitigate that.
> 
> **Overview**
> **Hardens queue and cron startup** so worker processes do not open hundreds of Redis connections at once or report “started” before workers are actually connected.
> 
> `combineQueueProcessors` now starts children **sequentially** (replacing `Promise.all`) and **rolls back** already-started processors if a later one fails. BullMQ workers use **`autorun: false`**, **`waitUntilReady()`** before the next queue starts, then **`run()`** with Sentry logging if the worker dies unexpectedly. Producer **`Queue`** instances are **lazy** (memoized) so worker-only processes do not connect until publish.
> 
> **Cron** follows the same pattern: queue/worker creation deferred to `start`, readiness gating, cleanup on scheduler/worker errors, and closing both queue and worker on shutdown.
> 
> Adds **Vitest** coverage for lazy producer construction, worker readiness ordering, and sequential startup/rollback in `combineQueueProcessors`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a87a7355d4b2cf197dc26f37d34b5c512ce082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->