### PR TITLE
Harden notification settings

### DIFF
--- a/src/metorial/modules/organization/src/lib/notificationSettings.test.ts
+++ b/src/metorial/modules/organization/src/lib/notificationSettings.test.ts
@@ -2,17 +2,21 @@ import { describe, expect, it, vi } from 'vitest';
 
 let mocks = vi.hoisted(() => ({
   settingUpsert: vi.fn(),
+  settingFindUnique: vi.fn(),
   digestSettingUpsert: vi.fn(),
+  digestSettingFindUnique: vi.fn(),
   generateId: vi.fn()
 }));
 
 vi.mock('@metorial/db', () => ({
   db: {
     organizationNotificationSetting: {
-      upsert: mocks.settingUpsert
+      upsert: mocks.settingUpsert,
+      findUnique: mocks.settingFindUnique
     },
     organizationNotificationDigestSetting: {
-      upsert: mocks.digestSettingUpsert
+      upsert: mocks.digestSettingUpsert,
+      findUnique: mocks.digestSettingFindUnique
     }
   },
   ID: { generateId: mocks.generateId }
@@ -78,6 +82,68 @@ describe('organization notification setting defaults', () => {
         update: {}
       })
     );
+  });
+
+  it('returns the existing setting after a concurrent unique conflict', async () => {
+    let setting = { id: 'ons_1', emailEnabled: true, type: { oid: 3n } };
+    mocks.generateId.mockResolvedValueOnce('ons_race');
+    mocks.settingUpsert.mockRejectedValueOnce({ code: 'P2002' });
+    mocks.settingFindUnique.mockResolvedValueOnce(setting);
+
+    await expect(
+      getOrCreateOrganizationNotificationSetting({
+        member: { userOid: 1n } as any,
+        organization: { oid: 2n } as any,
+        type: { oid: 3n, sendEmail: true } as any
+      })
+    ).resolves.toBe(setting);
+
+    expect(mocks.settingFindUnique).toHaveBeenCalledWith({
+      where: {
+        userOid_organizationOid_typeOid: {
+          userOid: 1n,
+          organizationOid: 2n,
+          typeOid: 3n
+        }
+      },
+      include: { type: true }
+    });
+  });
+
+  it('returns the existing digest setting after a concurrent unique conflict', async () => {
+    let setting = { id: 'onds_1', timeMinutes: 480 };
+    mocks.generateId.mockResolvedValueOnce('onds_race');
+    mocks.digestSettingUpsert.mockRejectedValueOnce({ code: 'P2002' });
+    mocks.digestSettingFindUnique.mockResolvedValueOnce(setting);
+
+    await expect(
+      getOrCreateOrganizationNotificationDigestSetting({
+        member: { userOid: 1n } as any,
+        organization: { oid: 2n } as any
+      })
+    ).resolves.toBe(setting);
+
+    expect(mocks.digestSettingFindUnique).toHaveBeenCalledWith({
+      where: {
+        userOid_organizationOid: {
+          userOid: 1n,
+          organizationOid: 2n
+        }
+      }
+    });
+  });
+
+  it('rethrows non-unique errors from setting upsert', async () => {
+    mocks.generateId.mockResolvedValueOnce('ons_err');
+    mocks.settingUpsert.mockRejectedValueOnce({ code: 'P2025' });
+
+    await expect(
+      getOrCreateOrganizationNotificationSetting({
+        member: { userOid: 1n } as any,
+        organization: { oid: 2n } as any,
+        type: { oid: 3n, sendEmail: true } as any
+      })
+    ).rejects.toEqual({ code: 'P2025' });
   });
 });
 

