### PR TITLE
Harden scm webhook reconciler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3326,6 +3326,7 @@
         "@lowerdeck/hash": "workspace:2.0.0",
         "@lowerdeck/hono": "workspace:2.0.0",
         "@lowerdeck/id": "workspace:2.0.0",
+        "@lowerdeck/lock": "workspace:2.0.0",
         "@lowerdeck/once": "workspace:2.0.0",
         "@lowerdeck/pagination": "workspace:2.0.0",
         "@lowerdeck/queue": "workspace:2.0.0",

--- a/src/metorial/multi-region/src/sync/fromDeployment/user.ts
+++ b/src/metorial/multi-region/src/sync/fromDeployment/user.ts
@@ -55,7 +55,11 @@ export let syncUserSingleQueueProcessor = syncUserSingleQueue.process(async data
   if (!data.force && multiRegionUser && multiRegionUser.lastEditByOid === (await cell).oid)
     return;
 
-  await upsertUser(user);
+  try {
+    await upsertUser(user);
+  } catch (err: any) {
+    if (err.code !== 'P2002') throw err;
+  }
 });
 
 Fabric.listen('user.updated:after', async event => {

--- a/src/origin/apps/service/package.json
+++ b/src/origin/apps/service/package.json
@@ -43,6 +43,7 @@
     "@lowerdeck/hash": "workspace:2.0.0",
     "@lowerdeck/hono": "workspace:2.0.0",
     "@lowerdeck/id": "workspace:2.0.0",
+    "@lowerdeck/lock": "workspace:2.0.0",
     "@lowerdeck/once": "workspace:2.0.0",
     "@lowerdeck/pagination": "workspace:2.0.0",
     "@lowerdeck/queue": "workspace:2.0.0",

--- a/src/origin/apps/service/src/lib/bitbucket.test.ts
+++ b/src/origin/apps/service/src/lib/bitbucket.test.ts
@@ -6,10 +6,14 @@ let mocks = vi.hoisted(() => ({
       findUnique: vi.fn(),
       update: vi.fn()
     }
-  }
+  },
+  usingTokenRefreshLock: vi.fn()
 }));
 
 vi.mock('../db', () => ({ db: mocks.db }));
