### PR TITLE
Remove consumer sso groups

### DIFF
--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/get-member-consumer.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/get-member-consumer.ts
@@ -32,7 +32,6 @@ export type ConsumersGetMemberConsumerOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -95,10 +94,6 @@ export let mapConsumersGetMemberConsumerOutput = mtMap.union([
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/profiles/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/profiles/get.ts
@@ -22,7 +22,6 @@ export type ConsumersProfilesGetOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapConsumersProfilesGetOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/consumers/profiles/list.ts
@@ -23,7 +23,6 @@ export type ConsumersProfilesListOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -102,10 +101,6 @@ export let mapConsumersProfilesListOutput =
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/create.ts
@@ -70,7 +70,6 @@ export type ConversationsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapConversationsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/get.ts
@@ -70,7 +70,6 @@ export type ConversationsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -233,10 +232,6 @@ export let mapConversationsGetOutput = mtMap.object<ConversationsGetOutput>({
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/list.ts
@@ -71,7 +71,6 @@ export type ConversationsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -255,10 +254,6 @@ export let mapConversationsListOutput = mtMap.object<ConversationsListOutput>({
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/create.ts
@@ -94,7 +94,6 @@ export type ConversationsMessagesCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapConversationsMessagesCreateOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/get.ts
@@ -94,7 +94,6 @@ export type ConversationsMessagesGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapConversationsMessagesGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/handoff-responses.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/handoff-responses.ts
@@ -94,7 +94,6 @@ export type ConversationsMessagesHandoffResponsesOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapConversationsMessagesHandoffResponsesOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/messages/list.ts
@@ -95,7 +95,6 @@ export type ConversationsMessagesListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -322,10 +321,6 @@ export let mapConversationsMessagesListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/conversations/update.ts
@@ -70,7 +70,6 @@ export type ConversationsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapConversationsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/get-member-consumer.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/get-member-consumer.ts
@@ -32,7 +32,6 @@ export type DashboardInstanceConsumersGetMemberConsumerOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -95,10 +94,6 @@ export let mapDashboardInstanceConsumersGetMemberConsumerOutput = mtMap.union([
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/profiles/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/profiles/get.ts
@@ -22,7 +22,6 @@ export type DashboardInstanceConsumersProfilesGetOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapDashboardInstanceConsumersProfilesGetOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/consumers/profiles/list.ts
@@ -23,7 +23,6 @@ export type DashboardInstanceConsumersProfilesListOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -102,10 +101,6 @@ export let mapDashboardInstanceConsumersProfilesListOutput =
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/create.ts
@@ -70,7 +70,6 @@ export type DashboardInstanceConversationsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapDashboardInstanceConversationsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/get.ts
@@ -70,7 +70,6 @@ export type DashboardInstanceConversationsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapDashboardInstanceConversationsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/list.ts
@@ -71,7 +71,6 @@ export type DashboardInstanceConversationsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -262,10 +261,6 @@ export let mapDashboardInstanceConversationsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/create.ts
@@ -94,7 +94,6 @@ export type DashboardInstanceConversationsMessagesCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapDashboardInstanceConversationsMessagesCreateOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/get.ts
@@ -94,7 +94,6 @@ export type DashboardInstanceConversationsMessagesGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapDashboardInstanceConversationsMessagesGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/handoff-responses.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/handoff-responses.ts
@@ -94,7 +94,6 @@ export type DashboardInstanceConversationsMessagesHandoffResponsesOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapDashboardInstanceConversationsMessagesHandoffResponsesOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/messages/list.ts
@@ -95,7 +95,6 @@ export type DashboardInstanceConversationsMessagesListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -322,10 +321,6 @@ export let mapDashboardInstanceConversationsMessagesListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/conversations/update.ts
@@ -70,7 +70,6 @@ export type DashboardInstanceConversationsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapDashboardInstanceConversationsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/clone.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/clone.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceDocumentsCloneOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapDashboardInstanceDocumentsCloneOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/create.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceDocumentsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapDashboardInstanceDocumentsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/delete.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceDocumentsDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapDashboardInstanceDocumentsDeleteOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/get.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceDocumentsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapDashboardInstanceDocumentsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/list.ts
@@ -73,7 +73,6 @@ export type DashboardInstanceDocumentsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -230,10 +229,6 @@ export let mapDashboardInstanceDocumentsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/participants/get.ts
@@ -70,7 +70,6 @@ export type DashboardInstanceDocumentsParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -197,10 +196,6 @@ export let mapDashboardInstanceDocumentsParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/participants/list.ts
@@ -71,7 +71,6 @@ export type DashboardInstanceDocumentsParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -219,10 +218,6 @@ export let mapDashboardInstanceDocumentsParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/update.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceDocumentsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapDashboardInstanceDocumentsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/versions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/versions/get.ts
@@ -71,7 +71,6 @@ export type DashboardInstanceDocumentsVersionsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -209,10 +208,6 @@ export let mapDashboardInstanceDocumentsVersionsGetOutput =
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/versions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/documents/versions/list.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceDocumentsVersionsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -258,10 +257,6 @@ export let mapDashboardInstanceDocumentsVersionsListOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/files/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/files/delete.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceFilesDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -210,10 +209,6 @@ export let mapDashboardInstanceFilesDeleteOutput = mtMap.union([
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/files/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/files/get.ts
@@ -72,7 +72,6 @@ export type DashboardInstanceFilesGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -210,10 +209,6 @@ export let mapDashboardInstanceFilesGetOutput = mtMap.union([
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/files/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/files/list.ts
@@ -73,7 +73,6 @@ export type DashboardInstanceFilesListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -266,10 +265,6 @@ export let mapDashboardInstanceFilesListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/create.ts
@@ -77,7 +77,6 @@ export type DashboardInstancePortalsAccessCreateOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapDashboardInstancePortalsAccessCreateOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/delete.ts
@@ -77,7 +77,6 @@ export type DashboardInstancePortalsAccessDeleteOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapDashboardInstancePortalsAccessDeleteOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/get.ts
@@ -77,7 +77,6 @@ export type DashboardInstancePortalsAccessGetOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapDashboardInstancePortalsAccessGetOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/list.ts
@@ -78,7 +78,6 @@ export type DashboardInstancePortalsAccessListOutput = {
       name: string;
       description: string | null;
       isDefault: boolean;
-      ssoGroupIds: string[];
       createdAt: Date;
       updatedAt: Date;
     };
@@ -210,10 +209,6 @@ export let mapDashboardInstancePortalsAccessListOutput =
                 mtMap.passthrough()
               ),
               isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              ssoGroupIds: mtMap.objectField(
-                'sso_group_ids',
-                mtMap.array(mtMap.passthrough())
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/access/update.ts
@@ -77,7 +77,6 @@ export type DashboardInstancePortalsAccessUpdateOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapDashboardInstancePortalsAccessUpdateOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/create.ts
@@ -7,7 +7,6 @@ export type DashboardInstancePortalsConsumerGroupsCreateOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapDashboardInstancePortalsConsumerGroupsCreateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });
@@ -31,7 +26,6 @@ export let mapDashboardInstancePortalsConsumerGroupsCreateOutput =
 export type DashboardInstancePortalsConsumerGroupsCreateBody = {
   name: string;
   description?: string | undefined;
-  ssoGroupIds?: string[] | undefined;
   isDefault?: boolean | undefined;
 };
 
@@ -39,10 +33,6 @@ export let mapDashboardInstancePortalsConsumerGroupsCreateBody =
   mtMap.object<DashboardInstancePortalsConsumerGroupsCreateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/delete.ts
@@ -7,7 +7,6 @@ export type DashboardInstancePortalsConsumerGroupsDeleteOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapDashboardInstancePortalsConsumerGroupsDeleteOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/get.ts
@@ -7,7 +7,6 @@ export type DashboardInstancePortalsConsumerGroupsGetOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapDashboardInstancePortalsConsumerGroupsGetOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/list.ts
@@ -8,7 +8,6 @@ export type DashboardInstancePortalsConsumerGroupsListOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   }[];
@@ -27,10 +26,6 @@ export let mapDashboardInstancePortalsConsumerGroupsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          ssoGroupIds: mtMap.objectField(
-            'sso_group_ids',
-            mtMap.array(mtMap.passthrough())
-          ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-groups/update.ts
@@ -7,7 +7,6 @@ export type DashboardInstancePortalsConsumerGroupsUpdateOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapDashboardInstancePortalsConsumerGroupsUpdateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });
@@ -31,7 +26,6 @@ export let mapDashboardInstancePortalsConsumerGroupsUpdateOutput =
 export type DashboardInstancePortalsConsumerGroupsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
-  ssoGroupIds?: string[] | undefined;
   isDefault?: boolean | undefined;
 };
 
@@ -39,10 +33,6 @@ export let mapDashboardInstancePortalsConsumerGroupsUpdateBody =
   mtMap.object<DashboardInstancePortalsConsumerGroupsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/assign-groups.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/assign-groups.ts
@@ -22,7 +22,6 @@ export type DashboardInstancePortalsConsumerProfilesAssignGroupsOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapDashboardInstancePortalsConsumerProfilesAssignGroupsOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/create.ts
@@ -22,7 +22,6 @@ export type DashboardInstancePortalsConsumerProfilesCreateOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapDashboardInstancePortalsConsumerProfilesCreateOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/delete.ts
@@ -22,7 +22,6 @@ export type DashboardInstancePortalsConsumerProfilesDeleteOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapDashboardInstancePortalsConsumerProfilesDeleteOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/get.ts
@@ -22,7 +22,6 @@ export type DashboardInstancePortalsConsumerProfilesGetOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapDashboardInstancePortalsConsumerProfilesGetOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/list.ts
@@ -23,7 +23,6 @@ export type DashboardInstancePortalsConsumerProfilesListOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -102,10 +101,6 @@ export let mapDashboardInstancePortalsConsumerProfilesListOutput =
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/unassign-groups.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/portals/consumer-profiles/unassign-groups.ts
@@ -22,7 +22,6 @@ export type DashboardInstancePortalsConsumerProfilesUnassignGroupsOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapDashboardInstancePortalsConsumerProfilesUnassignGroupsOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/create.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsCreateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsCreateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsCreateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsCreateOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsCreateOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/delete.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsDeleteOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsDeleteOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsDeleteOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsDeleteOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsDeleteOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsDeleteOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/duplicate.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/duplicate.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsDuplicateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsDuplicateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsDuplicateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsDuplicateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsDuplicateOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsDuplicateOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/create.ts
@@ -77,7 +77,6 @@ export type DashboardInstanceSkillsExportsCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -161,7 +160,6 @@ export type DashboardInstanceSkillsExportsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -309,10 +307,6 @@ export let mapDashboardInstanceSkillsExportsCreateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -457,10 +451,6 @@ export let mapDashboardInstanceSkillsExportsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/get.ts
@@ -77,7 +77,6 @@ export type DashboardInstanceSkillsExportsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -161,7 +160,6 @@ export type DashboardInstanceSkillsExportsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -309,10 +307,6 @@ export let mapDashboardInstanceSkillsExportsGetOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -457,10 +451,6 @@ export let mapDashboardInstanceSkillsExportsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/exports/list.ts
@@ -78,7 +78,6 @@ export type DashboardInstanceSkillsExportsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -162,7 +161,6 @@ export type DashboardInstanceSkillsExportsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -361,10 +359,6 @@ export let mapDashboardInstanceSkillsExportsListOutput =
                                       'is_default',
                                       mtMap.passthrough()
                                     ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
                                       mtMap.date()
@@ -524,10 +518,6 @@ export let mapDashboardInstanceSkillsExportsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/fork.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/fork.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsForkOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsForkOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsForkOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsForkOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsForkOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsForkOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/get.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsGetOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsGetOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsGetOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/list.ts
@@ -83,7 +83,6 @@ export type DashboardInstanceSkillsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -159,7 +158,6 @@ export type DashboardInstanceSkillsListOutput = {
                         name: string;
                         description: string | null;
                         isDefault: boolean;
-                        ssoGroupIds: string[];
                         createdAt: Date;
                         updatedAt: Date;
                       };
@@ -232,7 +230,6 @@ export type DashboardInstanceSkillsListOutput = {
                         name: string;
                         description: string | null;
                         isDefault: boolean;
-                        ssoGroupIds: string[];
                         createdAt: Date;
                         updatedAt: Date;
                       };
@@ -486,10 +483,6 @@ export let mapDashboardInstanceSkillsListOutput =
                                       'is_default',
                                       mtMap.passthrough()
                                     ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
                                       mtMap.date()
@@ -721,10 +714,6 @@ export let mapDashboardInstanceSkillsListOutput =
                                           'is_default',
                                           mtMap.passthrough()
                                         ),
-                                        ssoGroupIds: mtMap.objectField(
-                                          'sso_group_ids',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
                                         createdAt: mtMap.objectField(
                                           'created_at',
                                           mtMap.date()
@@ -947,10 +936,6 @@ export let mapDashboardInstanceSkillsListOutput =
                                         isDefault: mtMap.objectField(
                                           'is_default',
                                           mtMap.passthrough()
-                                        ),
-                                        ssoGroupIds: mtMap.objectField(
-                                          'sso_group_ids',
-                                          mtMap.array(mtMap.passthrough())
                                         ),
                                         createdAt: mtMap.objectField(
                                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/close.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/close.ts
@@ -88,7 +88,6 @@ export type DashboardInstanceSkillsMergeRequestsCloseOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapDashboardInstanceSkillsMergeRequestsCloseOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/create.ts
@@ -67,7 +67,6 @@ export type DashboardInstanceSkillsMergeRequestsCommentsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapDashboardInstanceSkillsMergeRequestsCommentsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/delete.ts
@@ -67,7 +67,6 @@ export type DashboardInstanceSkillsMergeRequestsCommentsDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapDashboardInstanceSkillsMergeRequestsCommentsDeleteOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/get.ts
@@ -67,7 +67,6 @@ export type DashboardInstanceSkillsMergeRequestsCommentsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapDashboardInstanceSkillsMergeRequestsCommentsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/list.ts
@@ -68,7 +68,6 @@ export type DashboardInstanceSkillsMergeRequestsCommentsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -221,10 +220,6 @@ export let mapDashboardInstanceSkillsMergeRequestsCommentsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/comments/update.ts
@@ -67,7 +67,6 @@ export type DashboardInstanceSkillsMergeRequestsCommentsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapDashboardInstanceSkillsMergeRequestsCommentsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/create.ts
@@ -88,7 +88,6 @@ export type DashboardInstanceSkillsMergeRequestsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapDashboardInstanceSkillsMergeRequestsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/events/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/events/get.ts
@@ -75,7 +75,6 @@ export type DashboardInstanceSkillsMergeRequestsEventsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -152,7 +151,6 @@ export type DashboardInstanceSkillsMergeRequestsEventsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -292,10 +290,6 @@ export let mapDashboardInstanceSkillsMergeRequestsEventsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',
@@ -444,10 +438,6 @@ export let mapDashboardInstanceSkillsMergeRequestsEventsGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/events/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/events/list.ts
@@ -76,7 +76,6 @@ export type DashboardInstanceSkillsMergeRequestsEventsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -153,7 +152,6 @@ export type DashboardInstanceSkillsMergeRequestsEventsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -314,10 +312,6 @@ export let mapDashboardInstanceSkillsMergeRequestsEventsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
@@ -511,10 +505,6 @@ export let mapDashboardInstanceSkillsMergeRequestsEventsListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/get.ts
@@ -88,7 +88,6 @@ export type DashboardInstanceSkillsMergeRequestsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapDashboardInstanceSkillsMergeRequestsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/items/bulk-resolve.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/items/bulk-resolve.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsMergeRequestsItemsBulkResolveOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -246,10 +245,6 @@ export let mapDashboardInstanceSkillsMergeRequestsItemsBulkResolveOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/items/resolve.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/items/resolve.ts
@@ -81,7 +81,6 @@ export type DashboardInstanceSkillsMergeRequestsItemsResolveOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -218,10 +217,6 @@ export let mapDashboardInstanceSkillsMergeRequestsItemsResolveOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/list.ts
@@ -89,7 +89,6 @@ export type DashboardInstanceSkillsMergeRequestsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -282,10 +281,6 @@ export let mapDashboardInstanceSkillsMergeRequestsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/perform.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/perform.ts
@@ -88,7 +88,6 @@ export type DashboardInstanceSkillsMergeRequestsPerformOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapDashboardInstanceSkillsMergeRequestsPerformOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/plan/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/plan/get.ts
@@ -90,7 +90,6 @@ export type DashboardInstanceSkillsMergeRequestsPlanGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -191,7 +190,6 @@ export type DashboardInstanceSkillsMergeRequestsPlanGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -407,10 +405,6 @@ export let mapDashboardInstanceSkillsMergeRequestsPlanGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',
@@ -631,10 +625,6 @@ export let mapDashboardInstanceSkillsMergeRequestsPlanGetOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/rollback.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/merge-requests/rollback.ts
@@ -88,7 +88,6 @@ export type DashboardInstanceSkillsMergeRequestsRollbackOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapDashboardInstanceSkillsMergeRequestsRollbackOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/participants/get.ts
@@ -68,7 +68,6 @@ export type DashboardInstanceSkillsParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -194,10 +193,6 @@ export let mapDashboardInstanceSkillsParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/participants/list.ts
@@ -69,7 +69,6 @@ export type DashboardInstanceSkillsParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -216,10 +215,6 @@ export let mapDashboardInstanceSkillsParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/publish-consumer-skill.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/publish-consumer-skill.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsPublishConsumerSkillOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsPublishConsumerSkillOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsPublishConsumerSkillOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsPublishConsumerSkillOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsPublishConsumerSkillOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsPublishConsumerSkillOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/share.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/share.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsShareOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsShareOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsShareOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsShareOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsShareOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsShareOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/skills/update.ts
@@ -82,7 +82,6 @@ export type DashboardInstanceSkillsUpdateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type DashboardInstanceSkillsUpdateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type DashboardInstanceSkillsUpdateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapDashboardInstanceSkillsUpdateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapDashboardInstanceSkillsUpdateOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapDashboardInstanceSkillsUpdateOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/items/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/items/get.ts
@@ -79,7 +79,6 @@ export type DashboardInstanceStoresItemsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -164,7 +163,6 @@ export type DashboardInstanceStoresItemsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -315,10 +313,6 @@ export let mapDashboardInstanceStoresItemsGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',
@@ -479,10 +473,6 @@ export let mapDashboardInstanceStoresItemsGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/items/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/items/list.ts
@@ -80,7 +80,6 @@ export type DashboardInstanceStoresItemsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -165,7 +164,6 @@ export type DashboardInstanceStoresItemsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -367,10 +365,6 @@ export let mapDashboardInstanceStoresItemsListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
@@ -576,10 +570,6 @@ export let mapDashboardInstanceStoresItemsListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/items/modify.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/items/modify.ts
@@ -81,7 +81,6 @@ export type DashboardInstanceStoresItemsModifyOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -166,7 +165,6 @@ export type DashboardInstanceStoresItemsModifyOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -368,10 +366,6 @@ export let mapDashboardInstanceStoresItemsModifyOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
@@ -577,10 +571,6 @@ export let mapDashboardInstanceStoresItemsModifyOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/participants/get.ts
@@ -68,7 +68,6 @@ export type DashboardInstanceStoresParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -196,10 +195,6 @@ export let mapDashboardInstanceStoresParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/stores/participants/list.ts
@@ -69,7 +69,6 @@ export type DashboardInstanceStoresParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -218,10 +217,6 @@ export let mapDashboardInstanceStoresParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/clone.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/clone.ts
@@ -72,7 +72,6 @@ export type DocumentsCloneOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -204,10 +203,6 @@ export let mapDocumentsCloneOutput = mtMap.object<DocumentsCloneOutput>({
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/create.ts
@@ -72,7 +72,6 @@ export type DocumentsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -204,10 +203,6 @@ export let mapDocumentsCreateOutput = mtMap.object<DocumentsCreateOutput>({
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/delete.ts
@@ -72,7 +72,6 @@ export type DocumentsDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -204,10 +203,6 @@ export let mapDocumentsDeleteOutput = mtMap.object<DocumentsDeleteOutput>({
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/get.ts
@@ -72,7 +72,6 @@ export type DocumentsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -204,10 +203,6 @@ export let mapDocumentsGetOutput = mtMap.object<DocumentsGetOutput>({
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/list.ts
@@ -73,7 +73,6 @@ export type DocumentsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -223,10 +222,6 @@ export let mapDocumentsListOutput = mtMap.object<DocumentsListOutput>({
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/participants/get.ts
@@ -70,7 +70,6 @@ export type DocumentsParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -197,10 +196,6 @@ export let mapDocumentsParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/participants/list.ts
@@ -71,7 +71,6 @@ export type DocumentsParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -219,10 +218,6 @@ export let mapDocumentsParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/update.ts
@@ -72,7 +72,6 @@ export type DocumentsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -204,10 +203,6 @@ export let mapDocumentsUpdateOutput = mtMap.object<DocumentsUpdateOutput>({
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/versions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/versions/get.ts
@@ -71,7 +71,6 @@ export type DocumentsVersionsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -209,10 +208,6 @@ export let mapDocumentsVersionsGetOutput =
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/versions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/documents/versions/list.ts
@@ -72,7 +72,6 @@ export type DocumentsVersionsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -258,10 +257,6 @@ export let mapDocumentsVersionsListOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/files/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/files/delete.ts
@@ -72,7 +72,6 @@ export type FilesDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -210,10 +209,6 @@ export let mapFilesDeleteOutput = mtMap.union([
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/files/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/files/get.ts
@@ -72,7 +72,6 @@ export type FilesGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -210,10 +209,6 @@ export let mapFilesGetOutput = mtMap.union([
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/files/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/files/list.ts
@@ -73,7 +73,6 @@ export type FilesListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -256,10 +255,6 @@ export let mapFilesListOutput = mtMap.object<FilesListOutput>({
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/get-member-consumer.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/get-member-consumer.ts
@@ -32,7 +32,6 @@ export type ManagementInstanceConsumersGetMemberConsumerOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -95,10 +94,6 @@ export let mapManagementInstanceConsumersGetMemberConsumerOutput = mtMap.union([
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/profiles/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/profiles/get.ts
@@ -22,7 +22,6 @@ export type ManagementInstanceConsumersProfilesGetOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapManagementInstanceConsumersProfilesGetOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/consumers/profiles/list.ts
@@ -23,7 +23,6 @@ export type ManagementInstanceConsumersProfilesListOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -102,10 +101,6 @@ export let mapManagementInstanceConsumersProfilesListOutput =
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/create.ts
@@ -70,7 +70,6 @@ export type ManagementInstanceConversationsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapManagementInstanceConversationsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/get.ts
@@ -70,7 +70,6 @@ export type ManagementInstanceConversationsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapManagementInstanceConversationsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/list.ts
@@ -71,7 +71,6 @@ export type ManagementInstanceConversationsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -262,10 +261,6 @@ export let mapManagementInstanceConversationsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/create.ts
@@ -94,7 +94,6 @@ export type ManagementInstanceConversationsMessagesCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapManagementInstanceConversationsMessagesCreateOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/get.ts
@@ -94,7 +94,6 @@ export type ManagementInstanceConversationsMessagesGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapManagementInstanceConversationsMessagesGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/handoff-responses.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/handoff-responses.ts
@@ -94,7 +94,6 @@ export type ManagementInstanceConversationsMessagesHandoffResponsesOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -267,10 +266,6 @@ export let mapManagementInstanceConversationsMessagesHandoffResponsesOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/messages/list.ts
@@ -95,7 +95,6 @@ export type ManagementInstanceConversationsMessagesListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -322,10 +321,6 @@ export let mapManagementInstanceConversationsMessagesListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/conversations/update.ts
@@ -70,7 +70,6 @@ export type ManagementInstanceConversationsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -237,10 +236,6 @@ export let mapManagementInstanceConversationsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/clone.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/clone.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceDocumentsCloneOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapManagementInstanceDocumentsCloneOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/create.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceDocumentsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapManagementInstanceDocumentsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/delete.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceDocumentsDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapManagementInstanceDocumentsDeleteOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/get.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceDocumentsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapManagementInstanceDocumentsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/list.ts
@@ -73,7 +73,6 @@ export type ManagementInstanceDocumentsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -230,10 +229,6 @@ export let mapManagementInstanceDocumentsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/participants/get.ts
@@ -70,7 +70,6 @@ export type ManagementInstanceDocumentsParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -197,10 +196,6 @@ export let mapManagementInstanceDocumentsParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/participants/list.ts
@@ -71,7 +71,6 @@ export type ManagementInstanceDocumentsParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -219,10 +218,6 @@ export let mapManagementInstanceDocumentsParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/update.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceDocumentsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -208,10 +207,6 @@ export let mapManagementInstanceDocumentsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/versions/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/versions/get.ts
@@ -71,7 +71,6 @@ export type ManagementInstanceDocumentsVersionsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -209,10 +208,6 @@ export let mapManagementInstanceDocumentsVersionsGetOutput =
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/versions/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/documents/versions/list.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceDocumentsVersionsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -258,10 +257,6 @@ export let mapManagementInstanceDocumentsVersionsListOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/files/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/files/delete.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceFilesDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -210,10 +209,6 @@ export let mapManagementInstanceFilesDeleteOutput = mtMap.union([
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/files/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/files/get.ts
@@ -72,7 +72,6 @@ export type ManagementInstanceFilesGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -210,10 +209,6 @@ export let mapManagementInstanceFilesGetOutput = mtMap.union([
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/files/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/files/list.ts
@@ -73,7 +73,6 @@ export type ManagementInstanceFilesListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -266,10 +265,6 @@ export let mapManagementInstanceFilesListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/create.ts
@@ -77,7 +77,6 @@ export type ManagementInstancePortalsAccessCreateOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapManagementInstancePortalsAccessCreateOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/delete.ts
@@ -77,7 +77,6 @@ export type ManagementInstancePortalsAccessDeleteOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapManagementInstancePortalsAccessDeleteOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/get.ts
@@ -77,7 +77,6 @@ export type ManagementInstancePortalsAccessGetOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapManagementInstancePortalsAccessGetOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/list.ts
@@ -78,7 +78,6 @@ export type ManagementInstancePortalsAccessListOutput = {
       name: string;
       description: string | null;
       isDefault: boolean;
-      ssoGroupIds: string[];
       createdAt: Date;
       updatedAt: Date;
     };
@@ -210,10 +209,6 @@ export let mapManagementInstancePortalsAccessListOutput =
                 mtMap.passthrough()
               ),
               isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-              ssoGroupIds: mtMap.objectField(
-                'sso_group_ids',
-                mtMap.array(mtMap.passthrough())
-              ),
               createdAt: mtMap.objectField('created_at', mtMap.date()),
               updatedAt: mtMap.objectField('updated_at', mtMap.date())
             })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/access/update.ts
@@ -77,7 +77,6 @@ export type ManagementInstancePortalsAccessUpdateOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapManagementInstancePortalsAccessUpdateOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/create.ts
@@ -7,7 +7,6 @@ export type ManagementInstancePortalsConsumerGroupsCreateOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapManagementInstancePortalsConsumerGroupsCreateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });
@@ -31,7 +26,6 @@ export let mapManagementInstancePortalsConsumerGroupsCreateOutput =
 export type ManagementInstancePortalsConsumerGroupsCreateBody = {
   name: string;
   description?: string | undefined;
-  ssoGroupIds?: string[] | undefined;
   isDefault?: boolean | undefined;
 };
 
@@ -39,10 +33,6 @@ export let mapManagementInstancePortalsConsumerGroupsCreateBody =
   mtMap.object<ManagementInstancePortalsConsumerGroupsCreateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/delete.ts
@@ -7,7 +7,6 @@ export type ManagementInstancePortalsConsumerGroupsDeleteOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapManagementInstancePortalsConsumerGroupsDeleteOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/get.ts
@@ -7,7 +7,6 @@ export type ManagementInstancePortalsConsumerGroupsGetOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapManagementInstancePortalsConsumerGroupsGetOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/list.ts
@@ -8,7 +8,6 @@ export type ManagementInstancePortalsConsumerGroupsListOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   }[];
@@ -27,10 +26,6 @@ export let mapManagementInstancePortalsConsumerGroupsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          ssoGroupIds: mtMap.objectField(
-            'sso_group_ids',
-            mtMap.array(mtMap.passthrough())
-          ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-groups/update.ts
@@ -7,7 +7,6 @@ export type ManagementInstancePortalsConsumerGroupsUpdateOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapManagementInstancePortalsConsumerGroupsUpdateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });
@@ -31,7 +26,6 @@ export let mapManagementInstancePortalsConsumerGroupsUpdateOutput =
 export type ManagementInstancePortalsConsumerGroupsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
-  ssoGroupIds?: string[] | undefined;
   isDefault?: boolean | undefined;
 };
 
@@ -39,10 +33,6 @@ export let mapManagementInstancePortalsConsumerGroupsUpdateBody =
   mtMap.object<ManagementInstancePortalsConsumerGroupsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/assign-groups.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/assign-groups.ts
@@ -22,7 +22,6 @@ export type ManagementInstancePortalsConsumerProfilesAssignGroupsOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapManagementInstancePortalsConsumerProfilesAssignGroupsOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/create.ts
@@ -22,7 +22,6 @@ export type ManagementInstancePortalsConsumerProfilesCreateOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapManagementInstancePortalsConsumerProfilesCreateOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/delete.ts
@@ -22,7 +22,6 @@ export type ManagementInstancePortalsConsumerProfilesDeleteOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapManagementInstancePortalsConsumerProfilesDeleteOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/get.ts
@@ -22,7 +22,6 @@ export type ManagementInstancePortalsConsumerProfilesGetOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapManagementInstancePortalsConsumerProfilesGetOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/list.ts
@@ -23,7 +23,6 @@ export type ManagementInstancePortalsConsumerProfilesListOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -102,10 +101,6 @@ export let mapManagementInstancePortalsConsumerProfilesListOutput =
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/unassign-groups.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/portals/consumer-profiles/unassign-groups.ts
@@ -22,7 +22,6 @@ export type ManagementInstancePortalsConsumerProfilesUnassignGroupsOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -89,10 +88,6 @@ export let mapManagementInstancePortalsConsumerProfilesUnassignGroupsOutput =
                   isDefault: mtMap.objectField(
                     'is_default',
                     mtMap.passthrough()
-                  ),
-                  ssoGroupIds: mtMap.objectField(
-                    'sso_group_ids',
-                    mtMap.array(mtMap.passthrough())
                   ),
                   createdAt: mtMap.objectField('created_at', mtMap.date()),
                   updatedAt: mtMap.objectField('updated_at', mtMap.date())

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/create.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsCreateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsCreateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsCreateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsCreateOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsCreateOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/delete.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsDeleteOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsDeleteOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsDeleteOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsDeleteOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsDeleteOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsDeleteOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/duplicate.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/duplicate.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsDuplicateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsDuplicateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsDuplicateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsDuplicateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsDuplicateOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsDuplicateOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/create.ts
@@ -77,7 +77,6 @@ export type ManagementInstanceSkillsExportsCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -161,7 +160,6 @@ export type ManagementInstanceSkillsExportsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -309,10 +307,6 @@ export let mapManagementInstanceSkillsExportsCreateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -457,10 +451,6 @@ export let mapManagementInstanceSkillsExportsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/get.ts
@@ -77,7 +77,6 @@ export type ManagementInstanceSkillsExportsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -161,7 +160,6 @@ export type ManagementInstanceSkillsExportsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -309,10 +307,6 @@ export let mapManagementInstanceSkillsExportsGetOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -457,10 +451,6 @@ export let mapManagementInstanceSkillsExportsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/exports/list.ts
@@ -78,7 +78,6 @@ export type ManagementInstanceSkillsExportsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -162,7 +161,6 @@ export type ManagementInstanceSkillsExportsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -361,10 +359,6 @@ export let mapManagementInstanceSkillsExportsListOutput =
                                       'is_default',
                                       mtMap.passthrough()
                                     ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
                                       mtMap.date()
@@ -524,10 +518,6 @@ export let mapManagementInstanceSkillsExportsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/fork.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/fork.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsForkOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsForkOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsForkOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsForkOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsForkOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsForkOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/get.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsGetOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsGetOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsGetOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/list.ts
@@ -83,7 +83,6 @@ export type ManagementInstanceSkillsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -159,7 +158,6 @@ export type ManagementInstanceSkillsListOutput = {
                         name: string;
                         description: string | null;
                         isDefault: boolean;
-                        ssoGroupIds: string[];
                         createdAt: Date;
                         updatedAt: Date;
                       };
@@ -232,7 +230,6 @@ export type ManagementInstanceSkillsListOutput = {
                         name: string;
                         description: string | null;
                         isDefault: boolean;
-                        ssoGroupIds: string[];
                         createdAt: Date;
                         updatedAt: Date;
                       };
@@ -486,10 +483,6 @@ export let mapManagementInstanceSkillsListOutput =
                                       'is_default',
                                       mtMap.passthrough()
                                     ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
-                                    ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
                                       mtMap.date()
@@ -721,10 +714,6 @@ export let mapManagementInstanceSkillsListOutput =
                                           'is_default',
                                           mtMap.passthrough()
                                         ),
-                                        ssoGroupIds: mtMap.objectField(
-                                          'sso_group_ids',
-                                          mtMap.array(mtMap.passthrough())
-                                        ),
                                         createdAt: mtMap.objectField(
                                           'created_at',
                                           mtMap.date()
@@ -947,10 +936,6 @@ export let mapManagementInstanceSkillsListOutput =
                                         isDefault: mtMap.objectField(
                                           'is_default',
                                           mtMap.passthrough()
-                                        ),
-                                        ssoGroupIds: mtMap.objectField(
-                                          'sso_group_ids',
-                                          mtMap.array(mtMap.passthrough())
                                         ),
                                         createdAt: mtMap.objectField(
                                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/close.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/close.ts
@@ -88,7 +88,6 @@ export type ManagementInstanceSkillsMergeRequestsCloseOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapManagementInstanceSkillsMergeRequestsCloseOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/create.ts
@@ -67,7 +67,6 @@ export type ManagementInstanceSkillsMergeRequestsCommentsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapManagementInstanceSkillsMergeRequestsCommentsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/delete.ts
@@ -67,7 +67,6 @@ export type ManagementInstanceSkillsMergeRequestsCommentsDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapManagementInstanceSkillsMergeRequestsCommentsDeleteOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/get.ts
@@ -67,7 +67,6 @@ export type ManagementInstanceSkillsMergeRequestsCommentsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapManagementInstanceSkillsMergeRequestsCommentsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/list.ts
@@ -68,7 +68,6 @@ export type ManagementInstanceSkillsMergeRequestsCommentsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -221,10 +220,6 @@ export let mapManagementInstanceSkillsMergeRequestsCommentsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/comments/update.ts
@@ -67,7 +67,6 @@ export type ManagementInstanceSkillsMergeRequestsCommentsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapManagementInstanceSkillsMergeRequestsCommentsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/create.ts
@@ -88,7 +88,6 @@ export type ManagementInstanceSkillsMergeRequestsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapManagementInstanceSkillsMergeRequestsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/events/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/events/get.ts
@@ -75,7 +75,6 @@ export type ManagementInstanceSkillsMergeRequestsEventsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -152,7 +151,6 @@ export type ManagementInstanceSkillsMergeRequestsEventsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -292,10 +290,6 @@ export let mapManagementInstanceSkillsMergeRequestsEventsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',
@@ -444,10 +438,6 @@ export let mapManagementInstanceSkillsMergeRequestsEventsGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/events/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/events/list.ts
@@ -76,7 +76,6 @@ export type ManagementInstanceSkillsMergeRequestsEventsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -153,7 +152,6 @@ export type ManagementInstanceSkillsMergeRequestsEventsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -314,10 +312,6 @@ export let mapManagementInstanceSkillsMergeRequestsEventsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
@@ -511,10 +505,6 @@ export let mapManagementInstanceSkillsMergeRequestsEventsListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/get.ts
@@ -88,7 +88,6 @@ export type ManagementInstanceSkillsMergeRequestsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapManagementInstanceSkillsMergeRequestsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/items/bulk-resolve.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/items/bulk-resolve.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsMergeRequestsItemsBulkResolveOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -246,10 +245,6 @@ export let mapManagementInstanceSkillsMergeRequestsItemsBulkResolveOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/items/resolve.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/items/resolve.ts
@@ -81,7 +81,6 @@ export type ManagementInstanceSkillsMergeRequestsItemsResolveOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -218,10 +217,6 @@ export let mapManagementInstanceSkillsMergeRequestsItemsResolveOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/list.ts
@@ -89,7 +89,6 @@ export type ManagementInstanceSkillsMergeRequestsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -282,10 +281,6 @@ export let mapManagementInstanceSkillsMergeRequestsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/perform.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/perform.ts
@@ -88,7 +88,6 @@ export type ManagementInstanceSkillsMergeRequestsPerformOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapManagementInstanceSkillsMergeRequestsPerformOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/plan/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/plan/get.ts
@@ -90,7 +90,6 @@ export type ManagementInstanceSkillsMergeRequestsPlanGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -191,7 +190,6 @@ export type ManagementInstanceSkillsMergeRequestsPlanGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -407,10 +405,6 @@ export let mapManagementInstanceSkillsMergeRequestsPlanGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',
@@ -631,10 +625,6 @@ export let mapManagementInstanceSkillsMergeRequestsPlanGetOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/rollback.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/merge-requests/rollback.ts
@@ -88,7 +88,6 @@ export type ManagementInstanceSkillsMergeRequestsRollbackOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapManagementInstanceSkillsMergeRequestsRollbackOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/participants/get.ts
@@ -68,7 +68,6 @@ export type ManagementInstanceSkillsParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -194,10 +193,6 @@ export let mapManagementInstanceSkillsParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/participants/list.ts
@@ -69,7 +69,6 @@ export type ManagementInstanceSkillsParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -216,10 +215,6 @@ export let mapManagementInstanceSkillsParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/publish-consumer-skill.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/publish-consumer-skill.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsPublishConsumerSkillOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsPublishConsumerSkillOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsPublishConsumerSkillOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsPublishConsumerSkillOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsPublishConsumerSkillOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsPublishConsumerSkillOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/share.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/share.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsShareOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsShareOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsShareOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsShareOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsShareOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsShareOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/skills/update.ts
@@ -82,7 +82,6 @@ export type ManagementInstanceSkillsUpdateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type ManagementInstanceSkillsUpdateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type ManagementInstanceSkillsUpdateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapManagementInstanceSkillsUpdateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapManagementInstanceSkillsUpdateOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapManagementInstanceSkillsUpdateOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/items/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/items/get.ts
@@ -79,7 +79,6 @@ export type ManagementInstanceStoresItemsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -164,7 +163,6 @@ export type ManagementInstanceStoresItemsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -315,10 +313,6 @@ export let mapManagementInstanceStoresItemsGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',
@@ -479,10 +473,6 @@ export let mapManagementInstanceStoresItemsGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/items/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/items/list.ts
@@ -80,7 +80,6 @@ export type ManagementInstanceStoresItemsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -165,7 +164,6 @@ export type ManagementInstanceStoresItemsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -367,10 +365,6 @@ export let mapManagementInstanceStoresItemsListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
@@ -576,10 +570,6 @@ export let mapManagementInstanceStoresItemsListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/items/modify.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/items/modify.ts
@@ -81,7 +81,6 @@ export type ManagementInstanceStoresItemsModifyOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -166,7 +165,6 @@ export type ManagementInstanceStoresItemsModifyOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -368,10 +366,6 @@ export let mapManagementInstanceStoresItemsModifyOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',
@@ -577,10 +571,6 @@ export let mapManagementInstanceStoresItemsModifyOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/participants/get.ts
@@ -68,7 +68,6 @@ export type ManagementInstanceStoresParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -196,10 +195,6 @@ export let mapManagementInstanceStoresParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/management/instance/stores/participants/list.ts
@@ -69,7 +69,6 @@ export type ManagementInstanceStoresParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -218,10 +217,6 @@ export let mapManagementInstanceStoresParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/create.ts
@@ -77,7 +77,6 @@ export type PortalsAccessCreateOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapPortalsAccessCreateOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/delete.ts
@@ -77,7 +77,6 @@ export type PortalsAccessDeleteOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapPortalsAccessDeleteOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/get.ts
@@ -77,7 +77,6 @@ export type PortalsAccessGetOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -187,10 +186,6 @@ export let mapPortalsAccessGetOutput = mtMap.object<PortalsAccessGetOutput>({
       name: mtMap.objectField('name', mtMap.passthrough()),
       description: mtMap.objectField('description', mtMap.passthrough()),
       isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-      ssoGroupIds: mtMap.objectField(
-        'sso_group_ids',
-        mtMap.array(mtMap.passthrough())
-      ),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())
     })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/list.ts
@@ -78,7 +78,6 @@ export type PortalsAccessListOutput = {
       name: string;
       description: string | null;
       isDefault: boolean;
-      ssoGroupIds: string[];
       createdAt: Date;
       updatedAt: Date;
     };
@@ -206,10 +205,6 @@ export let mapPortalsAccessListOutput = mtMap.object<PortalsAccessListOutput>({
             name: mtMap.objectField('name', mtMap.passthrough()),
             description: mtMap.objectField('description', mtMap.passthrough()),
             isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-            ssoGroupIds: mtMap.objectField(
-              'sso_group_ids',
-              mtMap.array(mtMap.passthrough())
-            ),
             createdAt: mtMap.objectField('created_at', mtMap.date()),
             updatedAt: mtMap.objectField('updated_at', mtMap.date())
           })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/access/update.ts
@@ -77,7 +77,6 @@ export type PortalsAccessUpdateOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   };
@@ -197,10 +196,6 @@ export let mapPortalsAccessUpdateOutput =
         name: mtMap.objectField('name', mtMap.passthrough()),
         description: mtMap.objectField('description', mtMap.passthrough()),
         isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-        ssoGroupIds: mtMap.objectField(
-          'sso_group_ids',
-          mtMap.array(mtMap.passthrough())
-        ),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/create.ts
@@ -7,7 +7,6 @@ export type PortalsConsumerGroupsCreateOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapPortalsConsumerGroupsCreateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });
@@ -31,7 +26,6 @@ export let mapPortalsConsumerGroupsCreateOutput =
 export type PortalsConsumerGroupsCreateBody = {
   name: string;
   description?: string | undefined;
-  ssoGroupIds?: string[] | undefined;
   isDefault?: boolean | undefined;
 };
 
@@ -39,10 +33,6 @@ export let mapPortalsConsumerGroupsCreateBody =
   mtMap.object<PortalsConsumerGroupsCreateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/delete.ts
@@ -7,7 +7,6 @@ export type PortalsConsumerGroupsDeleteOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapPortalsConsumerGroupsDeleteOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/get.ts
@@ -7,7 +7,6 @@ export type PortalsConsumerGroupsGetOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapPortalsConsumerGroupsGetOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/list.ts
@@ -8,7 +8,6 @@ export type PortalsConsumerGroupsListOutput = {
     name: string;
     description: string | null;
     isDefault: boolean;
-    ssoGroupIds: string[];
     createdAt: Date;
     updatedAt: Date;
   }[];
@@ -27,10 +26,6 @@ export let mapPortalsConsumerGroupsListOutput =
           name: mtMap.objectField('name', mtMap.passthrough()),
           description: mtMap.objectField('description', mtMap.passthrough()),
           isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-          ssoGroupIds: mtMap.objectField(
-            'sso_group_ids',
-            mtMap.array(mtMap.passthrough())
-          ),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-groups/update.ts
@@ -7,7 +7,6 @@ export type PortalsConsumerGroupsUpdateOutput = {
   name: string;
   description: string | null;
   isDefault: boolean;
-  ssoGroupIds: string[];
   createdAt: Date;
   updatedAt: Date;
 };
@@ -20,10 +19,6 @@ export let mapPortalsConsumerGroupsUpdateOutput =
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });
@@ -31,7 +26,6 @@ export let mapPortalsConsumerGroupsUpdateOutput =
 export type PortalsConsumerGroupsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
-  ssoGroupIds?: string[] | undefined;
   isDefault?: boolean | undefined;
 };
 
@@ -39,10 +33,6 @@ export let mapPortalsConsumerGroupsUpdateBody =
   mtMap.object<PortalsConsumerGroupsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    ssoGroupIds: mtMap.objectField(
-      'sso_group_ids',
-      mtMap.array(mtMap.passthrough())
-    ),
     isDefault: mtMap.objectField('is_default', mtMap.passthrough())
   });
 

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/assign-groups.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/assign-groups.ts
@@ -22,7 +22,6 @@ export type PortalsConsumerProfilesAssignGroupsOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapPortalsConsumerProfilesAssignGroupsOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/create.ts
@@ -22,7 +22,6 @@ export type PortalsConsumerProfilesCreateOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapPortalsConsumerProfilesCreateOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/delete.ts
@@ -22,7 +22,6 @@ export type PortalsConsumerProfilesDeleteOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapPortalsConsumerProfilesDeleteOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/get.ts
@@ -22,7 +22,6 @@ export type PortalsConsumerProfilesGetOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapPortalsConsumerProfilesGetOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/list.ts
@@ -23,7 +23,6 @@ export type PortalsConsumerProfilesListOutput = {
             name: string;
             description: string | null;
             isDefault: boolean;
-            ssoGroupIds: string[];
             createdAt: Date;
             updatedAt: Date;
           };
@@ -102,10 +101,6 @@ export let mapPortalsConsumerProfilesListOutput =
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/unassign-groups.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/portals/consumer-profiles/unassign-groups.ts
@@ -22,7 +22,6 @@ export type PortalsConsumerProfilesUnassignGroupsOutput = ({
           name: string;
           description: string | null;
           isDefault: boolean;
-          ssoGroupIds: string[];
           createdAt: Date;
           updatedAt: Date;
         };
@@ -86,10 +85,6 @@ export let mapPortalsConsumerProfilesUnassignGroupsOutput = mtMap.union([
                   mtMap.passthrough()
                 ),
                 isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
-                ssoGroupIds: mtMap.objectField(
-                  'sso_group_ids',
-                  mtMap.array(mtMap.passthrough())
-                ),
                 createdAt: mtMap.objectField('created_at', mtMap.date()),
                 updatedAt: mtMap.objectField('updated_at', mtMap.date())
               })

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/create.ts
@@ -82,7 +82,6 @@ export type SkillsCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsCreateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsCreateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -421,10 +418,6 @@ export let mapSkillsCreateOutput = mtMap.object<SkillsCreateOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -578,10 +571,6 @@ export let mapSkillsCreateOutput = mtMap.object<SkillsCreateOutput>({
                                   'is_default',
                                   mtMap.passthrough()
                                 ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
                                   mtMap.date()
@@ -726,10 +715,6 @@ export let mapSkillsCreateOutput = mtMap.object<SkillsCreateOutput>({
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/delete.ts
@@ -82,7 +82,6 @@ export type SkillsDeleteOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsDeleteOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsDeleteOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -421,10 +418,6 @@ export let mapSkillsDeleteOutput = mtMap.object<SkillsDeleteOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -578,10 +571,6 @@ export let mapSkillsDeleteOutput = mtMap.object<SkillsDeleteOutput>({
                                   'is_default',
                                   mtMap.passthrough()
                                 ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
                                   mtMap.date()
@@ -726,10 +715,6 @@ export let mapSkillsDeleteOutput = mtMap.object<SkillsDeleteOutput>({
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/duplicate.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/duplicate.ts
@@ -82,7 +82,6 @@ export type SkillsDuplicateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsDuplicateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsDuplicateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -421,10 +418,6 @@ export let mapSkillsDuplicateOutput = mtMap.object<SkillsDuplicateOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -578,10 +571,6 @@ export let mapSkillsDuplicateOutput = mtMap.object<SkillsDuplicateOutput>({
                                   'is_default',
                                   mtMap.passthrough()
                                 ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
                                   mtMap.date()
@@ -726,10 +715,6 @@ export let mapSkillsDuplicateOutput = mtMap.object<SkillsDuplicateOutput>({
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/create.ts
@@ -77,7 +77,6 @@ export type SkillsExportsCreateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -161,7 +160,6 @@ export type SkillsExportsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -309,10 +307,6 @@ export let mapSkillsExportsCreateOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -457,10 +451,6 @@ export let mapSkillsExportsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/get.ts
@@ -77,7 +77,6 @@ export type SkillsExportsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -161,7 +160,6 @@ export type SkillsExportsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -305,10 +303,6 @@ export let mapSkillsExportsGetOutput = mtMap.object<SkillsExportsGetOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -450,10 +444,6 @@ export let mapSkillsExportsGetOutput = mtMap.object<SkillsExportsGetOutput>({
                         isDefault: mtMap.objectField(
                           'is_default',
                           mtMap.passthrough()
-                        ),
-                        ssoGroupIds: mtMap.objectField(
-                          'sso_group_ids',
-                          mtMap.array(mtMap.passthrough())
                         ),
                         createdAt: mtMap.objectField(
                           'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/exports/list.ts
@@ -78,7 +78,6 @@ export type SkillsExportsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -162,7 +161,6 @@ export type SkillsExportsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -351,10 +349,6 @@ export let mapSkillsExportsListOutput = mtMap.object<SkillsExportsListOutput>({
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -508,10 +502,6 @@ export let mapSkillsExportsListOutput = mtMap.object<SkillsExportsListOutput>({
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/fork.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/fork.ts
@@ -82,7 +82,6 @@ export type SkillsForkOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsForkOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsForkOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -421,10 +418,6 @@ export let mapSkillsForkOutput = mtMap.object<SkillsForkOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -578,10 +571,6 @@ export let mapSkillsForkOutput = mtMap.object<SkillsForkOutput>({
                                   'is_default',
                                   mtMap.passthrough()
                                 ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
                                   mtMap.date()
@@ -726,10 +715,6 @@ export let mapSkillsForkOutput = mtMap.object<SkillsForkOutput>({
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/get.ts
@@ -82,7 +82,6 @@ export type SkillsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -421,10 +418,6 @@ export let mapSkillsGetOutput = mtMap.object<SkillsGetOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -578,10 +571,6 @@ export let mapSkillsGetOutput = mtMap.object<SkillsGetOutput>({
                                   'is_default',
                                   mtMap.passthrough()
                                 ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
                                   mtMap.date()
@@ -726,10 +715,6 @@ export let mapSkillsGetOutput = mtMap.object<SkillsGetOutput>({
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/list.ts
@@ -83,7 +83,6 @@ export type SkillsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -159,7 +158,6 @@ export type SkillsListOutput = {
                         name: string;
                         description: string | null;
                         isDefault: boolean;
-                        ssoGroupIds: string[];
                         createdAt: Date;
                         updatedAt: Date;
                       };
@@ -232,7 +230,6 @@ export type SkillsListOutput = {
                         name: string;
                         description: string | null;
                         isDefault: boolean;
-                        ssoGroupIds: string[];
                         createdAt: Date;
                         updatedAt: Date;
                       };
@@ -473,10 +470,6 @@ export let mapSkillsListOutput = mtMap.object<SkillsListOutput>({
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -690,10 +683,6 @@ export let mapSkillsListOutput = mtMap.object<SkillsListOutput>({
                                         'is_default',
                                         mtMap.passthrough()
                                       ),
-                                      ssoGroupIds: mtMap.objectField(
-                                        'sso_group_ids',
-                                        mtMap.array(mtMap.passthrough())
-                                      ),
                                       createdAt: mtMap.objectField(
                                         'created_at',
                                         mtMap.date()
@@ -898,10 +887,6 @@ export let mapSkillsListOutput = mtMap.object<SkillsListOutput>({
                                       isDefault: mtMap.objectField(
                                         'is_default',
                                         mtMap.passthrough()
-                                      ),
-                                      ssoGroupIds: mtMap.objectField(
-                                        'sso_group_ids',
-                                        mtMap.array(mtMap.passthrough())
                                       ),
                                       createdAt: mtMap.objectField(
                                         'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/close.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/close.ts
@@ -88,7 +88,6 @@ export type SkillsMergeRequestsCloseOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapSkillsMergeRequestsCloseOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/create.ts
@@ -67,7 +67,6 @@ export type SkillsMergeRequestsCommentsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapSkillsMergeRequestsCommentsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/delete.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/delete.ts
@@ -67,7 +67,6 @@ export type SkillsMergeRequestsCommentsDeleteOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapSkillsMergeRequestsCommentsDeleteOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/get.ts
@@ -67,7 +67,6 @@ export type SkillsMergeRequestsCommentsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapSkillsMergeRequestsCommentsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/list.ts
@@ -68,7 +68,6 @@ export type SkillsMergeRequestsCommentsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -221,10 +220,6 @@ export let mapSkillsMergeRequestsCommentsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/comments/update.ts
@@ -67,7 +67,6 @@ export type SkillsMergeRequestsCommentsUpdateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -199,10 +198,6 @@ export let mapSkillsMergeRequestsCommentsUpdateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/create.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/create.ts
@@ -88,7 +88,6 @@ export type SkillsMergeRequestsCreateOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapSkillsMergeRequestsCreateOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/events/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/events/get.ts
@@ -75,7 +75,6 @@ export type SkillsMergeRequestsEventsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -152,7 +151,6 @@ export type SkillsMergeRequestsEventsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -292,10 +290,6 @@ export let mapSkillsMergeRequestsEventsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',
@@ -444,10 +438,6 @@ export let mapSkillsMergeRequestsEventsGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/events/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/events/list.ts
@@ -76,7 +76,6 @@ export type SkillsMergeRequestsEventsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -153,7 +152,6 @@ export type SkillsMergeRequestsEventsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -314,10 +312,6 @@ export let mapSkillsMergeRequestsEventsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
@@ -511,10 +505,6 @@ export let mapSkillsMergeRequestsEventsListOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/get.ts
@@ -88,7 +88,6 @@ export type SkillsMergeRequestsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapSkillsMergeRequestsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/items/bulk-resolve.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/items/bulk-resolve.ts
@@ -82,7 +82,6 @@ export type SkillsMergeRequestsItemsBulkResolveOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -246,10 +245,6 @@ export let mapSkillsMergeRequestsItemsBulkResolveOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/items/resolve.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/items/resolve.ts
@@ -81,7 +81,6 @@ export type SkillsMergeRequestsItemsResolveOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -218,10 +217,6 @@ export let mapSkillsMergeRequestsItemsResolveOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/list.ts
@@ -89,7 +89,6 @@ export type SkillsMergeRequestsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -282,10 +281,6 @@ export let mapSkillsMergeRequestsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/perform.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/perform.ts
@@ -88,7 +88,6 @@ export type SkillsMergeRequestsPerformOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapSkillsMergeRequestsPerformOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/plan/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/plan/get.ts
@@ -90,7 +90,6 @@ export type SkillsMergeRequestsPlanGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -191,7 +190,6 @@ export type SkillsMergeRequestsPlanGetOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -407,10 +405,6 @@ export let mapSkillsMergeRequestsPlanGetOutput =
                               isDefault: mtMap.objectField(
                                 'is_default',
                                 mtMap.passthrough()
-                              ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
                               ),
                               createdAt: mtMap.objectField(
                                 'created_at',
@@ -631,10 +625,6 @@ export let mapSkillsMergeRequestsPlanGetOutput =
                                     isDefault: mtMap.objectField(
                                       'is_default',
                                       mtMap.passthrough()
-                                    ),
-                                    ssoGroupIds: mtMap.objectField(
-                                      'sso_group_ids',
-                                      mtMap.array(mtMap.passthrough())
                                     ),
                                     createdAt: mtMap.objectField(
                                       'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/rollback.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/merge-requests/rollback.ts
@@ -88,7 +88,6 @@ export type SkillsMergeRequestsRollbackOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -251,10 +250,6 @@ export let mapSkillsMergeRequestsRollbackOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/participants/get.ts
@@ -68,7 +68,6 @@ export type SkillsParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -194,10 +193,6 @@ export let mapSkillsParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/participants/list.ts
@@ -69,7 +69,6 @@ export type SkillsParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -216,10 +215,6 @@ export let mapSkillsParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/publish-consumer-skill.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/publish-consumer-skill.ts
@@ -82,7 +82,6 @@ export type SkillsPublishConsumerSkillOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsPublishConsumerSkillOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsPublishConsumerSkillOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -428,10 +425,6 @@ export let mapSkillsPublishConsumerSkillOutput =
                                 'is_default',
                                 mtMap.passthrough()
                               ),
-                              ssoGroupIds: mtMap.objectField(
-                                'sso_group_ids',
-                                mtMap.array(mtMap.passthrough())
-                              ),
                               createdAt: mtMap.objectField(
                                 'created_at',
                                 mtMap.date()
@@ -615,10 +608,6 @@ export let mapSkillsPublishConsumerSkillOutput =
                                     'is_default',
                                     mtMap.passthrough()
                                   ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
-                                  ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
                                     mtMap.date()
@@ -793,10 +782,6 @@ export let mapSkillsPublishConsumerSkillOutput =
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/share.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/share.ts
@@ -82,7 +82,6 @@ export type SkillsShareOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsShareOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsShareOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -421,10 +418,6 @@ export let mapSkillsShareOutput = mtMap.object<SkillsShareOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -578,10 +571,6 @@ export let mapSkillsShareOutput = mtMap.object<SkillsShareOutput>({
                                   'is_default',
                                   mtMap.passthrough()
                                 ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
                                   mtMap.date()
@@ -726,10 +715,6 @@ export let mapSkillsShareOutput = mtMap.object<SkillsShareOutput>({
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/update.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/skills/update.ts
@@ -82,7 +82,6 @@ export type SkillsUpdateOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -158,7 +157,6 @@ export type SkillsUpdateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -231,7 +229,6 @@ export type SkillsUpdateOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -421,10 +418,6 @@ export let mapSkillsUpdateOutput = mtMap.object<SkillsUpdateOutput>({
                               'is_default',
                               mtMap.passthrough()
                             ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
-                            ),
                             createdAt: mtMap.objectField(
                               'created_at',
                               mtMap.date()
@@ -578,10 +571,6 @@ export let mapSkillsUpdateOutput = mtMap.object<SkillsUpdateOutput>({
                                   'is_default',
                                   mtMap.passthrough()
                                 ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
-                                ),
                                 createdAt: mtMap.objectField(
                                   'created_at',
                                   mtMap.date()
@@ -726,10 +715,6 @@ export let mapSkillsUpdateOutput = mtMap.object<SkillsUpdateOutput>({
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/items/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/items/get.ts
@@ -79,7 +79,6 @@ export type StoresItemsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -164,7 +163,6 @@ export type StoresItemsGetOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -311,10 +309,6 @@ export let mapStoresItemsGetOutput = mtMap.object<StoresItemsGetOutput>({
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',
@@ -472,10 +466,6 @@ export let mapStoresItemsGetOutput = mtMap.object<StoresItemsGetOutput>({
                             isDefault: mtMap.objectField(
                               'is_default',
                               mtMap.passthrough()
-                            ),
-                            ssoGroupIds: mtMap.objectField(
-                              'sso_group_ids',
-                              mtMap.array(mtMap.passthrough())
                             ),
                             createdAt: mtMap.objectField(
                               'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/items/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/items/list.ts
@@ -80,7 +80,6 @@ export type StoresItemsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -165,7 +164,6 @@ export type StoresItemsListOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -357,10 +355,6 @@ export let mapStoresItemsListOutput = mtMap.object<StoresItemsListOutput>({
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
@@ -557,10 +551,6 @@ export let mapStoresItemsListOutput = mtMap.object<StoresItemsListOutput>({
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/items/modify.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/items/modify.ts
@@ -81,7 +81,6 @@ export type StoresItemsModifyOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -166,7 +165,6 @@ export type StoresItemsModifyOutput = {
                       name: string;
                       description: string | null;
                       isDefault: boolean;
-                      ssoGroupIds: string[];
                       createdAt: Date;
                       updatedAt: Date;
                     };
@@ -358,10 +356,6 @@ export let mapStoresItemsModifyOutput = mtMap.object<StoresItemsModifyOutput>({
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',
@@ -558,10 +552,6 @@ export let mapStoresItemsModifyOutput = mtMap.object<StoresItemsModifyOutput>({
                                   isDefault: mtMap.objectField(
                                     'is_default',
                                     mtMap.passthrough()
-                                  ),
-                                  ssoGroupIds: mtMap.objectField(
-                                    'sso_group_ids',
-                                    mtMap.array(mtMap.passthrough())
                                   ),
                                   createdAt: mtMap.objectField(
                                     'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/participants/get.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/participants/get.ts
@@ -68,7 +68,6 @@ export type StoresParticipantsGetOutput = {
                   name: string;
                   description: string | null;
                   isDefault: boolean;
-                  ssoGroupIds: string[];
                   createdAt: Date;
                   updatedAt: Date;
                 };
@@ -196,10 +195,6 @@ export let mapStoresParticipantsGetOutput =
                           isDefault: mtMap.objectField(
                             'is_default',
                             mtMap.passthrough()
-                          ),
-                          ssoGroupIds: mtMap.objectField(
-                            'sso_group_ids',
-                            mtMap.array(mtMap.passthrough())
                           ),
                           createdAt: mtMap.objectField(
                             'created_at',

--- a/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/participants/list.ts
+++ b/clients/metorial-dashboard/src/gen/src/mt_2025_01_01_dashboard/resources/stores/participants/list.ts
@@ -69,7 +69,6 @@ export type StoresParticipantsListOutput = {
                     name: string;
                     description: string | null;
                     isDefault: boolean;
-                    ssoGroupIds: string[];
                     createdAt: Date;
                     updatedAt: Date;
                   };
@@ -218,10 +217,6 @@ export let mapStoresParticipantsListOutput =
                                 isDefault: mtMap.objectField(
                                   'is_default',
                                   mtMap.passthrough()
-                                ),
-                                ssoGroupIds: mtMap.objectField(
-                                  'sso_group_ids',
-                                  mtMap.array(mtMap.passthrough())
                                 ),
                                 createdAt: mtMap.objectField(
                                   'created_at',

--- a/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerGroup.ts
+++ b/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerGroup.ts
@@ -104,7 +104,6 @@ export let portalConsumerGroupController = Controller.create(
         v.object({
           name: v.string(),
           description: v.optional(v.string()),
-          sso_group_ids: v.optional(v.array(v.string())),
           is_default: v.optional(v.boolean())
         })
       )
@@ -115,7 +114,6 @@ export let portalConsumerGroupController = Controller.create(
           input: {
             name: ctx.body.name,
             description: ctx.body.description,
-            ssoGroupIds: ctx.body.sso_group_ids,
             isDefault: ctx.body.is_default
           }
         });
@@ -141,7 +139,6 @@ export let portalConsumerGroupController = Controller.create(
         v.object({
           name: v.optional(v.string()),
           description: v.optional(v.string()),
-          sso_group_ids: v.optional(v.array(v.string())),
           is_default: v.optional(v.boolean())
         })
       )
@@ -152,7 +149,6 @@ export let portalConsumerGroupController = Controller.create(
           input: {
             name: ctx.body.name,
             description: ctx.body.description,
-            ssoGroupIds: ctx.body.sso_group_ids,
             isDefault: ctx.body.is_default
           }
         });

--- a/src/metorial/apis/core/src/presenters/implementation/consumer/consumerGroup.ts
+++ b/src/metorial/apis/core/src/presenters/implementation/consumer/consumerGroup.ts
@@ -10,7 +10,6 @@ export let v1ConsumerGroupPresenter = Presenter.create(consumerGroupType)
     name: consumerGroup.name,
     description: consumerGroup.description,
     is_default: consumerGroup.isDefault,
-    sso_group_ids: consumerGroup.ssoGroupIds,
     created_at: consumerGroup.createdAt,
     updated_at: consumerGroup.updatedAt
   }))
@@ -22,7 +21,6 @@ export let v1ConsumerGroupPresenter = Presenter.create(consumerGroupType)
       name: v.string(),
       description: v.nullable(v.string()),
       is_default: v.boolean(),
-      sso_group_ids: v.array(v.string()),
       created_at: v.date(),
       updated_at: v.date()
     })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many generated types and may break dashboard code that still reads or sets `ssoGroupIds` on consumer groups until those usages are removed.
> 
> **Overview**
> Removes **SSO group ID mapping** from the generated Metorial dashboard API client so `consumer.group` no longer exposes `ssoGroupIds` / `sso_group_ids`.
> 
> The change is applied across nested `consumer.group` shapes (profiles, conversations, documents, portal access, skills, stores, etc.) and drops **`ssoGroupIds` from consumer-group create/update request bodies** in the portal consumer-groups resources.
> 
> This is a **generated-client-only** sync with the API schema; callers can no longer read or send SSO group IDs on consumer groups through these types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fd9a7270d2e5be6dda50e7c39a0f54a061b081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->