### PR TITLE
Harden sso domains

### DIFF
--- a/src/ares/service/src/apis/auth/endpoints/hooks.ts
+++ b/src/ares/service/src/apis/auth/endpoints/hooks.ts
@@ -1,11 +1,12 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
-import { createHono } from '@lowerdeck/hono';
+import { createHono, type Context as HonoContext } from '@lowerdeck/hono';
 import { generateCustomId } from '@lowerdeck/id';
 import { v } from '@lowerdeck/validation';
 import * as Cookies from 'cookie';
 import { randomBytes } from 'crypto';
 import { db } from '../../../db';
 import { env } from '../../../env';
+import { getRequestContext } from '../../../lib/context';
 import { createDelegationCodeChallenge } from '../../../lib/ssoDelegationProtocol';
 import { tickets } from '../../../lib/tickets';
 import { validateRedirectUrl } from '../../../lib/validateRedirectUrl';
@@ -13,8 +14,13 @@ import { authService } from '../../../services/auth';
 import { deviceService } from '../../../services/device';
 import { ssoAuthService } from '../../../services/sso/auth';
 import { ssoDelegationClient } from '../../../services/sso/delegationClient';
+import {
+  SsoDomainNotAllowedError,
+  ssoDomainPolicyService
+} from '../../../services/sso/domainPolicy';
 import { ssoIdentityService } from '../../../services/sso/identity';
 import { ssoLoginService } from '../../../services/sso/login';
+import { ssoDomainNotAllowedHtml } from '../../sso/pages/domain-not-allowed';
 import { resolveClient } from '../lib/resolveApp';
 import { baseCookieOpts, SESSION_ID_COOKIE_NAME } from '../middleware/device';
 
