### PR TITLE
Fix mr access for org members

### DIFF
--- a/src/metorial/cargo/modules/skill/src/services/skillMergeRequestAccess.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillMergeRequestAccess.ts
@@ -1,0 +1,54 @@
+import type { ResourceAuthorization } from '@metorial/module-access';
+import type { Prisma, StoreParticipantPermissions } from '@metorial/db';
+
+let readableStorePermissions: StoreParticipantPermissions[] = [
+  'content_read',
+  'content_write'
+];
+
+export let getVisibleSkillMergeRequestWhere = (d: {
+  resourceTenantOid: bigint;
+  resourceGroupOid: bigint;
+  authorization: ResourceAuthorization;
+}) => {
+  let scopeWhere = {
+    resourceTenantOid: d.resourceTenantOid,
+    resourceGroupOid: d.resourceGroupOid
+  } satisfies Prisma.SkillMergeRequestWhereInput;
+
+  if (d.authorization.type === 'privileged') return scopeWhere;
+
+  let actorOid = d.authorization.resourceActor.oid;
+  let readableStoreWhere: Prisma.StoreWhereInput = {
+    OR: [
+      { access: { in: ['public_read', 'public_write'] } },
+      { createdByResourceActorOid: actorOid },
+      {
+        storeParticipants: {
+          some: {
+            resourceActorOid: actorOid,
+            permissions: {
+              hasSome: readableStorePermissions
+            }
+          }
+        }
+      }
+    ]
+  };
+
+  return {
+    ...scopeWhere,
+    OR: [
+      {
+        sourceSkill: {
+          store: readableStoreWhere
+        }
+      },
+      {
+        targetSkill: {
+          store: readableStoreWhere
+        }
+      }
+    ]
+  } satisfies Prisma.SkillMergeRequestWhereInput;
+};

