### PR TITLE
Harden portal routing

### DIFF
--- a/src/metorial-frontend/packages/state/src/user/auth/isAuthRoute.test.ts
+++ b/src/metorial-frontend/packages/state/src/user/auth/isAuthRoute.test.ts
@@ -29,4 +29,13 @@ describe('isAuthRoute', () => {
       })
     ).toBe(false);
   });
+
+  test('treats an empty authFrontendUrl as the current origin', () => {
+    expect(
+      isAuthRoute('http://localhost:3103/login', {
+        ...auth,
+        authFrontendUrl: ''
+      })
+    ).toBe(true);
+  });
 });

--- a/src/metorial-frontend/packages/state/src/user/auth/isAuthRoute.ts
+++ b/src/metorial-frontend/packages/state/src/user/auth/isAuthRoute.ts
@@ -8,7 +8,7 @@ export let isAuthRoute = (
   }
 ) => {
   let current = new URL(currentUrl);
-  let authOrigin = auth.authFrontendUrl ?? current.origin;
+  let authOrigin = auth.authFrontendUrl || current.origin;
 
   return [auth.loginPath, auth.logoutPath, auth.signupPath].some(path => {
     let route = new URL(path, authOrigin);

--- a/src/metorial-frontend/packages/state/src/user/auth/redirect.ts
+++ b/src/metorial-frontend/packages/state/src/user/auth/redirect.ts
@@ -12,7 +12,7 @@ export let redirectToAuth = async (
 
   let config = await awaitConfig();
 
-  let u = new URL(config.auth.loginPath, config.auth.authFrontendUrl ?? location.origin);
+  let u = new URL(config.auth.loginPath, config.auth.authFrontendUrl || location.origin);
   u.searchParams.set('redirect_uri', nextUrl);
 
   if (opts?.intent) u.searchParams.set('intent', opts.intent);
@@ -27,7 +27,7 @@ export let redirectToLogout = async () => {
 
   let config = await awaitConfig();
 
-  let u = new URL(config.auth.logoutPath, config.auth.authFrontendUrl ?? location.origin);
+  let u = new URL(config.auth.logoutPath, config.auth.authFrontendUrl || location.origin);
 
   window.location.replace(u.toString());
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small behavioral fix in auth URL resolution with a targeted test; no new APIs or broad refactors.
> 
> **Overview**
> Auth route detection and login/logout redirects now use **`||`** instead of **`??`** when resolving `authFrontendUrl`, so an **empty string** falls back to the current page origin the same way `undefined` does.
> 
> Previously, `authFrontendUrl: ''` could produce wrong base URLs for `new URL(path, authOrigin)` and misclassify routes. **`isAuthRoute`**, **`redirectToAuth`**, and **`redirectToLogout`** are aligned on this behavior.
> 
> A test confirms `/login` on the current origin is recognized when `authFrontendUrl` is `''`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 098a0ecd8adf2fba578013609c5b68e12d9dcc46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->