### PR TITLE
Fix markdown import

### DIFF
--- a/src/metorial-frontend/packages/docs-editor-schema/src/index.test.ts
+++ b/src/metorial-frontend/packages/docs-editor-schema/src/index.test.ts
@@ -3,8 +3,11 @@ import { JSDOM } from 'jsdom';
 import {
   composeFullMarkdown,
   markdownToYjsUpdate,
+  replaceYjsBodyFromMarkdown,
+  yjsUpdateToMarkdown,
   yjsUpdateToDocumentSnapshot
 } from './index';
+import * as Y from 'yjs';
 
 let dom = new JSDOM('<!doctype html><html><body></body></html>');
 (globalThis as any).window = dom.window;
@@ -60,6 +63,25 @@ describe('docs editor schema conversion', () => {
     expect(snapshot.body).toContain('Inside callout');
     expect(snapshot.body).toContain('</info>');
     expect(snapshot.body).toContain('<equation>x^2</equation>');
+  });
+
+  it('replaces an existing collaborative body with imported markdown', () => {
+    let ydoc = new Y.Doc();
+    let initialUpdate = markdownToYjsUpdate('Original body');
+    expect(initialUpdate).toBeTruthy();
+
+    let binary = atob(initialUpdate!);
+    let bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    Y.applyUpdate(ydoc, bytes);
+
+    replaceYjsBodyFromMarkdown({ ydoc, markdown: 'Imported **body**' });
+
+    let update = Y.encodeStateAsUpdate(ydoc);
+    let encoded = btoa(String.fromCharCode(...update));
+    expect(yjsUpdateToMarkdown(encoded)).toContain('Imported **body**');
+    expect(yjsUpdateToMarkdown(encoded)).not.toContain('Original body');
+    ydoc.destroy();
   });
 
   it('composes full persisted markdown', () => {

--- a/src/metorial-frontend/packages/docs-editor-schema/src/index.ts
+++ b/src/metorial-frontend/packages/docs-editor-schema/src/index.ts
@@ -342,6 +342,28 @@ export let markdownToYjsUpdate = (markdown: string, origin?: unknown) => {
   }
 };
 
+export let replaceYjsBodyFromMarkdown = (d: {
+  ydoc: Y.Doc;
+  markdown: string;
+  origin?: unknown;
+}) => {
+  let body = d.ydoc.getXmlFragment('body');
+  let editor = new Editor({
+    extensions: buildHeadlessExtensions(),
+    content: d.markdown,
+    editable: false
+  });
+
+  try {
+    d.ydoc.transact(() => {
+      if (body.length > 0) body.delete(0, body.length);
+      prosemirrorJSONToYXmlFragment(editor.schema, editor.getJSON(), body);
+    }, d.origin);
+  } finally {
+    editor.destroy();
+  }
+};
+
 export let yjsUpdateToMarkdown = (update: string) => {
   let ydoc = new Y.Doc();
   try {

--- a/src/metorial-frontend/scenes/docs/src/scenes/documentEditor.tsx
+++ b/src/metorial-frontend/scenes/docs/src/scenes/documentEditor.tsx
@@ -1,4 +1,4 @@
-import { markdownToYjsUpdate } from '@metorial/docs-editor-schema';
+import { markdownToYjsUpdate, replaceYjsBodyFromMarkdown } from '@metorial/docs-editor-schema';
 import type { SkillSharePanelContext } from '@metorial/scene-skills';
 import {
   DocumentParticipant,
@@ -999,19 +999,40 @@ let DocumentEditorLoaded = (p: {
       let text = await file.text();
       let split = splitFrontMatter(text);
       let titleSplit = splitTitleFromBody(split.body);
-      titleRef.current = titleSplit.title || file.name.replace(/\.md$/i, '');
+      let importedTitle = titleSplit.title || file.name.replace(/\.md$/i, '');
+      titleRef.current = importedTitle;
       frontMatterRef.current = split.frontMatter;
       markdownRef.current = titleSplit.body;
-      setTitle(titleSplit.title || file.name.replace(/\.md$/i, ''));
+      setTitle(importedTitle);
       setFrontMatter(split.frontMatter);
       setFrontMatterOpen(split.frontMatter.trim().length > 0);
       setMarkdown(titleSplit.body);
-      setLastUpdatedAt(new Date());
-      setEditorKey(k => k + 1);
+
+      if (collaboration.isFallback) {
+        setEditorKey(k => k + 1);
+      } else {
+        collaboration.ydoc.transact(() => {
+          collaborationMeta.set('title', importedTitle);
+          collaborationMeta.set('frontMatter', split.frontMatter);
+          replaceYjsBodyFromMarkdown({
+            ydoc: collaboration.ydoc,
+            markdown: titleSplit.body
+          });
+        });
+      }
+
+      markChanged();
       e.target.value = '';
       showToast(`Imported ${file.name}`);
     },
-    [readOnly, showToast]
+    [
+      collaboration.isFallback,
+      collaboration.ydoc,
+      collaborationMeta,
+      markChanged,
+      readOnly,
+      showToast
+    ]
   );
 
   let handleRequestLinkEdit = useCallback(() => {

--- a/src/metorial-frontend/scenes/scm/src/repositoryPicker.tsx
+++ b/src/metorial-frontend/scenes/scm/src/repositoryPicker.tsx
@@ -192,7 +192,7 @@ let SearchRow = styled.div`
   display: flex;
   align-items: end;
   gap: 8px;
-  margin-top: 18px;
+  margin-top: 10px;
 
   > :first-child {
     flex: 1;
@@ -931,25 +931,29 @@ export let ScmRepositoryPicker = (p: ScmRepositoryPickerProps) => {
             {publicRepositoryOption}
 
             {!installations.data.items.length && !publicRepository && (
-              <EmptyState>
-                <Text size="2" weight="strong">
-                  Select a public repository or add a connection
-                </Text>
-                <Spacer size={4} />
-                <Text size="2" color="gray600">
-                  Paste a public GitHub, GitLab, or Bitbucket repository URL above.
-                </Text>
-                <Spacer size={12} />
-                <Button
-                  size="2"
-                  variant="outline"
-                  onClick={connect}
-                  loading={createInstallation.isLoading}
-                  iconLeft={<RiAddLine />}
-                >
-                  Add connection
-                </Button>
-              </EmptyState>
+              <>
+                <Spacer height={20} />
+
+                <EmptyState>
+                  <Text size="2" weight="strong">
+                    Select a public repository or add a connection
+                  </Text>
+                  <Spacer size={4} />
+                  <Text size="2" color="gray600">
+                    Paste a public GitHub, GitLab, or Bitbucket repository URL above.
+                  </Text>
+                  <Spacer size={12} />
+                  <Button
+                    size="2"
+                    variant="outline"
+                    onClick={connect}
+                    loading={createInstallation.isLoading}
+                    iconLeft={<RiAddLine />}
+                  >
+                    Add connection
+                  </Button>
+                </EmptyState>
+              </>
             )}
 
             {selectedAccount ? (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Collaborative document import touches shared Yjs state and autosave; incorrect body replacement could affect all editors, though scope is limited to import and covered by a new unit test.
> 
> **Overview**
> **Markdown import in collaborative editing** no longer relies only on remounting the editor. When live collaboration is active, import updates the shared `ydoc`: title and front matter go into `meta`, and the body is replaced via new **`replaceYjsBodyFromMarkdown`** in `docs-editor-schema` (clear `body` fragment, re-import from markdown). Fallback/non-collaborative mode still bumps `editorKey` to remount.
> 
> Import now calls **`markChanged()`** so snapshot/autosave picks up the import instead of only bumping local `lastUpdatedAt`.
> 
> **`docs-editor-schema`** adds **`replaceYjsBodyFromMarkdown`** plus a test that verifies replacing an existing collaborative body.
> 
> **SCM repository picker** gets small layout tweaks: reduced search row top margin and spacing above the empty state when there are no installations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e2e36d7c332d58b897af447c61eaf56182ce81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->