### PR TITLE
Store signup method with user

### DIFF
--- a/src/ares/service/prisma/schema/user/user.prisma
+++ b/src/ares/service/prisma/schema/user/user.prisma
@@ -13,6 +13,12 @@ enum UserStatus {
   deleted
 }
 
+enum UserSignupMethod {
+  email
+  oauth
+  sso
+}
+
 model User {
   oid BigInt @id
   id  String @unique
@@ -39,6 +45,7 @@ model User {
   image Json
 
   isFullyCreated Boolean @default(true)
+  signupMethod   UserSignupMethod @default(email)
 
   lastLoginAt  DateTime?
   lastActiveAt DateTime?

--- a/src/ares/service/src/apis/admin/presenters/user.ts
+++ b/src/ares/service/src/apis/admin/presenters/user.ts
@@ -21,6 +21,7 @@ export let adminUserPresenter = async (
 
   id: user.id,
 
+  signupMethod: user.signupMethod,
   email: user.deletedAt ? deletedEmail.restoreAnonymized(user.email) : user.email,
   name: user.name,
   firstName: user.firstName,

--- a/src/ares/service/src/apis/auth/presenters/user.ts
+++ b/src/ares/service/src/apis/auth/presenters/user.ts
@@ -10,6 +10,7 @@ export let userPresenter = async (user: User & { userEmails: UserEmail[] }) => (
 
   id: user.id,
 
+  signupMethod: user.signupMethod,
   email: user.deletedAt ? deletedEmail.restoreAnonymized(user.email) : user.email,
   name: user.name,
   firstName: user.firstName,

--- a/src/ares/service/src/apis/internal/presenters/user.ts
+++ b/src/ares/service/src/apis/internal/presenters/user.ts
@@ -6,6 +6,7 @@ export let userPresenter = async (user: User) => ({
 
   id: user.id,
 
+  signupMethod: user.signupMethod,
   email: user.email,
   name: user.name,
   firstName: user.firstName,

--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -716,6 +716,7 @@ class AuthServiceImpl {
         lastName: d.ssoUser.lastName,
         acceptedTerms: true,
         type: 'standard_user',
+        signupMethod: 'sso',
         context: d.context,
         app: d.app
       });
@@ -1021,6 +1022,7 @@ class AuthServiceImpl {
       lastName: d.input.lastName,
       acceptedTerms: d.input.acceptedTerms,
       type: 'standard_user',
+      signupMethod: d.authIntent.type == 'oauth' ? 'oauth' : 'email',
       context,
       app: d.app
     });

--- a/src/ares/service/src/services/sso/login.test.ts
+++ b/src/ares/service/src/services/sso/login.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { authWithSso, exchangeAuthAttemptForSession } = vi.hoisted(() => ({
+  authWithSso: vi.fn(),
+  exchangeAuthAttemptForSession: vi.fn()
+}));
+
+vi.mock('../auth', () => ({
+  authService: { authWithSso }
+}));
+
+vi.mock('../device', () => ({
+  deviceService: { exchangeAuthAttemptForSession }
+}));
+
+import { ssoLoginService } from './login';
+
+describe('ssoLoginService.completeLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authWithSso.mockResolvedValue({ redirectUrl: 'https://app.example.com/callback' });
+    exchangeAuthAttemptForSession.mockResolvedValue({ id: 'session_1' });
+  });
+
+  it.each([
+    ['local', { importedDelegationOid: null }],
+    ['delegated', { importedDelegationOid: 20n }]
+  ])('uses the shared SSO authentication flow for a %s connection', async (_, connectionFields) => {
+    let tenant = {
+      oid: 10n,
+      appOid: 1n,
+      enrollment: 'disabled',
+      accountOid: null,
+      ...connectionFields
+    } as any;
+    let connection = {
+      id: 'connection_1',
+      tenantOid: tenant.oid,
+      ...connectionFields
+    } as any;
+    let userProfile = {
+      oid: 30n,
+      email: 'user@example.com',
+      firstName: 'Test',
+      lastName: 'User',
+      uid: 'identity_1'
+    } as any;
+    let app = {
+      oid: 1n,
+      redirectDomains: ['app.example.com']
+    } as any;
+    let device = { oid: 40n } as any;
+    let context = { ip: '1.2.3.4', ua: 'agent' };
+
+    await ssoLoginService.completeLogin({
+      tenant,
+      connection,
+      userProfile,
+      app,
+      device,
+      context,
+      redirectUrl: 'https://app.example.com/callback'
+    });
+
+    expect(authWithSso).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssoTenant: tenant,
+        ssoUserProfile: userProfile,
+        ssoConnectionId: connection.id,
+        ssoUid: userProfile.uid
+      })
+    );
+  });
+});

