### PR TITLE
Harden sso user creation

### DIFF
--- a/src/ares/service/src/apis/auth/endpoints/hooks.ts
+++ b/src/ares/service/src/apis/auth/endpoints/hooks.ts
@@ -1,4 +1,4 @@
-import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, isServiceError, ServiceError } from '@lowerdeck/error';
 import { createHono, type Context as HonoContext } from '@lowerdeck/hono';
 import { generateCustomId } from '@lowerdeck/id';
 import { v } from '@lowerdeck/validation';
@@ -21,6 +21,7 @@ import {
 import { ssoIdentityService } from '../../../services/sso/identity';
 import { ssoLoginService } from '../../../services/sso/login';
 import { ssoDomainNotAllowedHtml } from '../../sso/pages/domain-not-allowed';
+import { errorHtml } from '../../sso/pages/error';
 import { resolveClient } from '../lib/resolveApp';
 import { baseCookieOpts, SESSION_ID_COOKIE_NAME } from '../middleware/device';
 
@@ -41,13 +42,23 @@ let getAccountLoginUrl = (d: {
 let createCodeVerifier = () => randomBytes(32).toString('base64url');
 
 // Hono hands downstream errors to the app-level handler, which answers JSON.
-// These hooks are reached by a browser redirect, so a blocked domain has to be
-// caught in the handler and rendered as a page.
-let renderSsoDomainError = (ctx: HonoContext, error: unknown) => {
+// These hooks are reached by a browser redirect, so failures have to be caught
+// in the handler and rendered as a page.
+let renderSsoError = (ctx: HonoContext, error: unknown) => {
   if (error instanceof SsoDomainNotAllowedError) {
     return ctx.html(ssoDomainNotAllowedHtml(error), 403);
   }
-  throw error;
+
+  console.error('SSO hook failed:', error);
+
+  return ctx.html(
+    errorHtml({
+      title: 'Unable to Authenticate',
+      message: 'An error occurred during authentication.',
+      details: isServiceError(error) ? error.data.message : undefined
+    }),
+    500
+  );
 };
 
 export let authHooksApp = createHono()
@@ -289,7 +300,7 @@ export let authHooksApp = createHono()
         `${env.service.ARES_SSO_URL}/sso/auth?client_secret=${ssoAuth.clientSecret}`
       );
     } catch (error) {
-      return renderSsoDomainError(ctx, error);
+      return renderSsoError(ctx, error);
     }
   })
   .get('/sso-delegation-response', async ctx => {
@@ -413,7 +424,7 @@ export let authHooksApp = createHono()
       next.searchParams.set('auth_id', auth.id);
       return ctx.redirect(next.toString());
     } catch (error) {
-      return renderSsoDomainError(ctx, error);
+      return renderSsoError(ctx, error);
     }
   })
   .get('/sso-response', async ctx => {
@@ -488,7 +499,7 @@ export let authHooksApp = createHono()
       redirectUrl.searchParams.set('code', session.authorizationCode);
       return ctx.redirect(redirectUrl.toString());
     } catch (error) {
-      return renderSsoDomainError(ctx, error);
+      return renderSsoError(ctx, error);
     }
   })
 

--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -31,13 +31,13 @@ import { parseEmail } from '../lib/parseEmail';
 import type { OAuthCredentials } from '../lib/socials';
 import { socials } from '../lib/socials';
 import { turnstileVerifier } from '../lib/turnstile';
+import { markAresUserChanged } from '../queues/syncCallback';
 import { accessGroupService } from './accessGroup';
 import { auditLogService } from './auditLog';
 import { authBlockService } from './authBlock';
 import { deviceService } from './device';
 import { ssoDomainPolicyService } from './sso/domainPolicy';
 import { userService } from './user';