+vi.mock('./scmTokenRefreshLock', () => ({
+  usingScmTokenRefreshLock: mocks.usingTokenRefreshLock
+}));
 
 import {
   createBitbucketClientWithToken,
@@ -44,6 +48,10 @@ describe('Bitbucket OAuth and REST client', () => {
     vi.restoreAllMocks();
     mocks.db.scmInstallation.findUnique.mockReset();
     mocks.db.scmInstallation.update.mockReset();
+    mocks.usingTokenRefreshLock.mockReset();
+    mocks.usingTokenRefreshLock.mockImplementation(
+      async (_provider, _installationOid, fn) => await fn()
+    );
   });
 
   it('builds Cloud and Data Center authorization URLs', () => {
@@ -312,12 +320,39 @@ describe('Bitbucket OAuth and REST client', () => {
   });
 
   it('uses credentials won by a concurrent rotating refresh', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    let fetch = vi.spyOn(globalThis, 'fetch');
     mocks.db.scmInstallation.findUnique.mockResolvedValue({
       accessToken: 'winner-access-token',
       refreshToken: 'winner-refresh-token',
       accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000)
     });
+
+    await expect(
+      getBitbucketAccessTokenWithInstallation(
+        installation({ accessTokenExpiresAt: new Date(0) })
+      )
+    ).resolves.toBe('winner-access-token');
+    expect(mocks.usingTokenRefreshLock).toHaveBeenCalledWith(
+      'bitbucket',
+      42n,
+      expect.any(Function)
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses credentials persisted while a refresh request is in flight', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    mocks.db.scmInstallation.findUnique
+      .mockResolvedValueOnce({
+        accessToken: 'old-access-token',
+        refreshToken: 'old-refresh-token',
+        accessTokenExpiresAt: new Date(0)
+      })
+      .mockResolvedValueOnce({
+        accessToken: 'winner-access-token',
+        refreshToken: 'winner-refresh-token',
+        accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000)
+      });
 
     await expect(
       getBitbucketAccessTokenWithInstallation(

--- a/src/origin/apps/service/src/lib/bitbucket.ts
+++ b/src/origin/apps/service/src/lib/bitbucket.ts
@@ -3,6 +3,7 @@ import { badRequestError, ServiceError, unauthorizedError } from '@lowerdeck/err
 import type { ScmBackend, ScmInstallation } from '../../prisma/generated/client';
 import { db } from '../db';
 import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
+import { usingScmTokenRefreshLock } from './scmTokenRefreshLock';
 
 type BitbucketInstallation = ScmInstallation & { backend: ScmBackend };
 type BitbucketCredentials = {
@@ -45,7 +46,7 @@ export type BitbucketPullRequestStatus = BitbucketPullRequest & {
   mergeability: 'mergeable' | 'blocked' | 'conflicting' | 'unknown';
 };
 
-let tokenRefreshes = new Map<bigint, Promise<BitbucketCredentials>>();
+let tokenRefreshes = new Map<bigint, Promise<string>>();
 
 let isDataCenter = (backend: ScmBackend) => backend.type === 'bitbucket_data_center';
 let trimSlash = (value: string) => value.replace(/\/+$/, '');
@@ -927,46 +928,54 @@ let tokenNeedsRefresh = (expiresAt: Date | null) =>
 
 let refreshInstallation = async (
   installation: BitbucketInstallation
-): Promise<BitbucketCredentials> => {
-  if (!installation.refreshToken) {
-    throw new ServiceError(
-      unauthorizedError({
-        message: 'Bitbucket authentication expired. Reconnect the integration.'
-      })
-    );
-  }
-  try {
-    let refreshed = await exchangeBitbucketToken({
-      backend: installation.backend,
-      grant: { refreshToken: installation.refreshToken }
+): Promise<string> =>
+  usingScmTokenRefreshLock('bitbucket', installation.oid, async () => {
+    let persisted = await db.scmInstallation.findUnique({
+      where: { oid: installation.oid }
     });
-    await db.scmInstallation.update({
-      where: { oid: installation.oid },
-      data: {
-        accessToken: refreshed.accessToken,
-        refreshToken: refreshed.refreshToken,
-        accessTokenExpiresAt: refreshed.expiresAt
-      }
-    });
-    return refreshed;
-  } catch (error) {
-    let current = await db.scmInstallation.findUnique({ where: { oid: installation.oid } });
-    if (
-      current?.accessToken &&
-      current.refreshToken &&
-      !tokenNeedsRefresh(current.accessTokenExpiresAt) &&
-      (current.accessToken !== installation.accessToken ||
-        current.refreshToken !== installation.refreshToken)
-    ) {
-      return {
-        accessToken: current.accessToken,
-        refreshToken: current.refreshToken,
-        expiresAt: current.accessTokenExpiresAt!
-      };
+    let current = persisted ? { ...installation, ...persisted } : installation;
+
+    if (current.accessToken && !tokenNeedsRefresh(current.accessTokenExpiresAt)) {
+      return current.accessToken;
     }
-    throw error;
-  }
-};
+    if (!current.refreshToken) {
+      throw new ServiceError(
+        unauthorizedError({
+          message: 'Bitbucket authentication expired. Reconnect the integration.'
+        })
+      );
+    }
+
+    try {
+      let refreshed = await exchangeBitbucketToken({
+        backend: current.backend,
+        grant: { refreshToken: current.refreshToken }
+      });
+      await db.scmInstallation.update({
+        where: { oid: current.oid },
+        data: {
+          accessToken: refreshed.accessToken,
+          refreshToken: refreshed.refreshToken,
+          accessTokenExpiresAt: refreshed.expiresAt
+        }
+      });
+      return refreshed.accessToken;
+    } catch (error) {
+      let winner = await db.scmInstallation.findUnique({
+        where: { oid: current.oid }
+      });
+      if (
+        winner?.accessToken &&
+        !tokenNeedsRefresh(winner.accessTokenExpiresAt) &&
+        (winner.accessToken !== current.accessToken ||
+          winner.refreshToken !== current.refreshToken)
+      ) {
+        return winner.accessToken;
+      }
+
+      throw error;
+    }
+  });
 
 export let getBitbucketAccessTokenWithInstallation = async (
   installation: BitbucketInstallation
@@ -985,7 +994,7 @@ export let getBitbucketAccessTokenWithInstallation = async (
     };
     void refresh.then(clear, clear);
   }
-  return (await refresh).accessToken;
+  return await refresh;
 };
 
 export let createBitbucketClientWithToken = (token: string, backend: ScmBackend) =>

--- a/src/origin/apps/service/src/lib/gitlab.test.ts
+++ b/src/origin/apps/service/src/lib/gitlab.test.ts
@@ -6,10 +6,14 @@ let mocks = vi.hoisted(() => ({
       findUnique: vi.fn(),
       update: vi.fn()
     }
-  }
+  },
+  usingTokenRefreshLock: vi.fn()
 }));
 
 vi.mock('../db', () => ({ db: mocks.db }));
+vi.mock('./scmTokenRefreshLock', () => ({
+  usingScmTokenRefreshLock: mocks.usingTokenRefreshLock
+}));
 
 import { getGitLabAccessTokenWithInstallation } from './gitlab';
 
@@ -32,6 +36,10 @@ describe('GitLab installation access tokens', () => {
     vi.restoreAllMocks();
     mocks.db.scmInstallation.findUnique.mockReset();
     mocks.db.scmInstallation.update.mockReset();
+    mocks.usingTokenRefreshLock.mockReset();
+    mocks.usingTokenRefreshLock.mockImplementation(
+      async (_provider, _installationOid, fn) => await fn()
+    );
   });
 
   it('uses a token that is not close to expiring', async () => {
@@ -89,7 +97,7 @@ describe('GitLab installation access tokens', () => {
   });
 
   it('uses credentials persisted by a concurrent refresh winner', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    let fetch = vi.spyOn(globalThis, 'fetch');
     mocks.db.scmInstallation.findUnique.mockResolvedValue({
       accessToken: 'winner-access-token',
       refreshToken: 'winner-refresh-token',
@@ -103,6 +111,32 @@ describe('GitLab installation access tokens', () => {
     expect(mocks.db.scmInstallation.findUnique).toHaveBeenCalledWith({
       where: { oid: 42n }
     });
+    expect(mocks.usingTokenRefreshLock).toHaveBeenCalledWith(
+      'gitlab',
+      42n,
+      expect.any(Function)
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses credentials persisted while a refresh request is in flight', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    mocks.db.scmInstallation.findUnique
+      .mockResolvedValueOnce({
+        accessToken: 'old-access-token',
+        refreshToken: 'old-refresh-token',
+        accessTokenExpiresAt: new Date(0)
+      })
+      .mockResolvedValueOnce({
+        accessToken: 'winner-access-token',
+        refreshToken: 'winner-refresh-token',
+        accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000)
+      });
+    let installation = createInstallation({ accessTokenExpiresAt: new Date(0) });
+
+    await expect(getGitLabAccessTokenWithInstallation(installation)).resolves.toBe(
+      'winner-access-token'
+    );
   });
 
   it('surfaces an invalid refresh token when no concurrent refresh won', async () => {

--- a/src/origin/apps/service/src/lib/gitlab.ts
+++ b/src/origin/apps/service/src/lib/gitlab.ts
@@ -3,15 +3,11 @@ import { badRequestError, ServiceError, unauthorizedError } from '@lowerdeck/err
 import type { ScmBackend, ScmInstallation } from '../../prisma/generated/client';
 import { db } from '../db';
 import { withScmProviderError, wrapScmProviderError } from './scmProviderError';
+import { usingScmTokenRefreshLock } from './scmTokenRefreshLock';
 
 type GitLabInstallation = ScmInstallation & { backend: ScmBackend };
-type GitLabCredentials = {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt: Date;
-};
 
-let tokenRefreshes = new Map<bigint, Promise<GitLabCredentials>>();
+let tokenRefreshes = new Map<bigint, Promise<string>>();
 
 export let createGitLabClient = (backend?: ScmBackend) => {
   let host = backend?.webUrl ?? 'https://gitlab.com';
@@ -158,54 +154,56 @@ let tokenNeedsRefresh = (expiresAt: Date | null) => {
 
 let refreshGitLabInstallationCredentials = async (
   installation: GitLabInstallation
-): Promise<GitLabCredentials> => {
-  if (!installation.refreshToken) {
-    throw new ServiceError(
-      unauthorizedError({
-        message: 'GitLab authentication expired. Reconnect the GitLab integration.'
-      })
-    );
-  }
-
-  try {
-    let refreshed = await refreshGitLabAccessToken({
-      backend: installation.backend,
-      refreshToken: installation.refreshToken
-    });
-
-    await db.scmInstallation.update({
-      where: { oid: installation.oid },
-      data: {
-        accessToken: refreshed.accessToken,
-        refreshToken: refreshed.refreshToken,
-        accessTokenExpiresAt: refreshed.expiresAt
-      }
-    });
-
-    return refreshed;
-  } catch (error) {
-    // GitLab rotates refresh tokens. A concurrent worker may have refreshed first,
-    // making this request's refresh token invalid. Prefer the winner's credentials.
-    let current = await db.scmInstallation.findUnique({
+): Promise<string> =>
+  usingScmTokenRefreshLock('gitlab', installation.oid, async () => {
+    let persisted = await db.scmInstallation.findUnique({
       where: { oid: installation.oid }
     });
-    if (
-      current?.accessToken &&
-      current.refreshToken &&
-      !tokenNeedsRefresh(current.accessTokenExpiresAt) &&
-      (current.accessToken !== installation.accessToken ||
-        current.refreshToken !== installation.refreshToken)
-    ) {
-      return {
-        accessToken: current.accessToken,
-        refreshToken: current.refreshToken,
-        expiresAt: current.accessTokenExpiresAt!
-      };
+    let current = persisted ? { ...installation, ...persisted } : installation;
+
+    if (current.accessToken && !tokenNeedsRefresh(current.accessTokenExpiresAt)) {
+      return current.accessToken;
+    }
+    if (!current.refreshToken) {
+      throw new ServiceError(
+        unauthorizedError({
+          message: 'GitLab authentication expired. Reconnect the GitLab integration.'
+        })
+      );
     }
 
-    throw error;
-  }
-};
+    try {
+      let refreshed = await refreshGitLabAccessToken({
+        backend: current.backend,
+        refreshToken: current.refreshToken
+      });
+
+      await db.scmInstallation.update({
+        where: { oid: current.oid },
+        data: {
+          accessToken: refreshed.accessToken,
+          refreshToken: refreshed.refreshToken,
+          accessTokenExpiresAt: refreshed.expiresAt
+        }
+      });
+
+      return refreshed.accessToken;
+    } catch (error) {
+      let winner = await db.scmInstallation.findUnique({
+        where: { oid: current.oid }
+      });
+      if (
+        winner?.accessToken &&
+        !tokenNeedsRefresh(winner.accessTokenExpiresAt) &&
+        (winner.accessToken !== current.accessToken ||
+          winner.refreshToken !== current.refreshToken)
+      ) {
+        return winner.accessToken;
+      }
+
+      throw error;
+    }
+  });
 
 export let getGitLabAccessTokenWithInstallation = async (
   installation: GitLabInstallation
@@ -228,5 +226,5 @@ export let getGitLabAccessTokenWithInstallation = async (
     void refresh.then(clearRefresh, clearRefresh);
   }
 
-  return (await refresh).accessToken;
+  return await refresh;
 };

--- a/src/origin/apps/service/src/lib/scmProviderError.test.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.test.ts
@@ -59,6 +59,24 @@ describe('SCM provider errors', () => {
     expect(mapped.parent).toBe(providerError);
   });
 
+  it('retains provider classification after wrapping the error', () => {
+    let mapped = wrapScmProviderError(
+      'gitlab',
+      {
+        response: { status: 400 },
+        description: 'The refresh token is no longer valid'
+      },
+      'refresh the OAuth token'
+    );
+
+    expect(getScmProviderErrorDetails(mapped)).toMatchObject({
+      status: 400,
+      description: 'The refresh token is no longer valid',
+      classification: 'invalid_request'
+    });
+    expect(isRetryableScmProviderError(mapped)).toBe(false);
+  });
+
   it('keeps the public error short while retaining full structured log details', () => {
     let mapped = wrapScmProviderError(
       'gitlab',

--- a/src/origin/apps/service/src/lib/scmProviderError.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.ts
@@ -28,6 +28,8 @@ let getEmbeddedHttpStatus = (value: unknown) => {
 
 export let getScmProviderErrorStatus = (error: any): number | undefined =>
   error?.status ??
+  error?.scmProviderDiagnostic?.status ??
+  error?.data?.status ??
   error?.response?.status ??
   error?.cause?.response?.status ??
   error?.cause?.response?.statusCode ??
@@ -76,6 +78,9 @@ let sanitizeText = (value: unknown, maxLength = 1000): string | undefined => {
 
 let getDescription = (error: any) => {
   let candidates = [
+    error?.scmProviderDiagnostic?.description,
+    error?.data?.description,
+    error?.data?.message,
     error?.cause?.description,
     error?.description,
     error?.details,
@@ -177,9 +182,15 @@ let classifyScmProviderError = (
 
 export let getScmProviderErrorDetails = (error: unknown): ScmProviderErrorDetails => {
   let value = error as any;
+  let attached = value?.scmProviderDiagnostic;
   let request = getRequest(value);
   let response = getResponse(value);
-  let method = typeof request?.method === 'string' ? request.method.toUpperCase() : undefined;
+  let method =
+    typeof request?.method === 'string'
+      ? request.method.toUpperCase()
+      : typeof attached?.method === 'string'
+        ? attached.method.toUpperCase()
+        : undefined;
   let status = getScmProviderErrorStatus(value);
   let description = getDescription(value);
 
@@ -187,10 +198,11 @@ export let getScmProviderErrorDetails = (error: unknown): ScmProviderErrorDetail
     status,
     description,
     method,
-    endpoint: getSanitizedEndpoint(value),
+    endpoint: getSanitizedEndpoint(value) ?? sanitizeText(attached?.endpoint, 500),
     requestId:
       getHeader(response?.headers, 'x-request-id') ??
-      getHeader(response?.headers, 'x-gitlab-meta'),
+      getHeader(response?.headers, 'x-gitlab-meta') ??
+      sanitizeText(attached?.requestId, 200),
     classification: classifyScmProviderError(
       status,
       description,

--- a/src/origin/apps/service/src/lib/scmTokenRefreshLock.test.ts
+++ b/src/origin/apps/service/src/lib/scmTokenRefreshLock.test.ts
@@ -1,0 +1,28 @@
+import { expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => {
+  let usingLock = vi.fn(async (_key: string, fn: () => Promise<unknown>) => await fn());
+  return {
+    usingLock,
+    createLock: vi.fn(() => ({ usingLock }))
+  };
+});
+
+vi.mock('@lowerdeck/lock', () => ({ createLock: mocks.createLock }));
+vi.mock('../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost' } }
+}));
+
+import { usingScmTokenRefreshLock } from './scmTokenRefreshLock';
+
+it('locks token refreshes by provider and installation', async () => {
+  await expect(
+    usingScmTokenRefreshLock('gitlab', 42n, async () => 'access-token')
+  ).resolves.toBe('access-token');
+
+  expect(mocks.createLock).toHaveBeenCalledWith({
+    name: 'origin/scm/token-refresh',
+    redisUrl: 'redis://localhost'
+  });
+  expect(mocks.usingLock).toHaveBeenCalledWith('gitlab:42', expect.any(Function));
+});

--- a/src/origin/apps/service/src/lib/scmTokenRefreshLock.ts
+++ b/src/origin/apps/service/src/lib/scmTokenRefreshLock.ts
@@ -1,0 +1,17 @@
+import { createLock } from '@lowerdeck/lock';
+import { env } from '../env';
+
+let scmTokenRefreshLock = createLock({
+  name: 'origin/scm/token-refresh',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let usingScmTokenRefreshLock = <T>(
+  provider: 'gitlab' | 'bitbucket',
+  installationOid: bigint,
+  fn: () => Promise<T>
+) =>
+  scmTokenRefreshLock.usingLock(
+    `${provider}:${installationOid.toString()}`,
+    async () => await fn()
+  );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes OAuth token refresh coordination and depends on Redis for locks; incorrect locking could break SCM API access, but behavior is covered by targeted tests and preserves existing winner-token fallback.
> 
> **Overview**
> Adds **Redis-backed locking** so GitLab and Bitbucket OAuth refreshes run only one at a time per installation across workers, using new `usingScmTokenRefreshLock` and `@lowerdeck/lock`.
> 
> Inside the lock, refresh paths **re-read** `scmInstallation` from the DB and skip the provider call if credentials were already renewed; on refresh failure they still prefer **winner** tokens persisted by another worker. In-process `tokenRefreshes` deduplication remains for callers on the same instance.
> 
> **scmProviderError** now derives status, description, and classification from wrapped `ServiceError` fields (`scmProviderDiagnostic`, `data`) so retry/classification still work after `wrapScmProviderError`.
> 
> Multi-region **user sync** treats Prisma **P2002** on `upsertUser` as benign (concurrent upserts). Tests cover lock keys, concurrent refresh winners, and in-flight refresh races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff01fcb8af4b50f8e34ee41ff1c32523e3e122d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->