### PR TITLE
Harden skill sync

### DIFF
--- a/src/metorial/cargo/modules/skill/src/import/materialize.ts
+++ b/src/metorial/cargo/modules/skill/src/import/materialize.ts
@@ -5,12 +5,11 @@ import type { Prisma, ResourceActor } from '@metorial/db';
 import type { ResourceAuthorization } from '@metorial/module-access';
 import { type ResourceScope } from '@metorial/module-resource-tenant';
 import { posix as path } from 'node:path';
-import { parse } from 'yaml';
+import { parseSkillDocumentFrontmatter } from '../serializers/skill/frontmatter';
 import { skillService } from '../services/skill';
 import { getRelativeSkillPath, shouldImportSkillPath } from './discovery';
 import { getCodeBucketFiles } from './repository';
 
-let frontmatterRegex = /^---[ \t]*\r?\n([\s\S]*?)^---[ \t]*(?:\r?\n|$)/m;
 let maxSkillFiles = 1000;
 let maxSkillBytes = 100 * 1024 * 1024;
 
@@ -25,9 +24,7 @@ export let parseImportedSkillMetadata = (d: {
   rootPath: string;
   repositoryName?: string | null;
 }) => {
-  let match = d.content.match(frontmatterRegex);
-  let parsed = match ? parse(match[1] ?? '') : {};
-  let frontmatter = isRecord(parsed) ? parsed : {};
+  let { frontmatter } = parseSkillDocumentFrontmatter(d.content);
   let rootName = d.rootPath === '/' ? d.repositoryName : path.basename(d.rootPath);
   let name = optionalString(frontmatter.name) ?? rootName ?? 'Imported skill';
 

--- a/src/metorial/cargo/modules/skill/src/serializers/skill/frontmatter.ts
+++ b/src/metorial/cargo/modules/skill/src/serializers/skill/frontmatter.ts
@@ -1,0 +1,23 @@
+import { parse } from 'yaml';
+
+let frontmatterRegex =
+  /^(?:\uFEFF)?---[ \t]*\r?\n(?:([\s\S]*?)\r?\n)?---[ \t]*(?:\r?\n|$)/;
+
+let isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+export let parseSkillDocumentFrontmatter = (content: string) => {
+  let match = content.match(frontmatterRegex);
+  if (!match) return { frontmatter: {}, body: content, hasFrontmatter: false };
+
+  let parsed: unknown = {};
+  try {
+    parsed = parse(match[1] ?? '');
+  } catch {}
+
+  return {
+    frontmatter: isRecord(parsed) ? parsed : {},
+    body: content.slice(match[0].length),
+    hasFrontmatter: true
+  };
+};

--- a/src/metorial/cargo/modules/skill/src/serializers/skill/index.test.ts
+++ b/src/metorial/cargo/modules/skill/src/serializers/skill/index.test.ts
@@ -1,5 +1,42 @@
 import { describe, expect, it } from 'vitest';
 import { isAllowedBySkillConfig } from './config';
+import { parseSkillDocumentFrontmatter } from './frontmatter';
+
+describe('skill document frontmatter parsing', () => {
+  it('does not treat markdown horizontal rules as frontmatter', () => {
+    let content = `# Review
+
+Introduction
+
+---
+
+Details
+
+---
+`;
+
+    expect(parseSkillDocumentFrontmatter(content)).toEqual({
+      frontmatter: {},
+      body: content,
+      hasFrontmatter: false
+    });
+  });
+
+  it('ignores invalid frontmatter fields and preserves the document body', () => {
+    let content = `---
+name: review
+invalid: *missing-alias
+---
+# Review
+`;
+
+    expect(parseSkillDocumentFrontmatter(content)).toEqual({
+      frontmatter: {},
+      body: '# Review\n',
+      hasFrontmatter: true
+    });
+  });
+});
 
 describe('skill serializer config filtering', () => {
   it('always allows the root SKILL.md document', () => {

--- a/src/metorial/cargo/modules/skill/src/serializers/skill/index.ts
+++ b/src/metorial/cargo/modules/skill/src/serializers/skill/index.ts
@@ -5,7 +5,7 @@ import { fileService } from '@metorial/cargo-module-file';
 import type { Prisma } from '@metorial/db';
 import { db } from '@metorial/db';
 import PQueue from 'p-queue';
-import { parse, stringify } from 'yaml';
+import { stringify } from 'yaml';
 import { combineConfigs } from '../../lib/combineConfigs';
 import { scriptsFolder } from '../../lib/files';
 import { assertSkillStoreFileLimit } from '../../lib/limits';
@@ -18,6 +18,7 @@ import {
   isRootSkillDocument,
   normalizeSkillPath
 } from './config';
+import { parseSkillDocumentFrontmatter } from './frontmatter';
 
 export let getSkillPath = (d: SkillSerializerInput) => {
   let inner = `skills/${d.skillPluginSkill.pluginSkillSlug}`;
@@ -36,8 +37,6 @@ let storeItemInclude = {
   },
   file: true
 } satisfies Prisma.StoreItemInclude;
-
-let frontmatterRegex = /^---[ \t]*\r?\n([\s\S]*?)^---[ \t]*(?:\r?\n|$)/m;
 
 let sanitizeSkillDocumentFileNamePart = (part: string) =>
   part
@@ -67,19 +66,6 @@ let isRecord = (value: unknown): value is Record<string, unknown> =>
 
 let stripUndefined = (value: Record<string, unknown>) =>
   Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined && v !== null));
-
-let parseSkillDocumentFrontmatter = (content: string) => {
-  let match = content.match(frontmatterRegex);
-  if (!match) return { frontmatter: {}, body: content, hasFrontmatter: false };
-
-  let parsed = parse(match[1] ?? '');
-
-  return {
-    frontmatter: isRecord(parsed) ? parsed : {},
-    body: content.slice(match[0].length),
-    hasFrontmatter: true
-  };
-};
 
 let applySkillDocumentFrontmatter = (content: string, input: SkillSerializerInput) => {
   let {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized to skill document parsing and metadata extraction; behavior is safer for edge-case markdown with no auth or data-model changes.
> 
> **Overview**
> Skill import and sync now share a single **`parseSkillDocumentFrontmatter`** helper instead of duplicated regex/YAML logic in the serializer and import path.
> 
> Parsing is stricter at the **start of the document** so markdown **horizontal rules** (`---`) are not treated as YAML frontmatter. Optional **UTF-8 BOM** is accepted before the opening `---`. **Invalid YAML** in a frontmatter block no longer throws: metadata is treated as empty while the **body after the closing `---`** is still returned correctly.
> 
> Tests cover horizontal-rule documents and broken frontmatter fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00571c45152a4f014f77d9fd9b9d6acf5bed049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->