### PR TITLE
Harden multiregion db

### DIFF
--- a/src/metorial/multi-region/src/cell.ts
+++ b/src/metorial/multi-region/src/cell.ts
@@ -1,4 +1,4 @@
-import { globalDB } from './db';
+import { ensureGlobalDatabaseReady, globalDB } from './db';
 import { env } from './env';
 
 export let deploymentIdentifier = env.service.METORIAL_REGION ?? 'default';
@@ -9,12 +9,15 @@ let getSecureRandomInt = () => {
   return array[0] & 0x7fffffff;
 };
 
-export let cell = globalDB.cell.upsert({
-  where: { identifier: deploymentIdentifier },
-  create: {
-    identifier: deploymentIdentifier,
-    oid: getSecureRandomInt(),
-    endpointUrl: env.service.EXTERNAL_MULTI_REGION_ENDPOINT
-  },
-  update: { endpointUrl: env.service.EXTERNAL_MULTI_REGION_ENDPOINT }
-});
+export let cell = ensureGlobalDatabaseReady().then(
+  async () =>
+    await globalDB.cell.upsert({
+      where: { identifier: deploymentIdentifier },
+      create: {
+        identifier: deploymentIdentifier,
+        oid: getSecureRandomInt(),
+        endpointUrl: env.service.EXTERNAL_MULTI_REGION_ENDPOINT
+      },
+      update: { endpointUrl: env.service.EXTERNAL_MULTI_REGION_ENDPOINT }
+    })
+);

