### PR TITLE
Harden ares user signup claim

### DIFF
--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -803,6 +803,7 @@ class AuthServiceImpl {
 
     let user = await db.user.findUnique({ where: { oid: userIdentity.userOid! } });
     if (!user) throw new Error('User not found after SSO identity linking');
+    user = await userService.claimSsoSignup({ user });
     user = await userService.linkToAccount({ user });
     await markAresUserChanged({ userId: user.id });
 

--- a/src/ares/service/src/services/user.test.ts
+++ b/src/ares/service/src/services/user.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let { db, auditLogService, markAresUserChanged, userEvents } = vi.hoisted(() => ({
   db: {
-    user: { findFirst: vi.fn(), create: vi.fn() },
+    user: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
     userEmail: { findFirst: vi.fn(), create: vi.fn() },
     userTermsAgreement: { upsert: vi.fn() },
     accountDomain: { findUnique: vi.fn() },
@@ -138,6 +138,44 @@ describe('userService.resolveOrCreateUser', () => {
 
     await expect(userService.resolveOrCreateUser(input)).rejects.toThrow('connection reset');
     expect(db.user.findFirst).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('userService.claimSsoSignup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    db.user.update.mockImplementation(async ({ data }: any) => ({ ...existingUser, ...data }));
+  });
+
+  it('claims a user another writer just created', async () => {
+    let user = { ...existingUser, signupMethod: 'email', createdAt: new Date() } as any;
+
+    await expect(userService.claimSsoSignup({ user })).resolves.toMatchObject({
+      signupMethod: 'sso'
+    });
+    expect(db.user.update).toHaveBeenCalledWith({
+      where: { oid: existingUser.oid },
+      data: { signupMethod: 'sso' }
+    });
+  });
+
+  it('leaves an established email signup alone', async () => {
+    let user = {
+      ...existingUser,
+      signupMethod: 'email',
+      createdAt: new Date(Date.now() - 6 * 60 * 1000)
+    } as any;
+
+    await expect(userService.claimSsoSignup({ user })).resolves.toBe(user);
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it('does not write when the user already signed up through SSO', async () => {
+    let user = { ...existingUser, signupMethod: 'sso', createdAt: new Date() } as any;
+
+    await expect(userService.claimSsoSignup({ user })).resolves.toBe(user);
+    expect(db.user.update).not.toHaveBeenCalled();
   });
 });
 

--- a/src/ares/service/src/services/user.ts
+++ b/src/ares/service/src/services/user.ts
@@ -24,6 +24,8 @@ export class EmailInUseError extends ServiceError<ReturnType<typeof conflictErro
 
 let isUniqueConstraintError = (e: any) => e?.code === 'P2002';
 
+let SSO_SIGNUP_CLAIM_WINDOW_MS = 3 * 60 * 1000;
+
 class UserServiceImpl {
   async getSyncSnapshot(d: { user: User }) {
     let user = await db.user.findUniqueOrThrow({
@@ -434,6 +436,16 @@ class UserServiceImpl {
 
       return { user: raced, created: false };
     }
+  }
+
+  async claimSsoSignup(d: { user: User }) {
+    if (d.user.signupMethod === 'sso') return d.user;
+    if (Date.now() - d.user.createdAt.getTime() > SSO_SIGNUP_CLAIM_WINDOW_MS) return d.user;
+
+    return await db.user.update({
+      where: { oid: d.user.oid },
+      data: { signupMethod: 'sso' }
+    });
   }
 
   async listUserProfile(d: { user: User }) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches login-time user metadata that gates email vs SSO options; behavior is bounded by a short time window and covered by tests.
> 
> **Overview**
> Adds **`claimSsoSignup`** so SSO login can correct **`signupMethod`** when the user row was created moments earlier by another path (e.g. SCIM/hyperplane or a create race) and still shows **`email`**.
> 
> On SSO auth, after identity linking, the flow now calls **`claimSsoSignup`** before **`linkToAccount`**. The helper only updates **`signupMethod`** to **`sso`** if the user is not already SSO and **`createdAt`** is within a **3-minute** window; older **`email`** signups are left unchanged.
> 
> Unit tests cover the claim path, the time window, and the no-op cases when **`signupMethod`** is already **`sso`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91bd509956103ce7c1f0e55bcd371ce2c2aa822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->