### PR TITLE
Improve auth emails

### DIFF
--- a/src/ares/service/src/email/successfulLogin.tsx
+++ b/src/ares/service/src/email/successfulLogin.tsx
@@ -6,18 +6,29 @@ import {
   Layout,
   Text
 } from '@metorial-platform-systems/relay-client';
-import type { User } from '@sentry/bun';
 import { UAParser } from 'ua-parser-js';
-import type { AuthIntent } from '../../prisma/generated/client';
+import type { User } from '../../prisma/generated/client';
 import { createTemplateSender, emailIdentity, sender } from './client';
 
 export let successfulLoginVerification = createTemplateSender(
   createTemplate({
-    render: async ({ authIntent, user }: { authIntent: AuthIntent; user: User }) => {
-      let ua = authIntent.ua ? new UAParser(authIntent.ua).getResult() : undefined;
-      let geo = await ipInfo.getSafe(authIntent.ip);
+    render: async ({
+      user,
+      method,
+      ip,
+      ua: uaString,
+      createdAt
+    }: {
+      user: User;
+      method: string;
+      ip: string;
+      ua?: string | null;
+      createdAt: Date;
+    }) => {
+      let ua = uaString ? new UAParser(uaString).getResult() : undefined;
+      let geo = await ipInfo.getSafe(ip);
 
-      let localDate = new Date(authIntent.createdAt);
+      let localDate = new Date(createdAt);
 
       try {
         localDate = geo?.timezone
@@ -43,7 +54,7 @@ export let successfulLoginVerification = createTemplateSender(
                 <DataList
                   items={[
                     { label: 'Time', value: localDate.toLocaleString() },
-                    { label: 'IP Address', value: authIntent.ip },
+                    { label: 'IP Address', value: ip },
                     {
                       label: 'Browser',
                       value: ua
@@ -60,7 +71,7 @@ export let successfulLoginVerification = createTemplateSender(
                     },
                     {
                       label: 'Method',
-                      value: authIntent.type == 'email_code' ? 'Email Code' : 'Social Login'
+                      value: method
                     }
                   ]}
                 />

--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -38,6 +38,40 @@ import { deviceService } from './device';
 import { userService } from './user';
 import { markAresUserChanged } from '../queues/syncCallback';
 
+let sendSuccessfulLoginEmail = async (d: {
+  user: User;
+  method: string;
+  ip: string;
+  ua?: string | null;
+  createdAt?: Date;
+}) => {
+  await successfulLoginVerification.send({
+    data: {
+      user: d.user,
+      method: d.method,
+      ip: d.ip,
+      ua: d.ua,
+      createdAt: d.createdAt ?? new Date()
+    },
+    to: [d.user.email]
+  });
+};
+
+let resolveAuthIntentLoginMethod = async (authIntent: AuthIntent) => {
+  if (authIntent.type == 'email_code') return 'Email Code';
+
+  if (authIntent.userIdentityOid) {
+    let identity = await db.userIdentity.findUnique({
+      where: { oid: authIntent.userIdentityOid },
+      include: { provider: true }
+    });
+
+    if (identity?.provider.name) return identity.provider.name;
+  }
+
+  return 'Social Login';
+};
+
 class AuthServiceImpl {
   async ensureEmailAuthEnabled(d: {
     app?: App;
@@ -708,6 +742,13 @@ class AuthServiceImpl {
       }
     });
 
+    await sendSuccessfulLoginEmail({
+      user,
+      method: `SSO (${d.ssoTenant.name})`,
+      ip: d.context.ip,
+      ua: d.context.ua
+    });
+
     return await this.createAuthAttempt({
       user,
       device: d.device,
@@ -1083,15 +1124,13 @@ class AuthServiceImpl {
       throw new ServiceError(forbiddenError({ message: 'Invalid account' }));
     }
 
-    if (Date.now() - user.createdAt.getTime() > 60 * 1000) {
-      await successfulLoginVerification.send({
-        data: {
-          user,
-          authIntent: d.authIntent
-        },
-        to: [user.email]
-      });
-    }
+    await sendSuccessfulLoginEmail({
+      user,
+      method: await resolveAuthIntentLoginMethod(d.authIntent),
+      ip: d.authIntent.ip,
+      ua: d.authIntent.ua,
+      createdAt: d.authIntent.createdAt
+    });
 
     return withTransaction(async tdb => {
       await tdb.authIntent.update({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when and how login alert emails are sent across SSO and new-user flows; behavior is user-facing and security-adjacent but does not alter core authentication logic.
> 
> **Overview**
> Refactors the **successful login** email so it no longer depends on an `AuthIntent`; the template now takes explicit `method`, `ip`, `ua`, and `createdAt` (and fixes the `User` type import to the Prisma client).
> 
> In `auth.ts`, login notifications are centralized in `sendSuccessfulLoginEmail`, with **method labels** resolved via `resolveAuthIntentLoginMethod` (email code, linked identity provider name, or fallback “Social Login”). **SSO logins** now trigger this email with `SSO ({tenant name})`. Completing an auth intent always sends the notification— the previous **60-second post-signup skip** is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80211188bf6763f8db9156ba13a2901c5300cc0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->