### PR TITLE
Decouple test sso

### DIFF
--- a/src/ares/service/prisma/schema/sso/profile.prisma
+++ b/src/ares/service/prisma/schema/sso/profile.prisma
@@ -138,7 +138,6 @@ model SsoUserProfile {
   updatedAt DateTime @default(now()) @updatedAt
 
   auths                        SsoAuth[]
-  ssoTests                     SsoTest[]
   delegationAuthorizationCodes SsoDelegationAuthorizationCode[]
   delegationTokens             SsoDelegationToken[]
 

--- a/src/ares/service/prisma/schema/sso/test.prisma
+++ b/src/ares/service/prisma/schema/sso/test.prisma
@@ -20,11 +20,14 @@ model SsoTest {
   connectionOid BigInt
   connection    SsoConnection @relation(fields: [connectionOid], references: [oid], onDelete: Cascade)
 
-  userOid BigInt?
-  user    SsoUser? @relation(fields: [userOid], references: [oid], onDelete: SetNull)
-
-  userProfileOid BigInt?
-  userProfile    SsoUserProfile? @relation(fields: [userProfileOid], references: [oid], onDelete: SetNull)
+  email     String?
+  firstName String?
+  lastName  String?
+  uid       String?
+  sub       String?
+  groups    String[]
+  roles     String[]
+  raw       Json?
 
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt

--- a/src/ares/service/prisma/schema/sso/user.prisma
+++ b/src/ares/service/prisma/schema/sso/user.prisma
@@ -28,7 +28,6 @@ model SsoUser {
   groupLinks SsoUserGroup[]
   roleLinks  SsoUserRole[]
   auths      SsoAuth[]
-  ssoTests   SsoTest[]
   changes    SsoUserChange[]
 
   @@index([tenantOid, email])

--- a/src/ares/service/src/apis/internal/controllers/ssoV2/connections.ts
+++ b/src/ares/service/src/apis/internal/controllers/ssoV2/connections.ts
@@ -1,4 +1,4 @@
-import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { randomUUID } from 'crypto';
@@ -13,6 +13,7 @@ import {
   ssoConnectionGroupPresenter,
   ssoConnectionPresenter,
   ssoConnectionRolePresenter,
+  ssoTestPresenter,
   ssoUserProfilePresenter
 } from '../../presenters';
 import { tenantApp } from './_middleware';
@@ -146,6 +147,34 @@ export let ssoConnectionsController = tenantApp.controller({
       let url = new URL('/sso/auth', env.service.ARES_SSO_URL);
       url.searchParams.set('client_secret', auth.clientSecret);
       return { url: url.toString() };
+    }),
+
+  getTest: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        connectionId: v.string(),
+        testId: v.string()
+      })
+    )
+    .do(async ({ input, tenant }) => {
+      let connection = await ssoConnectionService.getConnectionById({
+        tenant,
+        connectionId: input.connectionId
+      });
+
+      let test = await db.ssoTest.findFirst({
+        where: {
+          id: input.testId,
+          tenantOid: tenant.oid,
+          connectionOid: connection.oid
+        },
+        include: { connection: { select: { id: true, name: true, status: true } } }
+      });
+      if (!test) throw new ServiceError(notFoundError('ssoTest'));
+
+      return ssoTestPresenter(test);
     }),
 
   update: tenantApp

