### PR TITLE
Improve consumer sso

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3978,6 +3978,7 @@
         "@metorial-subspace/module-tenant": "^1.0.0",
         "@metorial-subspace/presenters": "^1.0.0",
         "@metorial-subspace/provider-native": "^1.0.0",
+        "@metorial/ui": "workspace:*",
         "@sentry/bun": "^10.34.0",
         "@sentry/cli": "^3.2.0",
         "@types/react-dom": "19.2.3",

--- a/src/metorial/db/prisma/schema/consumer/consumer.prisma
+++ b/src/metorial/db/prisma/schema/consumer/consumer.prisma
@@ -194,6 +194,11 @@ model ConsumerInvite {
   @@unique([surfaceOid, consumerOid])
 }
 
+enum ConsumerProfileGroupAssignedVia {
+  manual
+  sso
+}
+
 model ConsumerProfileGroup {
   oid BigInt @id @default(autoincrement())
 
@@ -202,6 +207,8 @@ model ConsumerProfileGroup {
 
   groupOid BigInt
   group    ConsumerGroup @relation(fields: [groupOid], references: [oid], onDelete: Cascade)
+
+  assignedVia ConsumerProfileGroupAssignedVia @default(manual)
 
   createdAt DateTime @default(now())
 

--- a/src/metorial/modules/access/src/env.ts
+++ b/src/metorial/modules/access/src/env.ts
@@ -3,6 +3,6 @@ import { v } from '@lowerdeck/validation';
 
 export let env = createValidatedEnv({
   service: {
-    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1']))
+    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1', 'dev']))
   }
 });

--- a/src/metorial/modules/consumer/src/services/consumers/consumerProfile.ts
+++ b/src/metorial/modules/consumer/src/services/consumers/consumerProfile.ts
@@ -10,6 +10,7 @@ import {
 import {
   ConsumerGroup,
   ConsumerProfile,
+  ConsumerProfileGroupAssignedVia,
   ConsumerProfileInviteStatus,
   ConsumerSurface,
   db,
@@ -893,7 +894,10 @@ class ConsumerProfileServiceImpl {
     consumerProfiles: Array<
       ConsumerProfileWithRelations & {
         personalConsumerGroup: ConsumerGroup;
-        groups: Array<{ group: ConsumerGroup }>;
+        groups: Array<{
+          group: ConsumerGroup;
+          assignedVia?: ConsumerProfileGroupAssignedVia;
+        }>;
       }
     >;
   }) {
@@ -918,7 +922,9 @@ class ConsumerProfileServiceImpl {
     let groupsByProfile: Record<string, EffectiveConsumerGroup[]> = {};
 
     for (let consumerProfile of d.consumerProfiles) {
-      let manualGroupIds = new Set(consumerProfile.groups.map(({ group }) => group.oid));
+      let membershipByGroupOid = new Map(
+        consumerProfile.groups.map(membership => [membership.group.oid, membership])
+      );
       let ssoGroupIds = new Set(consumerProfile.ssoGroupIds ?? []);
 
       groupsByProfile[consumerProfile.id] = activeGroups.flatMap(group => {
@@ -934,8 +940,9 @@ class ConsumerProfileServiceImpl {
           return [toAssignedGroup(group, 'sso')];
         }
 
-        if (manualGroupIds.has(group.oid)) {
-          return [toAssignedGroup(group, 'manual')];
+        let membership = membershipByGroupOid.get(group.oid);
+        if (membership) {
+          return [toAssignedGroup(group, membership.assignedVia ?? 'manual')];
         }
 
         return [];
@@ -948,8 +955,10 @@ class ConsumerProfileServiceImpl {
   async assignToGroups<T extends ConsumerProfileWithRelations>(d: {
     consumerProfile: T;
     groupIds: string[];
+    assignedVia?: ConsumerProfileGroupAssignedVia;
   }) {
     let groups = await this.getAssignableGroupsOrThrow(d);
+    let assignedVia = d.assignedVia ?? 'manual';
 
     if (groups.length) {
       await withTransaction(async db => {
@@ -961,12 +970,24 @@ class ConsumerProfileServiceImpl {
             }
           }
         });
-        let existingGroupOids = new Set(
-          existingMemberships.map(membership => membership.groupOid)
+        let existingByGroupOid = new Map(
+          existingMemberships.map(membership => [membership.groupOid, membership])
         );
-        let groupsToAdd = groups.filter(group => !existingGroupOids.has(group.oid));
 
-        for (let group of groupsToAdd) {
+        for (let group of groups) {
+          let existing = existingByGroupOid.get(group.oid);
+
+          if (existing) {
+            if (existing.assignedVia != assignedVia && assignedVia == 'sso') {
+              await db.consumerProfileGroup.update({
+                where: { oid: existing.oid },
+                data: { assignedVia }
+              });
+            }
+
+            continue;
+          }
+
           await Fabric.fire('consumer.profile.group.added:before', {
             consumerProfile: d.consumerProfile,
             consumerGroup: group
@@ -975,7 +996,8 @@ class ConsumerProfileServiceImpl {
           let consumerProfileGroup = await db.consumerProfileGroup.create({
             data: {
               profileOid: d.consumerProfile.oid,
-              groupOid: group.oid
+              groupOid: group.oid,
+              assignedVia
             }
           });
 
@@ -996,14 +1018,17 @@ class ConsumerProfileServiceImpl {
   async removeFromGroups<T extends ConsumerProfileWithRelations>(d: {
     consumerProfile: T;
     groupIds: string[];
+    assignedVia?: ConsumerProfileGroupAssignedVia;
   }) {
     let groups = await this.getAssignableGroupsOrThrow(d);
+    let assignedVia = d.assignedVia ?? 'manual';
 
     await withTransaction(async db => {
       let existingMemberships = await db.consumerProfileGroup.findMany({
         where: {
           profileOid: d.consumerProfile.oid,
-          groupOid: { in: groups.map(group => group.oid) }
+          groupOid: { in: groups.map(group => group.oid) },
+          assignedVia
         }
       });
       let existingMembershipByGroupOid = new Map(

--- a/src/metorial/modules/machine-access/src/env.ts
+++ b/src/metorial/modules/machine-access/src/env.ts
@@ -3,6 +3,6 @@ import { v } from '@lowerdeck/validation';
 
 export let env = createValidatedEnv({
   service: {
-    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1']))
+    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1', 'dev']))
   }
 });

--- a/src/metorial/modules/magic/src/env.ts
+++ b/src/metorial/modules/magic/src/env.ts
@@ -3,6 +3,6 @@ import { v } from '@lowerdeck/validation';
 
 export let env = createValidatedEnv({
   service: {
-    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1']))
+    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1', 'dev']))
   }
 });

--- a/src/metorial/modules/organization/src/env.ts
+++ b/src/metorial/modules/organization/src/env.ts
@@ -3,6 +3,6 @@ import { v } from '@lowerdeck/validation';
 
 export let env = createValidatedEnv({
   service: {
-    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1']))
+    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1', 'dev']))
   }
 });

--- a/src/metorial/multi-region/src/env.ts
+++ b/src/metorial/multi-region/src/env.ts
@@ -3,7 +3,7 @@ import { v } from '@lowerdeck/validation';
 
 export let env = createValidatedEnv({
   service: {
-    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1'])),
+    METORIAL_REGION: v.optional(v.enumOf(['us1', 'eu1', 'dev'])),
     GLOBAL_DB_TRANSACTION_MAX_WAIT_MS: v.optional(v.number()),
     GLOBAL_DB_TRANSACTION_TIMEOUT_MS: v.optional(v.number()),
     GLOBAL_DB_KEEPALIVE_INTERVAL_MS: v.optional(v.number()),

--- a/src/metorial/packages/consumer-auth/src/index.ts
+++ b/src/metorial/packages/consumer-auth/src/index.ts
@@ -183,10 +183,16 @@ export let getEffectiveConsumerGroups = async (d: {
             }
           : undefined!
       ].filter(Boolean)
+    },
+    include: {
+      profiles: {
+        where: { profileOid: d.consumerProfile.oid },
+        select: { assignedVia: true }
+      }
     }
   });
 
-  return groups.map(group => {
+  return groups.map(({ profiles, ...group }) => {
     if (group.oid == d.consumerProfile.personalConsumerGroupOid) {
       return {
         ...group,
@@ -210,7 +216,7 @@ export let getEffectiveConsumerGroups = async (d: {
 
     return {
       ...group,
-      assignedVia: 'manual' as const
+      assignedVia: profiles[0]?.assignedVia == 'sso' ? ('sso' as const) : ('manual' as const)
     };
   });
 };

--- a/src/subspace/apps/public/package.json
+++ b/src/subspace/apps/public/package.json
@@ -39,6 +39,7 @@
     "@lowerdeck/validation": "workspace:2.0.0",
     "@metorial-io/data-hooks": "^1.0.1",
     "@metorial-io/pages": "^1.0.0",
+    "@metorial/ui": "workspace:*",
     "@metorial-subspace/app-controller": "workspace:*",
     "@metorial-subspace/module-auth": "^1.0.0",
     "@metorial-subspace/module-integration": "^1.0.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes consumer access/group membership semantics and requires a schema migration; incorrect assignedVia handling could mis-assign or fail to remove SSO groups.
> 
> **Overview**
> **Consumer profile–group links** now record whether membership was **`manual` or `sso`**, and that value drives how effective groups and removals behave.
> 
> A new **`ConsumerProfileGroupAssignedVia`** field is stored on **`ConsumerProfileGroup`**. **`assignToGroups`** accepts **`assignedVia`** (default manual), writes it on create, and can **upgrade** an existing row to **`sso`** when SSO sync runs. **`removeFromGroups`** only deletes memberships matching the requested **`assignedVia`**, so portal/manual unassign does not drop SSO-provisioned links. **`getStoredGroupsForProfiles`** and **`@metorial/consumer-auth`** use the stored **`assignedVia`** when labeling manual memberships instead of always treating them as manual.
> 
> Also adds **`dev`** as an allowed **`METORIAL_REGION`** in several service env validators and wires **`@metorial/ui`** into the public subspace app dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b66d05448b793b4bb879b568b321b47ad001736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->