### PR TITLE
Harden tooltips

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@metorial/oss",

--- a/src/metorial-frontend/packages/layout/src/applicationLayout/switcher/instanceMenu.tsx
+++ b/src/metorial-frontend/packages/layout/src/applicationLayout/switcher/instanceMenu.tsx
@@ -4,8 +4,8 @@ import {
   useCurrentOrganization,
   useCurrentProject
 } from '@metorial/state';
-import { Button, Menu, Text, theme } from '@metorial/ui';
-import { RiArrowDownSLine } from '@remixicon/react';
+import { Button, Menu, Text, theme, Tooltip } from '@metorial/ui';
+import { RiArrowDownSLine, RiFlaskLine } from '@remixicon/react';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -265,9 +265,22 @@ export let SandboxButton = () => {
         }
       }}
     >
-      <Button size="2" color="gray400" shadow={false}>
-        {instance.data?.type === 'development' ? 'Exit Sandbox' : 'Sandboxes'}
-      </Button>
+      {instance.data?.type === 'development' ? (
+        <Button size="2" color="gray400" shadow={false}>
+          Exit Sandbox
+        </Button>
+      ) : (
+        <Tooltip content="Manage Sandboxes">
+          <Button
+            variant="ghost"
+            size="3"
+            iconLeft={
+              <RiFlaskLine style={{ height: 16, width: 16, color: theme.colors.gray800 }} />
+            }
+            title="Manage Sandboxes"
+          />
+        </Tooltip>
+      )}
     </Menu>
   );
 };

--- a/src/metorial-frontend/packages/ui/src/contextMenu/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/contextMenu/index.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { keyframes, styled } from 'styled-components';
 import { theme } from '..';
 import { useDialogZIndex } from '../dialog/state';
+import { OverlayOpenProvider, useSuppressTooltipWhileOpen } from '../tooltip/state';
 
 let fadeInBottom = keyframes`
   from { opacity: 0; transform: translateY(-10px) scale(0.99); }
@@ -140,6 +141,8 @@ export let ContextMenu = ({
 
   useEffect(() => setIsOpen?.(open), [open]);
 
+  useSuppressTooltipWhileOpen(open);
+
   useEffect(() => {
     if (!open) return;
 
@@ -174,7 +177,7 @@ export let ContextMenu = ({
         setOpen(true);
       }}
     >
-      {children}
+      <OverlayOpenProvider value={open}>{children}</OverlayOpenProvider>
       {open
         ? createPortal(
             <Content

--- a/src/metorial-frontend/packages/ui/src/menu/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/menu/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { keyframes, styled } from 'styled-components';
 import { theme } from '..';
 import { useDialogZIndex } from '../dialog/state';
+import { OverlayOpenProvider, useSuppressTooltipWhileOpen } from '../tooltip/state';
 
 let fadeInBottom = keyframes`
   from { opacity: 0; transform: translateY(-10px) scale(0.99); }
@@ -191,66 +192,80 @@ export type MenuProps = {
   setIsOpen?: (isOpen: boolean) => void;
   matchTriggerWidth?: boolean;
   lightMode?: boolean;
-};
+} & Omit<React.ComponentPropsWithoutRef<'button'>, 'children' | 'title'>;
 
