### PR TITLE
Add native links to item grids

### DIFF
--- a/src/metorial-frontend/packages/ui-product/src/itemGrid.tsx
+++ b/src/metorial-frontend/packages/ui-product/src/itemGrid.tsx
@@ -212,10 +212,17 @@ let getActionProps = ({ href, onClick, disabled }: ItemGridActionProps) => {
   return {};
 };
 
-let wrapAction = (children: React.ReactNode, href?: string, disabled?: boolean) => {
+let NativeLink = styled.a``;
+
+let wrapAction = (
+  children: React.ReactNode,
+  href?: string,
+  disabled?: boolean,
+  nativeLink?: boolean
+) => {
   if (!href || disabled) return children;
 
-  let Link = getLink();
+  let Link = nativeLink ? NativeLink : getLink();
 
   return (
     <Link
@@ -254,7 +261,8 @@ export let ItemGrid = {
     small,
     height,
     disabled = false,
-    loading = false
+    loading = false,
+    nativeLink = false
   }: {
     title: React.ReactNode;
     description?: React.ReactNode;
@@ -270,6 +278,7 @@ export let ItemGrid = {
     height?: number;
     disabled?: boolean;
     loading?: boolean;
+    nativeLink?: boolean;
   }) => {
     let menuItems = [
       ...(entity && showCopyId ? [{ id: 'id', label: 'Copy ID' }] : []),
@@ -362,7 +371,8 @@ export let ItemGrid = {
         )}
       </Wrapper>,
       onClick ? undefined : href,
-      disabled
+      disabled,
+      nativeLink
     );
   },
   CenteredItem: ({
@@ -372,7 +382,8 @@ export let ItemGrid = {
     href,
     onClick,
     disabled = false,
-    loading = false
+    loading = false,
+    nativeLink = false
   }: {
     title: React.ReactNode;
     description?: React.ReactNode;
@@ -381,6 +392,7 @@ export let ItemGrid = {
     onClick?: () => void;
     disabled?: boolean;
     loading?: boolean;
+    nativeLink?: boolean;
   }) => {
     return wrapAction(
       <Wrapper
@@ -415,7 +427,8 @@ export let ItemGrid = {
         )}
       </Wrapper>,
       onClick ? undefined : href,
-      disabled
+      disabled,
+      nativeLink
     );
   },
   RawItem: Wrapper


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, opt-in UI change in link rendering with default behavior unchanged.
> 
> **Overview**
> **Item grid cards** can now render their `href` wrapper as a plain native `<a>` instead of the app’s `getLink()` router component.
> 
> `ItemGrid.Item` and `ItemGrid.CenteredItem` accept an optional **`nativeLink`** prop (default `false`). When enabled, `wrapAction` uses a styled `NativeLink` (`<a>`) rather than `getLink()`, while keeping the same layout styles and existing client-router behavior when the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862de7c4749d8e9dc0583483593b00cb2369a09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->