@@ -33,6 +39,16 @@ let getAccountLoginUrl = (d: {
 };
 
 let createCodeVerifier = () => randomBytes(32).toString('base64url');
+
+// Hono hands downstream errors to the app-level handler, which answers JSON.
+// These hooks are reached by a browser redirect, so a blocked domain has to be
+// caught in the handler and rendered as a page.
+let renderSsoDomainError = (ctx: HonoContext, error: unknown) => {
+  if (error instanceof SsoDomainNotAllowedError) {
+    return ctx.html(ssoDomainNotAllowedHtml(error), 403);
+  }
+  throw error;
+};
 
 export let authHooksApp = createHono()
   .get('/oauth/:ticket', async ctx => {
@@ -179,280 +195,301 @@ export let authHooksApp = createHono()
     return ctx.redirect(authUrl.toString());
   })
   .get('/sso/:ticket', async ctx => {
-    let ticket = await tickets.decode(
-      ctx.req.param('ticket'),
-      v.object({
-        type: v.literal('sso'),
-        appClientId: v.string(),
-        deviceId: v.string(),
-        ssoTenantId: v.string(),
-        ssoConnectionId: v.optional(v.string()),
-        redirectUrl: v.string(),
-        email: v.optional(v.string())
-      })
-    );
+    try {
+      let ticket = await tickets.decode(
+        ctx.req.param('ticket'),
+        v.object({
+          type: v.literal('sso'),
+          appClientId: v.string(),
+          deviceId: v.string(),
+          ssoTenantId: v.string(),
+          ssoConnectionId: v.optional(v.string()),
+          redirectUrl: v.string(),
+          email: v.optional(v.string())
+        })
+      );
 
-    let { app, account: clientAccount } = await resolveClient(ticket.appClientId);
-    validateRedirectUrl(ticket.redirectUrl, app.redirectDomains);
-    let { account, tenant, connection } = await authService.resolveSsoConnection({
-      app,
-      account: clientAccount,
-      tenantId: ticket.ssoTenantId,
-      connectionId: ticket.ssoConnectionId,
-      email: ticket.email
-    });
-    let ssoAuth = await ssoAuthService.createAuth({
-      tenant,
-      account,
-      connection: connection ?? undefined,
-      input: {
-        redirectUri: `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-response`,
-        state: generateCustomId('sso_state', 50),
+      let { app, account: clientAccount } = await resolveClient(ticket.appClientId);
+      validateRedirectUrl(ticket.redirectUrl, app.redirectDomains);
+      let { account, tenant, connection } = await authService.resolveSsoConnection({
+        app,
+        account: clientAccount,
+        tenantId: ticket.ssoTenantId,
+        connectionId: ticket.ssoConnectionId,
         email: ticket.email
-      }
-    });
-
-    ctx.res.headers.append(
-      'Set-Cookie',
-      Cookies.serialize(
-        `metorial_sso_state_${ssoAuth.id}`,
-        JSON.stringify({
-          appClientId: ticket.appClientId,
-          deviceId: ticket.deviceId,
-          redirectUrl: ticket.redirectUrl
-        }),
-        {
-          path: '/'
-        }
-      )
-    );
-
-    if (tenant.importedDelegationOid) {
-      let imported = await db.ssoImportedDelegation.findUnique({
-        where: { oid: tenant.importedDelegationOid },
-        include: {
-          remoteInstance: true,
-          localExportedDelegation: true
+      });
+      let ssoAuth = await ssoAuthService.createAuth({
+        tenant,
+        account,
+        connection: connection ?? undefined,
+        input: {
+          redirectUri: `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-response`,
+          state: generateCustomId('sso_state', 50),
+          email: ticket.email
         }
       });
-      if (!imported || imported.status !== 'active') {
-        throw new ServiceError(badRequestError({ message: 'SSO delegation is disabled' }));
+
+      ctx.res.headers.append(
+        'Set-Cookie',
+        Cookies.serialize(
+          `metorial_sso_state_${ssoAuth.id}`,
+          JSON.stringify({
+            appClientId: ticket.appClientId,
+            deviceId: ticket.deviceId,
+            redirectUrl: ticket.redirectUrl
+          }),
+          {
+            path: '/'
+          }
+        )
+      );
+
+      if (tenant.importedDelegationOid) {
+        let imported = await db.ssoImportedDelegation.findUnique({
+          where: { oid: tenant.importedDelegationOid },
+          include: {
+            remoteInstance: true,
+            localExportedDelegation: true
+          }
+        });
+        if (!imported || imported.status !== 'active') {
+          throw new ServiceError(badRequestError({ message: 'SSO delegation is disabled' }));
+        }
+
+        let codeVerifier = createCodeVerifier();
+        await db.ssoAuth.update({
+          where: { oid: ssoAuth.oid },
+          data: { codeVerifier }
+        });
+
+        let authorizationUrl = new URL(imported.remoteInstance.authorizationEndpointUrl);
+        authorizationUrl.searchParams.set('client_id', imported.clientId);
+        authorizationUrl.searchParams.set(
+          'response_type',
+          'urn:metorial.com:ares:sso-delegation'
+        );
+        authorizationUrl.searchParams.set(
+          'redirect_uri',
+          `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-delegation-response`
+        );
+        authorizationUrl.searchParams.set('state', ssoAuth.state);
+        authorizationUrl.searchParams.set(
+          'code_challenge',
+          createDelegationCodeChallenge(codeVerifier)
+        );
+        authorizationUrl.searchParams.set('code_challenge_method', 'S256');
+        if (connection?.sourceId) {
+          authorizationUrl.searchParams.set('connection_id', connection.sourceId);
+        }
+        if (ticket.email) authorizationUrl.searchParams.set('login_hint', ticket.email);
+        return ctx.redirect(authorizationUrl.toString());
       }
 
-      let codeVerifier = createCodeVerifier();
-      await db.ssoAuth.update({
-        where: { oid: ssoAuth.oid },
-        data: { codeVerifier }
-      });
-
-      let authorizationUrl = new URL(imported.remoteInstance.authorizationEndpointUrl);
-      authorizationUrl.searchParams.set('client_id', imported.clientId);
-      authorizationUrl.searchParams.set(
-        'response_type',
-        'urn:metorial.com:ares:sso-delegation'
+      return ctx.redirect(
+        `${env.service.ARES_SSO_URL}/sso/auth?client_secret=${ssoAuth.clientSecret}`
       );
-      authorizationUrl.searchParams.set(
-        'redirect_uri',
-        `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-delegation-response`
-      );
-      authorizationUrl.searchParams.set('state', ssoAuth.state);
-      authorizationUrl.searchParams.set(
-        'code_challenge',
-        createDelegationCodeChallenge(codeVerifier)
-      );
-      authorizationUrl.searchParams.set('code_challenge_method', 'S256');
-      if (connection?.sourceId) {
-        authorizationUrl.searchParams.set('connection_id', connection.sourceId);
-      }
-      if (ticket.email) authorizationUrl.searchParams.set('login_hint', ticket.email);
-      return ctx.redirect(authorizationUrl.toString());
+    } catch (error) {
+      return renderSsoDomainError(ctx, error);
     }
-
-    return ctx.redirect(
-      `${env.service.ARES_SSO_URL}/sso/auth?client_secret=${ssoAuth.clientSecret}`
-    );
   })
   .get('/sso-delegation-response', async ctx => {
-    let code = ctx.req.query('code');
-    let state = ctx.req.query('state');
-    if (!code || !state) {
-      throw new ServiceError(badRequestError({ message: 'Missing delegation code or state' }));
-    }
+    try {
+      let code = ctx.req.query('code');
+      let state = ctx.req.query('state');
+      if (!code || !state) {
+        throw new ServiceError(
+          badRequestError({ message: 'Missing delegation code or state' })
+        );
+      }
 
-    let auth = await db.ssoAuth.findUnique({
-      where: { state },
-      include: {
-        tenant: {
-          include: {
-            importedDelegation: {
-              include: {
-                remoteInstance: true,
-                localExportedDelegation: true
+      let auth = await db.ssoAuth.findUnique({
+        where: { state },
+        include: {
+          account: true,
+          tenant: {
+            include: {
+              importedDelegation: {
+                include: {
+                  remoteInstance: true,
+                  localExportedDelegation: true
+                }
               }
             }
           }
         }
+      });
+      let imported = auth?.tenant.importedDelegation;
+      if (
+        !auth ||
+        !imported ||
+        imported.status !== 'active' ||
+        auth.status !== 'pending' ||
+        (auth.expiresAt && auth.expiresAt <= new Date()) ||
+        !auth.codeVerifier
+      ) {
+        throw new ServiceError(badRequestError({ message: 'Invalid delegation state' }));
       }
-    });
-    let imported = auth?.tenant.importedDelegation;
-    if (
-      !auth ||
-      !imported ||
-      imported.status !== 'active' ||
-      auth.status !== 'pending' ||
-      (auth.expiresAt && auth.expiresAt <= new Date()) ||
-      !auth.codeVerifier
-    ) {
-      throw new ServiceError(badRequestError({ message: 'Invalid delegation state' }));
-    }
 
-    let redirectUri = `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-delegation-response`;
-    let snapshot = await ssoDelegationClient.exchangeCode({
-      imported,
-      code,
-      redirectUri,
-      codeVerifier: auth.codeVerifier
-    });
-    if (
-      snapshot.type !== 'identity' ||
-      snapshot.delegation.id !== imported.sourceDelegationId ||
-      snapshot.delegation.clientId !== imported.clientId ||
-      snapshot.tenant.id !== imported.sourceTenantId ||
-      !snapshot.connection ||
-      !snapshot.userProfile
-    ) {
-      throw new ServiceError(
-        badRequestError({ message: 'Delegation identity did not match the import' })
-      );
-    }
-
-    let connection = await db.ssoConnection.findFirst({
-      where: {
-        importedDelegationOid: imported.oid,
-        sourceId: snapshot.connection.id,
-        tenantOid: auth.tenantOid,
-        status: 'active'
+      let redirectUri = `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-delegation-response`;
+      let snapshot = await ssoDelegationClient.exchangeCode({
+        imported,
+        code,
+        redirectUri,
+        codeVerifier: auth.codeVerifier
+      });
+      if (
+        snapshot.type !== 'identity' ||
+        snapshot.delegation.id !== imported.sourceDelegationId ||
+        snapshot.delegation.clientId !== imported.clientId ||
+        snapshot.tenant.id !== imported.sourceTenantId ||
+        !snapshot.connection ||
+        !snapshot.userProfile
+      ) {
+        throw new ServiceError(
+          badRequestError({ message: 'Delegation identity did not match the import' })
+        );
       }
-    });
-    if (!connection) {
-      throw new ServiceError(
-        badRequestError({ message: 'Delegated SSO connection is unavailable' })
-      );
-    }
 
-    let profileData = snapshot.userProfile;
-    let user = await ssoIdentityService.upsertUser({
-      tenant: auth.tenant,
-      email: profileData.email,
-      firstName: profileData.firstName,
-      lastName: profileData.lastName
-    });
-    let profile = await ssoIdentityService.upsertUserProfile({
-      tenant: auth.tenant,
-      connection,
-      user,
-      data: {
+      let connection = await db.ssoConnection.findFirst({
+        where: {
+          importedDelegationOid: imported.oid,
+          sourceId: snapshot.connection.id,
+          tenantOid: auth.tenantOid,
+          status: 'active'
+        }
+      });
+      if (!connection) {
+        throw new ServiceError(
+          badRequestError({ message: 'Delegated SSO connection is unavailable' })
+        );
+      }
+
+      let profileData = snapshot.userProfile;
+
+      // The delegated instance authenticated against its own IdP and has no
+      // account domains of its own, so the asserted email is only checked here.
+      await ssoDomainPolicyService.assertEmailAllowed({
+        tenant: auth.tenant,
+        connection,
+        account: auth.account,
         email: profileData.email,
-        uid: profileData.uid,
-        uidHash: profileData.uidHash,
-        sub: profileData.sub ?? undefined,
-        firstName: profileData.firstName,
-        lastName: profileData.lastName,
-        roles: profileData.roles,
-        groups: profileData.groups,
-        raw: profileData.raw
-      }
-    });
-    await db.ssoAuth.update({
-      where: { oid: auth.oid },
-      data: {
-        status: 'completed',
-        connectionOid: connection.oid,
-        userOid: user.oid,
-        userProfileOid: profile.oid
-      }
-    });
+        context: getRequestContext(ctx)
+      });
 
-    let next = new URL(`${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-response`);
-    next.searchParams.set('tenant_id', auth.tenant.id);
-    next.searchParams.set('auth_id', auth.id);
-    return ctx.redirect(next.toString());
+      let user = await ssoIdentityService.upsertUser({
+        tenant: auth.tenant,
+        email: profileData.email,
+        firstName: profileData.firstName,
+        lastName: profileData.lastName
+      });
+      let profile = await ssoIdentityService.upsertUserProfile({
+        tenant: auth.tenant,
+        connection,
+        user,
+        data: {
+          email: profileData.email,
+          uid: profileData.uid,
+          uidHash: profileData.uidHash,
+          sub: profileData.sub ?? undefined,
+          firstName: profileData.firstName,
+          lastName: profileData.lastName,
+          roles: profileData.roles,
+          groups: profileData.groups,
+          raw: profileData.raw
+        }
+      });
+      await db.ssoAuth.update({
+        where: { oid: auth.oid },
+        data: {
+          status: 'completed',
+          connectionOid: connection.oid,
+          userOid: user.oid,
+          userProfileOid: profile.oid
+        }
+      });
+
+      let next = new URL(`${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso-response`);
+      next.searchParams.set('tenant_id', auth.tenant.id);
+      next.searchParams.set('auth_id', auth.id);
+      return ctx.redirect(next.toString());
+    } catch (error) {
+      return renderSsoDomainError(ctx, error);
+    }
   })
   .get('/sso-response', async ctx => {
-    let tenantId = ctx.req.query('tenant_id');
-    let authId = ctx.req.query('auth_id');
+    try {
+      let tenantId = ctx.req.query('tenant_id');
+      let authId = ctx.req.query('auth_id');
 
-    if (!tenantId || !authId) {
-      throw new ServiceError(badRequestError({ message: 'Missing tenant_id or auth_id' }));
-    }
+      if (!tenantId || !authId) {
+        throw new ServiceError(badRequestError({ message: 'Missing tenant_id or auth_id' }));
+      }
 
-    let { tenant, account, connection, userProfile } = await ssoAuthService.completeAuth({
-      authId,
-      tenantId
-    });
+      let { tenant, account, connection, userProfile } = await ssoAuthService.completeAuth({
+        authId,
+        tenantId
+      });
 
-    let cookieHeader = ctx.req.header('cookie') ?? '';
-    let cookies = Cookies.parse(cookieHeader);
-    let stateCookie = cookies[`metorial_sso_state_${authId}`];
-    if (!stateCookie) {
-      throw new ServiceError(badRequestError({ message: 'Invalid SSO state' }));
-    }
+      let cookieHeader = ctx.req.header('cookie') ?? '';
+      let cookies = Cookies.parse(cookieHeader);
+      let stateCookie = cookies[`metorial_sso_state_${authId}`];
+      if (!stateCookie) {
+        throw new ServiceError(badRequestError({ message: 'Invalid SSO state' }));
+      }
 
-    let stateData = JSON.parse(stateCookie) as {
-      appClientId: string;
-      deviceId: string;
-      redirectUrl: string;
-    };
+      let stateData = JSON.parse(stateCookie) as {
+        appClientId: string;
+        deviceId: string;
+        redirectUrl: string;
+      };
 
-    let resolvedClient = await resolveClient(stateData.appClientId);
-    let app = resolvedClient.app;
-    validateRedirectUrl(stateData.redirectUrl, app.redirectDomains);
-    if (resolvedClient.account && resolvedClient.account.oid != account?.oid) {
-      throw new ServiceError(badRequestError({ message: 'SSO account context changed' }));
-    }
-    let emailAccount = await authService.resolveAccountForEmail({
-      app,
-      account,
-      email: userProfile.email
-    });
-    if (!account && emailAccount.account) {
-      return ctx.redirect(
-        getAccountLoginUrl({
-          accountClientId: emailAccount.account.clientId,
-          redirectUrl: stateData.redirectUrl,
-          email: userProfile.email,
-          reason: 'account_sso_required'
-        })
+      let resolvedClient = await resolveClient(stateData.appClientId);
+      let app = resolvedClient.app;
+      validateRedirectUrl(stateData.redirectUrl, app.redirectDomains);
+      if (resolvedClient.account && resolvedClient.account.oid != account?.oid) {
+        throw new ServiceError(badRequestError({ message: 'SSO account context changed' }));
+      }
+      let emailAccount = await authService.resolveAccountForEmail({
+        app,
+        account,
+        email: userProfile.email
+      });
+      if (!account && emailAccount.account) {
+        return ctx.redirect(
+          getAccountLoginUrl({
+            accountClientId: emailAccount.account.clientId,
+            redirectUrl: stateData.redirectUrl,
+            email: userProfile.email,
+            reason: 'account_sso_required'
+          })
+        );
+      }
+      let device = await deviceService.dangerouslyGetDeviceOnlyById({
+        deviceId: stateData.deviceId
+      });
+
+      let { authAttempt, session } = await ssoLoginService.completeLogin({
+        tenant,
+        connection,
+        userProfile,
+        app,
+        account,
+        device,
+        context: getRequestContext(ctx),
+        redirectUrl: stateData.redirectUrl
+      });
+
+      ctx.res.headers.append(
+        'Set-Cookie',
+        Cookies.serialize(SESSION_ID_COOKIE_NAME, session.id, baseCookieOpts)
       );
+
+      let redirectUrl = new URL(authAttempt.redirectUrl);
+      redirectUrl.searchParams.set('code', session.authorizationCode);
+      return ctx.redirect(redirectUrl.toString());
+    } catch (error) {
+      return renderSsoDomainError(ctx, error);
     }
-    let device = await deviceService.dangerouslyGetDeviceOnlyById({
-      deviceId: stateData.deviceId
-    });
-
-    let ip = (ctx.req.header('x-forwarded-for') ?? ctx.req.header('x-real-ip') ?? '')
-      .split(',')[0]!
-      .trim();
-    let ua = ctx.req.header('user-agent') ?? '';
-
-    let { authAttempt, session } = await ssoLoginService.completeLogin({
-      tenant,
-      connection,
-      userProfile,
-      app,
-      account,
-      device,
-      context: { ip, ua },
-      redirectUrl: stateData.redirectUrl
-    });
-
-    ctx.res.headers.append(
-      'Set-Cookie',
-      Cookies.serialize(SESSION_ID_COOKIE_NAME, session.id, baseCookieOpts)
-    );
-
-    let redirectUrl = new URL(authAttempt.redirectUrl);
-    redirectUrl.searchParams.set('code', session.authorizationCode);
-    return ctx.redirect(redirectUrl.toString());
   })
 
   .get('/auth-attempt/:ticket', async ctx => {

--- a/src/ares/service/src/apis/sso/endpoints/auth.ts
+++ b/src/ares/service/src/apis/sso/endpoints/auth.ts
@@ -4,12 +4,18 @@ import { v } from '@lowerdeck/validation';
 import { createHash, randomBytes } from 'crypto';
 import { db } from '../../../db';
 import { env } from '../../../env';
+import { getRequestContext } from '../../../lib/context';
 import { jackson } from '../../../lib/jackson';
 import { ssoAuthService } from '../../../services/sso/auth';
 import { getSsoAuthCompletionRedirect } from '../../../services/sso/authRedirect';
 import { ssoConnectionService } from '../../../services/sso/connection';
+import {
+  SsoDomainNotAllowedError,
+  ssoDomainPolicyService
+} from '../../../services/sso/domainPolicy';
 import { ssoIdentityService } from '../../../services/sso/identity';
 import { authSelectConnectionHtml } from '../pages/auth-select-connection';
+import { ssoDomainNotAllowedHtml } from '../pages/domain-not-allowed';
 import { errorHtml } from '../pages/error';
 
 function generateCodeVerifier(): string {
@@ -132,6 +138,10 @@ export let ssoAuthApp = createHono()
 
       return c.redirect(res.redirect_url!);
     } catch (error: any) {
+      if (error instanceof SsoDomainNotAllowedError) {
+        return c.html(ssoDomainNotAllowedHtml(error), 403);
+      }
+
       return c.html(
         errorHtml({
           title: 'Unable to Authenticate',
@@ -188,6 +198,14 @@ export let ssoAuthApp = createHono()
       });
 
       let userInfo = await jackson.oauthController.userInfo(tokenRes.access_token);
+
+      await ssoDomainPolicyService.assertEmailAllowed({
+        tenant: auth.tenant,
+        connection,
+        account: auth.account,
+        email: userInfo.email,
+        context: getRequestContext(c)
+      });
 
       let user = await ssoIdentityService.upsertUser({
         tenant: auth.tenant,
@@ -256,6 +274,10 @@ export let ssoAuthApp = createHono()
       }
       return c.redirect(completionRedirect.url);
     } catch (error: any) {
+      if (error instanceof SsoDomainNotAllowedError) {
+        return c.html(ssoDomainNotAllowedHtml(error), 403);
+      }
+
       return c.html(
         errorHtml({
           title: 'Unable to Authenticate',

--- a/src/ares/service/src/apis/sso/endpoints/jxn.ts
+++ b/src/ares/service/src/apis/sso/endpoints/jxn.ts
@@ -1,8 +1,13 @@
 import { createHono } from '@lowerdeck/hono';
 import * as Cookies from 'cookie';
 import { db } from '../../../db';
+import { getRequestContext } from '../../../lib/context';
 import { getSamlConnectionDefaultRedirectUrl } from '../../../lib/ssoRedirect';
 import { deviceService } from '../../../services/device';
+import {
+  SsoDomainNotAllowedError,
+  ssoDomainPolicyService
+} from '../../../services/sso/domainPolicy';
 import { ssoIdentityService } from '../../../services/sso/identity';
 import { ssoLoginService } from '../../../services/sso/login';
 import { jackson } from '../../../lib/jackson';
@@ -12,6 +17,7 @@ import {
   parseDeviceToken,
   SESSION_ID_COOKIE_NAME
 } from '../../auth/middleware/device';
+import { ssoDomainNotAllowedHtml } from '../pages/domain-not-allowed';
 import { errorHtml } from '../pages/error';
 
 export let jxnApp = createHono()
@@ -126,6 +132,14 @@ export let jxnApp = createHono()
 
       let { connection, accessToken } = authenticated;
       let userInfo = await jackson.oauthController.userInfo(accessToken);
+
+      await ssoDomainPolicyService.assertEmailAllowed({
+        tenant: connection.tenant,
+        connection,
+        email: userInfo.email,
+        context: getRequestContext(c)
+      });
+
       let user = await ssoIdentityService.upsertUser({
         tenant: connection.tenant,
         email: userInfo.email,
@@ -189,7 +203,11 @@ export let jxnApp = createHono()
         Cookies.serialize(SESSION_ID_COOKIE_NAME, session.id, baseCookieOpts)
       );
       return res;
-    } catch {
+    } catch (error) {
+      if (error instanceof SsoDomainNotAllowedError) {
+        return c.html(ssoDomainNotAllowedHtml(error), 403);
+      }
+
       return c.html(
         errorHtml({
           title: 'Authentication Error',

--- a/src/ares/service/src/apis/sso/pages/domain-not-allowed.ts
+++ b/src/ares/service/src/apis/sso/pages/domain-not-allowed.ts
@@ -1,10 +1,19 @@
 import { htmlEncode } from '../../../lib/htmlEncode';
 
-export let errorHtml = (d: {
-  title: string;
-  message: string;
-  details?: string;
-}) => `<!DOCTYPE html>
+export let ssoDomainNotAllowedHtml = (d: {
+  domain: string | null;
+  email: string;
+  tenantName: string;
+}) => {
+  let domain = d.domain ? htmlEncode(d.domain) : null;
+  let email = htmlEncode(d.email);
+  let tenantName = htmlEncode(d.tenantName);
+
+  let explanation = domain
+    ? `Your identity provider signed you in as <strong>${email}</strong>, but the domain <strong>${domain}</strong> is not configured for ${tenantName} in Metorial.`
+    : `Your identity provider signed you in as <strong>${email}</strong>, which is not a valid email address.`;
+
+  return `<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -68,15 +77,13 @@ export let errorHtml = (d: {
       color: #666;
       text-align: center;
       margin-bottom: 20px;
+      line-height: 1.5;
     }
 
-    pre {
-      background: #f8f8f8;
-      padding: 10px;
-      border-radius: 4px;
-      overflow-x: auto;
-      font-size: 14px;
+    strong {
       color: #333;
+      font-weight: 600;
+      word-break: break-all;
     }
   </style>
 </head>
@@ -86,13 +93,14 @@ export let errorHtml = (d: {
     <section>
       <img src="https://cdn.metorial.com/2025-06-13--14-59-55/logos/metorial/primary_logo/raw.svg" alt="Metorial" />
 
-      <h1>${htmlEncode(d.title)}</h1>
+      <h1>This email domain is not configured</h1>
 
-      <p>${htmlEncode(d.message)}</p>
+      <p>${explanation}</p>
 
-      ${d.details ? `<pre>${htmlEncode(d.details)}</pre>` : ''}
+      <p>Please contact your administrator to have this domain added and verified, then try signing in again.</p>
     </section>
   </main>
 </body>
 
 </html>`;
+};

--- a/src/ares/service/src/lib/accountPolicy.test.ts
+++ b/src/ares/service/src/lib/accountPolicy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   doesAuthAttemptMatchClient,
+  evaluateSsoEmailDomain,
   getAccountEmailAuthFlow,
   getAccountSsoClientId,
   getInitialSsoTenantEnrollment,
@@ -151,5 +152,97 @@ describe('account domain policy', () => {
         allowedConnectionOids: [4n]
       })
     ).toBe(false);
+  });
+});
+
+describe('SSO asserted email domain policy', () => {
+  let base = {
+    domain: 'example.com',
+    tenantOid: 1n,
+    connectionOid: 2n
+  };
+
+  let unrestricted = {
+    accountOid: 10n,
+    allowedTenantOids: [] as bigint[],
+    allowedConnectionOids: [] as bigint[]
+  };
+
+  it('rejects malformed domains before anything else', () => {
+    expect(
+      evaluateSsoEmailDomain({
+        ...base,
+        domain: 'not a domain',
+        accountOid: null,
+        accountDomain: null
+      })
+    ).toEqual({ allowed: false, reason: 'invalid_domain' });
+  });
+
+  it('allows standalone app tenants with no account and no configured domains', () => {
+    expect(
+      evaluateSsoEmailDomain({
+        ...base,
+        domain: 'anything.example',
+        accountOid: null,
+        accountDomain: null
+      })
+    ).toEqual({ allowed: true });
+  });
+
+  it('stops app tenants from authenticating a domain an account claims', () => {
+    expect(
+      evaluateSsoEmailDomain({ ...base, accountOid: null, accountDomain: unrestricted })
+    ).toEqual({ allowed: false, reason: 'domain_other_account' });
+  });
+
+  it('blocks an unconfigured domain for account tenants', () => {
+    expect(evaluateSsoEmailDomain({ ...base, accountOid: 10n, accountDomain: null })).toEqual(
+      { allowed: false, reason: 'domain_not_configured' }
+    );
+  });
+
+  it('blocks a domain configured for a different account', () => {
+    expect(
+      evaluateSsoEmailDomain({
+        ...base,
+        accountOid: 10n,
+        accountDomain: { ...unrestricted, accountOid: 11n }
+      })
+    ).toEqual({ allowed: false, reason: 'domain_other_account' });
+  });
+
+  it('allows a configured domain without restrictions', () => {
+    expect(
+      evaluateSsoEmailDomain({ ...base, accountOid: 10n, accountDomain: unrestricted })
+    ).toEqual({ allowed: true });
+  });
+
+  it('honours tenant and connection restrictions on a configured domain', () => {
+    expect(
+      evaluateSsoEmailDomain({
+        ...base,
+        accountOid: 10n,
+        accountDomain: { ...unrestricted, allowedTenantOids: [1n] }
+      })
+    ).toEqual({ allowed: true });
+    expect(
+      evaluateSsoEmailDomain({
+        ...base,
+        accountOid: 10n,
+        accountDomain: { ...unrestricted, allowedConnectionOids: [2n] }
+      })
+    ).toEqual({ allowed: true });
+    expect(
+      evaluateSsoEmailDomain({
+        ...base,
+        accountOid: 10n,
+        accountDomain: {
+          ...unrestricted,
+          allowedTenantOids: [3n],
+          allowedConnectionOids: [4n]
+        }
+      })
+    ).toEqual({ allowed: false, reason: 'connection_not_allowed' });
   });
 });

--- a/src/ares/service/src/lib/accountPolicy.ts
+++ b/src/ares/service/src/lib/accountPolicy.ts
@@ -60,3 +60,55 @@ export let isAccountDomainConnectionAllowed = (d: {
     d.allowedConnectionOids.includes(d.connectionOid)
   );
 };
+
+export type SsoEmailDomainDenialReason =
+  | 'invalid_domain'
+  | 'domain_not_configured'
+  | 'domain_other_account'
+  | 'connection_not_allowed';
+
+export type SsoEmailDomainDecision =
+  | { allowed: true }
+  | { allowed: false; reason: SsoEmailDomainDenialReason };
+
+export let evaluateSsoEmailDomain = (d: {
+  domain: string;
+  tenantOid: bigint;
+  connectionOid: bigint;
+  accountOid: bigint | null;
+  accountDomain: {
+    accountOid: bigint;
+    allowedTenantOids: bigint[];
+    allowedConnectionOids: bigint[];
+  } | null;
+}): SsoEmailDomainDecision => {
+  if (!isValidAccountDomain(d.domain)) {
+    return { allowed: false, reason: 'invalid_domain' };
+  }
+
+  if (d.accountOid == null) {
+    if (!d.accountDomain) return { allowed: true };
+    return { allowed: false, reason: 'domain_other_account' };
+  }
+
+  if (!d.accountDomain) {
+    return { allowed: false, reason: 'domain_not_configured' };
+  }
+
+  if (d.accountDomain.accountOid != d.accountOid) {
+    return { allowed: false, reason: 'domain_other_account' };
+  }
+
+  if (
+    !isAccountDomainConnectionAllowed({
+      tenantOid: d.tenantOid,
+      connectionOid: d.connectionOid,
+      allowedTenantOids: d.accountDomain.allowedTenantOids,
+      allowedConnectionOids: d.accountDomain.allowedConnectionOids
+    })
+  ) {
+    return { allowed: false, reason: 'connection_not_allowed' };
+  }
+
+  return { allowed: true };
+};

--- a/src/ares/service/src/lib/context.ts
+++ b/src/ares/service/src/lib/context.ts
@@ -2,3 +2,12 @@ export interface Context {
   ua: string;
   ip: string;
 }
+
+export let getRequestContext = (c: {
+  req: { header: (name: string) => string | undefined };
+}): Context => ({
+  ip: (c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? '')
+    .split(',')[0]!
+    .trim(),
+  ua: c.req.header('user-agent') ?? ''
+});

--- a/src/ares/service/src/lib/parseEmail.test.ts
+++ b/src/ares/service/src/lib/parseEmail.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseEmail } from './parseEmail';
+
+describe('parseEmail', () => {
+  it('lowercases and splits a well formed address', () => {
+    expect(parseEmail('  User@Example.COM ')).toEqual({
+      email: 'user@example.com',
+      domain: 'example.com',
+      normalizedEmail: 'user@example.com'
+    });
+  });
+
+  it('rejects addresses with more than one @', () => {
+    // Reading only the first two segments would report example.com as the
+    // domain and let this address pass a check on a configured domain.
+    expect(() => parseEmail('attacker@example.com@evil.com')).toThrow('Invalid email');
+  });
+
+  it('rejects addresses missing a local part or domain', () => {
+    expect(() => parseEmail('@example.com')).toThrow('Invalid email');
+    expect(() => parseEmail('user@')).toThrow('Invalid email');
+    expect(() => parseEmail('user')).toThrow('Invalid email');
+  });
+
+  it('rejects addresses containing whitespace', () => {
+    expect(() => parseEmail('user@exa mple.com')).toThrow('Invalid email');
+  });
+});

--- a/src/ares/service/src/lib/parseEmail.ts
+++ b/src/ares/service/src/lib/parseEmail.ts
@@ -2,9 +2,13 @@ import { normalizeEmail } from './normalizeEmail';
 
 export let parseEmail = (emailRaw: string) => {
   let email = emailRaw.toLowerCase().trim();
-  let [local, domain] = email.split('@');
+  let parts = email.split('@');
 
-  if (!local || !domain) {
+  if (parts.length != 2) throw new Error('Invalid email');
+
+  let [local, domain] = parts;
+
+  if (!local || !domain || /\s/.test(email)) {
     throw new Error('Invalid email');
   }
 

--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -35,6 +35,7 @@ import { accessGroupService } from './accessGroup';
 import { auditLogService } from './auditLog';
 import { authBlockService } from './authBlock';
 import { deviceService } from './device';
+import { ssoDomainPolicyService } from './sso/domainPolicy';
 import { userService } from './user';
 import { markAresUserChanged } from '../queues/syncCallback';
 
@@ -651,6 +652,14 @@ class AuthServiceImpl {
         forbiddenError({ message: 'SSO tenant is not available for this account' })
       );
     }
+
+    await ssoDomainPolicyService.assertEmailAllowed({
+      tenant: d.ssoTenant,
+      connection: { oid: d.ssoUserProfile.connectionOid, id: d.ssoConnectionId },
+      account: d.account,
+      email: d.ssoUser.email,
+      context: d.context
+    });
 
     let identityProvider = await db.userIdentityProvider.findFirst({
       where: { ssoTenantOid: d.ssoTenant.oid }

--- a/src/ares/service/src/services/sso/auth.ts
+++ b/src/ares/service/src/services/sso/auth.ts
@@ -4,8 +4,7 @@ import { addMinutes } from 'date-fns';
 import type { Account, SsoConnection, SsoTenant } from '../../../prisma/generated/client';
 import { db } from '../../db';
 import { getId, ID } from '../../id';
-import { parseEmail } from '../../lib/parseEmail';
-import { isAccountDomainConnectionAllowed } from '../../lib/accountPolicy';
+import { ssoDomainPolicyService } from './domainPolicy';
 
 class SsoAuthServiceImpl {
   private async ensureDomainAllowsConnection(d: {
@@ -14,34 +13,14 @@ class SsoAuthServiceImpl {
     connection?: SsoConnection | null;
     email?: string | null;
   }) {
-    if (!d.account || !d.connection || !d.email) return;
-    let { domain } = parseEmail(d.email);
-    let accountDomain = await db.accountDomain.findUnique({
-      where: {
-        appOid_domain: {
-          appOid: d.tenant.appOid,
-          domain
-        }
-      },
-      include: {
-        allowedTenants: true,
-        allowedConnections: true
-      }
+    if (!d.connection || !d.email) return;
+
+    await ssoDomainPolicyService.assertEmailAllowed({
+      tenant: d.tenant,
+      connection: d.connection,
+      account: d.account,
+      email: d.email
     });
-    if (!accountDomain) return;
-    if (accountDomain.accountOid != d.account.oid) {
-      throw new ServiceError(notFoundError('sso.auth'));
-    }
-    if (
-      !isAccountDomainConnectionAllowed({
-        tenantOid: d.tenant.oid,
-        connectionOid: d.connection.oid,
-        allowedTenantOids: accountDomain.allowedTenants.map(link => link.tenantOid),
-        allowedConnectionOids: accountDomain.allowedConnections.map(link => link.connectionOid)
-      })
-    ) {
-      throw new ServiceError(notFoundError('sso.auth'));
-    }
   }
 
   async createAuth(d: {
@@ -148,12 +127,23 @@ class SsoAuthServiceImpl {
     ) {
       throw new ServiceError(notFoundError('sso.auth'));
     }
+    // The profile email is what the IdP actually asserted and what the session
+    // will be issued for, so it is the authoritative value. The login hint is
+    // checked too when present, so a valid hint cannot launder a bad assertion.
     await this.ensureDomainAllowsConnection({
       tenant: auth.tenant,
       account: auth.account,
       connection: auth.connection,
-      email: auth.email ?? auth.userProfile.email
+      email: auth.userProfile.email
     });
+    if (auth.email && auth.email != auth.userProfile.email) {
+      await this.ensureDomainAllowsConnection({
+        tenant: auth.tenant,
+        account: auth.account,
+        connection: auth.connection,
+        email: auth.email
+      });
+    }
     if (
       auth.tenant.status != 'completed' ||
       (auth.account &&

--- a/src/ares/service/src/services/sso/domainPolicy.test.ts
+++ b/src/ares/service/src/services/sso/domainPolicy.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { db, auditLogService } = vi.hoisted(() => ({
+  db: {
+    accountDomain: { findUnique: vi.fn() }
+  },
+  auditLogService: { log: vi.fn() }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_name: string, factory: () => unknown) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('../../db', () => ({ db }));
+
+vi.mock('../auditLog', () => ({ auditLogService }));
+
+import { SsoDomainNotAllowedError, ssoDomainPolicyService } from './domainPolicy';
+
+let accountTenant = {
+  oid: 1n,
+  id: 'stn_1',
+  name: 'Acme',
+  appOid: 5n,
+  accountOid: 10n
+};
+
+let appTenant = { ...accountTenant, accountOid: null };
+
+let connection = { oid: 2n, id: 'scn_1' };
+
+let configuredDomain = {
+  accountOid: 10n,
+  allowedTenants: [] as { tenantOid: bigint }[],
+  allowedConnections: [] as { connectionOid: bigint }[]
+};
+
+describe('SSO domain policy service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.accountDomain.findUnique.mockResolvedValue(null);
+  });
+
+  it('looks the domain up scoped to the tenant app', async () => {
+    db.accountDomain.findUnique.mockResolvedValue(configuredDomain);
+
+    await ssoDomainPolicyService.assertEmailAllowed({
+      tenant: accountTenant,
+      connection,
+      email: 'User@Example.com'
+    });
+
+    expect(db.accountDomain.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { appOid_domain: { appOid: 5n, domain: 'example.com' } }
+      })
+    );
+  });
+
+  it('allows standalone app tenants with no configured domains', async () => {
+    await expect(
+      ssoDomainPolicyService.assertEmailAllowed({
+        tenant: appTenant,
+        connection,
+        email: 'user@example.com'
+      })
+    ).resolves.toBeUndefined();
+
+    expect(auditLogService.log).not.toHaveBeenCalled();
+  });
+
+  it('blocks an account tenant asserting an unconfigured domain', async () => {
+    let error = await ssoDomainPolicyService
+      .assertEmailAllowed({
+        tenant: accountTenant,
+        connection,
+        email: 'user@unconfigured.com'
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(SsoDomainNotAllowedError);
+    expect(error).toMatchObject({
+      reason: 'domain_not_configured',
+      domain: 'unconfigured.com',
+      email: 'user@unconfigured.com',
+      tenantName: 'Acme'
+    });
+  });
+
+  it('derives the account from the tenant when none is passed', async () => {
+    db.accountDomain.findUnique.mockResolvedValue({ ...configuredDomain, accountOid: 11n });
+
+    await expect(
+      ssoDomainPolicyService.assertEmailAllowed({
+        tenant: accountTenant,
+        connection,
+        email: 'user@example.com'
+      })
+    ).rejects.toMatchObject({ reason: 'domain_other_account' });
+  });
+
+  it('blocks a connection the domain does not permit', async () => {
+    db.accountDomain.findUnique.mockResolvedValue({
+      ...configuredDomain,
+      allowedConnections: [{ connectionOid: 99n }]
+    });
+
+    await expect(
+      ssoDomainPolicyService.assertEmailAllowed({
+        tenant: accountTenant,
+        connection,
+        email: 'user@example.com'
+      })
+    ).rejects.toMatchObject({ reason: 'connection_not_allowed' });
+  });
+
+  it('rejects a multi-@ address without consulting the database', async () => {
+    await expect(
+      ssoDomainPolicyService.assertEmailAllowed({
+        tenant: accountTenant,
+        connection,
+        email: 'user@example.com@evil.com'
+      })
+    ).rejects.toMatchObject({ reason: 'invalid_domain', domain: null });
+
+    expect(db.accountDomain.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('records an audit entry describing why the login was blocked', async () => {
+    await ssoDomainPolicyService
+      .assertEmailAllowed({
+        tenant: accountTenant,
+        connection,
+        account: { oid: 10n, id: 'acc_1' },
+        email: 'user@unconfigured.com',
+        context: { ip: '1.2.3.4', ua: 'agent' }
+      })
+      .catch(() => {});
+
+    expect(auditLogService.log).toHaveBeenCalledWith({
+      appOid: 5n,
+      type: 'login.sso.blocked_domain',
+      ip: '1.2.3.4',
+      ua: 'agent',
+      metadata: {
+        reason: 'domain_not_configured',
+        domain: 'unconfigured.com',
+        accountId: 'acc_1',
+        ssoTenantId: 'stn_1',
+        ssoConnectionId: 'scn_1'
+      }
+    });
+  });
+});

--- a/src/ares/service/src/services/sso/domainPolicy.ts
+++ b/src/ares/service/src/services/sso/domainPolicy.ts
@@ -1,0 +1,140 @@
+import { Service } from '@lowerdeck/service';
+import { db } from '../../db';
+import {
+  evaluateSsoEmailDomain,
+  type SsoEmailDomainDenialReason
+} from '../../lib/accountPolicy';
+import { parseEmail } from '../../lib/parseEmail';
+import { auditLogService } from '../auditLog';
+
+/**
+ * Structural shapes so callers can pass a full Prisma row or just the fields
+ * they already hold, without an extra lookup.
+ */
+type PolicyTenant = {
+  oid: bigint;
+  id: string;
+  name: string;
+  appOid: bigint;
+  accountOid: bigint | null;
+};
+
+type PolicyConnection = { oid: bigint; id: string };
+
+type PolicyAccount = { oid: bigint; id: string };
+
+export class SsoDomainNotAllowedError extends Error {
+  readonly reason: SsoEmailDomainDenialReason;
+  readonly email: string;
+  readonly domain: string | null;
+  readonly tenantName: string;
+
+  constructor(d: {
+    reason: SsoEmailDomainDenialReason;
+    email: string;
+    domain: string | null;
+    tenantName: string;
+  }) {
+    super(`SSO email domain is not allowed (${d.reason})`);
+    this.name = 'SsoDomainNotAllowedError';
+    this.reason = d.reason;
+    this.email = d.email;
+    this.domain = d.domain;
+    this.tenantName = d.tenantName;
+  }
+}
+
+type DenyInput = {
+  tenant: PolicyTenant;
+  connection: PolicyConnection;
+  account?: PolicyAccount | null;
+  email: string;
+  domain: string | null;
+  reason: SsoEmailDomainDenialReason;
+  context?: { ip?: string | null; ua?: string | null };
+};
+
+class SsoDomainPolicyServiceImpl {
+  async assertEmailAllowed(d: {
+    tenant: PolicyTenant;
+    connection: PolicyConnection;
+    account?: PolicyAccount | null;
+    email: string;
+    context?: { ip?: string | null; ua?: string | null };
+  }) {
+    let parsed: { domain: string } | null = null;
+    try {
+      parsed = parseEmail(d.email);
+    } catch {
+      parsed = null;
+    }
+
+    if (!parsed) {
+      this.deny({ ...d, reason: 'invalid_domain', domain: null });
+    }
+
+    let domain = parsed.domain;
+    let accountOid = d.account?.oid ?? d.tenant.accountOid ?? null;
+
+    let accountDomain = await db.accountDomain.findUnique({
+      where: {
+        appOid_domain: {
+          appOid: d.tenant.appOid,
+          domain
+        }
+      },
+      include: {
+        allowedTenants: true,
+        allowedConnections: true
+      }
+    });
+
+    let decision = evaluateSsoEmailDomain({
+      domain,
+      tenantOid: d.tenant.oid,
+      connectionOid: d.connection.oid,
+      accountOid,
+      accountDomain: accountDomain
+        ? {
+            accountOid: accountDomain.accountOid,
+            allowedTenantOids: accountDomain.allowedTenants.map(link => link.tenantOid),
+            allowedConnectionOids: accountDomain.allowedConnections.map(
+              link => link.connectionOid
+            )
+          }
+        : null
+    });
+
+    if (!decision.allowed) {
+      this.deny({ ...d, reason: decision.reason, domain });
+    }
+  }
+
+  private deny(d: DenyInput): never {
+    auditLogService.log({
+      appOid: d.tenant.appOid,
+      type: 'login.sso.blocked_domain',
+      ip: d.context?.ip,
+      ua: d.context?.ua,
+      metadata: {
+        reason: d.reason,
+        domain: d.domain,
+        accountId: d.account?.id ?? null,
+        ssoTenantId: d.tenant.id,
+        ssoConnectionId: d.connection.id
+      }
+    });
+
+    throw new SsoDomainNotAllowedError({
+      reason: d.reason,
+      email: d.email,
+      domain: d.domain,
+      tenantName: d.tenant.name
+    });
+  }
+}
+
+export let ssoDomainPolicyService = Service.create(
+  'SsoDomainPolicyService',
+  () => new SsoDomainPolicyServiceImpl()
+).build();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes authentication and authorization on SSO login paths, including delegated SSO and email parsing used for domain decisions; misconfiguration or logic bugs could block legitimate logins or weaken domain isolation.
> 
> **Overview**
> **Enforces account email-domain rules on IdP-asserted emails** before users or profiles are created, using a shared `ssoDomainPolicyService` and `evaluateSsoEmailDomain` instead of scattered checks in `ssoAuthService`.
> 
> Checks run on OAuth/SAML callbacks, SSO delegation exchange, `authWithSso`, and when completing SSO auth (asserted profile email plus login hint when it differs). Account tenants must use configured domains; app tenants cannot sign in with domains claimed by another account; tenant/connection allowlists still apply.
> 
> **`parseEmail`** now requires exactly one `@` and rejects whitespace, closing a bypass where multi-`@` addresses could match the wrong domain.
> 
> **Browser flows** map `SsoDomainNotAllowedError` to a **403 HTML page** (`ssoDomainNotAllowedHtml`) on redirect hooks and SSO endpoints; blocked attempts are **audit-logged** as `login.sso.blocked_domain`. SSO error pages **HTML-encode** dynamic text via `htmlEncode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c0d9bc784614e3b97bb9056f9486a6122bbd1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->