### PR TITLE
Cleanly handle repo import errors

### DIFF
--- a/src/metorial/cargo/modules/skill/src/queues/import/acquire.ts
+++ b/src/metorial/cargo/modules/skill/src/queues/import/acquire.ts
@@ -139,6 +139,12 @@ export let skillImportAcquireQueueProcessor = skillImportAcquireQueue.process(as
         await skillImportAcquireQueue.add({ skillImportId: skillImport.id }, { delay: 2000 });
         return;
       }
+      if (bucket.status === 'failed') {
+        throw new Error(
+          bucket.errorMessage ??
+            'The repository could not be imported. It may have been deleted or is no longer accessible.'
+        );
+      }
       if (bucket.status !== 'ready') {
         throw new Error(`Origin codebucket entered unexpected status: ${bucket.status}`);
       }

--- a/src/origin/apps/code-bucket/internal/service/rpc.go
+++ b/src/origin/apps/code-bucket/internal/service/rpc.go
@@ -27,36 +27,53 @@ var (
 	providerBearerPattern     = regexp.MustCompile(`(?i)bearer\s+[a-z0-9._~+/-]+=*`)
 )
 
-func providerExportError(provider string, err error) error {
-	message := err.Error()
-	grpcCode := codes.Internal
-
+func providerHTTPStatusToGRPCCode(message string) codes.Code {
 	if matches := providerHTTPStatusPattern.FindStringSubmatch(message); len(matches) == 2 {
 		if httpStatus, parseErr := strconv.Atoi(matches[1]); parseErr == nil {
 			switch {
 			case httpStatus == 400 || httpStatus == 422:
-				grpcCode = codes.InvalidArgument
+				return codes.InvalidArgument
 			case httpStatus == 401:
-				grpcCode = codes.Unauthenticated
+				return codes.Unauthenticated
 			case httpStatus == 403 && isProtectedBranchError(message):
-				grpcCode = codes.FailedPrecondition
+				return codes.FailedPrecondition
 			case httpStatus == 403:
-				grpcCode = codes.PermissionDenied
+				return codes.PermissionDenied
 			case httpStatus == 404:
-				grpcCode = codes.NotFound
+				return codes.NotFound
 			case httpStatus == 408 || httpStatus == 504:
-				grpcCode = codes.DeadlineExceeded
+				return codes.DeadlineExceeded
 			case httpStatus == 409:
-				grpcCode = codes.Aborted
+				return codes.Aborted
 			case httpStatus == 429:
-				grpcCode = codes.ResourceExhausted
+				return codes.ResourceExhausted
 			case httpStatus >= 500:
-				grpcCode = codes.Unavailable
+				return codes.Unavailable
 			}
 		}
 	}
 
-	return status.Errorf(grpcCode, "failed to upload to %s: %s", provider, sanitizeProviderError(message))
+	return codes.Internal
+}
+
+func providerExportError(provider string, err error) error {
+	message := err.Error()
+	return status.Errorf(
+		providerHTTPStatusToGRPCCode(message),
+		"failed to upload to %s: %s",
+		provider,
+		sanitizeProviderError(message),
+	)
+}
+
+func providerImportError(provider string, err error) error {
+	message := err.Error()
+	return status.Errorf(
+		providerHTTPStatusToGRPCCode(message),
+		"failed to download %s repository: %s",
+		provider,
+		sanitizeProviderError(message),
+	)
 }
 
 func isProtectedBranchError(message string) bool {
@@ -105,7 +122,7 @@ func (rs *RcpService) CloneBucket(ctx context.Context, req *rpc.CloneBucketReque
 func (rs *RcpService) CreateBucketFromGithub(ctx context.Context, req *rpc.CreateBucketFromGithubRequest) (*rpc.CreateBucketResponse, error) {
 	iter, err := github.DownloadRepo(req.Owner, req.Repo, req.Path, req.Ref, req.Token)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to download GitHub repository: %v", err)
+		return nil, providerImportError("GitHub", err)
 	}
 	defer iter.Close()
 
@@ -306,7 +323,7 @@ func (rs *RcpService) ExportBucketToGithub(ctx context.Context, req *rpc.ExportB
 func (rs *RcpService) CreateBucketFromGitlab(ctx context.Context, req *rpc.CreateBucketFromGitlabRequest) (*rpc.CreateBucketResponse, error) {
 	iter, err := gitlab.DownloadRepo(req.ProjectId, req.Path, req.Ref, req.Token, req.GitlabApiUrl)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to download GitLab repository: %v", err)
+		return nil, providerImportError("GitLab", err)
 	}
 	defer iter.Close()
 
@@ -348,7 +365,7 @@ func (rs *RcpService) CreateBucketFromBitbucketCloud(ctx context.Context, req *r
 		req.BitbucketWebUrl,
 	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to prepare Bitbucket Cloud repository: %v", err)
+		return nil, providerImportError("Bitbucket Cloud", err)
 	}
 	defer cleanup()
 
@@ -400,7 +417,7 @@ func (rs *RcpService) CreateBucketFromBitbucketDataCenter(ctx context.Context, r
 		req.Token,
 	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to prepare Bitbucket Data Center repository: %v", err)
+		return nil, providerImportError("Bitbucket Data Center", err)
 	}
 	defer cleanup()
 	if err := rs.clearBucket(ctx, req.NewBucketId); err != nil {

--- a/src/origin/apps/code-bucket/internal/service/rpc_test.go
+++ b/src/origin/apps/code-bucket/internal/service/rpc_test.go
@@ -61,6 +61,23 @@ func TestProviderExportErrorMapsProviderFailures(t *testing.T) {
 	}
 }
 
+func TestProviderImportErrorMapsRepositoryNotFound(t *testing.T) {
+	err := providerImportError(
+		"GitHub",
+		errors.New("failed to download zip: bad status: 404 Not Found"),
+	)
+	if got := status.Code(err); got != codes.NotFound {
+		t.Fatalf("expected gRPC code NotFound, got %s", got)
+	}
+	message := status.Convert(err).Message()
+	if !strings.Contains(message, "GitHub") {
+		t.Fatalf("expected provider context in error: %s", message)
+	}
+	if !strings.Contains(message, "404") {
+		t.Fatalf("expected status in error: %s", message)
+	}
+}
+
 func TestProviderExportErrorSanitizesCredentials(t *testing.T) {
 	err := providerExportError(
 		"GitLab",

--- a/src/origin/apps/service/prisma/schema/codeBucket.prisma
+++ b/src/origin/apps/service/prisma/schema/codeBucket.prisma
@@ -12,6 +12,7 @@ model CodeBucketPurpose {
 enum CodeBucketStatus {
   ready
   importing
+  failed
 }
 
 model CodeBucket {
@@ -21,7 +22,8 @@ model CodeBucket {
   purposeOid BigInt
   purpose    CodeBucketPurpose @relation(fields: [purposeOid], references: [oid])
 
-  status CodeBucketStatus @default(ready)
+  status       CodeBucketStatus @default(ready)
+  errorMessage String?
 
   isReadOnly Boolean @default(false)
 

--- a/src/origin/apps/service/src/lib/scmProviderError.test.ts
+++ b/src/origin/apps/service/src/lib/scmProviderError.test.ts
@@ -169,15 +169,20 @@ describe('SCM provider errors', () => {
       'bitbucket',
       `failed to upload to Bitbucket Cloud: source upload failed (status 403): branch restriction rejected the push`,
       'protected_branch'
+    ],
+    [
+      'github',
+      `failed to download GitHub repository: failed to download zip: bad status: 404 Not Found`,
+      'resource_not_found'
     ]
-  ])('classifies %s code-bucket 403 details', (_provider, details, classification) => {
+  ])('classifies %s code-bucket details', (_provider, details, classification) => {
     let error = Object.assign(new Error(`/rpc.CodeBucket/Export INTERNAL: ${details}`), {
       code: 13,
       details
     });
 
     expect(getScmProviderErrorDetails(error)).toMatchObject({
-      status: 403,
+      status: classification === 'resource_not_found' ? 404 : 403,
       description: details,
       classification
     });

--- a/src/origin/apps/service/src/presenters/codeBucket.ts
+++ b/src/origin/apps/service/src/presenters/codeBucket.ts
@@ -8,6 +8,7 @@ export let codeBucketPresenter = (
 
   id: codeBucket.id,
   status: codeBucket.status,
+  errorMessage: codeBucket.errorMessage,
   isReadOnly: codeBucket.isReadOnly,
   path: codeBucket.path,
 

--- a/src/origin/apps/service/src/queues/codeBucket/importBitbucket.ts
+++ b/src/origin/apps/service/src/queues/codeBucket/importBitbucket.ts
@@ -1,10 +1,10 @@
-import { delay } from '@lowerdeck/delay';
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../db';
 import { env } from '../../env';
 import { getBitbucketAccessTokenWithInstallation } from '../../lib/bitbucket';
 import { codeBucketClient } from '../../lib/codeWorkspace';
 import { getBitbucketCloneUrl } from './bitbucket';
+import { runCodeBucketImport } from './importError';
 
 export let importBitbucketQueue = createQueue<{
   newBucketId: string;
@@ -21,32 +21,40 @@ export let importBitbucketQueueProcessor = importBitbucketQueue.process(async da
     where: { id: data.repoId },
     include: { installation: { include: { backend: true } } }
   });
-  let token = await getBitbucketAccessTokenWithInstallation(repo.installation);
 
-  if (repo.installation.backend.type === 'bitbucket_data_center') {
-    await codeBucketClient.createBucketFromBitbucketDataCenter({
-      newBucketId: data.newBucketId,
-      cloneUrl: getBitbucketCloneUrl(repo),
-      path: data.path,
-      ref: data.ref,
-      username: '',
-      token
-    });
-  } else {
-    await codeBucketClient.createBucketFromBitbucketCloud({
-      newBucketId: data.newBucketId,
-      workspace: repo.externalOwner,
+  await runCodeBucketImport({
+    provider: 'bitbucket',
+    bucketId: data.newBucketId,
+    context: {
+      owner: repo.externalOwner,
       repo: repo.externalName,
-      path: data.path,
       ref: data.ref,
-      token,
-      bitbucketWebUrl: repo.installation.backend.webUrl
-    });
-  }
+      path: data.path,
+      repoId: data.repoId
+    },
+    importFn: async () => {
+      let token = await getBitbucketAccessTokenWithInstallation(repo.installation);
 
-  await delay(2000);
-  await db.codeBucket.updateMany({
-    where: { id: data.newBucketId },
-    data: { status: 'ready' }
+      if (repo.installation.backend.type === 'bitbucket_data_center') {
+        await codeBucketClient.createBucketFromBitbucketDataCenter({
+          newBucketId: data.newBucketId,
+          cloneUrl: getBitbucketCloneUrl(repo),
+          path: data.path,
+          ref: data.ref,
+          username: '',
+          token
+        });
+      } else {
+        await codeBucketClient.createBucketFromBitbucketCloud({
+          newBucketId: data.newBucketId,
+          workspace: repo.externalOwner,
+          repo: repo.externalName,
+          path: data.path,
+          ref: data.ref,
+          token,
+          bitbucketWebUrl: repo.installation.backend.webUrl
+        });
+      }
+    }
   });
 });

--- a/src/origin/apps/service/src/queues/codeBucket/importError.test.ts
+++ b/src/origin/apps/service/src/queues/codeBucket/importError.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  updateMany: vi.fn(),
+  delay: vi.fn(async () => undefined)
+}));
+
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({ captureException: mocks.captureException })
+}));
+
+vi.mock('@lowerdeck/delay', () => ({
+  delay: mocks.delay
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    codeBucket: {
+      updateMany: mocks.updateMany
+    }
+  }
+}));
+
+import {
+  getCodeBucketImportFailureMessage,
+  runCodeBucketImport
+} from './importError';
+
+describe('code bucket import errors', () => {
+  beforeEach(() => {
+    mocks.captureException.mockClear();
+    mocks.updateMany.mockClear();
+    mocks.delay.mockClear();
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it('maps repository download 404s to a clear failure message', () => {
+    let error = Object.assign(
+      new Error(
+        '/rpc.rpc.CodeBucket/CreateBucketFromGithub INTERNAL: failed to download GitHub repository: failed to download zip: bad status: 404 Not Found'
+      ),
+      {
+        code: 13,
+        details:
+          'failed to download GitHub repository: failed to download zip: bad status: 404 Not Found'
+      }
+    );
+
+    expect(getCodeBucketImportFailureMessage('github', error)).toBe(
+      'GitHub repository was not found. It may have been deleted, renamed, or the installation may lack access.'
+    );
+  });
+
+  it('maps gRPC NotFound import failures without reporting to Sentry', async () => {
+    let error = Object.assign(
+      new Error(
+        '/rpc.rpc.CodeBucket/CreateBucketFromGithub NOT_FOUND: failed to download GitHub repository: failed to download zip: bad status: 404 Not Found'
+      ),
+      {
+        code: 5,
+        details:
+          'failed to download GitHub repository: failed to download zip: bad status: 404 Not Found'
+      }
+    );
+
+    await runCodeBucketImport({
+      provider: 'github',
+      bucketId: 'bucket_123',
+      context: { owner: 'acme', repo: 'missing' },
+      importFn: async () => {
+        throw error;
+      }
+    });
+
+    expect(mocks.captureException).not.toHaveBeenCalled();
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: { id: 'bucket_123' },
+      data: {
+        status: 'failed',
+        errorMessage:
+          'GitHub repository was not found. It may have been deleted, renamed, or the installation may lack access.'
+      }
+    });
+  });
+
+  it('handles legacy INTERNAL 404 download failures without reporting to Sentry', async () => {
+    let error = Object.assign(
+      new Error(
+        '/rpc.rpc.CodeBucket/CreateBucketFromGithub INTERNAL: failed to download GitHub repository: failed to download zip: bad status: 404 Not Found'
+      ),
+      {
+        code: 13,
+        details:
+          'failed to download GitHub repository: failed to download zip: bad status: 404 Not Found'
+      }
+    );
+
+    await runCodeBucketImport({
+      provider: 'github',
+      bucketId: 'bucket_456',
+      importFn: async () => {
+        throw error;
+      }
+    });
+
+    expect(mocks.captureException).not.toHaveBeenCalled();
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: { id: 'bucket_456' },
+      data: {
+        status: 'failed',
+        errorMessage:
+          'GitHub repository was not found. It may have been deleted, renamed, or the installation may lack access.'
+      }
+    });
+  });
+
+  it('rethrows retryable provider failures so the queue can retry', async () => {
+    let error = Object.assign(new Error('provider unavailable'), {
+      response: { status: 503 }
+    });
+
+    await expect(
+      runCodeBucketImport({
+        provider: 'github',
+        bucketId: 'bucket_123',
+        importFn: async () => {
+          throw error;
+        }
+      })
+    ).rejects.toMatchObject({
+      data: {
+        status: 500
+      }
+    });
+
+    expect(mocks.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('marks the bucket ready after a successful import', async () => {
+    await runCodeBucketImport({
+      provider: 'github',
+      bucketId: 'bucket_123',
+      importFn: async () => undefined
+    });
+
+    expect(mocks.delay).toHaveBeenCalledWith(2000);
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: { id: 'bucket_123' },
+      data: { status: 'ready', errorMessage: null }
+    });
+  });
+});

--- a/src/origin/apps/service/src/queues/codeBucket/importError.ts
+++ b/src/origin/apps/service/src/queues/codeBucket/importError.ts
@@ -1,0 +1,81 @@
+import { delay } from '@lowerdeck/delay';
+import { db } from '../../db';
+import {
+  formatScmProviderPublicError,
+  getScmProviderErrorDetails,
+  getScmProviderLogDetails,
+  isRetryableScmProviderError,
+  wrapScmProviderError
+} from '../../lib/scmProviderError';
+
+type ScmProvider = 'github' | 'gitlab' | 'bitbucket';
+
+let providerLabel = (provider: ScmProvider) =>
+  provider === 'github' ? 'GitHub' : provider === 'gitlab' ? 'GitLab' : 'Bitbucket';
+
+export let getCodeBucketImportFailureMessage = (
+  provider: ScmProvider,
+  error: unknown
+) => {
+  let details = getScmProviderErrorDetails(error);
+  if (details.classification === 'resource_not_found') {
+    return `${providerLabel(provider)} repository was not found. It may have been deleted, renamed, or the installation may lack access.`;
+  }
+  if (details.classification === 'missing_branch') {
+    return `${providerLabel(provider)} could not import the repository: the requested branch or ref was not found.`;
+  }
+  if (details.classification === 'permission_denied') {
+    return `${providerLabel(provider)} could not import the repository: the installation lacks permission.`;
+  }
+  if (details.classification === 'authentication_failed') {
+    return `${providerLabel(provider)} could not import the repository: authentication failed.`;
+  }
+
+  return formatScmProviderPublicError({
+    provider,
+    operation: 'import the repository',
+    error
+  });
+};
+
+export let runCodeBucketImport = async (d: {
+  provider: ScmProvider;
+  bucketId: string;
+  context?: Record<string, unknown>;
+  importFn: () => Promise<void>;
+}) => {
+  try {
+    await d.importFn();
+    await delay(2000);
+    await db.codeBucket.updateMany({
+      where: { id: d.bucketId },
+      data: { status: 'ready', errorMessage: null }
+    });
+  } catch (error) {
+    let wrapped = wrapScmProviderError(d.provider, error, 'import the repository', {
+      context: d.context
+    });
+
+    if (isRetryableScmProviderError(error) || isRetryableScmProviderError(wrapped)) {
+      throw wrapped;
+    }
+
+    let message = getCodeBucketImportFailureMessage(d.provider, error);
+    console.error(
+      JSON.stringify({
+        event: 'code_bucket_import_failed',
+        level: 'error',
+        provider: d.provider,
+        bucketId: d.bucketId,
+        message,
+        context: d.context,
+        providerDiagnostic: getScmProviderLogDetails(wrapped)
+      })
+    );
+
+    await db.codeBucket.updateMany({
+      where: { id: d.bucketId },
+      data: { status: 'failed', errorMessage: message }
+    });
+  }
+};

--- a/src/origin/apps/service/src/queues/codeBucket/importGithub.ts
+++ b/src/origin/apps/service/src/queues/codeBucket/importGithub.ts
@@ -1,9 +1,9 @@
-import { delay } from '@lowerdeck/delay';
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../db';
 import { env } from '../../env';
 import { codeBucketClient } from '../../lib/codeWorkspace';
 import { getInstallationAccessToken } from '../../lib/githubApp';
+import { runCodeBucketImport } from './importError';
 
 export let importGithubQueue = createQueue<{
   newBucketId: string;
@@ -26,25 +26,30 @@ export let importGithubQueueProcessor = importGithubQueue.process(async data => 
     throw new Error('Installation ID not found');
   }
 
-  // Get a fresh installation access token
-  let token = await getInstallationAccessToken(
-    repo.installation.externalInstallationId,
-    repo.installation.backend
-  );
+  await runCodeBucketImport({
+    provider: 'github',
+    bucketId: data.newBucketId,
+    context: {
+      owner: data.owner,
+      repo: data.repo,
+      ref: data.ref,
+      path: data.path,
+      repoId: data.repoId
+    },
+    importFn: async () => {
+      let token = await getInstallationAccessToken(
+        repo.installation.externalInstallationId!,
+        repo.installation.backend
+      );
 
-  await codeBucketClient.createBucketFromGithub({
-    newBucketId: data.newBucketId,
-    owner: data.owner,
-    repo: data.repo,
-    ref: data.ref,
-    path: data.path,
-    token
-  });
-
-  await delay(2000);
-
-  await db.codeBucket.updateMany({
-    where: { id: data.newBucketId },
-    data: { status: 'ready' }
+      await codeBucketClient.createBucketFromGithub({
+        newBucketId: data.newBucketId,
+        owner: data.owner,
+        repo: data.repo,
+        ref: data.ref,
+        path: data.path,
+        token
+      });
+    }
   });
 });

--- a/src/origin/apps/service/src/queues/codeBucket/importGitlab.ts
+++ b/src/origin/apps/service/src/queues/codeBucket/importGitlab.ts
@@ -1,10 +1,10 @@
-import { delay } from '@lowerdeck/delay';
 import { createQueue } from '@lowerdeck/queue';
 import Long from 'long';
 import { db } from '../../db';
 import { env } from '../../env';
 import { codeBucketClient } from '../../lib/codeWorkspace';
 import { getGitLabAccessTokenWithInstallation } from '../../lib/gitlab';
+import { runCodeBucketImport } from './importError';
 
 export let importGitlabQueue = createQueue<{
   newBucketId: string;
@@ -24,22 +24,29 @@ export let importGitlabQueueProcessor = importGitlabQueue.process(async data => 
     include: { installation: { include: { backend: true } } }
   });
 
-  let token = await getGitLabAccessTokenWithInstallation(repo.installation);
-  let apiUrl = repo.installation.backend.apiUrl;
+  await runCodeBucketImport({
+    provider: 'gitlab',
+    bucketId: data.newBucketId,
+    context: {
+      owner: data.owner,
+      repo: data.repo,
+      ref: data.ref,
+      path: data.path,
+      repoId: data.repoId,
+      projectId: repo.externalId
+    },
+    importFn: async () => {
+      let token = await getGitLabAccessTokenWithInstallation(repo.installation);
+      let apiUrl = repo.installation.backend.apiUrl;
 
-  await codeBucketClient.createBucketFromGitlab({
-    newBucketId: data.newBucketId,
-    projectId: Long.fromString(repo.externalId),
-    ref: data.ref,
-    path: data.path,
-    token,
-    gitlabApiUrl: apiUrl
-  });
-
-  await delay(2000);
-
-  await db.codeBucket.updateMany({
-    where: { id: data.newBucketId },
-    data: { status: 'ready' }
+      await codeBucketClient.createBucketFromGitlab({
+        newBucketId: data.newBucketId,
+        projectId: Long.fromString(repo.externalId),
+        ref: data.ref,
+        path: data.path,
+        token,
+        gitlabApiUrl: apiUrl
+      });
+    }
   });
 });

--- a/src/origin/apps/service/src/services/codeBucket.ts
+++ b/src/origin/apps/service/src/services/codeBucket.ts
@@ -147,7 +147,7 @@ class codeBucketServiceImpl {
     // Set status to importing to prevent clone conflicts
     await db.codeBucket.update({
       where: { oid: d.codeBucket.oid },
-      data: { status: 'importing' }
+      data: { status: 'importing', errorMessage: null }
     });
 
     if (d.repo.provider === 'github') {
@@ -231,6 +231,16 @@ class codeBucketServiceImpl {
         where: { id: d.codeBucketId }
       });
     }
+
+    if (currentBucket.status === 'failed') {
+      throw new ServiceError(
+        badRequestError({
+          message: currentBucket.errorMessage ?? 'Code bucket import failed'
+        })
+      );
+    }
+
+    return currentBucket;
   }
 
   async cloneCodeBucket(d: { codeBucket: CodeBucket; isReadOnly?: boolean }) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a Prisma enum value and changes import failure semantics across Origin and Cargo skill flows; behavior is well-tested but affects core repo-to-bucket import paths.
> 
> **Overview**
> Repository imports that fail (missing repo, bad permissions, etc.) now end in a **`failed`** code bucket state with a stored **`errorMessage`**, instead of leaving buckets stuck in **`importing`** or surfacing generic internal errors.
> 
> The code-bucket gRPC service maps provider download failures through **`providerImportError`**, so HTTP statuses like **404** become **`NotFound`** and align with existing SCM error classification. Origin import queues (GitHub, GitLab, Bitbucket) share **`runCodeBucketImport`**, which marks non-retryable failures on the bucket, logs structured diagnostics, and still rethrows retryable provider errors for queue retries.
> 
> **`waitForCodeBucketReady`** and the skill import acquire path now fail fast when a bucket is **`failed`**, using the persisted message (also exposed on the code bucket API presenter). Re-sync clears **`errorMessage`** when import is kicked off again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec2d8c90a8aaec6e6697fb55195d6874997d850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->