--- a/src/metorial/modules/organization/src/lib/notificationSettings.ts
+++ b/src/metorial/modules/organization/src/lib/notificationSettings.ts
@@ -9,50 +9,83 @@ import {
 export let defaultNotificationDigestTimeMinutes = 8 * 60;
 export let defaultNotificationDigestTimezone = 'America/Los_Angeles';
 
+let isUniqueConstraintError = (error: any) => error?.code === 'P2002';
+
 export let getOrCreateOrganizationNotificationSetting = async (i: {
   member: OrganizationMember;
   organization: Organization;
   type: OrganizationNotificationType;
-}) =>
-  db.organizationNotificationSetting.upsert({
-    where: {
-      userOid_organizationOid_typeOid: {
-        userOid: i.member.userOid,
-        organizationOid: i.organization.oid,
-        typeOid: i.type.oid
-      }
-    },
-    create: {
-      id: await ID.generateId('organizationNotificationSetting'),
+}) => {
+  let where = {
+    userOid_organizationOid_typeOid: {
       userOid: i.member.userOid,
       organizationOid: i.organization.oid,
-      typeOid: i.type.oid,
-      emailEnabled: i.type.sendEmail
-    },
-    update: {},
-    include: { type: true }
-  });
+      typeOid: i.type.oid
+    }
+  };
+
+  try {
+    return await db.organizationNotificationSetting.upsert({
+      where,
+      create: {
+        id: await ID.generateId('organizationNotificationSetting'),
+        userOid: i.member.userOid,
+        organizationOid: i.organization.oid,
+        typeOid: i.type.oid,
+        emailEnabled: i.type.sendEmail
+      },
+      update: {},
+      include: { type: true }
+    });
+  } catch (error) {
+    // Concurrent upserts can both attempt create and race on the unique key.
+    if (!isUniqueConstraintError(error)) throw error;
+
+    let setting = await db.organizationNotificationSetting.findUnique({
+      where,
+      include: { type: true }
+    });
+    if (!setting) throw error;
+
+    return setting;
+  }
+};
 
 export let getOrCreateOrganizationNotificationDigestSetting = async (i: {
   member: OrganizationMember;
   organization: Organization;
-}) =>
-  db.organizationNotificationDigestSetting.upsert({
-    where: {
-      userOid_organizationOid: {
-        userOid: i.member.userOid,
-        organizationOid: i.organization.oid
-      }
-    },
-    create: {
-      id: await ID.generateId('organizationNotificationDigestSetting'),
+}) => {
+  let where = {
+    userOid_organizationOid: {
       userOid: i.member.userOid,
-      organizationOid: i.organization.oid,
-      timeMinutes: defaultNotificationDigestTimeMinutes,
-      timezone: defaultNotificationDigestTimezone
-    },
-    update: {}
-  });
+      organizationOid: i.organization.oid
+    }
+  };
+
+  try {
+    return await db.organizationNotificationDigestSetting.upsert({
+      where,
+      create: {
+        id: await ID.generateId('organizationNotificationDigestSetting'),
+        userOid: i.member.userOid,
+        organizationOid: i.organization.oid,
+        timeMinutes: defaultNotificationDigestTimeMinutes,
+        timezone: defaultNotificationDigestTimezone
+      },
+      update: {}
+    });
+  } catch (error) {
+    // Concurrent upserts can both attempt create and race on the unique key.
+    if (!isUniqueConstraintError(error)) throw error;
+
+    let setting = await db.organizationNotificationDigestSetting.findUnique({
+      where
+    });
+    if (!setting) throw error;
+
+    return setting;
+  }
+};
 
 let getZonedDateParts = (date: Date, timezone: string) => {
   let parts = new Intl.DateTimeFormat('en-US', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized change to get-or-create helpers with clearer failure behavior under concurrency; no auth or API surface changes.
> 
> **Overview**
> **Hardens lazy creation** of organization notification and digest settings when two requests try to create the same row at once.
> 
> `getOrCreateOrganizationNotificationSetting` and `getOrCreateOrganizationNotificationDigestSetting` still use Prisma `upsert`, but on **unique constraint errors (`P2002`)** they now **load the existing row** with `findUnique` and return it instead of failing. Other database errors are still thrown.
> 
> Tests cover the happy path for concurrent conflicts on both helpers and confirm non-`P2002` errors (e.g. `P2025`) are not swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07463e91b4ce0ef84e17cd40417b7e1261d9923f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->