-import { markAresUserChanged } from '../queues/syncCallback';
 
 let sendSuccessfulLoginEmail = async (d: {
   user: User;
@@ -710,22 +710,15 @@ class AuthServiceImpl {
     }
 
     if (!userIdentity.userOid) {
-      let user = await userService.findByEmailSafe({
+      let { user } = await userService.resolveOrCreateUser({
         email: d.ssoUser.email,
+        firstName: d.ssoUser.firstName,
+        lastName: d.ssoUser.lastName,
+        acceptedTerms: true,
+        type: 'standard_user',
+        context: d.context,
         app: d.app
       });
-
-      if (!user) {
-        user = await userService.createUser({
-          email: d.ssoUser.email,
-          firstName: d.ssoUser.firstName,
-          lastName: d.ssoUser.lastName,
-          acceptedTerms: true,
-          type: 'standard_user',
-          context: d.context,
-          app: d.app
-        });
-      }
 
       userIdentity = await db.userIdentity.update({
         where: { oid: userIdentity.oid },
@@ -1010,15 +1003,30 @@ class AuthServiceImpl {
       );
     }
 
-    let user = d.authIntent.identifier
-      ? await userService.findByEmailSafe({
-          email: d.authIntent.identifier,
-          app: d.app
+    if (!d.authIntent.identifier) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Cannot create user without email identifier'
         })
-      : null;
+      );
+    }
+
+    let context = { ip: d.authIntent.ip, ua: d.authIntent.ua ?? '' };
+
+    // Resolved ahead of the transaction below so that losing the create race
+    // can be recovered from -- see userService.resolveOrCreateUser.
+    let { user, created } = await userService.resolveOrCreateUser({
+      email: d.authIntent.identifier,
+      firstName: d.input.firstName,
+      lastName: d.input.lastName,
+      acceptedTerms: d.input.acceptedTerms,
+      type: 'standard_user',
+      context,
+      app: d.app
+    });
 
     return await withTransaction(async tdb => {
-      if (user) {
+      if (!created) {
         user = await userService.linkToAccount({ user });
         user = await userService.updateUser({
           user,
@@ -1026,31 +1034,7 @@ class AuthServiceImpl {
             firstName: d.input.firstName,
             lastName: d.input.lastName
           },
-          context: {
-            ip: d.authIntent.ip,
-            ua: d.authIntent.ua ?? ''
-          }
-        });
-      } else {
-        if (!d.authIntent.identifier) {
-          throw new ServiceError(
-            badRequestError({
-              message: 'Cannot create user without email identifier'
-            })
-          );
-        }
-
-        user = await userService.createUser({
-          email: d.authIntent.identifier,
-          firstName: d.input.firstName,
-          lastName: d.input.lastName,
-          acceptedTerms: d.input.acceptedTerms,
-          type: 'standard_user',
-          context: {
-            ip: d.authIntent.ip,
-            ua: d.authIntent.ua ?? ''
-          },
-          app: d.app
+          context
         });
       }
 

--- a/src/ares/service/src/services/user.test.ts
+++ b/src/ares/service/src/services/user.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { db, auditLogService, markAresUserChanged, userEvents } = vi.hoisted(() => ({
+  db: {
+    user: { findFirst: vi.fn(), create: vi.fn() },
+    userEmail: { findFirst: vi.fn(), create: vi.fn() },
+    userTermsAgreement: { upsert: vi.fn() },
+    accountDomain: { findUnique: vi.fn() },
+    emailDomain: { upsert: vi.fn() }
+  },
+  auditLogService: { log: vi.fn() },
+  markAresUserChanged: vi.fn(),
+  userEvents: { fire: vi.fn() }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_name: string, factory: () => unknown) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('../db', () => ({
+  db,
+  withTransaction: async (cb: (tdb: unknown) => Promise<unknown>) => await cb(db),
+  addAfterTransactionHook: (hook: () => unknown) => hook()
+}));
+
+vi.mock('../definitions', () => ({
+  terms: {
+    privacyPolicy: { oid: 90n, identifier: 'privacy_policy', version: '1' },
+    termsOfService: { oid: 91n, identifier: 'terms_of_service', version: '1' }
+  }
+}));
+
+vi.mock('../events/user', () => ({ userEvents }));
+
+vi.mock('../queues/syncCallback', () => ({ markAresUserChanged }));
+
+vi.mock('./auditLog', () => ({ auditLogService }));
+
+import { EmailInUseError, userService } from './user';
+
+let app = { oid: 5n, defaultTenantOid: 7n } as any;
+
+let context = { ip: '1.2.3.4', ua: 'agent' };
+
+let input = {
+  email: 'T2@a.herber.space',
+  firstName: 'T2',
+  lastName: 'Herber',
+  acceptedTerms: true,
+  type: 'standard_user' as const,
+  context,
+  app
+};
+
+let existingUser = { oid: 42n, id: 'usr_existing', appOid: 5n, email: 't2@a.herber.space' };
+
+let uniqueConstraintError = () =>
+  Object.assign(new Error('Unique constraint'), {
+    code: 'P2002'
+  });
+
+describe('userService.resolveOrCreateUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    db.user.findFirst.mockResolvedValue(null);
+    db.user.create.mockResolvedValue({ ...existingUser, id: 'usr_new' });
+    db.accountDomain.findUnique.mockResolvedValue(null);
+    db.userEmail.findFirst.mockResolvedValue(null);
+    db.emailDomain.upsert.mockResolvedValue({ oid: 3n });
+    db.userEmail.create.mockResolvedValue({ oid: 4n });
+    db.userTermsAgreement.upsert.mockResolvedValue({ oid: 5n });
+  });
+
+  it('returns the existing user without inserting', async () => {
+    db.user.findFirst.mockResolvedValue(existingUser);
+
+    await expect(userService.resolveOrCreateUser(input)).resolves.toEqual({
+      user: existingUser,
+      created: false
+    });
+
+    expect(db.user.create).not.toHaveBeenCalled();
+  });
+
+  it('looks the user up with the email lower-cased', async () => {
+    await userService.resolveOrCreateUser(input);
+
+    expect(db.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { email: 't2@a.herber.space' },
+            { userEmails: { some: { email: 't2@a.herber.space', verifiedAt: { not: null } } } }
+          ]
+        })
+      })
+    );
+  });
+
+  it('creates the user when there is none', async () => {
+    let created = { ...existingUser, id: 'usr_new' };
+    db.user.create.mockResolvedValue(created);
+
+    await expect(userService.resolveOrCreateUser(input)).resolves.toEqual({
+      user: created,
+      created: true
+    });
+  });
+
+  // The hyperplane projection lands SCIM-provisioned users into this cell and
+  // can insert the row for an email while an SSO login is mid-flight.
+  it('adopts the user a concurrent writer created', async () => {
+    db.user.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(existingUser);
+    db.user.create.mockRejectedValue(uniqueConstraintError());
+
+    await expect(userService.resolveOrCreateUser(input)).resolves.toEqual({
+      user: existingUser,
+      created: false
+    });
+  });
+
+  it('surfaces the conflict when no user turns up after the retry', async () => {
+    db.user.create.mockRejectedValue(uniqueConstraintError());
+
+    await expect(userService.resolveOrCreateUser(input)).rejects.toBeInstanceOf(
+      EmailInUseError
+    );
+  });
+
+  it('does not swallow unrelated failures', async () => {
+    db.user.create.mockRejectedValue(new Error('connection reset'));
+
+    await expect(userService.resolveOrCreateUser(input)).rejects.toThrow('connection reset');
+    expect(db.user.findFirst).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('userService.createUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    db.accountDomain.findUnique.mockResolvedValue(null);
+    db.userEmail.findFirst.mockResolvedValue(null);
+    db.emailDomain.upsert.mockResolvedValue({ oid: 3n });
+    db.userEmail.create.mockResolvedValue({ oid: 4n });
+    db.userTermsAgreement.upsert.mockResolvedValue({ oid: 5n });
+  });
+
+  it('reports a duplicate email as a 409', async () => {
+    db.user.create.mockRejectedValue(uniqueConstraintError());
+
+    let error = await userService.createUser(input).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(EmailInUseError);
+    expect((error as EmailInUseError).data).toMatchObject({
+      status: 409,
+      code: 'conflict',
+      message: 'This email is already in use'
+    });
+  });
+});

--- a/src/ares/service/src/services/user.ts
+++ b/src/ares/service/src/services/user.ts
@@ -13,8 +13,16 @@ import { userEvents } from '../events/user';
 import { getId } from '../id';
 import type { Context } from '../lib/context';
 import { parseEmail } from '../lib/parseEmail';
-import { auditLogService } from './auditLog';
 import { markAresUserChanged } from '../queues/syncCallback';
+import { auditLogService } from './auditLog';
+
+export class EmailInUseError extends ServiceError<ReturnType<typeof conflictError>> {
+  constructor() {
+    super(conflictError({ message: 'This email is already in use' }));
+  }
+}
+
+let isUniqueConstraintError = (e: any) => e?.code === 'P2002';
 
 class UserServiceImpl {
   async getSyncSnapshot(d: { user: User }) {
@@ -119,12 +127,17 @@ class UserServiceImpl {
     };
   }) {
     let authorityRevision = BigInt(d.input.authorityRevision);
-    let existing = d.input.userId
-      ? await db.user.findFirst({ where: { id: d.input.userId, appOid: d.app.oid } })
-      : null;
-    existing ??= await db.user.findFirst({
-      where: { appOid: d.app.oid, email: d.input.email }
-    });
+    let resolveExisting = async () => {
+      let byId = d.input.userId
+        ? await db.user.findFirst({ where: { id: d.input.userId, appOid: d.app.oid } })
+        : null;
+      return (
+        byId ??
+        (await db.user.findFirst({ where: { appOid: d.app.oid, email: d.input.email } }))
+      );
+    };
+
+    let existing = await resolveExisting();
     if (
       existing?.hyperplaneRevision != null &&
       existing.hyperplaneRevision >= authorityRevision
@@ -132,111 +145,125 @@ class UserServiceImpl {
       return existing;
     }
 
-    return await withTransaction(async tdb => {
-      if (existing) {
-        await tdb.$queryRaw`
-          SELECT "oid"
-          FROM "User"
-          WHERE "oid" = ${existing.oid}
-          FOR UPDATE
-        `;
-        existing = await tdb.user.findUniqueOrThrow({ where: { oid: existing.oid } });
+    let apply = async () =>
+      await withTransaction(async tdb => {
+        if (existing) {
+          await tdb.$queryRaw`
+            SELECT "oid"
+            FROM "User"
+            WHERE "oid" = ${existing.oid}
+            FOR UPDATE
+          `;
+          existing = await tdb.user.findUniqueOrThrow({ where: { oid: existing.oid } });
 
-        if (
-          existing.hyperplaneRevision != null &&
-          existing.hyperplaneRevision >= authorityRevision
-        ) {
-          return existing;
+          if (
+            existing.hyperplaneRevision != null &&
+            existing.hyperplaneRevision >= authorityRevision
+          ) {
+            return existing;
+          }
         }
-      }
 
-      let lastLoginAt =
-        !existing?.lastLoginAt ||
-        (d.input.lastLoginAt && d.input.lastLoginAt > existing.lastLoginAt)
-          ? d.input.lastLoginAt
-          : existing.lastLoginAt;
-      let lastActiveAt =
-        !existing?.lastActiveAt ||
-        (d.input.lastActiveAt && d.input.lastActiveAt > existing.lastActiveAt)
-          ? d.input.lastActiveAt
-          : existing.lastActiveAt;
-      let user = existing
-        ? await tdb.user.update({
-            where: { oid: existing.oid },
-            data: {
-              email: d.input.email,
-              name: d.input.name,
-              firstName: d.input.firstName,
-              lastName: d.input.lastName,
-              image: d.input.image,
-              status: d.input.status,
-              deletedAt: d.input.deletedAt,
-              lastLoginAt,
-              lastActiveAt,
-              hyperplaneRevision: authorityRevision
-            }
-          })
-        : await tdb.user.create({
-            data: {
-              ...getId('user'),
-              ...(d.input.userId ? { id: d.input.userId } : {}),
-              appOid: d.app.oid,
-              tenantOid: d.app.defaultTenantOid!,
-              type: 'user',
-              owner: 'self',
-              status: d.input.status,
-              email: d.input.email,
-              name: d.input.name,
-              firstName: d.input.firstName,
-              lastName: d.input.lastName,
-              image: d.input.image,
-              deletedAt: d.input.deletedAt,
-              lastLoginAt,
-              lastActiveAt,
-              hyperplaneRevision: authorityRevision
-            }
-          });
+        let lastLoginAt =
+          !existing?.lastLoginAt ||
+          (d.input.lastLoginAt && d.input.lastLoginAt > existing.lastLoginAt)
+            ? d.input.lastLoginAt
+            : existing.lastLoginAt;
+        let lastActiveAt =
+          !existing?.lastActiveAt ||
+          (d.input.lastActiveAt && d.input.lastActiveAt > existing.lastActiveAt)
+            ? d.input.lastActiveAt
+            : existing.lastActiveAt;
+        let user = existing
+          ? await tdb.user.update({
+              where: { oid: existing.oid },
+              data: {
+                email: d.input.email,
+                name: d.input.name,
+                firstName: d.input.firstName,
+                lastName: d.input.lastName,
+                image: d.input.image,
+                status: d.input.status,
+                deletedAt: d.input.deletedAt,
+                lastLoginAt,
+                lastActiveAt,
+                hyperplaneRevision: authorityRevision
+              }
+            })
+          : await tdb.user.create({
+              data: {
+                ...getId('user'),
+                ...(d.input.userId ? { id: d.input.userId } : {}),
+                appOid: d.app.oid,
+                tenantOid: d.app.defaultTenantOid!,
+                type: 'user',
+                owner: 'self',
+                status: d.input.status,
+                email: d.input.email,
+                name: d.input.name,
+                firstName: d.input.firstName,
+                lastName: d.input.lastName,
+                image: d.input.image,
+                deletedAt: d.input.deletedAt,
+                lastLoginAt,
+                lastActiveAt,
+                hyperplaneRevision: authorityRevision
+              }
+            });
 
-      await this.setEmails({ user, emails: d.input.emails, suppressSync: true });
+        await this.setEmails({ user, emails: d.input.emails, suppressSync: true });
 
-      for (let agreement of d.input.termsAgreements) {
-        let type = await tdb.userTermsType.upsert({
-          where: {
-            identifier_version: {
-              identifier: agreement.terms.identifier,
-              version: agreement.terms.version
-            }
-          },
-          create: { ...getId('userTermsType'), ...agreement.terms },
-          update: { name: agreement.terms.name }
-        });
-        let currentAgreement = await tdb.userTermsAgreement.findUnique({
-          where: { userOid_typeOid: { userOid: user.oid, typeOid: type.oid } }
-        });
-        if (!currentAgreement) {
-          await tdb.userTermsAgreement.create({
-            data: {
-              ...getId('userTermsAgreement'),
-              userOid: user.oid,
-              typeOid: type.oid,
-              ip: agreement.ip,
-              ua: agreement.ua,
-              createdAt: agreement.acceptedAt
-            }
+        for (let agreement of d.input.termsAgreements) {
+          let type = await tdb.userTermsType.upsert({
+            where: {
+              identifier_version: {
+                identifier: agreement.terms.identifier,
+                version: agreement.terms.version
+              }
+            },
+            create: { ...getId('userTermsType'), ...agreement.terms },
+            update: { name: agreement.terms.name }
           });
-        } else if (agreement.acceptedAt < currentAgreement.createdAt) {
-          await tdb.userTermsAgreement.update({
-            where: { oid: currentAgreement.oid },
-            data: {
-              ip: agreement.ip,
-              ua: agreement.ua,
-              createdAt: agreement.acceptedAt
-            }
+          let currentAgreement = await tdb.userTermsAgreement.findUnique({
+            where: { userOid_typeOid: { userOid: user.oid, typeOid: type.oid } }
           });
+          if (!currentAgreement) {
+            await tdb.userTermsAgreement.create({
+              data: {
+                ...getId('userTermsAgreement'),
+                userOid: user.oid,
+                typeOid: type.oid,
+                ip: agreement.ip,
+                ua: agreement.ua,
+                createdAt: agreement.acceptedAt
+              }
+            });
+          } else if (agreement.acceptedAt < currentAgreement.createdAt) {
+            await tdb.userTermsAgreement.update({
+              where: { oid: currentAgreement.oid },
+              data: {
+                ip: agreement.ip,
+                ua: agreement.ua,
+                createdAt: agreement.acceptedAt
+              }
+            });
+          }
         }
-      }
-      return user;
-    });
+        return user;
+      });
+
+    try {
+      return await apply();
+    } catch (e) {
+      if (!isUniqueConstraintError(e)) throw e;
+
+      // A login flow inserted the row for this email between our lookup and
+      // our insert. Re-resolve so the projection lands as an update instead.
+      existing = await resolveExisting();
+      if (!existing) throw e;
+
+      return await apply();
+    }
   }
 
   async linkToAccount(d: { user: User }) {
@@ -261,15 +288,19 @@ class UserServiceImpl {
   }
 
   async findByEmailSafe(d: { email: string; app: App }) {
+    // Emails are always persisted lower-cased, but identity providers assert
+    // them in whatever casing they please.
+    let email = d.email.trim().toLowerCase();
+
     return await db.user.findFirst({
       where: {
         appOid: d.app.oid,
         OR: [
-          { email: d.email },
+          { email },
           {
             userEmails: {
               some: {
-                email: d.email,
+                email,
                 verifiedAt: { not: null }
               }
             }
@@ -368,19 +399,49 @@ class UserServiceImpl {
 
         return user;
       } catch (e: any) {
+        if (isUniqueConstraintError(e)) throw new EmailInUseError();
+
         console.error('Error creating user:', e);
-
-        if (e.code === 'P2002') {
-          throw new ServiceError(
-            conflictError({
-              message: 'This email is already in use'
-            })
-          );
-        }
-
         throw e;
       }
     });
+  }
+
+  /**
+   * Resolves the user owning an email, creating one if there is none yet.
+   *
+   * A user row for a given email can be written by several independent
+   * writers -- an interactive login, and the hyperplane projection that lands
+   * SCIM-provisioned users into this cell. A lookup that comes back empty is
+   * therefore not a guarantee that the insert will succeed, so treat a unique
+   * constraint violation as "somebody else got there first" and adopt their
+   * row rather than failing the caller.
+   *
+   * Must not be called from inside a transaction: recovering from the
+   * conflict requires the failed insert to have been rolled back first.
+   */
+  async resolveOrCreateUser(d: {
+    email: string;
+    firstName: string;
+    lastName: string;
+    acceptedTerms: boolean;
+    context: Context;
+    app: App;
+    type: 'standard_user' | 'pre_created_user';
+  }): Promise<{ user: User; created: boolean }> {
+    let existing = await this.findByEmailSafe({ email: d.email, app: d.app });
+    if (existing) return { user: existing, created: false };
+
+    try {
+      return { user: await this.createUser(d), created: true };
+    } catch (e) {
+      if (!(e instanceof EmailInUseError) && !isUniqueConstraintError(e)) throw e;
+
+      let raced = await this.findByEmailSafe({ email: d.email, app: d.app });
+      if (!raced) throw e;
+
+      return { user: raced, created: false };
+    }
   }
 
   async listUserProfile(d: { user: User }) {
@@ -422,29 +483,25 @@ class UserServiceImpl {
   }) {
     d.email = d.email.trim().toLowerCase();
 
-    let existingEmail = await db.userEmail.findFirst({
-      where: {
-        appOid: d.app.oid,
-        email: d.email
-      }
-    });
-    if (existingEmail) {
-      if (existingEmail.userOid === d.user.oid) {
-        throw new ServiceError(
-          conflictError({
-            message: 'This email is already associated with your account'
-          })
-        );
-      }
-
-      throw new ServiceError(
-        conflictError({
-          message: 'This email is already in use'
-        })
-      );
-    }
-
     return withTransaction(async tdb => {
+      let existingEmail = await tdb.userEmail.findFirst({
+        where: {
+          appOid: d.app.oid,
+          email: d.email
+        }
+      });
+      if (existingEmail) {
+        if (existingEmail.userOid === d.user.oid) {
+          throw new ServiceError(
+            conflictError({
+              message: 'This email is already associated with your account'
+            })
+          );
+        }
+
+        throw new EmailInUseError();
+      }
+
       let parsedEmail = parseEmail(d.email);
 
       // Ensure email domain exists


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core authentication user-provisioning and SSO redirect error handling; race recovery is intentional but must not link the wrong user or mask real DB failures.
> 
> **Overview**
> **Hardens user creation when SSO login, auth-intent signup, and hyperplane (SCIM) projection can write the same email concurrently.** A new `userService.resolveOrCreateUser` looks up by normalized email and, on a unique-constraint failure, re-fetches and adopts the existing row instead of failing. SSO linking (`authWithSso`) and `createUserForAuthIntent` now use this helper; existing users on the auth-intent path still get `linkToAccount` and profile updates inside the transaction.
> 
> **User service details:** `findByEmailSafe` lowercases emails before lookup. Duplicate-email conflicts surface as `EmailInUseError` (409) from `createUser` and `createEmail` (duplicate check moved inside the email transaction). `applyProjection` retries after `P2002` by re-resolving the user and applying an update.
> 
> **SSO hook UX:** Browser redirect hooks replace domain-only HTML handling with `renderSsoError`, which still returns 403 for disallowed domains but returns a generic **Unable to Authenticate** HTML page (with service error message when available) for other failures instead of bubbling to JSON error handling.
> 
> **Tests:** Vitest coverage for `resolveOrCreateUser` (existing user, casing, create, concurrent adopt, conflict, non-P2002 errors) and `createUser` duplicate mapping to 409.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aec824653234d8801e91987a18c25e6e63c30d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->