-export let Menu = ({
-  children,
-  label,
-  onItemClick,
-  items,
-  title,
-  setIsOpen,
-  matchTriggerWidth,
-  lightMode
-}: MenuProps) => {
-  let [open, setOpen] = useState(false);
-  let zIndex = useDialogZIndex(open);
+export let Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
+  (
+    {
+      children,
+      label,
+      onItemClick,
+      items,
+      title,
+      setIsOpen,
+      matchTriggerWidth,
+      lightMode,
+      ...triggerProps
+    },
+    ref
+  ) => {
+    let [open, setOpen] = useState(false);
+    let zIndex = useDialogZIndex(open);
 
-  useEffect(() => setIsOpen?.(open), [open]);
+    useEffect(() => setIsOpen?.(open), [open]);
 
-  return (
-    <RadixMenu.Root open={open} onOpenChange={setOpen}>
-      <RadixMenu.Trigger aria-label={label} asChild>
-        {children}
-      </RadixMenu.Trigger>
-      <RadixMenu.Portal>
-        <Content
-          $lightMode={lightMode}
-          $matchTriggerWidth={matchTriggerWidth}
-          sideOffset={5}
-          style={{ zIndex }}
-        >
-          {title && (
-            <>
-              <Title $lightMode={lightMode}>{title}</Title>
-              <Separator $lightMode={lightMode} />
-            </>
-          )}
+    useSuppressTooltipWhileOpen(open);
 
-          {items.map((item: any, i) =>
-            item.type === 'separator' ? (
-              <Separator key={i} $lightMode={lightMode} />
-            ) : (
-              <Item
-                key={i}
-                $lightMode={lightMode}
-                $matchTriggerWidth={matchTriggerWidth}
-                onClick={() => {
-                  item.onClick?.();
-                  if (item.id != null) onItemClick?.(item.id);
-                }}
-                disabled={item.disabled}
-                asChild
-              >
-                <button type="button" disabled={item.disabled}>
-                  <h1>{item.label}</h1>
-                  {item.description && <p>{item.description}</p>}
-                </button>
-              </Item>
-            )
-          )}
-        </Content>
-      </RadixMenu.Portal>
-    </RadixMenu.Root>
-  );
-};
+    return (
+      <RadixMenu.Root open={open} onOpenChange={setOpen}>
+        {/* Props and the ref are forwarded to the trigger so the menu can itself be the child
+            of a tooltip trigger, and the open state is published so a tooltip on the trigger
+            knows to hide. */}
+        <OverlayOpenProvider value={open}>
+          <RadixMenu.Trigger aria-label={label} {...triggerProps} asChild ref={ref}>
+            {children}
+          </RadixMenu.Trigger>
+        </OverlayOpenProvider>
+
+        <RadixMenu.Portal>
+          <Content
+            $lightMode={lightMode}
+            $matchTriggerWidth={matchTriggerWidth}
+            sideOffset={5}
+            style={{ zIndex }}
+          >
+            {title && (
+              <>
+                <Title $lightMode={lightMode}>{title}</Title>
+                <Separator $lightMode={lightMode} />
+              </>
+            )}
+
+            {items.map((item: any, i) =>
+              item.type === 'separator' ? (
+                <Separator key={i} $lightMode={lightMode} />
+              ) : (
+                <Item
+                  key={i}
+                  $lightMode={lightMode}
+                  $matchTriggerWidth={matchTriggerWidth}
+                  onClick={() => {
+                    item.onClick?.();
+                    if (item.id != null) onItemClick?.(item.id);
+                  }}
+                  disabled={item.disabled}
+                  asChild
+                >
+                  <button type="button" disabled={item.disabled}>
+                    <h1>{item.label}</h1>
+                    {item.description && <p>{item.description}</p>}
+                  </button>
+                </Item>
+              )
+            )}
+          </Content>
+        </RadixMenu.Portal>
+      </RadixMenu.Root>
+    );
+  }
+);

--- a/src/metorial-frontend/packages/ui/src/popover/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/popover/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { keyframes, styled } from 'styled-components';
 import { useDialogContext, useZindex } from '../dialog/state';
 import { theme } from '../theme';