--- a/src/metorial/multi-region/src/db/index.test.ts
+++ b/src/metorial/multi-region/src/db/index.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  queryRaw: vi.fn()
+}));
+
+vi.mock('@prisma/adapter-pg', () => ({
+  PrismaPg: class PrismaPg {}
+}));
+
+vi.mock('../../prisma/generated/client.js', () => ({
+  PrismaClient: class PrismaClient {
+    $queryRaw = mocks.queryRaw;
+  }
+}));
+
+vi.mock('../env', () => ({
+  env: {
+    service: {
+      GLOBAL_DB_CONNECTION_TIMEOUT_MS: 10,
+      GLOBAL_DB_KEEPALIVE_INTERVAL_MS: 60_000,
+      GLOBAL_DB_POOL_IDLE_TIMEOUT_MS: 60_000,
+      GLOBAL_DB_READY_MAX_ATTEMPTS: 3,
+      GLOBAL_DB_READY_RETRY_BASE_MS: 1,
+      GLOBAL_DB_READY_RETRY_MAX_MS: 1
+    }
+  }
+}));
+
+describe('global database readiness', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.queryRaw.mockReset();
+    process.env.GLOBAL_DATABASE_URL = 'postgres://test:test@localhost:5432/test';
+    delete process.env.GLOBAL_DATABASE_ARN;
+  });
+
+  afterEach(async () => {
+    let { stopGlobalDatabaseKeepalive } = await import('./index');
+    stopGlobalDatabaseKeepalive();
+  });
+
+  it('shares readiness work and retries a failed initial connection', async () => {
+    mocks.queryRaw.mockRejectedValueOnce(new Error('not ready')).mockResolvedValueOnce([]);
+
+    let { ensureGlobalDatabaseReady } = await import('./index');
+    let first = ensureGlobalDatabaseReady();
+    let second = ensureGlobalDatabaseReady();
+
+    expect(first).toBe(second);
+    await expect(first).resolves.toBeUndefined();
+    expect(mocks.queryRaw).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/metorial/multi-region/src/db/index.ts
+++ b/src/metorial/multi-region/src/db/index.ts
@@ -1,4 +1,5 @@
 import { Signer } from '@aws-sdk/rds-signer';
+import { delay } from '@lowerdeck/delay';
 import { PrismaPg } from '@prisma/adapter-pg';
 import type pg from 'pg';
 import { PrismaClient } from '../../prisma/generated/client.js';
@@ -36,6 +37,21 @@ let GLOBAL_DB_POOL_IDLE_TIMEOUT_MS = getPositiveInteger(
 let GLOBAL_DB_CONNECTION_TIMEOUT_MS = getPositiveInteger(
   env.service.GLOBAL_DB_CONNECTION_TIMEOUT_MS,
   10_000
+);
+
+let GLOBAL_DB_READY_MAX_ATTEMPTS = getPositiveInteger(
+  env.service.GLOBAL_DB_READY_MAX_ATTEMPTS,
+  6
+);
+
+let GLOBAL_DB_READY_RETRY_BASE_MS = getPositiveInteger(
+  env.service.GLOBAL_DB_READY_RETRY_BASE_MS,
+  250
+);
+
+let GLOBAL_DB_READY_RETRY_MAX_MS = getPositiveInteger(
+  env.service.GLOBAL_DB_READY_RETRY_MAX_MS,
+  5_000
 );
 
 let getGlobalDatabaseRegion = (url: URL) => {
@@ -132,6 +148,20 @@ export { globalDB };
 
 export type GlobalDB = typeof globalDB;
 
+let globalDatabaseReadyPromise: Promise<void> | null = null;
+let globalDatabaseKeepaliveStarted = false;
+let globalDatabaseKeepaliveTimer: ReturnType<typeof setTimeout> | null = null;
+
+let getReadyRetryDelay = (attempt: number) => {
+  let exponentialDelay = Math.min(
+    GLOBAL_DB_READY_RETRY_BASE_MS * Math.pow(2, attempt - 1),
+    GLOBAL_DB_READY_RETRY_MAX_MS
+  );
+  let jitter = Math.floor(Math.random() * Math.max(1, exponentialDelay * 0.2));
+
+  return exponentialDelay + jitter;
+};
+
 let keepGlobalDbWarm = async () => {
   try {
     await globalDB.$queryRaw`SELECT 1`;
@@ -139,14 +169,66 @@ let keepGlobalDbWarm = async () => {
     console.error('Error pinging global database:', error);
   }
 
-  let timeout = setTimeout(() => {
+  globalDatabaseKeepaliveTimer = setTimeout(() => {
     void keepGlobalDbWarm();
   }, GLOBAL_DB_KEEPALIVE_INTERVAL_MS);
 
-  timeout.unref?.();
+  globalDatabaseKeepaliveTimer.unref?.();
 };
 
-void keepGlobalDbWarm();
+export let startGlobalDatabaseKeepalive = () => {
+  if (globalDatabaseKeepaliveStarted) return;
+  globalDatabaseKeepaliveStarted = true;
+
+  globalDatabaseKeepaliveTimer = setTimeout(() => {
+    void keepGlobalDbWarm();
+  }, GLOBAL_DB_KEEPALIVE_INTERVAL_MS);
+  globalDatabaseKeepaliveTimer.unref?.();
+};
+
+export let stopGlobalDatabaseKeepalive = () => {
+  if (globalDatabaseKeepaliveTimer) clearTimeout(globalDatabaseKeepaliveTimer);
+  globalDatabaseKeepaliveTimer = null;
+  globalDatabaseKeepaliveStarted = false;
+};
+
+export let ensureGlobalDatabaseReady = () => {
+  if (globalDatabaseReadyPromise) return globalDatabaseReadyPromise;
+
+  let readiness = (async () => {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= GLOBAL_DB_READY_MAX_ATTEMPTS; attempt++) {
+      try {
+        await globalDB.$queryRaw`SELECT 1`;
+        startGlobalDatabaseKeepalive();
+        return;
+      } catch (error) {
+        lastError = error;
+
+        if (attempt >= GLOBAL_DB_READY_MAX_ATTEMPTS) break;
+
+        let retryDelay = getReadyRetryDelay(attempt);
+        console.warn(
+          `Global database connection attempt ${attempt}/${GLOBAL_DB_READY_MAX_ATTEMPTS} failed; retrying in ${retryDelay}ms`
+        );
+        await delay(retryDelay);
+      }
+    }
+
+    throw new Error(
+      `Global database was not ready after ${GLOBAL_DB_READY_MAX_ATTEMPTS} attempts`,
+      { cause: lastError }
+    );
+  })();
+
+  globalDatabaseReadyPromise = readiness.catch(error => {
+    globalDatabaseReadyPromise = null;
+    throw error;
+  });
+
+  return globalDatabaseReadyPromise;
+};
 
 declare global {
   namespace PrismaJson {}

--- a/src/metorial/multi-region/src/env.ts
+++ b/src/metorial/multi-region/src/env.ts
@@ -9,6 +9,9 @@ export let env = createValidatedEnv({
     GLOBAL_DB_KEEPALIVE_INTERVAL_MS: v.optional(v.number()),
     GLOBAL_DB_POOL_IDLE_TIMEOUT_MS: v.optional(v.number()),
     GLOBAL_DB_CONNECTION_TIMEOUT_MS: v.optional(v.number()),
+    GLOBAL_DB_READY_MAX_ATTEMPTS: v.optional(v.number()),
+    GLOBAL_DB_READY_RETRY_BASE_MS: v.optional(v.number()),
+    GLOBAL_DB_READY_RETRY_MAX_MS: v.optional(v.number()),
     INTERNAL_MULTI_REGION_ENDPOINT: v.string(),
     EXTERNAL_MULTI_REGION_ENDPOINT: v.string()
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes multi-region service startup and when global DB traffic runs; `cell` is async but existing `await cell` usage should absorb it, while mis-tuned retries could delay or fail boot.
> 
> **Overview**
> Multi-region startup now **waits for a working global Postgres connection** before cell registration and background pings run, instead of firing an upsert and keepalive immediately on import.
> 
> `ensureGlobalDatabaseReady()` deduplicates concurrent callers, runs `SELECT 1` with configurable exponential backoff/jitter (`GLOBAL_DB_READY_*` env vars), starts keepalive only after success, and clears the shared promise on failure so callers can retry. Module-load keepalive is removed in favor of `startGlobalDatabaseKeepalive` / `stopGlobalDatabaseKeepalive`.
> 
> **`cell`** is now a `Promise` resolved after readiness, then the same `cell.upsert` as before—call sites that already `await cell` keep working. A vitest test covers shared readiness and retry after a failed first ping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd54a2faa88f9b25ccb95396b207589dcacc6b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->