### PR TITLE
Fix marketplace plugin drag and drop

### DIFF
--- a/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.test.ts
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.test.ts
@@ -4,6 +4,7 @@ import {
   getMoveSkillInput,
   isCollapsedMarketplacePlugin,
   moveSkillOptimistically,
+  moveSkillToStandaloneOptimistically,
   sortMarketplacePluginHierarchy,
   shouldDeleteSourcePluginAfterMove
 } from './skillMarketplacePlugins';
@@ -183,6 +184,20 @@ describe('moveSkillOptimistically', () => {
 
     expect(result.map(item => item.skillPlugin!.id)).toEqual(['destination']);
     expect(result[0].skillPlugin!.skills[0].skillId).toBe('one');
+  });
+
+  it('keeps the standalone replacement while removing the skill from its source', () => {
+    let source = makePlugin('source', ['one', 'two']);
+    let standalone = makePlugin('standalone', ['one']);
+    let result = moveSkillToStandaloneOptimistically(
+      [source],
+      'source',
+      source.skillPlugin!.skills[0],
+      standalone
+    );
+
+    expect(result.map(item => item.skillPlugin!.id)).toEqual(['source', 'standalone']);
+    expect(result[0].skillPlugin!.skills.map(item => item.skillId)).toEqual(['two']);
   });
 });
 

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
@@ -49,7 +49,7 @@ import {
   RiMore2Line as RiMoreVerticalLine,
   RiPuzzle2Line
 } from '@remixicon/react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 type EmbeddedPluginSkill = SkillPlugin['skills'][number];
@@ -294,6 +294,30 @@ export let moveSkillOptimistically = (
 
     return [item];
   });