--- a/src/ares/service/src/services/user.test.ts
+++ b/src/ares/service/src/services/user.test.ts
@@ -52,6 +52,7 @@ let input = {
   lastName: 'Herber',
   acceptedTerms: true,
   type: 'standard_user' as const,
+  signupMethod: 'email' as const,
   context,
   app
 };
@@ -149,6 +150,28 @@ describe('userService.createUser', () => {
     db.emailDomain.upsert.mockResolvedValue({ oid: 3n });
     db.userEmail.create.mockResolvedValue({ oid: 4n });
     db.userTermsAgreement.upsert.mockResolvedValue({ oid: 5n });
+  });
+
+  it('stores the signup method and creates an email identity for email signup', async () => {
+    db.user.create.mockResolvedValue({ ...existingUser, id: 'usr_new' });
+
+    await userService.createUser(input);
+
+    expect(db.user.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ signupMethod: 'email' })
+    });
+    expect(db.userEmail.create).toHaveBeenCalledOnce();
+  });
+
+  it('stores the signup method without creating an email identity for SSO signup', async () => {
+    db.user.create.mockResolvedValue({ ...existingUser, id: 'usr_new' });
+
+    await userService.createUser({ ...input, signupMethod: 'sso' });
+
+    expect(db.user.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ signupMethod: 'sso' })
+    });
+    expect(db.userEmail.create).not.toHaveBeenCalled();
   });
 
   it('reports a duplicate email as a 409', async () => {

--- a/src/ares/service/src/services/user.ts
+++ b/src/ares/service/src/services/user.ts
@@ -324,6 +324,7 @@ class UserServiceImpl {
     context: Context;
     app: App;
     type: 'standard_user' | 'pre_created_user';
+    signupMethod: 'email' | 'oauth' | 'sso';
   }) {
     if (!d.acceptedTerms) {
       throw new ServiceError(
@@ -365,6 +366,7 @@ class UserServiceImpl {
             tenantOid: d.app.defaultTenantOid!,
 
             isFullyCreated: d.type === 'standard_user',
+            signupMethod: d.signupMethod,
 
             image: { type: 'default' }
           }
@@ -377,14 +379,16 @@ class UserServiceImpl {
           suppressSync: true
         });
 
-        await this.createEmail({
-          email: d.email,
-          user,
-          app: d.app,
-          context: d.context,
-          isForNewUser: true,
-          suppressSync: true
-        });
+        if (d.signupMethod !== 'sso') {
+          await this.createEmail({
+            email: d.email,
+            user,
+            app: d.app,
+            context: d.context,
+            isForNewUser: true,
+            suppressSync: true
+          });
+        }
 
         addAfterTransactionHook(() => userEvents.fire('create', user));
         await markAresUserChanged({ userId: user.id, db: tdb });
@@ -415,6 +419,7 @@ class UserServiceImpl {
     context: Context;
     app: App;
     type: 'standard_user' | 'pre_created_user';
+    signupMethod: 'email' | 'oauth' | 'sso';
   }): Promise<{ user: User; created: boolean }> {
     let existing = await this.findByEmailSafe({ email: d.email, app: d.app });
     if (existing) return { user: existing, created: false };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes user-creation behavior in auth/SSO paths and alters whether SSO users get an email identity at signup; requires a DB migration with a safe default for existing users.
> 
> **Overview**
> Adds a **`signupMethod`** field on users (`email`, `oauth`, or `sso`) so how an account was first created is stored and returned from admin, auth, and internal user APIs.
> 
> **User creation** now requires `signupMethod` on `createUser` / `resolveOrCreateUser`. SSO registration sets `sso`; completing an auth intent sets `oauth` or `email` from the intent type. **SSO signups no longer create a `UserEmail` row** at creation time (email/oauth still do). Existing rows default to `email` via the schema default.
> 
> Tests cover signup-method persistence, SSO vs email identity creation, and that SSO login still goes through the shared `authWithSso` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23a04251d7dbb76e1b7b36e0543745aa117ff47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->