### PR TITLE
Eager user init

### DIFF
--- a/src/ares/service/prisma/schema/auth/auth.prisma
+++ b/src/ares/service/prisma/schema/auth/auth.prisma
@@ -116,12 +116,20 @@ enum AuthAttemptStatus {
   consumed
 }
 
+enum AuthLoginMethod {
+  email
+  oauth
+  sso
+}
+
 model AuthAttempt {
   oid          BigInt @id
   id           String @unique
   clientSecret String @unique
 
   status AuthAttemptStatus
+
+  loginMethod AuthLoginMethod?
 
   authorizationCode String? @unique
 

--- a/src/ares/service/prisma/schema/user/user.prisma
+++ b/src/ares/service/prisma/schema/user/user.prisma
@@ -14,6 +14,7 @@ enum UserStatus {
 }
 
 enum UserSignupMethod {
+  unknown
   email
   oauth
   sso
@@ -45,7 +46,11 @@ model User {
   image Json
 
   isFullyCreated Boolean @default(true)
-  signupMethod   UserSignupMethod @default(email)
+
+  // The defaults describe rows that predate these columns. Writers that create a user
+  // without witnessing a login -- projections, SCIM -- pass `unknown` and `false`.
+  signupMethod UserSignupMethod @default(email)
+  hasLoggedIn  Boolean          @default(true)
 
   lastLoginAt  DateTime?
   lastActiveAt DateTime?

--- a/src/ares/service/src/apis/admin/presenters/user.ts
+++ b/src/ares/service/src/apis/admin/presenters/user.ts
@@ -22,6 +22,7 @@ export let adminUserPresenter = async (
   id: user.id,
 
   signupMethod: user.signupMethod,
+  hasLoggedIn: user.hasLoggedIn,
   email: user.deletedAt ? deletedEmail.restoreAnonymized(user.email) : user.email,
   name: user.name,
   firstName: user.firstName,

--- a/src/ares/service/src/apis/auth/presenters/user.ts
+++ b/src/ares/service/src/apis/auth/presenters/user.ts
@@ -11,6 +11,7 @@ export let userPresenter = async (user: User & { userEmails: UserEmail[] }) => (
   id: user.id,
 
   signupMethod: user.signupMethod,
+  hasLoggedIn: user.hasLoggedIn,
   email: user.deletedAt ? deletedEmail.restoreAnonymized(user.email) : user.email,
   name: user.name,
   firstName: user.firstName,

--- a/src/ares/service/src/apis/internal/presenters/user.ts
+++ b/src/ares/service/src/apis/internal/presenters/user.ts
@@ -7,6 +7,7 @@ export let userPresenter = async (user: User) => ({
   id: user.id,
 
   signupMethod: user.signupMethod,
+  hasLoggedIn: user.hasLoggedIn,
   email: user.email,
   name: user.name,
   firstName: user.firstName,

--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -13,6 +13,7 @@ import type {
   AuthDevice,
   AuthIntent,
   AuthIntentStep,
+  AuthLoginMethod,
   SsoTenant,
   SsoUserProfile,
   User
@@ -346,6 +347,9 @@ class AuthServiceImpl {
       connectionName: connection.name
     }));
 
+    // A signup method of `unknown` belongs to a user an external writer created who has
+    // never logged in here, and it reads like no user at all: the domain decides, so the
+    // options stay limited to its SSO connections.
     if (
       !d.app.disableEmailAuth &&
       user?.status === 'active' &&
@@ -436,6 +440,7 @@ class AuthServiceImpl {
             authAttempt: await this.createAuthAttempt({
               user,
               device: d.device,
+              loginMethod: 'email',
               redirectUrl: d.redirectUrl,
               account
             })
@@ -667,6 +672,7 @@ class AuthServiceImpl {
         authAttempt: await this.createAuthAttempt({
           user,
           device: d.device,
+          loginMethod: 'oauth',
           redirectUrl: d.redirectUrl,
           account
         })
@@ -803,7 +809,6 @@ class AuthServiceImpl {
 
     let user = await db.user.findUnique({ where: { oid: userIdentity.userOid! } });
     if (!user) throw new Error('User not found after SSO identity linking');
-    user = await userService.claimSsoSignup({ user });
     user = await userService.linkToAccount({ user });
     await markAresUserChanged({ userId: user.id });
 
@@ -830,6 +835,7 @@ class AuthServiceImpl {
     return await this.createAuthAttempt({
       user,
       device: d.device,
+      loginMethod: 'sso',
       redirectUrl: d.redirectUrl,
       account: d.account
     });
@@ -1128,6 +1134,7 @@ class AuthServiceImpl {
     user: User;
     device: AuthDevice;
     authIntent?: AuthIntent;
+    loginMethod: AuthLoginMethod;
     redirectUrl: string;
     account?: Account | null;
   }) {
@@ -1149,6 +1156,7 @@ class AuthServiceImpl {
           clientSecret: generateCustomId('aat_sec_'),
 
           status: 'pending',
+          loginMethod: d.loginMethod,
 
           userOid: user.oid,
           deviceOid: d.device.oid,
@@ -1210,6 +1218,7 @@ class AuthServiceImpl {
 
       return await this.createAuthAttempt({
         authIntent: d.authIntent,
+        loginMethod: d.authIntent.type == 'oauth' ? 'oauth' : 'email',
         redirectUrl: d.authIntent.redirectUrl,
         user,
         device,

--- a/src/ares/service/src/services/auth.userSelect.test.ts
+++ b/src/ares/service/src/services/auth.userSelect.test.ts
@@ -159,6 +159,9 @@ describe('authService.getUserAuthOptions', () => {
 
   it.each([
     null,
+    // A user a projection or SCIM sync created, who has never logged in here, tells us
+    // nothing about how they should: the domain does.
+    { status: 'active', signupMethod: 'unknown' },
     { status: 'active', signupMethod: 'sso' },
     { status: 'active', signupMethod: 'oauth' },
     { status: 'deleted', signupMethod: 'email' }
@@ -265,26 +268,29 @@ describe('authService.authWithEmail on an SSO domain', () => {
     expect(createAuthAttempt).toHaveBeenCalledWith(expect.objectContaining({ user, account }));
   });
 
-  it('keeps routing unknown users through SSO', async () => {
-    userService.findByEmailSafe.mockResolvedValue(null);
+  it.each([null, { oid: 8n, status: 'active', signupMethod: 'unknown' }])(
+    'keeps routing users without a signup method through SSO',
+    async user => {
+      userService.findByEmailSafe.mockResolvedValue(user);
 
-    let result = await authService.authWithEmail({
-      app,
-      device: { oid: 9n } as any,
-      context: { ip: '1.2.3.4', ua: 'agent' },
-      email: 'unknown@acme.com',
-      redirectUrl: 'https://app.example.com/callback'
-    });
+      let result = await authService.authWithEmail({
+        app,
+        device: { oid: 9n } as any,
+        context: { ip: '1.2.3.4', ua: 'agent' },
+        email: 'unknown@acme.com',
+        redirectUrl: 'https://app.example.com/callback'
+      });
 
-    expect(result).toEqual(
-      expect.objectContaining({
-        type: 'hook',
-        authType: 'sso',
-        ssoConnection: localConnection
-      })
-    );
-    expect(authBlockService.registerBlock).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'hook',
+          authType: 'sso',
+          ssoConnection: localConnection
+        })
+      );
+      expect(authBlockService.registerBlock).not.toHaveBeenCalled();
+    }
+  );
 
   it('keeps routing email-origin users through SSO when account email login is disabled', async () => {
     db.accountDomain.findUnique.mockResolvedValue({

--- a/src/ares/service/src/services/device.ts
+++ b/src/ares/service/src/services/device.ts
@@ -14,6 +14,7 @@ import { getId, snowflake } from '../id';
 import type { Context } from '../lib/context';
 import { auditLogService } from './auditLog';
 import { markAresUserChanged } from '../queues/syncCallback';
+import { userService } from './user';
 
 class DeviceService {
   async getAllUsersForDevice(d: { device: AuthDevice }) {
@@ -152,11 +153,11 @@ class DeviceService {
       });
       if (existingSession) return existingSession;
 
-      await db.user.updateMany({
-        where: { oid: user.oid },
-        data: { lastLoginAt: new Date() }
+      await userService.recordLogin({
+        user,
+        method: d.authAttempt.loginMethod,
+        db
       });
-      await markAresUserChanged({ userId: user.id, db });
 
       auditLogService.log({
         appOid: user.appOid,

--- a/src/ares/service/src/services/user.test.ts
+++ b/src/ares/service/src/services/user.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let { db, auditLogService, markAresUserChanged, userEvents } = vi.hoisted(() => ({
   db: {
-    user: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    user: { findFirst: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
     userEmail: { findFirst: vi.fn(), create: vi.fn() },
     userTermsAgreement: { upsert: vi.fn() },
     accountDomain: { findUnique: vi.fn() },
@@ -141,41 +141,43 @@ describe('userService.resolveOrCreateUser', () => {
   });
 });
 
-describe('userService.claimSsoSignup', () => {
+describe('userService.recordLogin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    db.user.update.mockImplementation(async ({ data }: any) => ({ ...existingUser, ...data }));
+    db.user.updateMany.mockResolvedValue({ count: 1 });
   });
 
-  it('claims a user another writer just created', async () => {
-    let user = { ...existingUser, signupMethod: 'email', createdAt: new Date() } as any;
+  let recordedData = () => db.user.updateMany.mock.calls[0]![0].data;
 
-    await expect(userService.claimSsoSignup({ user })).resolves.toMatchObject({
-      signupMethod: 'sso'
+  it('settles the signup method for a user that arrived without one', async () => {
+    let user = { ...existingUser, signupMethod: 'unknown', hasLoggedIn: false } as any;
+
+    await userService.recordLogin({ user, method: 'sso' });
+
+    expect(recordedData()).toMatchObject({
+      hasLoggedIn: true,
+      signupMethod: 'sso',
+      lastLoginAt: expect.any(Date)
     });
-    expect(db.user.update).toHaveBeenCalledWith({
-      where: { oid: existingUser.oid },
-      data: { signupMethod: 'sso' }
-    });
   });
 
-  it('leaves an established email signup alone', async () => {
-    let user = {
-      ...existingUser,
-      signupMethod: 'email',
-      createdAt: new Date(Date.now() - 6 * 60 * 1000)
-    } as any;
+  it('leaves a known signup method alone', async () => {
+    let user = { ...existingUser, signupMethod: 'email', hasLoggedIn: true } as any;
 
-    await expect(userService.claimSsoSignup({ user })).resolves.toBe(user);
-    expect(db.user.update).not.toHaveBeenCalled();
+    await userService.recordLogin({ user, method: 'sso' });
+
+    expect(recordedData()).toMatchObject({ hasLoggedIn: true });
+    expect(recordedData()).not.toHaveProperty('signupMethod');
   });
 
-  it('does not write when the user already signed up through SSO', async () => {
-    let user = { ...existingUser, signupMethod: 'sso', createdAt: new Date() } as any;
+  it('records the login of an attempt that predates the login method', async () => {
+    let user = { ...existingUser, signupMethod: 'unknown', hasLoggedIn: false } as any;
 
-    await expect(userService.claimSsoSignup({ user })).resolves.toBe(user);
-    expect(db.user.update).not.toHaveBeenCalled();
+    await userService.recordLogin({ user, method: null });
+
+    expect(recordedData()).toMatchObject({ hasLoggedIn: true });
+    expect(recordedData()).not.toHaveProperty('signupMethod');
   });
 });
 

--- a/src/ares/service/src/services/user.ts
+++ b/src/ares/service/src/services/user.ts
@@ -6,8 +6,14 @@ import {
   ServiceError
 } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
-import type { App, User, UserEmail, UserTermsType } from '../../prisma/generated/client';
-import { addAfterTransactionHook, db, withTransaction } from '../db';
+import type {
+  App,
+  AuthLoginMethod,
+  User,
+  UserEmail,
+  UserTermsType
+} from '../../prisma/generated/client';
+import { addAfterTransactionHook, db, type TransactionDB, withTransaction } from '../db';
 import { terms } from '../definitions';
 import { userEvents } from '../events/user';
 import { getId } from '../id';
@@ -23,8 +29,6 @@ export class EmailInUseError extends ServiceError<ReturnType<typeof conflictErro
 }
 
 let isUniqueConstraintError = (e: any) => e?.code === 'P2002';
-
-let SSO_SIGNUP_CLAIM_WINDOW_MS = 3 * 60 * 1000;
 
 class UserServiceImpl {
   async getSyncSnapshot(d: { user: User }) {
@@ -201,6 +205,10 @@ class UserServiceImpl {
                 type: 'user',
                 owner: 'self',
                 status: d.input.status,
+                // The authority knows the user exists, not how they will get in. The
+                // first login on this instance is what settles the signup method.
+                signupMethod: 'unknown',
+                hasLoggedIn: false,
                 email: d.input.email,
                 name: d.input.name,
                 firstName: d.input.firstName,
@@ -438,14 +446,19 @@ class UserServiceImpl {
     }
   }
 
-  async claimSsoSignup(d: { user: User }) {
-    if (d.user.signupMethod === 'sso') return d.user;
-    if (Date.now() - d.user.createdAt.getTime() > SSO_SIGNUP_CLAIM_WINDOW_MS) return d.user;
+  async recordLogin(d: { user: User; method: AuthLoginMethod | null; db?: TransactionDB }) {
+    let tdb = d.db ?? db;
 
-    return await db.user.update({
+    await tdb.user.updateMany({
       where: { oid: d.user.oid },
-      data: { signupMethod: 'sso' }
+      data: {
+        lastLoginAt: new Date(),
+        hasLoggedIn: true,
+        ...(d.method && d.user.signupMethod === 'unknown' ? { signupMethod: d.method } : {})
+      }
     });
+
+    await markAresUserChanged({ userId: d.user.id, db: tdb });
   }
 
   async listUserProfile(d: { user: User }) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes login-time user state and SSO/email routing for provisioned users; schema adds nullable loginMethod on auth attempts with migration implications for in-flight attempts.
> 
> **Overview**
> Users created by projections/SCIM (or other writers that never see a login) are now stored with **`signupMethod: unknown`** and **`hasLoggedIn: false`** instead of being treated as email or eagerly claimed as SSO. **Signup method is set on the first successful session** via `userService.recordLogin`, using the **`loginMethod`** now recorded on each **`AuthAttempt`** (email / oauth / sso).
> 
> **`claimSsoSignup`** (time-window SSO overwrite) is removed; SSO no longer mutates signup at auth-attempt time. Login side effects (`lastLoginAt`, `hasLoggedIn`, optional signup settlement) run when the auth attempt is exchanged for a device session. **`hasLoggedIn`** is exposed on admin/auth/internal user APIs. Auth option and email routing treat **`unknown`** like “no established method”—SSO domain rules drive login paths until the user has logged in once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7255113bdb9b75f51294ec6ae3fef8477641d2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->