+
+export let moveSkillToStandaloneOptimistically = (
+  items: SkillMarketplacePlugin[],
+  sourcePluginId: string,
+  skill: EmbeddedPluginSkill,
+  standalonePlugin: SkillMarketplacePlugin
+) => [
+  ...items.flatMap(item => {
+    let plugin = item.skillPlugin;
+    if (!plugin || plugin.id !== sourcePluginId) return [item];
+    if (plugin.skills.length === 1) return [];
+
+    return [
+      {
+        ...item,
+        skillPlugin: {
+          ...plugin,
+          skills: plugin.skills.filter(current => current.id !== skill.id)
+        }
+      }
+    ];
+  }),
+  standalonePlugin
+];
 
 let compareNames = (
   aName: string | null | undefined,
@@ -809,6 +833,7 @@ export let SkillMarketplacePluginsScene = (p: {
   let createPlugin = useCreateSkillPlugin();
   let addPluginSkill = useCreateSkillPluginSkill();
   let removePluginSkill = useDeleteSkillPluginSkill();
+  let moveVersionRef = useRef(0);
   let [movingSkill, setMovingSkill] = useState<EmbeddedPluginSkill | null>(null);
   let [movePending, setMovePending] = useState(false);
   let [optimisticPlugins, setOptimisticPlugins] = useState<SkillMarketplacePlugin[] | null>(
@@ -835,7 +860,13 @@ export let SkillMarketplacePluginsScene = (p: {
   );
   let refresh = async () => {
     await marketplacePlugins.refetch();
-    await marketplace.refetch();
+  };
+  let finishMove = (version: number, plugins: SkillMarketplacePlugin[]) => {
+    setOptimisticPlugins(plugins);
+    setMovePending(false);
+    void refresh().finally(() => {
+      if (moveVersionRef.current === version) setOptimisticPlugins(null);
+    });
   };
   let actionsDisabled =
     movePending ||
@@ -932,8 +963,6 @@ export let SkillMarketplacePluginsScene = (p: {
   }) => {
     if (!p.instanceId || !p.skillMarketplaceId) return;
 
-    setMovePending(true);
-
     let sourcePluginId = p2.sourceItem.skillPlugin!.id;
     let [plugin] = await createPlugin.mutate({
       instanceId: p.instanceId,
@@ -1022,7 +1051,7 @@ export let SkillMarketplacePluginsScene = (p: {
       }
     }
 
-    await refresh();
+    return marketplaceMembership;
   };
 
   let onDragEnd = async (event: DragEndEvent) => {
@@ -1039,24 +1068,41 @@ export let SkillMarketplacePluginsScene = (p: {
       (!destinationId && !createStandalonePlugin)
     )
       return;
-    let sourceItem = marketplacePlugins.data?.find(
-      item => item.skillPlugin?.id === data.pluginId
-    );
+    let sourceItem = displayedPlugins.find(item => item.skillPlugin?.id === data.pluginId);
     if (!sourceItem?.skillPlugin) return;
 
     if (createStandalonePlugin) {
       if (isCollapsedMarketplacePlugin(sourceItem)) return;
+      let moveVersion = ++moveVersionRef.current;
+      let moveCompleted = false;
+      setMovePending(true);
       try {
-        await moveSkillToStandalonePlugin({ sourceItem, skill: data.skill });
+        let standalonePlugin = await moveSkillToStandalonePlugin({
+          sourceItem,
+          skill: data.skill
+        });
+        if (!standalonePlugin) return;
+        moveCompleted = true;
+        finishMove(
+          moveVersion,
+          moveSkillToStandaloneOptimistically(
+            displayedPlugins,
+            data.pluginId,
+            data.skill,
+            standalonePlugin
+          )
+        );
       } finally {
-        setOptimisticPlugins(null);
-        setMovePending(false);
+        if (!moveCompleted && moveVersionRef.current === moveVersion) {
+          setOptimisticPlugins(null);
+          setMovePending(false);
+        }
       }
       return;
     }
 
     if (!destinationId || destinationId === data.pluginId) return;
-    let destination = marketplacePlugins.data?.find(
+    let destination = displayedPlugins.find(
       item => item.skillPlugin?.id === destinationId
     )?.skillPlugin;
     if (
@@ -1064,15 +1110,16 @@ export let SkillMarketplacePluginsScene = (p: {
       destination.skills.some(skill => skill.skillId === data.skill!.skillId)
     )
       return;
-    setOptimisticPlugins(
-      moveSkillOptimistically(
-        marketplacePlugins.data ?? [],
-        data.pluginId,
-        destinationId,
-        data.skill
-      )
+    let moveVersion = ++moveVersionRef.current;
+    let nextPlugins = moveSkillOptimistically(
+      displayedPlugins,
+      data.pluginId,
+      destinationId,
+      data.skill
     );
+    setOptimisticPlugins(nextPlugins);
     setMovePending(true);
+    let moveCompleted = false;
     try {
       let [created] = await addPluginSkill.mutate({
         instanceId: p.instanceId,
@@ -1142,10 +1189,13 @@ export let SkillMarketplacePluginsScene = (p: {
           return;
         }
       }
-      await refresh();
+      moveCompleted = true;
+      finishMove(moveVersion, nextPlugins);
     } finally {
-      setOptimisticPlugins(null);
-      setMovePending(false);
+      if (!moveCompleted && moveVersionRef.current === moveVersion) {
+        setOptimisticPlugins(null);
+        setMovePending(false);
+      }
     }
   };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only optimistic state and drag handlers in the skills marketplace scene; no auth or data-model changes beyond existing move APIs.
> 
> **Overview**
> Fixes **marketplace plugin drag-and-drop** so the tree stays consistent with in-flight moves and server refetches.
> 
> Drag resolution now uses **`displayedPlugins`** (optimistic + server data) instead of raw query data, so source/destination lookup matches what the user sees. **Between-plugin moves** apply an immediate optimistic layout via `moveSkillOptimistically`, then **`finishMove`** keeps that state until `marketplacePlugins` refetch finishes; a **`moveVersionRef`** avoids clearing optimistic UI when a newer move started or the API failed.
> 
> **Standalone moves** (drop on marketplace header) get a new **`moveSkillToStandaloneOptimistically`** helper and the same versioned finish flow after `moveSkillToStandalonePlugin` succeeds. **`refresh`** only refetches marketplace plugins (not the whole marketplace). Failure paths reset pending/optimistic state only when the move did not complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c8964931ae0709290964d403e93f853ee4a3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->