### PR TITLE
Improve callbacks UI

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/callbacks/overview.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/callbacks/overview.tsx
@@ -1,4 +1,7 @@
-import type { DashboardInstanceCallbacksInstancesListOutput } from '@metorial/dashboard-sdk';
+import type {
+  DashboardInstanceCallbacksInstancesListOutput,
+  DashboardInstanceProvidersTriggersListOutput
+} from '@metorial/dashboard-sdk';
 import { renderWithLoader } from '@metorial/data-hooks';
 import {
   useCallback,
@@ -29,9 +32,11 @@ import {
   showModal,
   toast
 } from '@metorial/ui';
+import { Paths } from '@metorial/frontend-config';
 import { Box, ID, Table } from '@metorial/ui-product';
 import { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { DeleteResourceDangerZone } from '../deleteResourceDangerZone';
 import { showProviderCreationPanel } from '../providerCreationPanel';
 import { RouterPanel } from '../routerPanel';
 import {
@@ -51,6 +56,32 @@ let getCallbackType = (
   if (triggers.some(trigger => trigger.webhookUrl)) return 'Webhook';
   if (triggers.some(trigger => trigger.pollIntervalSeconds != null)) return 'Polling';
   return 'Managed';
+};
+
+let formatPollInterval = (seconds: number) =>
+  seconds >= 60 && seconds % 60 === 0 ? `every ${seconds / 60} min` : `every ${seconds}s`;
+
+let getTriggerInvocationHint = (
+  invocation: DashboardInstanceProvidersTriggersListOutput['items'][number]['invocation']
+) => {
+  if (invocation.type === 'polling') {
+    return `Polling · ${formatPollInterval(invocation.intervalSeconds)}`;
+  }
+
+  return invocation.autoRegistration.status === 'supported'
+    ? 'Webhook · registers automatically'
+    : 'Webhook · manual setup';
+};
+
+type ReceiverUrlState = 'inactive' | 'autoRegistered' | 'manual';
+
+let getReceiverUrlState = (
+  triggers: CallbackInstanceListItem['triggers']
+): ReceiverUrlState => {
+  let webhookTriggers = triggers.filter(trigger => trigger.source === 'webhook');
+  if (webhookTriggers.length === 0) return 'inactive';
+  if (webhookTriggers.every(trigger => trigger.isWebhookRegistered)) return 'autoRegistered';
+  return 'manual';
 };
 
 export let CallbackOverview = (p: { callbackId: string | undefined }) => {
@@ -75,6 +106,8 @@ export let CallbackOverview = (p: { callbackId: string | undefined }) => {
     providerVersionId ? { providerVersionId, limit: 100 } : null
   );
   let deleteCallbackInstance = instancesLoader.useDeleteMutator();
+  let deleteCallback = callbackLoader.useDeleteMutator();
+  let navigate = useNavigate();
   let [_, setSearchParams] = useSearchParams();
   let [selectedTriggerKeys, setSelectedTriggerKeys] = useState<string[]>([]);
   let shouldPollOverview =
@@ -109,7 +142,8 @@ export let CallbackOverview = (p: { callbackId: string | undefined }) => {
     () =>
       (availableTriggers.data?.items ?? []).map(trigger => ({
         id: trigger.key,
-        label: `${trigger.name} (${trigger.key})`
+        label: `${trigger.name} (${trigger.key})`,
+        hint: getTriggerInvocationHint(trigger.invocation)
       })),
     [availableTriggers.data?.items]
   );
@@ -136,7 +170,8 @@ export let CallbackOverview = (p: { callbackId: string | undefined }) => {
         .map(instance => ({
           id: instance.id,
           label: instance.config.name || instance.config.id,
-          webhookUrl: instance.webhookUrl
+          webhookUrl: instance.webhookUrl,
+          urlState: getReceiverUrlState(instance.triggers)
         }));
       let nextPollAt = triggerInstances
         .map(trigger => trigger.nextPollAt)
@@ -170,7 +205,7 @@ export let CallbackOverview = (p: { callbackId: string | undefined }) => {
             <>
               <Box
                 title="Receiver URLs"
-                description={`${provider.data.name} requires manual configuration. Register the following receiver URLs with the provider to start receiving events.`}
+                description="Each callback instance has a receiver URL that accepts webhook events from the provider. URLs are only active while a webhook trigger is attached; triggers that support automatic registration are wired up for you."
               >
                 <Table
                   headers={['Receiver', 'Receiver URL', '']}
@@ -194,23 +229,38 @@ export let CallbackOverview = (p: { callbackId: string | undefined }) => {
                           {item.id}
                         </Text>
                       </Flex>,
-                      <div style={{ width: '100%', minWidth: 0 }}>
-                        <Text
-                          size="2"
-                          style={{
-                            display: 'block',
-                            width: '100%',
-                            minWidth: 0,
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            fontFamily: 'monospace'
-                          }}
-                        >
-                          {item.webhookUrl}
+                      item.urlState === 'inactive' ? (
+                        <Text size="2" color="gray600">
+                          Inactive — attach a webhook trigger in Manage Triggers to activate
+                          this URL.
                         </Text>
-                      </div>,
-                      <InlineCopy value={item.webhookUrl} />
+                      ) : (
+                        <div style={{ width: '100%', minWidth: 0 }}>
+                          <Text
+                            size="2"
+                            style={{
+                              display: 'block',
+                              width: '100%',
+                              minWidth: 0,
+                              whiteSpace: 'nowrap',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              fontFamily: 'monospace'
+                            }}
+                          >
+                            {item.webhookUrl}
+                          </Text>
+                        </div>
+                      ),
+                      item.urlState === 'inactive' ? (
+                        ''
+                      ) : item.urlState === 'autoRegistered' ? (
+                        <Badge color="green" size="1">
+                          Registered automatically
+                        </Badge>
+                      ) : (
+                        <InlineCopy value={item.webhookUrl} />
+                      )
                     ]
                   }))}
                 />
@@ -337,6 +387,30 @@ export let CallbackOverview = (p: { callbackId: string | undefined }) => {
               </Callout>
             )}
           </Box>
+
+          <Spacer height={15} />
+
+          <DeleteResourceDangerZone
+            description="Delete this callback. Event delivery for all attached instances stops immediately."
+            buttonLabel="Delete Callback"
+            confirmTitle="Delete callback"
+            confirmDescription="Are you sure you want to delete this callback? Attached instances will stop receiving events."
+            loading={deleteCallback.isLoading}
+            success={deleteCallback.isSuccess}
+            onDelete={async () => {
+              let [res] = await deleteCallback.mutate({});
+              if (!res) return;
+
+              toast.success('Callback deleted');
+              navigate(
+                Paths.instance.callbacks(
+                  instance.data?.organization,
+                  instance.data?.project,
+                  instance.data
+                )
+              );
+            }}
+          />
 
           <RouterPanel param="callback_instance_id" width={1000}>
             {callbackInstanceId => {
@@ -483,9 +557,7 @@ let CallbackInstanceDetails = (p: {
   >;
 }) => {
   let webhookUrl = p.callbackInstance.webhookUrl;
-  let needsManualWebhookSetup = p.callbackInstance.triggers.some(
-    trigger => trigger.webhookUrl && !trigger.isWebhookRegistered
-  );
+  let needsManualWebhookSetup = getReceiverUrlState(p.callbackInstance.triggers) === 'manual';
 
   return (
     <>

--- a/src/metorial-frontend/packages/ui/src/multiSelect/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/multiSelect/index.tsx
@@ -68,7 +68,20 @@ let Content = styled(RadixPopover.Content)`
   }
 `;
 
-let Item = styled('div')``;
+let Item = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+let ItemHint = styled('span')`
+  font-size: 12px;
+  font-weight: 400;
+  color: ${theme.colors.gray700};
+  white-space: nowrap;
+  flex-shrink: 0;
+`;
 
 let Value = styled('div')`
   font-size: 12px;
@@ -109,6 +122,7 @@ export let MultiSelect = ({
   items: {
     id: string;
     label: string;
+    hint?: string;
     disabled?: boolean;
   }[];
 }) => {
@@ -164,6 +178,8 @@ export let MultiSelect = ({
                   label={item.label}
                   disabled={item.disabled || disabled}
                 />
+
+                {item.hint && <ItemHint>{item.hint}</ItemHint>}
               </Item>
             ))}
           </Content>

--- a/src/slates/apps/hub/src/apis/public/index.ts
+++ b/src/slates/apps/hub/src/apis/public/index.ts
@@ -58,6 +58,14 @@ let handleTriggerWebhookRequest =
       });
     }
 
+    if (result.type === 'ignored') {
+      return c.json({
+        status: 'ignored',
+        reason: result.reason,
+        webhookRequestId: result.webhookRequestId
+      });
+    }
+
     if (result.type === 'response') {
       return createSanitizedWebhookResponse(result.response);
     }

--- a/src/slates/apps/hub/src/apis/public/tests/slateTriggerWebhook.e2e.test.ts
+++ b/src/slates/apps/hub/src/apis/public/tests/slateTriggerWebhook.e2e.test.ts
@@ -1495,6 +1495,35 @@ describe('slate:trigger webhook E2E', () => {
     expect(eventInput).toBeNull();
   });
 
+  it('reports ignored webhook requests when only polling triggers are attached', async () => {
+    const { receiver } = await setupWebhookScenario({
+      triggerInvocation: SlateTriggerReceiverTriggerSource.polling
+    });
+
+    const response = await hubApp.fetch(
+      new Request(buildReceiverWebhookUrl(receiver.id), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ type: 'url_verification', challenge: 'challenge-value' })
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string; webhookRequestId: string };
+    expect(body).toMatchObject({
+      status: 'ignored',
+      reason: 'no_webhook_triggers_attached',
+      webhookRequestId: expect.any(String)
+    });
+    expect(queueMocks.webhookAdd).not.toHaveBeenCalled();
+    expect(invocationMocks.handleWebhookRequest).not.toHaveBeenCalled();
+
+    const requestRecord = await testDb.slateTriggerWebhookRequest.findFirstOrThrow({
+      where: { id: body.webhookRequestId }
+    });
+    expect(requestRecord.processedAt).not.toBeNull();
+  });
+
   it('does not enqueue inputs when webhook handler returns an error', async () => {
     const { tenant, receiverTrigger, deployment, bucket } = await setupWebhookScenario();
 

--- a/src/slates/apps/hub/src/services/slateTriggerWebhookSync.ts
+++ b/src/slates/apps/hub/src/services/slateTriggerWebhookSync.ts
@@ -166,6 +166,11 @@ class slateTriggerWebhookSyncServiceImpl {
     request: TriggerWebhookRequestPayload;
   }): Promise<
     | { type: 'methodNotAllowed'; allowedMethods: WebhookHttpMethod[] }
+    | {
+        type: 'ignored';
+        webhookRequestId: string;
+        reason: 'no_webhook_triggers_attached' | 'no_webhook_triggers_for_method';
+      }
     | { type: 'queued'; webhookRequestId: string }
     | { type: 'response'; webhookRequestId: string; response: WebhookHttpResponse }
   > {
@@ -201,6 +206,22 @@ class slateTriggerWebhookSyncServiceImpl {
     let applicableTriggers = target.triggers.filter(trigger =>
       webhookTriggerAllowsMethod(trigger.action, method)
     );
+
+    // Queue processing would fan out to nothing; tell the caller (visible in provider
+    // dashboards like Slack's URL verification panel) instead of pretending to queue.
+    if (applicableTriggers.length === 0) {
+      await finalize();
+      let hasWebhookTriggers = target.triggers.some(
+        trigger => trigger.source === SlateTriggerReceiverTriggerSource.webhook
+      );
+      return {
+        type: 'ignored',
+        webhookRequestId: requestRecord.id,
+        reason: hasWebhookTriggers
+          ? 'no_webhook_triggers_for_method'
+          : 'no_webhook_triggers_attached'
+      };
+    }
 
     let candidates = target.active
       ? getSyncCandidates(applicableTriggers, method).filter(candidate => {


### PR DESCRIPTION
Improve callbacks UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hub webhook responses change for receivers with no webhook triggers (behavior visible to external providers during URL verification); callback delete is destructive but follows existing dashboard patterns.
> 
> **Overview**
> **Callbacks overview** now explains receiver URLs by state: inactive until a webhook trigger is attached, **Registered automatically** when all webhook triggers are registered, or copy-to-clipboard for manual setup. **Manage Triggers** options show hints (polling interval vs webhook auto/manual registration). A **Delete Callback** danger zone was added with redirect back to the callbacks list.
> 
> **MultiSelect** items can include an optional right-aligned **hint** in the dropdown.
> 
> **Slates Hub** stops returning a fake `queued` response when a receiver webhook has no applicable webhook triggers (e.g. only polling). It now responds with `status: 'ignored'` and a reason (`no_webhook_triggers_attached` or `no_webhook_triggers_for_method`), with the request still audited and finalized—so provider URL verification UIs get a clear outcome instead of a silent no-op queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c186d2806861caf56fdce62289bbafcd296a6fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->