+import { OverlayOpenProvider, useSuppressTooltipWhileOpen } from '../tooltip/state';
 
 let fadeInTop = keyframes`
   from {
@@ -155,19 +156,7 @@ let Arrow = styled(RadixPopover.Arrow)`
   fill: ${theme.colors.background};
 `;
 
-let Root = ({
-  trigger,
-  children,
-  arrow,
-  operationKey,
-  onOpenChange,
-  onOpenAutoFocus,
-  side,
-  align,
-  sideOffset,
-  alignOffset,
-  open: openProp
-}: {
+export type PopoverProps = {
   trigger: React.ReactNode;
   children: React.ReactNode;
   arrow?: boolean;
@@ -182,49 +171,75 @@ let Root = ({
 
   // The the operationKey changes, the popover will close
   operationKey?: string;
-}) => {
-  let [open, setOpen] = useState(false);
-  let dialog = useDialogContext();
+} & Omit<React.ComponentPropsWithoutRef<'button'>, 'children' | 'content'>;
 
-  useEffect(() => {
-    setOpen(false);
-  }, [operationKey]);
+let Root = React.forwardRef<HTMLButtonElement, PopoverProps>(
+  (
+    {
+      trigger,
+      children,
+      arrow,
+      operationKey,
+      onOpenChange,
+      onOpenAutoFocus,
+      side,
+      align,
+      sideOffset,
+      alignOffset,
+      open: openProp,
+      ...triggerProps
+    },
+    ref
+  ) => {
+    let [open, setOpen] = useState(false);
+    let dialog = useDialogContext();
 
-  useEffect(() => {
-    if (onOpenChange) onOpenChange(open);
-  }, [open]);
+    useEffect(() => {
+      setOpen(false);
+    }, [operationKey]);
 
-  useEffect(() => {
-    if (typeof openProp === 'boolean') setOpen(openProp);
-  }, [openProp]);
+    useEffect(() => {
+      if (onOpenChange) onOpenChange(open);
+    }, [open]);
 
-  let zIndex = useZindex(open);
+    useEffect(() => {
+      if (typeof openProp === 'boolean') setOpen(openProp);
+    }, [openProp]);
 
-  return (
-    <RadixPopover.Root open={open} onOpenChange={setOpen}>
-      <RadixPopover.Trigger asChild>{trigger}</RadixPopover.Trigger>
+    useSuppressTooltipWhileOpen(open);
 
-      <RadixPopover.Portal container={dialog?.contentRef?.current}>
-        <Wrapper
-          style={{ zIndex }}
-          side={side}
-          align={align}
-          sideOffset={sideOffset}
-          alignOffset={alignOffset}
-          onOpenAutoFocus={onOpenAutoFocus}
-          onInteractOutside={event => {
-            let target = event.target as Element | null;
-            if (target?.closest('[data-metorial-select-content]')) event.preventDefault();
-          }}
-        >
-          {children}
+    let zIndex = useZindex(open);
 
-          {arrow && <Arrow />}
-        </Wrapper>
-      </RadixPopover.Portal>
-    </RadixPopover.Root>
-  );
-};
+    return (
+      <RadixPopover.Root open={open} onOpenChange={setOpen}>
+        <OverlayOpenProvider value={open}>
+          <RadixPopover.Trigger {...triggerProps} asChild ref={ref}>
+            {trigger}
+          </RadixPopover.Trigger>
+        </OverlayOpenProvider>
+
+        <RadixPopover.Portal container={dialog?.contentRef?.current}>
+          <Wrapper
+            style={{ zIndex }}
+            side={side}
+            align={align}
+            sideOffset={sideOffset}
+            alignOffset={alignOffset}
+            onOpenAutoFocus={onOpenAutoFocus}
+            onInteractOutside={event => {
+              let target = event.target as Element | null;
+              if (target?.closest('[data-metorial-select-content]')) event.preventDefault();
+            }}
+          >
+            {children}
+
+            {arrow && <Arrow />}
+          </Wrapper>
+        </RadixPopover.Portal>
+      </RadixPopover.Root>
+    );
+  }
+);
 
 let Content = ({
   children,

--- a/src/metorial-frontend/packages/ui/src/select/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/select/index.tsx
@@ -8,6 +8,7 @@ import { markSelectPointerDismiss, useZindex } from '../dialog/state';
 import { Error } from '../error';
 import { InputDescription, InputLabel } from '../input';
 import { theme } from '../theme';
+import { OverlayOpenProvider, useSuppressTooltipWhileOpen } from '../tooltip/state';
 
 let fadeIn = keyframes`
   from {
@@ -156,6 +157,8 @@ export let Select = ({
 
   let [isOpen, setIsOpen] = useState(false);
   let zIndex = useZindex(isOpen);
+
+  useSuppressTooltipWhileOpen(isOpen);
 
   let disabledItems = useMemo(
     () =>

--- a/src/metorial-frontend/packages/ui/src/tooltip/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/tooltip/index.tsx
@@ -3,6 +3,13 @@ import React, { useEffect, useState } from 'react';
 import Balancer from 'react-wrap-balancer';
 import { keyframes, styled } from 'styled-components';
 import { theme } from '..';
+import {
+  TooltipSuppressorProvider,
+  useIsInsideOpenOverlay,
+  useTooltipSuppressor
+} from './state';
+
+export * from './state';
 
 let fadeInTop = keyframes`
   from { opacity: 0; transform: translateY(-15px) scale(0.75); filter: blur(2px) }
@@ -113,15 +120,9 @@ let Arrow = styled(RadixTooltip.Arrow)`
   fill: ${theme.colors.foreground};
 `;
 
-export let Tooltip = ({
-  content,
-  children,
-  arrow,
-  delayDuration,
-  enabled,
-  side = 'bottom',
-  align = 'center'
-}: {
+let SUPPRESSION_LINGER = 300;
+
+export type TooltipProps = {
   content: React.ReactNode;
   children: React.ReactNode;
   arrow?: boolean;
@@ -129,38 +130,71 @@ export let Tooltip = ({
   enabled?: boolean;
   side?: 'top' | 'right' | 'bottom' | 'left';
   align?: 'start' | 'center' | 'end';
-}) => {
-  // We disable the trigger for a single render to prevent
-  // the tooltip from showing in dialogs
-  let [disabled, setDisabled] = useState(true);
+} & Omit<React.ComponentPropsWithoutRef<'button'>, 'content' | 'children'>;
 
-  useEffect(() => {
-    setDisabled(false);
-  }, []);
+export let Tooltip = React.forwardRef<HTMLButtonElement, TooltipProps>(
+  (
+    {
+      content,
+      children,
+      arrow,
+      delayDuration,
+      enabled,
+      side = 'bottom',
+      align = 'center',
+      ...triggerProps
+    },
+    ref
+  ) => {
+    let [isOpen, setIsOpen] = useState(false);
 
-  if (enabled === false) return <>{children}</>;
+    let [isSuppressed, setIsSuppressed] = useState(true);
 
-  return (
-    <RadixTooltip.Provider delayDuration={delayDuration}>
-      <RadixTooltip.Root>
-        <RadixTooltip.Trigger asChild disabled={disabled}>
-          {children}
-        </RadixTooltip.Trigger>
+    let { isHeld, suppressor } = useTooltipSuppressor();
+    let isInsideOpenOverlay = useIsInsideOpenOverlay();
+    let shouldSuppress = enabled === false || isHeld || isInsideOpenOverlay;
 
-        <RadixTooltip.Portal>
-          <Content sideOffset={5} side={side} align={align} hideWhenDetached>
-            {typeof content == 'string' ? (
-              <>
-                <Balancer>{content}</Balancer>
-              </>
-            ) : (
-              <>{content}</>
-            )}
+    useEffect(() => {
+      if (shouldSuppress) {
+        setIsSuppressed(true);
+        setIsOpen(false);
+        return;
+      }
 
-            {arrow && <Arrow />}
-          </Content>
-        </RadixTooltip.Portal>
-      </RadixTooltip.Root>
-    </RadixTooltip.Provider>
-  );
-};
+      let timeout = setTimeout(() => setIsSuppressed(false), SUPPRESSION_LINGER);
+      return () => clearTimeout(timeout);
+    }, [shouldSuppress]);
+
+    return (
+      <RadixTooltip.Provider delayDuration={delayDuration}>
+        <RadixTooltip.Root
+          open={isOpen && !isSuppressed}
+          onOpenChange={open => {
+            if (open && isSuppressed) return;
+            setIsOpen(open);
+          }}
+        >
+          <TooltipSuppressorProvider value={suppressor}>
+            <RadixTooltip.Trigger asChild {...triggerProps} ref={ref}>
+              {children}
+            </RadixTooltip.Trigger>
+          </TooltipSuppressorProvider>
+
+          <RadixTooltip.Portal>
+            <Content sideOffset={5} side={side} align={align} hideWhenDetached>
+              {typeof content == 'string' ? (
+                <>
+                  <Balancer>{content}</Balancer>
+                </>
+              ) : (
+                <>{content}</>
+              )}
+
+              {arrow && <Arrow />}
+            </Content>
+          </RadixTooltip.Portal>
+        </RadixTooltip.Root>
+      </RadixTooltip.Provider>
+    );
+  }
+);

--- a/src/metorial-frontend/packages/ui/src/tooltip/state.ts
+++ b/src/metorial-frontend/packages/ui/src/tooltip/state.ts
@@ -1,0 +1,46 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+
+let OverlayOpenContext = React.createContext(false);
+
+export let OverlayOpenProvider = OverlayOpenContext.Provider;
+
+export let useIsInsideOpenOverlay = () => useContext(OverlayOpenContext);
+
+export interface TooltipSuppressor {
+  hold: () => () => void;
+}
+
+let TooltipSuppressorContext = React.createContext<TooltipSuppressor | null>(null);
+
+export let TooltipSuppressorProvider = TooltipSuppressorContext.Provider;
+
+export let useTooltipSuppressor = () => {
+  let [holds, setHolds] = useState(0);
+
+  let suppressor = useMemo<TooltipSuppressor>(
+    () => ({
+      hold: () => {
+        setHolds(holds => holds + 1);
+        let isReleased = false;
+
+        return () => {
+          if (isReleased) return;
+          isReleased = true;
+          setHolds(holds => holds - 1);
+        };
+      }
+    }),
+    []
+  );
+
+  return { isHeld: holds > 0, suppressor };
+};
+
+export let useSuppressTooltipWhileOpen = (isOpen: boolean) => {
+  let suppressor = useContext(TooltipSuppressorContext);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    return suppressor?.hold();
+  }, [isOpen, suppressor]);
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Shared overlay primitives and tooltip open logic changed across the UI package, which can affect focus/hover behavior app-wide; the sandbox entry control also changed visually and in labeling.
> 
> **Overview**
> **Tooltip behavior** is reworked so they stay hidden while menus, popovers, selects, or context menus are open, and for a short linger after overlays close. A new `tooltip/state` module coordinates this via overlay-open context and a refcounted suppressor; `Menu`, `Popover`, `ContextMenu`, and `Select` call `useSuppressTooltipWhileOpen` and expose open state to descendants. `Tooltip` no longer uses a one-frame disabled trigger hack—it uses controlled open state, suppression, and **forwards ref/button props** so it can wrap other triggers.
> 
> **Menu** and **Popover** are now `forwardRef` components that forward trigger props and refs, enabling tooltip-wrapped menu triggers without broken composition.
> 
> In **SandboxButton** (production), the text “Sandboxes” control is replaced with a ghost flask icon inside a **“Manage Sandboxes”** tooltip; development still shows **Exit Sandbox**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb9c33d2c918e32a1a017d2b91e54b7fd9cf86df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->