### PR TITLE
Fix ares csp

### DIFF
--- a/src/ares/service/src/lib/securityHeaders.test.ts
+++ b/src/ares/service/src/lib/securityHeaders.test.ts
@@ -28,6 +28,12 @@ describe('security headers', () => {
     expect(response.headers.get('content-security-policy')).toContain(
       "script-src 'self' 'unsafe-inline'"
     );
+    expect(response.headers.get('content-security-policy')).toContain(
+      "img-src 'self' *.metorial-cdn.com metorial.com *.metorial.com"
+    );
+    expect(response.headers.get('content-security-policy')).toContain(
+      '*.metorial-staging.com'
+    );
   });
 
   it('does not add production headers for localhost', async () => {

--- a/src/ares/service/src/lib/securityHeaders.ts
+++ b/src/ares/service/src/lib/securityHeaders.ts
@@ -2,7 +2,7 @@ let cspDirectives = [
   `default-src 'self'`,
   `script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com`,
   `style-src 'self' 'unsafe-inline'`,
-  `img-src 'self' *.metorial-cdn.com *.metorial.com *.metorial.net *.metorial.dev *.metorial-files.com metorial-files.com`,
+  `img-src 'self' *.metorial-cdn.com metorial.com *.metorial.com *.metorial.net *.metorial.dev *.metorial-files.com metorial-files.com *.metorial-staging.com`,
   `font-src 'self' *.metorial-cdn.com`,
   `connect-src 'self' *.metorial.com *.metorial.net *.metorial.dev`,
   `frame-src https://challenges.cloudflare.com`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow CSP relaxation for images only on known Metorial domains; no auth or data-path changes.
> 
> **Overview**
> **Relaxes Ares production CSP** so SSO/auth pages can load images from the apex `metorial.com` host and from `*.metorial-staging.com`.
> 
> The `img-src` directive in `securityHeaders.ts` now lists `metorial.com` explicitly (wildcards do not cover the bare domain) and adds `*.metorial-staging.com`. Tests assert the production `Content-Security-Policy` includes those `img-src` entries on public hostnames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cffcf917d70088ceea52a449d8c3117b38d7d84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->