--- a/src/metorial/cargo/modules/skill/src/services/skillMergeRequestInternal.test.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillMergeRequestInternal.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getVisibleSkillMergeRequestWhere } from './skillMergeRequestAccess';
+
+let resourceTenantOid = 1n;
+let resourceGroupOid = 2n;
+let actor = {
+  oid: 3n,
+  resourceTenantOid,
+  consumerProfileOid: 4n
+} as any;
+
+describe('skill merge request visibility', () => {
+  it.each([
+    { type: 'privileged' } as const,
+    { type: 'privileged', resourceActor: actor } as const
+  ])('allows privileged authorization to see every request in scope', authorization => {
+    expect(
+      getVisibleSkillMergeRequestWhere({
+        resourceTenantOid,
+        resourceGroupOid,
+        authorization
+      })
+    ).toEqual({
+      resourceTenantOid,
+      resourceGroupOid
+    });
+  });
+
+  it('keeps restricted consumers limited to visible source or target stores', () => {
+    let where = getVisibleSkillMergeRequestWhere({
+      resourceTenantOid,
+      resourceGroupOid,
+      authorization: {
+        type: 'restricted',
+        resourceActor: actor,
+        accessTags: [{ accessTagOid: 5n }]
+      } as any
+    });
+    let readableStoreWhere = {
+      OR: [
+        { access: { in: ['public_read', 'public_write'] } },
+        { createdByResourceActorOid: actor.oid },
+        {
+          storeParticipants: {
+            some: {
+              resourceActorOid: actor.oid,
+              permissions: {
+                hasSome: ['content_read', 'content_write']
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    expect(where).toEqual({
+      resourceTenantOid,
+      resourceGroupOid,
+      OR: [
+        { sourceSkill: { store: readableStoreWhere } },
+        { targetSkill: { store: readableStoreWhere } }
+      ]
+    });
+  });
+});

--- a/src/metorial/cargo/modules/skill/src/services/skillMergeRequestInternal.ts
+++ b/src/metorial/cargo/modules/skill/src/services/skillMergeRequestInternal.ts
@@ -44,6 +44,7 @@ import {
   type Snapshot,
   type SnapshotItem
 } from '../lib/mergeSnapshot';
+import { getVisibleSkillMergeRequestWhere } from './skillMergeRequestAccess';
 import { skillMergeRequestEventService } from './skillMergeRequestEvent';
 
 export let skillMergeRequestInclude = {
@@ -664,43 +665,9 @@ class SkillMergeRequestInternalServiceImpl {
   async getVisibleMergeRequestWhere(d: {
     resourceTenantOid: bigint;
     resourceGroupOid: bigint;
-    actorOid?: bigint;
+    authorization: ResourceAuthorization;
   }) {
-    let readableStoreWhere: Prisma.StoreWhereInput = {
-      OR: d.actorOid
-        ? [
-            { access: { in: ['public_read', 'public_write'] } },
-            { createdByResourceActorOid: d.actorOid },
-            {
-              storeParticipants: {
-                some: {
-                  resourceActorOid: d.actorOid,
-                  permissions: {
-                    hasSome: [storeReadPermission, storeWritePermission]
-                  }
-                }
-              }
-            }
-          ]
-        : [{ access: { in: ['public_read', 'public_write'] } }]
-    };
-
-    return {
-      resourceTenantOid: d.resourceTenantOid,
-      resourceGroupOid: d.resourceGroupOid,
-      OR: [
-        {
-          sourceSkill: {
-            store: readableStoreWhere
-          }
-        },
-        {
-          targetSkill: {
-            store: readableStoreWhere
-          }
-        }
-      ]
-    } satisfies Prisma.SkillMergeRequestWhereInput;
+    return getVisibleSkillMergeRequestWhere(d);
   }
 
   async createSkillMergeRequest(
@@ -1001,14 +968,10 @@ class SkillMergeRequestInternalServiceImpl {
       authorization: ResourceAuthorization;
     }
   ) {
-    let actor =
-      d.authorization.type === 'restricted'
-        ? d.authorization.resourceActor
-        : undefined;
     let visibleWhere = await this.getVisibleMergeRequestWhere({
       resourceTenantOid: d.resourceTenant.oid,
       resourceGroupOid: d.resourceGroup.oid,
-      actorOid: actor?.oid
+      authorization: d.authorization
     });
     let sourceSkills = await resolveSkills(d, d.sourceSkillIds);
     let targetSkills = await resolveSkills(d, d.targetSkillIds);

--- a/src/metorial/cargo/modules/store/src/services/storeAccess.test.ts
+++ b/src/metorial/cargo/modules/store/src/services/storeAccess.test.ts
@@ -201,6 +201,20 @@ describe('native consumer skill store access', () => {
     expect(result.accessibleStoreOids).toEqual([store.oid]);
   });
 
+  it('allows privileged actors to write private stores', async () => {
+    let result = await storeAccessService.assertStoreAccessForStore({
+      ...scope,
+      authorization: {
+        type: 'privileged',
+        resourceActor: actor
+      },
+      requiredPermission: storeWritePermission,
+      store
+    });
+
+    expect(result.accessibleStoreOids).toEqual([store.oid]);
+  });
+
   it('does not recognize creator columns as skill access', async () => {
     authorization = {
       ...authorization,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authorization filtering for merge request lists and store participant permission checks; incorrect rules could hide or expose MRs across private stores.
> 
> **Overview**
> **Privileged org members** can now see **all skill merge requests** in the tenant/group when listing, instead of being filtered as if they only had access to public stores.
> 
> Visibility rules are moved into **`getVisibleSkillMergeRequestWhere`** in `skillMergeRequestAccess.ts`. **Privileged** auth returns scope-only filters; **restricted** actors still only see requests whose source or target store they can read (public, creator, or participant with `content_read` / `content_write`). **`skillMergeRequestInternal`** delegates to that helper and passes full **`ResourceAuthorization`** through listing instead of an optional actor OID.
> 
> Unit tests cover privileged vs restricted visibility; **`storeAccess`** gains a test that privileged actors can write private stores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73bda3c41dfb839d87bb41f9c2f6098bcf26b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->