### PR TITLE
Fix consumer invite emails

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -179,6 +179,7 @@
         "@types/ua-parser-js": "^0.7.39",
         "axios": "^1.13.2",
         "date-fns": "^4.1.0",
+        "framer-motion": "^12.43.0",
         "input-otp": "^1.4.2",
         "ipaddr.js": "^2.3.0",
         "jszip": "^3.10.1",
@@ -10073,6 +10074,8 @@
 
     "@metorial/ares/@vitejs/plugin-react": ["@vitejs/plugin-react@4.3.1", "", { "dependencies": { "@babel/core": "^7.24.5", "@babel/plugin-transform-react-jsx-self": "^7.24.5", "@babel/plugin-transform-react-jsx-source": "^7.24.1", "@types/babel__core": "^7.20.5", "react-refresh": "^0.14.2" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0" } }, "sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg=="],
 
+    "@metorial/ares/framer-motion": ["framer-motion@12.43.0", "", { "dependencies": { "motion-dom": "^12.43.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g=="],
+
     "@metorial/ares/vitest": ["vitest@4.0.17", "", { "dependencies": { "@vitest/expect": "4.0.17", "@vitest/mocker": "4.0.17", "@vitest/pretty-format": "4.0.17", "@vitest/runner": "4.0.17", "@vitest/snapshot": "4.0.17", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.17", "@vitest/browser-preview": "4.0.17", "@vitest/browser-webdriverio": "4.0.17", "@vitest/ui": "4.0.17", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg=="],
 
     "@metorial/auth/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -10966,6 +10969,8 @@
     "@metorial/ares/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@metorial/ares/@vitejs/plugin-react/react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
+
+    "@metorial/ares/framer-motion/motion-dom": ["motion-dom@12.43.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag=="],
 
     "@metorial/ares/vitest/@vitest/expect": ["@vitest/expect@4.0.17", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ=="],
 

--- a/src/ares/service/frontend/auth/src/scenes/authHome.tsx
+++ b/src/ares/service/frontend/auth/src/scenes/authHome.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   theme
 } from '@metorial-io/ui';
+import { AnimatePresence, motion } from 'framer-motion';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -23,7 +24,9 @@ import { AuthLayout } from '../components/layout';
 import {
   type AuthConnectionOption,
   type AuthConnectionSelection,
-  authState
+  type AuthUserSelection,
+  authState,
+  useUserSelect
 } from '../state/auth';
 
 let Notice = styled.div`
@@ -35,6 +38,23 @@ let Notice = styled.div`
   font-size: 13px;
   line-height: 1.5;
 `;
+
+let AnimatedMethod = styled(motion.div)`
+  width: 100%;
+`;
+
+let resemblesEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value.trim());
+
+let useDebouncedValue = <T,>(value: T, wait: number) => {
+  let [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    let timeout = window.setTimeout(() => setDebounced(value), wait);
+    return () => window.clearTimeout(timeout);
+  }, [value, wait]);
+
+  return debounced;
+};
 
 export let AuthHomeScene = ({
   clientId,
@@ -57,6 +77,7 @@ export let AuthHomeScene = ({
 }) => {
   let auth = authState.use({ clientId });
   let startAuthentication = useMutation(auth.mutators.start);
+  let selectUserAuthentication = useUserSelect();
 
   let [captchaToken, setCaptchaToken] = useState<string>();
   let captchaTokenRef = useRef<string | undefined>(undefined);
@@ -70,6 +91,7 @@ export let AuthHomeScene = ({
   let [connectionSelection, setConnectionSelection] = useState<AuthConnectionSelection | null>(
     null
   );
+  let [userSelection, setUserSelection] = useState<AuthUserSelection | null>(null);
   let selectionAuth = authState.use(
     connectionSelection ? { clientId: connectionSelection.clientId } : null
   );
@@ -121,23 +143,24 @@ export let AuthHomeScene = ({
     }
   });
 
-  let canAutoSubmit = form.values.email && email && !reason;
-  let autoSubmittedRef = useRef(false);
+  let debouncedEmail = useDebouncedValue(form.values.email.trim(), 300);
+  let userSelectionRequest = useRef(0);
 
   useEffect(() => {
-    if (
-      email &&
-      canAutoSubmit &&
-      !startAuthentication.isLoading &&
-      !startAuthentication.isSuccess
-    ) {
-      if (autoSubmittedRef.current) return;
-      autoSubmittedRef.current = true;
-
-      form.setFieldValue('email', email);
-      form.submitForm();
+    let request = ++userSelectionRequest.current;
+    if (!resemblesEmail(debouncedEmail)) {
+      setUserSelection(null);
+      return;
     }
-  }, [canAutoSubmit, email, startAuthentication.isLoading, startAuthentication.isSuccess]);
+
+    selectUserAuthentication
+      .mutate({ clientId, email: debouncedEmail })
+      .then(([selection]) => {
+        if (request === userSelectionRequest.current && selection) {
+          setUserSelection(selection);
+        }
+      });
+  }, [clientId, debouncedEmail]);
 
   let [sessionOrUserIdToLogInWith, setSessionOrUserIdToLogInWith] = useState<
     string | undefined
@@ -207,9 +230,7 @@ export let AuthHomeScene = ({
   }
 
   if (
-    ((canAutoSubmit || sessionOrUserId) &&
-      !connectionSelection &&
-      !startAuthentication.error) ||
+    (sessionOrUserId && !connectionSelection && !startAuthentication.error) ||
     auth.isLoading
   )
     return (
@@ -219,7 +240,16 @@ export let AuthHomeScene = ({
       </AuthLayout>
     );
 
-  let options = auth.data?.options ?? [];
+  let normalizedEmail = form.values.email.trim().toLowerCase();
+  let userSelectionMatchesEmail = userSelection?.email === normalizedEmail;
+  let userSelectionSupportsSso =
+    userSelection?.options.some(option => option.type === 'sso') ?? false;
+  let activeUserSelection =
+    userSelectionMatchesEmail ||
+    (resemblesEmail(normalizedEmail) && userSelectionSupportsSso)
+      ? userSelection
+      : null;
+  let options = activeUserSelection?.options ?? auth.data?.options ?? [];
   let hasEmailOption = options.some(o => o.type === 'email');
   let oauthOptions = options.filter(o => o.type === 'oauth');
   let ssoOptions = options.filter(o => o.type === 'sso');
@@ -230,98 +260,115 @@ export let AuthHomeScene = ({
   let bootClient = activeBoot?.client;
   let bootAccount = bootClient?.account;
   let selectionAccount = connectionSelection?.account;
-  let account = selectionAccount ?? bootAccount;
+  let account = selectionAccount ?? activeUserSelection?.account ?? bootAccount;
 
   let startSso = (option: AuthConnectionOption) => {
     setLoadingSource(`sso_${option.connectionId}`);
     startAuthentication.mutate({
       type: 'sso',
-      clientId: connectionSelection?.clientId ?? clientId,
+      clientId: connectionSelection?.clientId ?? activeUserSelection?.clientId ?? clientId,
       ssoTenantId: option.tenantId,
       ssoConnectionId: option.connectionId,
-      email: connectionSelection?.email ?? email,
+      email: connectionSelection?.email ?? form.values.email,
       redirectUrl: nextUrl
     });
   };
 
-  let lines: React.ReactNode[] = [];
+  let lines: { id: string; content: React.ReactNode }[] = [];
 
   if (connectionSelection) {
-    lines.push(
-      <>
-        {connectionSelection.options.map((option, i) => (
-          <Fragment key={option.connectionId}>
-            {i > 0 && <Spacer height={10} />}
-            <Button
-              onClick={() => startSso(option)}
-              size="2"
-              fullWidth
-              variant="outline"
-              loading={
-                startAuthentication.isLoading && loadingSource == `sso_${option.connectionId}`
-              }
-              disabled={startAuthentication.isLoading}
-            >
-              {option.tenantName} — {option.connectionName}
-            </Button>
-          </Fragment>
-        ))}
-      </>
-    );
+    lines.push({
+      id: 'connection-selection',
+      content: (
+        <>
+          {connectionSelection.options.map((option, i) => (
+            <Fragment key={option.connectionId}>
+              {i > 0 && <Spacer height={10} />}
+              <Button
+                onClick={() => startSso(option)}
+                size="2"
+                fullWidth
+                variant="outline"
+                loading={
+                  startAuthentication.isLoading &&
+                  loadingSource == `sso_${option.connectionId}`
+                }
+                disabled={startAuthentication.isLoading}
+              >
+                {option.tenantName} — {option.connectionName}
+              </Button>
+            </Fragment>
+          ))}
+        </>
+      )
+    });
   }
 
-  if (!connectionSelection && hasEmailOption) {
-    lines.push(
-      <form onSubmit={form.handleSubmit}>
-        <Input label="Email" {...form.getFieldProps('email')} />
-        <form.RenderError field="email" />
+  let keepsEmailInput = auth.data?.options.some(option => option.type === 'email');
+  if (!connectionSelection && keepsEmailInput) {
+    lines.push({
+      id: 'email',
+      content: (
+        <form id="auth-email-form" onSubmit={form.handleSubmit}>
+          <Input label="Email" {...form.getFieldProps('email')} />
+          <form.RenderError field="email" />
+          <selectUserAuthentication.RenderError />
 
-        <Spacer height={10} />
+          {hasEmailOption && ssoOptions.length === 0 && (
+            <>
+              <Spacer height={10} />
 
-        <Button
-          fullWidth
-          size="3"
-          type="submit"
-          loading={
-            (startAuthentication.isLoading || form.isSubmitting) && loadingSource == 'email'
-          }
-          disabled={startAuthentication.isLoading || form.isSubmitting}
-        >
-          {account && !account.allowEmailLogin && ssoOptions.length === 0
-            ? 'Log in as guest'
-            : 'Continue'}
-        </Button>
-        <startAuthentication.RenderError />
+              <Button
+                fullWidth
+                size="3"
+                type="submit"
+                variant={ssoOptions.length > 0 ? 'outline' : 'solid'}
+                loading={
+                  (startAuthentication.isLoading || form.isSubmitting) &&
+                  loadingSource == 'email'
+                }
+                disabled={startAuthentication.isLoading || form.isSubmitting}
+              >
+                {ssoOptions.length > 0
+                  ? 'Continue with email'
+                  : account && !account.allowEmailLogin
+                    ? 'Log in as guest'
+                    : 'Continue'}
+              </Button>
+            </>
+          )}
+          <startAuthentication.RenderError />
 
-        {type != 'switch' && (
-          <>
-            <Spacer height={10} />
+          {type != 'switch' && ssoOptions.length === 0 && (
+            <>
+              <Spacer height={10} />
 
-            <Text color="gray600" weight="medium" size="1">
-              {type == 'login' ? (
-                <Link
-                  to={`/signup?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}
-                  style={{ color: 'inherit' }}
-                  aria-disabled={startAuthentication.isLoading || form.isSubmitting}
-                >
-                  Don't have an account?{' '}
-                  <span style={{ textDecoration: 'underline' }}>Create one</span>
-                </Link>
-              ) : (
-                <Link
-                  to={`/login?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}
-                  style={{ color: 'inherit' }}
-                  aria-disabled={startAuthentication.isLoading || form.isSubmitting}
-                >
-                  Already have an account?{' '}
-                  <span style={{ textDecoration: 'underline' }}>Log in</span>.
-                </Link>
-              )}
-            </Text>
-          </>
-        )}
-      </form>
-    );
+              <Text color="gray600" weight="medium" size="1">
+                {type == 'login' ? (
+                  <Link
+                    to={`/signup?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}
+                    style={{ color: 'inherit' }}
+                    aria-disabled={startAuthentication.isLoading || form.isSubmitting}
+                  >
+                    Don't have an account?{' '}
+                    <span style={{ textDecoration: 'underline' }}>Create one</span>
+                  </Link>
+                ) : (
+                  <Link
+                    to={`/login?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}
+                    style={{ color: 'inherit' }}
+                    aria-disabled={startAuthentication.isLoading || form.isSubmitting}
+                  >
+                    Already have an account?{' '}
+                    <span style={{ textDecoration: 'underline' }}>Log in</span>.
+                  </Link>
+                )}
+              </Text>
+            </>
+          )}
+        </form>
+      )
+    });
   }
 
   if (!connectionSelection && hasOAuthOptions) {
@@ -344,63 +391,94 @@ export let AuthHomeScene = ({
       });
     }
 
-    lines.push(
-      <>
-        {oauthProviders.map(({ icon, type: providerType }, i) => (
-          <Fragment key={providerType}>
-            {i > 0 && <Spacer height={10} />}
-
-            <Button
-              onClick={() => {
-                setLoadingSource(providerType);
-                startAuthentication.mutate({
-                  type: 'oauth',
-                  clientId,
-                  provider: providerType,
-                  redirectUrl: nextUrl
-                });
-              }}
-              size="2"
-              fullWidth
-              variant="outline"
-              iconLeft={icon}
-              loading={startAuthentication.isLoading && loadingSource == providerType}
-              disabled={startAuthentication.isLoading}
-            >
-              {providerType[0].toUpperCase() + providerType.slice(1)}
-            </Button>
-          </Fragment>
-        ))}
-      </>
-    );
-  }
-
-  if (!connectionSelection && ssoOptions.length > 0) {
-    lines.push(
-      <>
-        {ssoOptions.map((option, i) => {
-          return (
-            <Fragment key={option.connectionId}>
+    lines.push({
+      id: 'oauth',
+      content: (
+        <>
+          {oauthProviders.map(({ icon, type: providerType }, i) => (
+            <Fragment key={providerType}>
               {i > 0 && <Spacer height={10} />}
 
               <Button
-                onClick={() => startSso(option)}
+                onClick={() => {
+                  setLoadingSource(providerType);
+                  startAuthentication.mutate({
+                    type: 'oauth',
+                    clientId,
+                    provider: providerType,
+                    redirectUrl: nextUrl
+                  });
+                }}
                 size="2"
                 fullWidth
                 variant="outline"
-                loading={
-                  startAuthentication.isLoading &&
-                  loadingSource == `sso_${option.connectionId}`
-                }
+                iconLeft={icon}
+                loading={startAuthentication.isLoading && loadingSource == providerType}
                 disabled={startAuthentication.isLoading}
               >
-                {option.tenantName} — {option.connectionName}
+                {providerType[0].toUpperCase() + providerType.slice(1)}
               </Button>
             </Fragment>
-          );
-        })}
-      </>
-    );
+          ))}
+        </>
+      )
+    });
+  }
+
+  if (!connectionSelection && ssoOptions.length > 0) {
+    let emailLineIndex = lines.findIndex(line => line.id === 'email');
+    let ssoLine = {
+      id: 'sso',
+      content: (
+        <>
+          {ssoOptions.map((option, i) => {
+            return (
+              <Fragment key={option.connectionId}>
+                {i > 0 && <Spacer height={10} />}
+
+                <Button
+                  onClick={() => startSso(option)}
+                  size="3"
+                  fullWidth
+                  variant="solid"
+                  loading={
+                    startAuthentication.isLoading &&
+                    loadingSource == `sso_${option.connectionId}`
+                  }
+                  disabled={startAuthentication.isLoading}
+                >
+                  Continue with {option.tenantName}
+                  {ssoOptions.length > 1 ? ` — ${option.connectionName}` : ''}
+                </Button>
+              </Fragment>
+            );
+          })}
+        </>
+      )
+    };
+    lines.splice(emailLineIndex >= 0 ? emailLineIndex + 1 : 0, 0, ssoLine);
+  }
+
+  if (!connectionSelection && hasEmailOption && ssoOptions.length > 0) {
+    let ssoLineIndex = lines.findIndex(line => line.id === 'sso');
+    lines.splice(ssoLineIndex + 1, 0, {
+      id: 'email-action',
+      content: (
+        <Button
+          fullWidth
+          size="3"
+          type="submit"
+          form="auth-email-form"
+          variant="outline"
+          loading={
+            (startAuthentication.isLoading || form.isSubmitting) && loadingSource == 'email'
+          }
+          disabled={startAuthentication.isLoading || form.isSubmitting}
+        >
+          Continue with email
+        </Button>
+      )
+    });
   }
 
   return (
@@ -507,19 +585,33 @@ export let AuthHomeScene = ({
         </>
       )}
 
-      {lines.map((line, i) => (
-        <Fragment key={i}>
-          {i > 0 && (
-            <>
-              <Spacer height={20} />
-              <Or />
-              <Spacer height={20} />
-            </>
-          )}
+      <AnimatePresence initial={false} mode="popLayout">
+        {lines.map((line, i) => (
+          <AnimatedMethod
+            layout
+            key={line.id}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+          >
+            {i > 0 &&
+              ((line.id === 'sso' && lines[i - 1]?.id === 'email') ||
+              (line.id === 'email' && lines[i - 1]?.id === 'sso') ||
+              (line.id === 'email-action' && lines[i - 1]?.id === 'sso') ? (
+                <Spacer height={10} />
+              ) : (
+                <>
+                  <Spacer height={20} />
+                  <Or />
+                  <Spacer height={20} />
+                </>
+              ))}
 
-          {line}
-        </Fragment>
-      ))}
+            {line.content}
+          </AnimatedMethod>
+        ))}
+      </AnimatePresence>
     </AuthLayout>
   );
 };

--- a/src/ares/service/frontend/auth/src/state/auth.ts
+++ b/src/ares/service/frontend/auth/src/state/auth.ts
@@ -1,19 +1,20 @@
-import { createLoader } from '@metorial-io/data-hooks';
+import { createLoader, useMutation } from '@metorial-io/data-hooks';
+import type { AuthClient } from '../../../../src/apis/auth/controllers';
 import { authIntentState } from './authIntent';
 import { authClient } from './client';
-import type { AuthClient } from '../../../../src/apis/auth/controllers';
 
 type PublicAuthStartInput = Parameters<AuthClient['authentication']['start']>[0];
 export type AuthStartInput = PublicAuthStartInput;
-export type AuthStartResponse = Awaited<
-  ReturnType<AuthClient['authentication']['start']>
->;
+export type AuthStartResponse = Awaited<ReturnType<AuthClient['authentication']['start']>>;
 export type AuthConnectionSelection = Extract<AuthStartResponse, { type: 'selection' }>;
 export type AuthConnectionOption = AuthConnectionSelection['options'][number];
 
 export type AuthStartOutcome =
   | AuthConnectionSelection
   | Extract<AuthStartResponse, { type: 'auth_intent' }>;
+export type AuthUserSelection = Awaited<
+  ReturnType<AuthClient['authentication']['userSelect']>
+>;
 
 let redirect = (url: string) => {
   window.location.replace(url);
@@ -81,3 +82,5 @@ export let authState = createLoader({
     }
   }
 });
+
+export let useUserSelect = () => useMutation(authClient.authentication.userSelect);

--- a/src/ares/service/package.json
+++ b/src/ares/service/package.json
@@ -46,13 +46,16 @@
     "@boxyhq/saml-jackson": "^1.52.2",
     "@looped/hooks": "^0.1.3",
     "@lowerdeck/api-mux": "workspace:2.0.0",
+    "@lowerdeck/base62": "workspace:2.0.0",
     "@lowerdeck/cache": "workspace:2.0.0",
     "@lowerdeck/canonicalize": "workspace:2.0.0",
     "@lowerdeck/cron": "workspace:2.0.0",
+    "@lowerdeck/delay": "workspace:2.0.0",
     "@lowerdeck/encryption": "workspace:2.0.0",
     "@lowerdeck/env": "workspace:2.0.0",
     "@lowerdeck/error": "workspace:2.0.0",
     "@lowerdeck/event": "workspace:2.0.0",
+    "@lowerdeck/execution-context": "workspace:2.0.0",
     "@lowerdeck/forwarded-for": "workspace:2.0.0",
     "@lowerdeck/hash": "workspace:2.0.0",
     "@lowerdeck/hono": "workspace:2.0.0",
@@ -84,6 +87,7 @@
     "@types/ua-parser-js": "^0.7.39",
     "axios": "^1.13.2",
     "date-fns": "^4.1.0",
+    "framer-motion": "^12.43.0",
     "input-otp": "^1.4.2",
     "ipaddr.js": "^2.3.0",
     "jszip": "^3.10.1",
@@ -97,10 +101,7 @@
     "styled-components": "^6.1.13",
     "ua-parser-js": "1",
     "vite": "5.4.21",
-    "yaml": "^2.8.2",
-    "@lowerdeck/delay": "workspace:2.0.0",
-    "@lowerdeck/base62": "workspace:2.0.0",
-    "@lowerdeck/execution-context": "workspace:2.0.0"
+    "yaml": "^2.8.2"
   },
   "overrides": {
     "@react-email/components": "1.0.8"

--- a/src/ares/service/src/apis/auth/controllers/auth.ts
+++ b/src/ares/service/src/apis/auth/controllers/auth.ts
@@ -59,6 +59,38 @@ export let authenticationController = publicApp.controller({
       };
     }),
 
+  userSelect: deviceApp
+    .handler()
+    .input(
+      v.object({
+        clientId: v.string(),
+        email: v.string({ modifiers: [v.maxLength(320)] })
+      })
+    )
+    .do(async ({ input }) => {
+      let { app, account: clientAccount } = await resolveClient(input.clientId);
+      let { options, account } = await authService.getUserAuthOptions({
+        app,
+        account: clientAccount,
+        email: input.email
+      });
+
+      return {
+        email: input.email.trim().toLowerCase(),
+        options,
+        clientId: getAccountSsoClientId(input.clientId, account?.clientId),
+        account: account
+          ? {
+              id: account.id,
+              name: account.name,
+              identifier: account.identifier,
+              allowEmailLogin: account.allowEmailLogin,
+              allowSocialLogin: account.allowSocialLogin
+            }
+          : null
+      };
+    }),
+
   start: deviceApp
     .handler()
     .input(

--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -115,7 +115,12 @@ class AuthServiceImpl {
     return app;
   }
 
-  async resolveAccountForEmail(d: { app: App; account?: Account | null; email: string }) {
+  async resolveAccountForEmail(d: {
+    app: App;
+    account?: Account | null;
+    email: string;
+    resolveLinkedUser?: boolean;
+  }) {
     let { email, domain } = parseEmail(d.email);
     let accountDomain = await db.accountDomain.findUnique({
       where: { appOid_domain: { appOid: d.app.oid, domain } },
@@ -133,7 +138,7 @@ class AuthServiceImpl {
     }
 
     let linkedUser =
-      !d.account && !accountDomain
+      d.resolveLinkedUser !== false && !d.account && !accountDomain
         ? await db.user.findFirst({
             where: {
               appOid: d.app.oid,
@@ -166,12 +171,14 @@ class AuthServiceImpl {
     account?: Account | null;
     email?: string;
     includeHidden?: boolean;
+    resolveLinkedUser?: boolean;
   }) {
     let resolved = d.email
       ? await this.resolveAccountForEmail({
           app: d.app,
           account: d.account,
-          email: d.email
+          email: d.email,
+          resolveLinkedUser: d.resolveLinkedUser
         })
       : { account: d.account ?? null, accountDomain: null };
     let account = resolved.account;
@@ -214,7 +221,7 @@ class AuthServiceImpl {
       );
     }
 
-    return { account, connections };
+    return { account, accountDomain: resolved.accountDomain, connections };
   }
 
   async resolveSsoConnection(d: {
@@ -292,6 +299,65 @@ class AuthServiceImpl {
     return { options };
   }
 
+  async getUserAuthOptions(d: { app: App; account?: Account | null; email: string }) {
+    let fallback = async () => ({
+      ...(await this.getAuthOptions({ app: d.app, account: d.account })),
+      account: d.account ?? null
+    });
+
+    try {
+      parseEmail(d.email);
+    } catch {
+      return await fallback();
+    }
+
+    let resolved: Awaited<ReturnType<typeof this.getSsoConnections>>;
+    try {
+      resolved = await this.getSsoConnections({
+        app: d.app,
+        account: d.account,
+        email: d.email,
+        includeHidden: false,
+        resolveLinkedUser: false
+      });
+    } catch (error) {
+      if (error instanceof ServiceError) return await fallback();
+      throw error;
+    }
+
+    let { account, accountDomain, connections } = resolved;
+    if (!accountDomain || connections.length === 0) return await fallback();
+    let user = await userService.findByEmailSafe({ email: d.email, app: d.app });
+
+    let options: (
+      | { type: 'email' }
+      | {
+          type: 'sso';
+          tenantId: string;
+          tenantName: string;
+          connectionId: string;
+          connectionName: string;
+        }
+    )[] = connections.map(connection => ({
+      type: 'sso' as const,
+      tenantId: connection.tenant.id,
+      tenantName: connection.tenant.name,
+      connectionId: connection.id,
+      connectionName: connection.name
+    }));
+
+    if (
+      !d.app.disableEmailAuth &&
+      user?.status === 'active' &&
+      user.signupMethod === 'email' &&
+      account?.allowEmailLogin !== false
+    ) {
+      options.unshift({ type: 'email' });
+    }
+
+    return { options, account };
+  }
+
   async authWithEmail(d: {
     email: string;
     context: Context;
@@ -306,14 +372,20 @@ class AuthServiceImpl {
     }
 
     let { email } = parseEmail(d.email);
-    let { account, connections } = await this.getSsoConnections({
+    let { account, accountDomain, connections } = await this.getSsoConnections({
       app: d.app,
       account: d.account,
       email,
       includeHidden: true
     });
+    let user = await userService.findByEmailSafe({ email, app: d.app });
+    let canUseEmail =
+      !d.app.disableEmailAuth &&
+      user?.status === 'active' &&
+      user.signupMethod === 'email' &&
+      (!accountDomain || account?.allowEmailLogin !== false);
     let accountEmailAuthFlow = getAccountEmailAuthFlow(!!account, connections.length);
-    if (accountEmailAuthFlow == 'sso_redirect') {
+    if (!canUseEmail && accountEmailAuthFlow == 'sso_redirect') {
       return {
         type: 'hook' as const,
         authType: 'sso' as const,
@@ -324,7 +396,7 @@ class AuthServiceImpl {
       };
     }
 
-    if (accountEmailAuthFlow == 'sso_selection') {
+    if (!canUseEmail && accountEmailAuthFlow == 'sso_selection') {
       return {
         type: 'selection' as const,
         account,
@@ -352,8 +424,6 @@ class AuthServiceImpl {
     });
 
     return await withTransaction(async tdb => {
-      let user = await userService.findByEmailSafe({ email, app: d.app });
-
       if (user) {
         let isLoggedIn = await deviceService.checkIfUserIsLoggedIn({
           user,
@@ -484,12 +554,16 @@ class AuthServiceImpl {
       );
     }
 
-    let { account } = await this.resolveAccountForEmail({
+    let { account, accountDomain, connections } = await this.getSsoConnections({
       app: d.app,
       account: d.account,
-      email: socialRes.email
+      email: socialRes.email,
+      includeHidden: true
     });
-    if (account && !account.allowSocialLogin) {
+    if (
+      account &&
+      (!account.allowSocialLogin || (accountDomain != null && connections.length > 0))
+    ) {
       return {
         type: 'social_disabled' as const,
         account,

--- a/src/ares/service/src/services/auth.userSelect.test.ts
+++ b/src/ares/service/src/services/auth.userSelect.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { authBlockService, db, deviceService, userService } = vi.hoisted(() => ({
+  authBlockService: { registerBlock: vi.fn() },
+  db: {
+    accountDomain: { findUnique: vi.fn() },
+    appOAuthProvider: { findMany: vi.fn() },
+    ssoConnection: { findMany: vi.fn() },
+    user: { findFirst: vi.fn() }
+  },
+  deviceService: { checkIfUserIsLoggedIn: vi.fn() },
+  userService: { findByEmailSafe: vi.fn() }
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_name: string, factory: () => unknown) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('../db', () => ({
+  db,
+  withTransaction: async (cb: (tdb: unknown) => Promise<unknown>) => await cb(db)
+}));
+
+vi.mock('../email/authCode', () => ({
+  sendAuthCodeEmail: { send: vi.fn() }
+}));
+
+vi.mock('../email/successfulLogin', () => ({
+  successfulLoginVerification: { send: vi.fn() }
+}));
+
+vi.mock('../queues/syncCallback', () => ({
+  markAresUserChanged: vi.fn()
+}));
+
+vi.mock('./accessGroup', () => ({
+  accessGroupService: {}
+}));
+
+vi.mock('./auditLog', () => ({
+  auditLogService: { log: vi.fn() }
+}));
+
+vi.mock('./authBlock', () => ({
+  authBlockService
+}));
+
+vi.mock('./device', () => ({
+  deviceService
+}));
+
+vi.mock('./sso/domainPolicy', () => ({
+  ssoDomainPolicyService: {}
+}));
+
+vi.mock('./user', () => ({
+  userService
+}));
+
+import { authService } from './auth';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+let app = {
+  oid: 1n,
+  disableEmailAuth: false
+} as any;
+
+let account = {
+  oid: 2n,
+  id: 'account_1',
+  appOid: app.oid,
+  status: 'active'
+} as any;
+
+let localConnection = {
+  oid: 3n,
+  id: 'connection_1',
+  tenantOid: 4n,
+  tenant: {
+    oid: 4n,
+    id: 'tenant_1',
+    name: 'Acme',
+    importedDelegationOid: null
+  },
+  name: 'Employees'
+} as any;
+
+describe('authService.getUserAuthOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.accountDomain.findUnique.mockResolvedValue({
+      accountOid: account.oid,
+      account,
+      allowedTenants: [],
+      allowedConnections: []
+    });
+    db.ssoConnection.findMany.mockResolvedValue([localConnection]);
+    db.user.findFirst.mockResolvedValue(null);
+    authBlockService.registerBlock.mockResolvedValue(undefined);
+    deviceService.checkIfUserIsLoggedIn.mockResolvedValue(false);
+    db.appOAuthProvider.findMany.mockResolvedValue([
+      { provider: 'google' },
+      { provider: 'github' }
+    ]);
+    userService.findByEmailSafe.mockResolvedValue(null);
+  });
+
+  it('offers email and SSO, but not OAuth, to an email-origin user on an SSO domain', async () => {
+    userService.findByEmailSafe.mockResolvedValue({
+      status: 'active',
+      signupMethod: 'email'
+    });
+
+    await expect(
+      authService.getUserAuthOptions({ app, email: 'user@acme.com' })
+    ).resolves.toEqual({
+      account,
+      options: [
+        { type: 'email' },
+        {
+          type: 'sso',
+          tenantId: 'tenant_1',
+          tenantName: 'Acme',
+          connectionId: 'connection_1',
+          connectionName: 'Employees'
+        }
+      ]
+    });
+  });
+
+  it('honors an account policy that disables email login', async () => {
+    db.accountDomain.findUnique.mockResolvedValue({
+      accountOid: account.oid,
+      account: { ...account, allowEmailLogin: false },
+      allowedTenants: [],
+      allowedConnections: []
+    });
+    userService.findByEmailSafe.mockResolvedValue({
+      status: 'active',
+      signupMethod: 'email'
+    });
+
+    let result = await authService.getUserAuthOptions({
+      app,
+      email: 'user@acme.com'
+    });
+
+    expect(result.options).toEqual([
+      expect.objectContaining({ type: 'sso', connectionId: 'connection_1' })
+    ]);
+  });
+
+  it.each([
+    null,
+    { status: 'active', signupMethod: 'sso' },
+    { status: 'active', signupMethod: 'oauth' },
+    { status: 'deleted', signupMethod: 'email' }
+  ])('offers only SSO when email login is not available to the user', async user => {
+    userService.findByEmailSafe.mockResolvedValue(user);
+
+    let result = await authService.getUserAuthOptions({
+      app,
+      email: 'user@acme.com'
+    });
+
+    expect(result.options).toEqual([
+      expect.objectContaining({ type: 'sso', connectionId: 'connection_1' })
+    ]);
+  });
+
+  it('treats a delegated connection like local SSO', async () => {
+    db.ssoConnection.findMany.mockResolvedValue([
+      {
+        ...localConnection,
+        importedDelegationOid: 5n,
+        tenant: { ...localConnection.tenant, importedDelegationOid: 5n }
+      }
+    ]);
+
+    let result = await authService.getUserAuthOptions({
+      app,
+      email: 'user@acme.com'
+    });
+
+    expect(result.options).toEqual([
+      expect.objectContaining({ type: 'sso', connectionId: 'connection_1' })
+    ]);
+  });
+
+  it('returns the default methods when the domain has no SSO connection', async () => {
+    db.accountDomain.findUnique.mockResolvedValue(null);
+    db.ssoConnection.findMany.mockResolvedValue([]);
+
+    await expect(
+      authService.getUserAuthOptions({ app, email: 'user@example.com' })
+    ).resolves.toEqual({
+      account: null,
+      options: [
+        { type: 'email' },
+        { type: 'oauth', provider: 'google' },
+        { type: 'oauth', provider: 'github' }
+      ]
+    });
+    expect(userService.findByEmailSafe).not.toHaveBeenCalled();
+  });
+
+  it('keeps the default layout for app-level SSO not owned by the email domain', async () => {
+    db.accountDomain.findUnique.mockResolvedValue(null);
+
+    let result = await authService.getUserAuthOptions({
+      app,
+      email: 'user@example.com'
+    });
+
+    expect(result.options).toEqual([
+      expect.objectContaining({ type: 'sso', connectionId: 'connection_1' }),
+      { type: 'email' },
+      { type: 'oauth', provider: 'google' },
+      { type: 'oauth', provider: 'github' }
+    ]);
+    expect(userService.findByEmailSafe).not.toHaveBeenCalled();
+  });
+});
+
+describe('authService.authWithEmail on an SSO domain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.accountDomain.findUnique.mockResolvedValue({
+      accountOid: account.oid,
+      account,
+      allowedTenants: [],
+      allowedConnections: []
+    });
+    db.ssoConnection.findMany.mockResolvedValue([localConnection]);
+    authBlockService.registerBlock.mockResolvedValue(undefined);
+  });
+
+  it('continues with email for an existing email-origin user', async () => {
+    let user = { oid: 8n, status: 'active', signupMethod: 'email' };
+    userService.findByEmailSafe.mockResolvedValue(user);
+    deviceService.checkIfUserIsLoggedIn.mockResolvedValue(true);
+    let createAuthAttempt = vi
+      .spyOn(authService, 'createAuthAttempt')
+      .mockResolvedValue({ id: 'attempt_1' } as any);
+
+    let result = await authService.authWithEmail({
+      app,
+      device: { oid: 9n } as any,
+      context: { ip: '1.2.3.4', ua: 'agent' },
+      email: 'user@acme.com',
+      redirectUrl: 'https://app.example.com/callback'
+    });
+
+    expect(result).toEqual({
+      type: 'auth_attempt',
+      authAttempt: { id: 'attempt_1' }
+    });
+    expect(createAuthAttempt).toHaveBeenCalledWith(expect.objectContaining({ user, account }));
+  });
+
+  it('keeps routing unknown users through SSO', async () => {
+    userService.findByEmailSafe.mockResolvedValue(null);
+
+    let result = await authService.authWithEmail({
+      app,
+      device: { oid: 9n } as any,
+      context: { ip: '1.2.3.4', ua: 'agent' },
+      email: 'unknown@acme.com',
+      redirectUrl: 'https://app.example.com/callback'
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: 'hook',
+        authType: 'sso',
+        ssoConnection: localConnection
+      })
+    );
+    expect(authBlockService.registerBlock).not.toHaveBeenCalled();
+  });
+
+  it('keeps routing email-origin users through SSO when account email login is disabled', async () => {
+    db.accountDomain.findUnique.mockResolvedValue({
+      accountOid: account.oid,
+      account: { ...account, allowEmailLogin: false },
+      allowedTenants: [],
+      allowedConnections: []
+    });
+    userService.findByEmailSafe.mockResolvedValue({
+      oid: 8n,
+      status: 'active',
+      signupMethod: 'email'
+    });
+
+    let result = await authService.authWithEmail({
+      app,
+      device: { oid: 9n } as any,
+      context: { ip: '1.2.3.4', ua: 'agent' },
+      email: 'user@acme.com',
+      redirectUrl: 'https://app.example.com/callback'
+    });
+
+    expect(result).toEqual(expect.objectContaining({ type: 'hook', authType: 'sso' }));
+    expect(authBlockService.registerBlock).not.toHaveBeenCalled();
+  });
+});

--- a/src/metorial-frontend/packages/state/src/user/auth/withAuth.test.ts
+++ b/src/metorial-frontend/packages/state/src/user/auth/withAuth.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { withDashboardSDK } = vi.hoisted(() => ({
+  withDashboardSDK: vi.fn()
+}));
+
+vi.mock('../../sdk', () => ({ withDashboardSDK }));
+vi.mock('@metorial/frontend-config', () => ({
+  awaitConfig: vi.fn(async () => ({
+    auth: {
+      loginPath: '/login',
+      logoutPath: '/logout',
+      signupPath: '/signup'
+    }
+  }))
+}));
+
+import { fetchUserSpecial } from './withAuth';
+
+describe('fetchUserSpecial', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('window', {
+      location: {
+        href: 'https://account.metorial.com/',
+        pathname: '/'
+      },
+      enterpriseRedirectToAuthIfNotAuthenticated: (fn: () => Promise<unknown>) => fn()
+    });
+  });
+
+  it('reuses the federation user without calling the dashboard SDK', async () => {
+    let user = {
+      id: 'usr_123',
+      name: 'Test User',
+      email: 'test@example.com'
+    };
+    (window as any).enterpriseUserPromise = Promise.resolve(user);
+
+    await expect(fetchUserSpecial()).resolves.toBe(user);
+    expect(withDashboardSDK).not.toHaveBeenCalled();
+  });
+});

--- a/src/metorial-frontend/packages/state/src/user/auth/withAuth.ts
+++ b/src/metorial-frontend/packages/state/src/user/auth/withAuth.ts
@@ -89,8 +89,12 @@ export let fetchUserSpecial = () => {
   return redirectToAuthIfNotAuthenticated(async () => {
     await delay(1);
 
-    if ((window as any).enterpriseUserPromise) {
-      await (window as any).enterpriseUserPromise;
+    let enterpriseUserPromise = (window as any).enterpriseUserPromise;
+    if (enterpriseUserPromise) {
+      let user = (await enterpriseUserPromise) as MetorialUser;
+      if (!firstUserPromise.value) firstUserPromise.resolve(user);
+
+      return user;
     }
 
     return await withDashboardSDK(async sdk => {

--- a/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerInvite.ts
+++ b/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerInvite.ts
@@ -1,7 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { consumerInviteService } from '@metorial/module-consumer';
+import { consumerInviteService, portalService } from '@metorial/module-consumer';
 import { Controller } from '@metorial/rest';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
@@ -74,8 +74,10 @@ export let portalConsumerInviteController = Controller.create(
         });
         let list = await paginator.run(ctx.query);
 
+        let portalUrl = await portalService.getPrimaryPortalUrl({ portal: ctx.portal });
+
         return Paginator.present(list, consumerInvite =>
-          consumerInvitePresenter.present({ consumerInvite })
+          consumerInvitePresenter.present({ consumerInvite, portalUrl })
         );
       }),
 
@@ -110,7 +112,8 @@ export let portalConsumerInviteController = Controller.create(
         });
 
         return consumerInvitePresenter.present({
-          consumerInvite
+          consumerInvite,
+          portalUrl: await portalService.getPrimaryPortalUrl({ portal: ctx.portal })
         });
       }),
 
@@ -130,7 +133,8 @@ export let portalConsumerInviteController = Controller.create(
       .output(consumerInvitePresenter)
       .do(async ctx => {
         return consumerInvitePresenter.present({
-          consumerInvite: ctx.consumerInvite
+          consumerInvite: ctx.consumerInvite,
+          portalUrl: await portalService.getPrimaryPortalUrl({ portal: ctx.portal })
         });
       })
   }

--- a/src/metorial/apis/core/src/presenters/implementation/consumer/consumerInvite.ts
+++ b/src/metorial/apis/core/src/presenters/implementation/consumer/consumerInvite.ts
@@ -1,16 +1,13 @@
 import { v } from '@lowerdeck/validation';
-import { portalService } from '@metorial/module-consumer';
 import { Presenter } from '@metorial/presenter';
 import { consumerInviteType } from '../../types';
 
 export let v1ConsumerInvitePresenter = Presenter.create(consumerInviteType)
-  .presenter(async ({ consumerInvite }, opts) => ({
+  .presenter(async ({ consumerInvite, portalUrl }, opts) => ({
     object: 'consumer.invite' as const,
     id: consumerInvite.id,
     status: consumerInvite.status,
-    portal_url: consumerInvite.surface.portal
-      ? portalService.getPortalHost({ portal: consumerInvite.surface.portal }).host
-      : null,
+    portal_url: consumerInvite.surface.portal ? portalUrl : null,
     consumer_profile: {
       object: 'consumer.profile#preview' as const,
       id: consumerInvite.consumerProfile.id,

--- a/src/metorial/apis/core/src/presenters/types.ts
+++ b/src/metorial/apis/core/src/presenters/types.ts
@@ -1407,6 +1407,7 @@ export let consumerInviteType = PresentableType.create<{
       portal: Portal | null;
     };
   };
+  portalUrl: string | null;
 }>()('consumer.invite');
 
 export let consumerType = PresentableType.create<{

--- a/src/metorial/modules/consumer/src/email/invite.tsx
+++ b/src/metorial/modules/consumer/src/email/invite.tsx
@@ -2,6 +2,7 @@ import { ConsumerInvite, ConsumerProfile, OrganizationActor, Portal } from '@met
 import { Button, createEmail, createTemplate, Layout, Text } from '@metorial/module-email';
 import React from 'react';
 import { notificationClient } from './client';
+import { buildConsumerInviteUrl } from './inviteUrl';
 
 export let sendConsumerInviteEmail = notificationClient.createTemplate(
   createTemplate({
@@ -18,9 +19,12 @@ export let sendConsumerInviteEmail = notificationClient.createTemplate(
       consumerProfile: ConsumerProfile;
       invitedBy: OrganizationActor;
     }) => {
-      let url = new URL(portalUrl);
-      url.searchParams.set('consumer_invite_id', invite.id);
-      url.searchParams.set('consumer_profile_id', consumerProfile.id);
+      let url = buildConsumerInviteUrl({
+        portalUrl,
+        inviteId: invite.id,
+        consumerProfileId: consumerProfile.id,
+        email: consumerProfile.email
+      });
 
       return createEmail({
         subject: `You're invited to ${portal.name}`,
@@ -36,7 +40,7 @@ export let sendConsumerInviteEmail = notificationClient.createTemplate(
               much more. Metorial is managed by your organization administrators.
             </Text>
 
-            <Button href={url.toString()}>Join {portal.name}</Button>
+            <Button href={url}>Join {portal.name}</Button>
 
             {!!invite.message?.trim().length && (
               <Text>

--- a/src/metorial/modules/consumer/src/email/inviteUrl.ts
+++ b/src/metorial/modules/consumer/src/email/inviteUrl.ts
@@ -1,0 +1,14 @@
+export let buildConsumerInviteUrl = (d: {
+  portalUrl: string;
+  inviteId: string;
+  consumerProfileId: string;
+  email: string;
+}) => {
+  let url = new URL(d.portalUrl);
+
+  url.searchParams.set('consumer_invite_id', d.inviteId);
+  url.searchParams.set('consumer_profile_id', d.consumerProfileId);
+  url.searchParams.set('email', d.email);
+
+  return url.toString();
+};

--- a/src/metorial/modules/consumer/src/queues/accessRequest/sendApprovedConsumerAccessRequestEmail.ts
+++ b/src/metorial/modules/consumer/src/queues/accessRequest/sendApprovedConsumerAccessRequestEmail.ts
@@ -36,7 +36,7 @@ export let sendApprovedConsumerAccessRequestEmailQueueProcessor =
     if (!consumerAccessRequest.consumerProfile.email.trim()) return;
     if (!consumerAccessRequest.surface.portal) return;
 
-    let urlRes = portalService.getPortalHost({
+    let portalUrl = await portalService.getPrimaryPortalUrl({
       portal: consumerAccessRequest.surface.portal
     });
 
@@ -46,7 +46,7 @@ export let sendApprovedConsumerAccessRequestEmailQueueProcessor =
         organization: consumerAccessRequest.surface.organization,
         consumerSurface: consumerAccessRequest.surface,
         consumerAccessRequest,
-        url: urlRes.host
+        url: portalUrl
       }
     });
   });

--- a/src/metorial/modules/consumer/src/queues/lifecycle/consumerInvite.ts
+++ b/src/metorial/modules/consumer/src/queues/lifecycle/consumerInvite.ts
@@ -31,7 +31,9 @@ let processInviteLifecycle = async (consumerInviteId: string) => {
   await sendConsumerInviteEmail.send({
     data: {
       portal: consumerInvite.surface.portal,
-      portalUrl: portalService.getPortalHost({ portal: consumerInvite.surface.portal }).host,
+      portalUrl: await portalService.getPrimaryPortalUrl({
+        portal: consumerInvite.surface.portal
+      }),
       invite: consumerInvite,
       consumerProfile: consumerInvite.consumerProfile,
       invitedBy: consumerInvite.invitedBy

--- a/src/metorial/modules/consumer/test/consumerInviteEmail.test.ts
+++ b/src/metorial/modules/consumer/test/consumerInviteEmail.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    consumerInvite: { findUnique: vi.fn() }
+  }
+}));
+
+vi.mock('@metorial/queue', () => ({
+  createQueue: vi.fn(config => ({
+    name: config.name,
+    add: vi.fn(),
+    process: vi.fn(handler => handler)
+  })),
+  QueueRetryError: class QueueRetryError extends Error {}
+}));
+
+vi.mock('../src/email/invite', () => ({
+  sendConsumerInviteEmail: { send: vi.fn() }
+}));
+
+vi.mock('../src/services/portal', () => ({
+  portalService: {
+    getPortalHost: vi.fn(() => ({ host: 'https://portals-us1.metorial.com/sso-test-1' })),
+    getPrimaryPortalUrl: vi.fn()
+  }
+}));
+
+let portal = { oid: 1n, id: 'portal_1', slug: 'sso-test-1', name: 'SSO Test', status: 'active' };
+
+let invite = {
+  id: 'coi_1',
+  status: 'pending',
+  message: null,
+  consumerProfile: { id: 'cop_1', name: 'Ada', email: 'ada@acme.test' },
+  invitedBy: { name: 'Grace', email: 'grace@acme.test' },
+  surface: { portal }
+};
+
+describe('consumer invite email', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('links to the portal namespace instead of the configured host template', async () => {
+    let { db } = await import('@metorial/db');
+    let { sendConsumerInviteEmail } = await import('../src/email/invite');
+    let { portalService } = await import('../src/services/portal');
+    let { consumerInviteCreatedQueueProcessor } = await import(
+      '../src/queues/lifecycle/consumerInvite'
+    );
+
+    vi.mocked(db.consumerInvite.findUnique).mockResolvedValue(invite as any);
+    vi.mocked(portalService.getPrimaryPortalUrl).mockResolvedValue(
+      'https://sso-test-1.portals.metorial.com'
+    );
+
+    await (consumerInviteCreatedQueueProcessor as any)({ consumerInviteId: invite.id });
+
+    expect(portalService.getPortalHost).not.toHaveBeenCalled();
+    expect(portalService.getPrimaryPortalUrl).toHaveBeenCalledWith({ portal });
+    expect(sendConsumerInviteEmail.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          portalUrl: 'https://sso-test-1.portals.metorial.com'
+        })
+      })
+    );
+  });
+});
+
+describe('buildConsumerInviteUrl', () => {
+  let params = {
+    inviteId: 'coi_1',
+    consumerProfileId: 'cop_1',
+    email: 'ada+test@acme.test'
+  };
+
+  it('identifies the invite, the profile and the invitee', async () => {
+    let { buildConsumerInviteUrl } = await import('../src/email/inviteUrl');
+
+    let url = new URL(
+      buildConsumerInviteUrl({
+        portalUrl: 'https://sso-test-1.portals.metorial.com',
+        ...params
+      })
+    );
+
+    expect(url.searchParams.get('consumer_invite_id')).toBe('coi_1');
+    expect(url.searchParams.get('consumer_profile_id')).toBe('cop_1');
+    expect(url.searchParams.get('email')).toBe('ada+test@acme.test');
+  });
+
+  it('keeps the path of a shared namespace portal URL', async () => {
+    let { buildConsumerInviteUrl } = await import('../src/email/inviteUrl');
+
+    let url = buildConsumerInviteUrl({
+      portalUrl: 'https://acme.portals.metorial.com/p/sso-test-1',
+      ...params
+    });
+
+    expect(url).toBe(
+      'https://acme.portals.metorial.com/p/sso-test-1?consumer_invite_id=coi_1&consumer_profile_id=cop_1&email=ada%2Btest%40acme.test'
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authentication routing and login UX in Ares plus user-facing invite URLs; mistakes could block logins or send broken invite links, though new tests cover key paths.
> 
> **Overview**
> **Consumer invite emails and API responses** now use `portalService.getPrimaryPortalUrl` instead of deriving links from `getPortalHost`, so invite and access-request emails point at the portal’s primary namespace URL (including shared-namespace paths). Invite CTAs are built via **`buildConsumerInviteUrl`**, which adds `consumer_invite_id`, `consumer_profile_id`, and **`email`** query params while preserving the portal URL path.
> 
> **Ares auth (bundled in the same PR):** adds **`authentication.userSelect`** and **`getUserAuthOptions`** so the login UI can debounce email entry and surface domain-specific SSO/email options (hiding OAuth on SSO-owned domains). **`authHome`** drops URL email auto-submit, reorders SSO vs email actions, and animates method changes with **framer-motion**. **`authWithEmail`** and OAuth handling are tightened so existing email-signup users can still use email on SSO domains when allowed, while unknown users and SSO-only policies keep SSO routing. **`fetchUserSpecial`** returns the resolved enterprise federation user instead of only awaiting the promise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61b88c9df7cd1643c901f7aca6a81336f5c741e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->