--- a/src/ares/service/src/apis/internal/presenters/sso.ts
+++ b/src/ares/service/src/apis/internal/presenters/sso.ts
@@ -10,6 +10,7 @@ import type {
   SsoRole,
   SsoScimOperation,
   SsoTenant,
+  SsoTest,
   SsoUser,
   SsoUserChange,
   SsoUserGroup,
@@ -506,6 +507,31 @@ export let ssoUserPresenter = (
   roles: (user.roleLinks ?? []).map(link => ssoRoleRefPresenter(link.role)),
   createdAt: user.createdAt,
   updatedAt: user.updatedAt
+});
+
+export let ssoTestPresenter = (
+  test: SsoTest & { connection?: Pick<SsoConnection, 'id' | 'name' | 'status'> | null }
+) => ({
+  object: 'ares#ssoTest' as const,
+  id: test.id,
+  status: test.status,
+  connectionId: test.connection?.id ?? null,
+  // The captured assertion. Present once the test completes, and held nowhere else.
+  profile:
+    test.status === 'completed'
+      ? {
+          email: test.email,
+          firstName: test.firstName,
+          lastName: test.lastName,
+          uid: test.uid,
+          sub: test.sub,
+          groups: test.groups,
+          roles: test.roles,
+          raw: test.raw
+        }
+      : null,
+  createdAt: test.createdAt,
+  completedAt: test.completedAt
 });
 
 export let ssoUserSyncSnapshotPresenter = (d: {

--- a/src/ares/service/src/apis/sso/endpoints/auth.ts
+++ b/src/ares/service/src/apis/sso/endpoints/auth.ts
@@ -207,6 +207,41 @@ export let ssoAuthApp = createHono()
         context: getRequestContext(c)
       });
 
+      if (auth.purpose === 'connection_test') {
+        let testSso = await db.ssoTest.findUnique({ where: { authOid: auth.oid } });
+        if (!testSso) {
+          throw new ServiceError(badRequestError({ message: 'SSO test record not found.' }));
+        }
+
+        await db.ssoTest.update({
+          where: { oid: testSso.oid },
+          data: {
+            status: 'completed',
+            email: userInfo.email,
+            firstName: userInfo.firstName,
+            lastName: userInfo.lastName,
+            uid: userInfo.id,
+            sub: userInfo.sub ?? null,
+            groups: userInfo.groups ?? [],
+            roles: userInfo.roles ?? [],
+            raw: userInfo.raw,
+            completedAt: new Date()
+          }
+        });
+
+        let testRedirect = getSsoAuthCompletionRedirect({
+          redirectUri: auth.redirectUri,
+          purpose: auth.purpose,
+          tenantId: auth.tenant.id,
+          authId: auth.id,
+          testSsoId: testSso.id
+        });
+
+        // The auth was only ever a vehicle for the test, and `SsoTest.authId` keeps the audit trail.
+        await db.ssoAuth.delete({ where: { oid: auth.oid } });
+        return c.redirect(testRedirect.url);
+      }
+
       let user = await ssoIdentityService.upsertUser({
         tenant: auth.tenant,
         email: userInfo.email,
@@ -241,37 +276,12 @@ export let ssoAuthApp = createHono()
         }
       });
 
-      let testSso =
-        auth.purpose === 'connection_test'
-          ? await db.ssoTest.findUnique({ where: { authOid: auth.oid } })
-          : null;
-      if (auth.purpose === 'connection_test' && !testSso) {
-        throw new ServiceError(badRequestError({ message: 'SSO test record not found.' }));
-      }
-      if (testSso) {
-        await db.ssoTest.update({
-          where: { oid: testSso.oid },
-          data: {
-            status: 'completed',
-            userOid: user.oid,
-            userProfileOid: profile.oid,
-            completedAt: new Date()
-          }
-        });
-      }
-
       let completionRedirect = getSsoAuthCompletionRedirect({
         redirectUri: auth.redirectUri,
         purpose: auth.purpose,
         tenantId: auth.tenant.id,
-        authId: auth.id,
-        userId: user.id,
-        testSsoId: testSso?.id
+        authId: auth.id
       });
-      if (completionRedirect.consumeAuth) {
-        await db.ssoAuth.delete({ where: { oid: auth.oid } });
-        return c.redirect(completionRedirect.url);
-      }
       return c.redirect(completionRedirect.url);
     } catch (error: any) {
       if (error instanceof SsoDomainNotAllowedError) {

--- a/src/ares/service/src/services/sso/authRedirect.test.ts
+++ b/src/ares/service/src/services/sso/authRedirect.test.ts
@@ -2,23 +2,32 @@ import { describe, expect, it } from 'vitest';
 import { getSsoAuthCompletionRedirect } from './authRedirect';
 
 describe('SSO auth completion redirect', () => {
-  it('returns connection tests with the user ID and preserves existing query parameters', () => {
+  it('returns connection tests with the test ID and preserves existing query parameters', () => {
     let result = getSsoAuthCompletionRedirect({
       redirectUri: 'https://dashboard.test/admin/auth?section=sso',
       purpose: 'connection_test',
       tenantId: 'tenant_123',
       authId: 'auth_123',
-      userId: 'user_123',
       testSsoId: 'test_123'
     });
     let url = new URL(result.url);
 
-    expect(result.consumeAuth).toBe(true);
     expect(url.searchParams.get('section')).toBe('sso');
-    expect(url.searchParams.get('test_sso_user_id')).toBe('user_123');
     expect(url.searchParams.get('test_sso_id')).toBe('test_123');
     expect(url.searchParams.has('tenant_id')).toBe(false);
     expect(url.searchParams.has('auth_id')).toBe(false);
+  });
+
+  it('never points a test at an SSO user, because a test does not create one', () => {
+    let result = getSsoAuthCompletionRedirect({
+      redirectUri: 'https://dashboard.test/admin/auth',
+      purpose: 'connection_test',
+      tenantId: 'tenant_123',
+      authId: 'auth_123',
+      testSsoId: 'test_123'
+    });
+
+    expect(new URL(result.url).searchParams.has('test_sso_user_id')).toBe(false);
   });
 
   it('keeps the existing tenant and auth callback contract for normal authentication', () => {
@@ -26,14 +35,12 @@ describe('SSO auth completion redirect', () => {
       redirectUri: 'https://auth.test/complete',
       purpose: 'authentication',
       tenantId: 'tenant_123',
-      authId: 'auth_123',
-      userId: 'user_123'
+      authId: 'auth_123'
     });
     let url = new URL(result.url);
 
-    expect(result.consumeAuth).toBe(false);
     expect(url.searchParams.get('tenant_id')).toBe('tenant_123');
     expect(url.searchParams.get('auth_id')).toBe('auth_123');
-    expect(url.searchParams.has('test_sso_user_id')).toBe(false);
+    expect(url.searchParams.has('test_sso_id')).toBe(false);
   });
 });

--- a/src/ares/service/src/services/sso/authRedirect.ts
+++ b/src/ares/service/src/services/sso/authRedirect.ts
@@ -3,18 +3,17 @@ export let getSsoAuthCompletionRedirect = (input: {
   purpose: 'authentication' | 'connection_test';
   tenantId: string;
   authId: string;
-  userId: string;
   testSsoId?: string;
 }) => {
   let redirectUri = new URL(input.redirectUri);
+
   if (input.purpose === 'connection_test') {
     if (!input.testSsoId) throw new Error('Missing SSO test ID.');
     redirectUri.searchParams.set('test_sso_id', input.testSsoId);
-    redirectUri.searchParams.set('test_sso_user_id', input.userId);
-    return { url: redirectUri.toString(), consumeAuth: true };
+    return { url: redirectUri.toString() };
   }
 
   redirectUri.searchParams.set('tenant_id', input.tenantId);
   redirectUri.searchParams.set('auth_id', input.authId);
-  return { url: redirectUri.toString(), consumeAuth: false };
+  return { url: redirectUri.toString() };
 };

--- a/src/metorial-frontend/packages/config/src/paths.ts
+++ b/src/metorial-frontend/packages/config/src/paths.ts
@@ -1018,8 +1018,10 @@ let AdminPaths = Object.assign(
 
       return AdminPaths(accountId, 'invites', inviteId, ...subPages);
     },
+    access: (accountId: string | null | undefined, ...subPages: SubPages) =>
+      AdminPaths(accountId, 'access', ...subPages),
     groups: (accountId: string | null | undefined, ...subPages: SubPages) =>
-      AdminPaths(accountId, 'groups', ...subPages),
+      AdminPaths(accountId, 'access', ...subPages),
     group: (
       accountId: string | null | undefined,
       groupId: string | null | undefined,
@@ -1027,10 +1029,10 @@ let AdminPaths = Object.assign(
     ) => {
       if (!groupId) return '#';
 
-      return AdminPaths(accountId, 'groups', groupId, ...subPages);
+      return AdminPaths(accountId, 'access', 'groups', groupId, ...subPages);
     },
     policies: (accountId: string | null | undefined, ...subPages: SubPages) =>
-      AdminPaths(accountId, 'policies', ...subPages),
+      AdminPaths(accountId, 'access', ...subPages),
     policy: (
       accountId: string | null | undefined,
       policyId: string | null | undefined,
@@ -1038,7 +1040,7 @@ let AdminPaths = Object.assign(
     ) => {
       if (!policyId) return '#';
 
-      return AdminPaths(accountId, 'policies', policyId, ...subPages);
+      return AdminPaths(accountId, 'access', 'policies', policyId, ...subPages);
     },
     workspaces: (accountId: string | null | undefined, ...subPages: SubPages) =>
       AdminPaths(accountId, 'workspaces', ...subPages),

--- a/src/metorial/modules/organization/src/services/organizationMember.test.ts
+++ b/src/metorial/modules/organization/src/services/organizationMember.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let countOrganizationMembersMock = vi.fn();
 let updateOrganizationMemberMock = vi.fn();
+let findFirstOrganizationMemberMock = vi.fn();
 let fabricFireMock = vi.fn();
 let syncOrgMemberToConsumerMock = vi.fn();
 let syncMemberDefaultPoliciesMock = vi.fn();
@@ -36,7 +37,8 @@ vi.mock('@metorial/db', () => ({
     await cb({
       organizationMember: {
         count: countOrganizationMembersMock,
-        update: updateOrganizationMemberMock
+        update: updateOrganizationMemberMock,
+        findFirst: findFirstOrganizationMemberMock
       }
     })
 }));
@@ -151,5 +153,42 @@ describe('organizationMemberService admin removal safeguards', () => {
     });
 
     expect(updateOrganizationMemberMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('organizationMemberService.createOrganizationMember', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateOrganizationMemberMock.mockImplementation(async ({ data }: { data: unknown }) => ({
+      id: 'orgmem_1',
+      ...((data ?? {}) as object)
+    }));
+  });
+
+  // Anything asking whether the seat is live reads the timestamp, so leaving the old one behind
+  // makes a member who is back look removed.
+  it('clears the removal timestamp when a removed member is added again', async () => {
+    findFirstOrganizationMemberMock.mockResolvedValue({
+      oid: 2n,
+      status: 'deleted',
+      deletedAt: new Date(),
+      actor: { oid: 3n }
+    });
+
+    let { organizationMemberService } = await import('./organizationMember');
+
+    await organizationMemberService.createOrganizationMember({
+      user: { oid: 4n, type: 'user', email: 'a@b.c', name: 'A' } as any,
+      organization: { oid: 1n, authVersion: 'v2' } as any,
+      input: { role: 'member' },
+      context: { ip: '127.0.0.1', ua: 'test' },
+      performedBy: { type: 'actor', actor: { oid: 3n } as any }
+    });
+
+    expect(updateOrganizationMemberMock).toHaveBeenCalledTimes(1);
+    expect(updateOrganizationMemberMock.mock.calls[0]![0].data).toMatchObject({
+      status: 'active',
+      deletedAt: null
+    });
   });
 });

--- a/src/metorial/modules/organization/src/services/organizationMember.test.ts
+++ b/src/metorial/modules/organization/src/services/organizationMember.test.ts
@@ -104,6 +104,35 @@ describe('organizationMemberService admin removal safeguards', () => {
     expect(updateOrganizationMemberMock).not.toHaveBeenCalled();
   });
 
+  it('tags the last admin rejection so callers can recognize it', async () => {
+    let { organizationMemberService } = await import('./organizationMember');
+
+    await expect(
+      organizationMemberService.deleteOrganizationMember({
+        organization: { oid: 1n } as any,
+        member: { oid: 2n, role: 'admin', status: 'active' } as any,
+        context: { ip: '127.0.0.1', ua: 'test' },
+        performedBy: { oid: 3n } as any
+      })
+    ).rejects.toMatchObject({ data: { reason: 'last_admin' } });
+  });
+
+  it('allows removing the last admin when the caller opts out of the guard', async () => {
+    let { organizationMemberService } = await import('./organizationMember');
+
+    await expect(
+      organizationMemberService.deleteOrganizationMember({
+        organization: { oid: 1n } as any,
+        member: { oid: 2n, role: 'admin', status: 'active' } as any,
+        context: { ip: '127.0.0.1', ua: 'test' },
+        performedBy: { oid: 3n } as any,
+        allowLastAdminRemoval: true
+      })
+    ).resolves.toMatchObject({ status: 'deleted' });
+
+    expect(countOrganizationMembersMock).not.toHaveBeenCalled();
+  });
+
   it('allows deleting an admin when another admin exists', async () => {
     countOrganizationMembersMock.mockResolvedValue(1);
 

--- a/src/metorial/modules/organization/src/services/organizationMember.ts
+++ b/src/metorial/modules/organization/src/services/organizationMember.ts
@@ -127,6 +127,7 @@ class OrganizationMemberService {
             where: { oid: existingMember.oid },
             data: {
               status: 'active',
+              deletedAt: null,
               isV2Member: d.organization.authVersion == 'v2',
               role: d.input.role,
               organizationOid: d.organization.oid,

--- a/src/metorial/modules/organization/src/services/organizationMember.ts
+++ b/src/metorial/modules/organization/src/services/organizationMember.ts
@@ -67,7 +67,8 @@ class OrganizationMemberService {
 
       throw new ServiceError(
         forbiddenError({
-          message: 'Admins cannot be removed unless there is another admin'
+          message: 'Admins cannot be removed unless there is another admin',
+          reason: 'last_admin'
         })
       );
     });
@@ -232,14 +233,17 @@ class OrganizationMemberService {
     member: OrganizationMember;
     context: Context;
     performedBy: OrganizationActor;
+    allowLastAdminRemoval?: boolean;
   }) {
     await this.ensureOrganizationMemberActive(d.member);
 
     return withTransaction(async db => {
-      await this.assertOrganizationStillHasAnotherAdmin({
-        organization: d.organization,
-        member: d.member
-      });
+      if (!d.allowLastAdminRemoval) {
+        await this.assertOrganizationStillHasAnotherAdmin({
+          organization: d.organization,
+          member: d.member
+        });
+      }
 
       await Fabric.fire('organization.member.deleted:before', {
         ...d,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the SSO auth callback and persistence model for connection tests (schema + redirect contract), which is security-adjacent though isolated from normal login. Admin path changes may break deep links until the UI follows the new routes.
> 
> **Overview**
> **SSO connection tests** no longer create or link `SsoUser` / `SsoUserProfile` records. Completed tests store the IdP assertion (email, names, uid, sub, groups, roles, raw) on `SsoTest` itself, and Prisma relations from users/profiles to tests are removed.
> 
> On the auth callback, `connection_test` is handled **before** identity upsert: the test row is completed, the temporary `SsoAuth` row is deleted (audit kept via `SsoTest.authId`), and the browser is redirected with **`test_sso_id`** only—**`test_sso_user_id`** and the `consumeAuth` redirect flag are dropped. A new internal **`getTest`** handler exposes completed test results via **`ssoTestPresenter`**.
> 
> **Admin URL helpers** move groups/policies under an **`access`** segment (e.g. `access/groups/...`).
> 
> **Organization members:** last-admin removal errors include **`reason: 'last_admin'`**; **`allowLastAdminRemoval`** can bypass the guard; re-adding a deleted member clears **`deletedAt`** when reactivating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aacfe8993b40b5a74d5d72c29a65c93c307b8f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->