### PR TITLE
Link consumer profiles to org actors

### DIFF
--- a/src/metorial/db/prisma/schema/consumer/consumer.prisma
+++ b/src/metorial/db/prisma/schema/consumer/consumer.prisma
@@ -33,18 +33,19 @@ model Consumer {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  profiles             ConsumerProfile[]
-  instanceConsumers    InstanceConsumer[]
-  consumerActors       ConsumerActor[]
-  consumerTokens       ConsumerToken[]
-  integrations         ConsumerIntegration[]
-  integrationEndpoints ConsumerIntegrationEndpoint[]
-  integrationSessions  ConsumerIntegrationSession[]
-  invites              ConsumerInvite[]
-  createdSkills        Skill[]
-  consumerSkills       ConsumerSkill[]
-  workspaceProfiles    WorkspaceProfile[]
-  resourceActors       ResourceActor[]
+  profiles                   ConsumerProfile[]
+  instanceConsumers          InstanceConsumer[]
+  consumerActors             ConsumerActor[]
+  consumerTokens             ConsumerToken[]
+  integrations               ConsumerIntegration[]
+  integrationEndpoints       ConsumerIntegrationEndpoint[]
+  integrationSessions        ConsumerIntegrationSession[]
+  invites                    ConsumerInvite[]
+  createdSkills              Skill[]
+  consumerSkills             ConsumerSkill[]
+  workspaceProfiles          WorkspaceProfile[]
+  resourceActors             ResourceActor[]
+  consumerOrganizationActors ConsumerOrganizationActor[]
 
   @@unique([email, organizationOid])
 }
@@ -213,4 +214,18 @@ model ConsumerProfileGroup {
   createdAt DateTime @default(now())
 
   @@unique([profileOid, groupOid])
+}
+
+model ConsumerOrganizationActor {
+  oid BigInt @id @default(autoincrement())
+
+  consumerOid BigInt
+  consumer    Consumer @relation(fields: [consumerOid], references: [oid], onDelete: Cascade)
+
+  organizationActorOid BigInt
+  organizationActor    OrganizationActor @relation(fields: [organizationActorOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([consumerOid, organizationActorOid])
 }

--- a/src/metorial/db/prisma/schema/organization/actor.prisma
+++ b/src/metorial/db/prisma/schema/organization/actor.prisma
@@ -4,6 +4,7 @@ enum OrganizationActorType {
   system
   oauth_application
   agent
+  consumer_profile
 }
 
 model OrganizationActor {
@@ -31,23 +32,24 @@ model OrganizationActor {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  member              OrganizationMember?
-  createdInvites      OrganizationInvite[]
-  machineAccess       MachineAccess[]
-  secretEvents        SecretEvent[]
-  profileUpdates      ProfileUpdate[]
-  accessLimiters      AccessLimiter[]
-  teams               TeamMember[]
-  oauthInstallations  OAuthInstallation[]
-  projectBrandUpdates ProjectBrandUpdate[]
-  consumers           Consumer[]
-  instanceConsumers   InstanceConsumer[]
-  consumerProfiles    ConsumerProfile[]
-  consumerInvites     ConsumerInvite[]
-  createdSkills       Skill[]
-  sandboxes           Sandbox[]
-  environments        Environment[]
-  resourceActors      ResourceActor[]
+  member                     OrganizationMember?
+  createdInvites             OrganizationInvite[]
+  machineAccess              MachineAccess[]
+  secretEvents               SecretEvent[]
+  profileUpdates             ProfileUpdate[]
+  accessLimiters             AccessLimiter[]
+  teams                      TeamMember[]
+  oauthInstallations         OAuthInstallation[]
+  projectBrandUpdates        ProjectBrandUpdate[]
+  consumers                  Consumer[]
+  instanceConsumers          InstanceConsumer[]
+  consumerProfiles           ConsumerProfile[]
+  consumerInvites            ConsumerInvite[]
+  createdSkills              Skill[]
+  sandboxes                  Sandbox[]
+  environments               Environment[]
+  resourceActors             ResourceActor[]
+  consumerOrganizationActors ConsumerOrganizationActor[]
 
   @@unique([isSystem, organizationOid])
 }

--- a/src/metorial/modules/consumer/src/index.ts
+++ b/src/metorial/modules/consumer/src/index.ts
@@ -14,6 +14,7 @@ import {
   reconcileConsumerActorQueueProcessor,
   syncIdentityConsumerQueueProcessor
 } from './queues/syncIdentityConsumer';
+import { reconcileConsumerProfileOrganizationActorsQueueProcessor } from './queues/reconcileConsumerProfileOrganizationActors';
 import {
   syncUserConsumerQueueProcessor,
   syncUserConsumersQueueProcessor
@@ -53,6 +54,7 @@ export let consumerQueueProcessor = combineQueueProcessors([
   resourceAuthorizationMigrationQueueProcessor,
   reconcileUserConsumersQueueProcessor,
   reconcileUserConsumerQueueProcessor,
+  reconcileConsumerProfileOrganizationActorsQueueProcessor,
 
   syncOrgMemberQueueProcessor,
   syncOrgMemberConsumerQueueProcessor,

--- a/src/metorial/modules/consumer/src/queues/reconcileConsumerProfileOrganizationActors.ts
+++ b/src/metorial/modules/consumer/src/queues/reconcileConsumerProfileOrganizationActors.ts
@@ -1,0 +1,86 @@
+import { createCron } from '@metorial/cron';
+import { db } from '@metorial/db';
+import { combineQueueProcessors, createQueue } from '@metorial/queue';
+import { consumerProfileService } from '../services';
+
+export let RECONCILE_CONSUMER_PROFILE_ORGANIZATION_ACTORS_BATCH_SIZE = 500;
+
+export let reconcileConsumerProfileOrganizationActorsCron = createCron(
+  {
+    name: 'cons/profileOrgActor/rec/cron',
+    cron: '30 5 * * *'
+  },
+  async () => {
+    await reconcileConsumerProfileOrganizationActorsSearchQueue.add(
+      {},
+      { id: 'consumer-profile-organization-actors-reconcile-search' }
+    );
+  }
+);
+
+export let reconcileConsumerProfileOrganizationActorsSearchQueue = createQueue<{
+  cursor?: string;
+}>({
+  name: 'cons/profileOrgActor/rec/search'
+});
+
+setTimeout(() => {
+  reconcileConsumerProfileOrganizationActorsSearchQueue.add(
+    {},
+    { id: 'consumer-profile-organization-actors-reconcile-search' }
+  );
+}, 10000);
+
+export let reconcileConsumerProfileOrganizationActorsSearchQueueProcessor =
+  reconcileConsumerProfileOrganizationActorsSearchQueue.process(async data => {
+    let consumerProfiles = await db.consumerProfile.findMany({
+      where: {
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: RECONCILE_CONSUMER_PROFILE_ORGANIZATION_ACTORS_BATCH_SIZE,
+      select: { id: true }
+    });
+    if (consumerProfiles.length === 0) return;
+
+    await reconcileConsumerProfileOrganizationActorQueue.addManyWithOps(
+      consumerProfiles.map(consumerProfile => ({
+        data: { consumerProfileId: consumerProfile.id },
+        opts: { id: consumerProfile.id }
+      }))
+    );
+
+    let lastConsumerProfile = consumerProfiles[consumerProfiles.length - 1];
+    if (!lastConsumerProfile) return;
+
+    await reconcileConsumerProfileOrganizationActorsSearchQueue.add({
+      cursor: lastConsumerProfile.id
+    });
+  });
+
+export let reconcileConsumerProfileOrganizationActorQueue = createQueue<{
+  consumerProfileId: string;
+}>({
+  name: 'cons/profileOrgActor/rec/single',
+  workerOpts: {
+    concurrency: 5
+  }
+});
+
+export let reconcileConsumerProfileOrganizationActorQueueProcessor =
+  reconcileConsumerProfileOrganizationActorQueue.process(async data => {
+    let consumerProfile = await db.consumerProfile.findUnique({
+      where: { id: data.consumerProfileId }
+    });
+    if (!consumerProfile) return;
+
+    await consumerProfileService.reconcileConsumerProfileOrganizationActor({
+      consumerProfile
+    });
+  });
+
+export let reconcileConsumerProfileOrganizationActorsQueueProcessor = combineQueueProcessors([
+  reconcileConsumerProfileOrganizationActorsCron,
+  reconcileConsumerProfileOrganizationActorsSearchQueueProcessor,
+  reconcileConsumerProfileOrganizationActorQueueProcessor
+]);

--- a/src/metorial/modules/consumer/src/services/consumers/consumerProfile.ts
+++ b/src/metorial/modules/consumer/src/services/consumers/consumerProfile.ts
@@ -17,6 +17,7 @@ import {
   ID,
   Instance,
   InstanceConsumer,
+  Organization,
   OrganizationMember,
   Prisma,
   User,
@@ -24,7 +25,7 @@ import {
 } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import { createLock } from '@metorial/lock';
-import { namespaceService } from '@metorial/module-organization';
+import { namespaceService, organizationActorService } from '@metorial/module-organization';
 import { searchConsumerIds } from '@metorial/module-search';
 import {
   consumerEmailEquals,
@@ -88,6 +89,151 @@ class ConsumerProfileServiceImpl {
         })
       );
     }
+  }
+
+  private async resolveOrganizationIdentity(d: {
+    consumerProfile?: ConsumerProfile;
+    surface: ConsumerSurface;
+    organization: Organization;
+    instanceConsumer: InstanceConsumer;
+    member?: OrganizationMember;
+    name: string;
+    email: string;
+  }) {
+    return withTransaction(
+      async db => {
+        if (d.surface.type === 'organization_members') {
+          let organizationMemberOid =
+            d.consumerProfile?.organizationMemberOid ??
+            d.member?.oid ??
+            d.consumerProfile?.organizationMemberOid ??
+            d.instanceConsumer.organizationMemberOid;
+
+          if (!organizationMemberOid) {
+            let consumer = await db.consumer.findUnique({
+              where: { oid: d.instanceConsumer.consumerOid },
+              select: { organizationMemberOid: true }
+            });
+            organizationMemberOid = consumer?.organizationMemberOid ?? null;
+          }
+
+          let member = organizationMemberOid
+            ? await db.organizationMember.findUnique({
+                where: { oid: organizationMemberOid }
+              })
+            : null;
+
+          return {
+            organizationMemberOid: member?.oid ?? null,
+            organizationActorOid: member?.actorOid ?? null
+          };
+        }
+
+        let currentOrganizationActor = d.consumerProfile?.organizationActorOid
+          ? await db.organizationActor.findUnique({
+              where: { oid: d.consumerProfile.organizationActorOid },
+              include: {
+                consumerProfiles: {
+                  select: { oid: true }
+                }
+              }
+            })
+          : null;
+        if (
+          currentOrganizationActor?.type === 'consumer_profile' &&
+          currentOrganizationActor.consumerProfiles.every(
+            profile => profile.oid === d.consumerProfile?.oid
+          )
+        ) {
+          return {
+            organizationMemberOid: null,
+            organizationActorOid: currentOrganizationActor.oid
+          };
+        }
+
+        let systemActor = await organizationActorService.getSystemActor({
+          organization: d.organization
+        });
+        let organizationActor = await organizationActorService.createOrganizationActor({
+          input: {
+            type: 'consumer_profile',
+            name: d.name,
+            email: d.email
+          },
+          organization: d.organization,
+          performedBy: { type: 'actor', actor: systemActor }
+        });
+
+        await db.consumerOrganizationActor.upsert({
+          where: {
+            consumerOid_organizationActorOid: {
+              consumerOid: d.instanceConsumer.consumerOid,
+              organizationActorOid: organizationActor.oid
+            }
+          },
+          create: {
+            consumerOid: d.instanceConsumer.consumerOid,
+            organizationActorOid: organizationActor.oid
+          },
+          update: {}
+        });
+
+        return {
+          organizationMemberOid: null,
+          organizationActorOid: organizationActor.oid
+        };
+      },
+      { ifExists: true }
+    );
+  }
+
+  async reconcileConsumerProfileOrganizationActor(d: { consumerProfile: ConsumerProfile }) {
+    return await ensureProfileLock.usingLock(
+      `${d.consumerProfile.instanceOid}-${normalizeConsumerEmail(d.consumerProfile.email)}`,
+      async () =>
+        await withTransaction(async db => {
+          let consumerProfile = await db.consumerProfile.findUnique({
+            where: { oid: d.consumerProfile.oid },
+            include: {
+              organization: true,
+              surface: true
+            }
+          });
+          if (!consumerProfile) return null;
+
+          let instanceConsumer = await db.instanceConsumer.findUnique({
+            where: {
+              instanceOid_consumerOid: {
+                instanceOid: consumerProfile.instanceOid,
+                consumerOid: consumerProfile.consumerOid
+              }
+            }
+          });
+          if (!instanceConsumer) return null;
+
+          let organizationIdentity = await this.resolveOrganizationIdentity({
+            consumerProfile,
+            surface: consumerProfile.surface,
+            organization: consumerProfile.organization,
+            instanceConsumer,
+            name: consumerProfile.name,
+            email: consumerProfile.email
+          });
+
+          if (
+            consumerProfile.organizationMemberOid ===
+              organizationIdentity.organizationMemberOid &&
+            consumerProfile.organizationActorOid === organizationIdentity.organizationActorOid
+          ) {
+            return consumerProfile;
+          }
+
+          return await db.consumerProfile.update({
+            where: { oid: consumerProfile.oid },
+            data: organizationIdentity
+          });
+        })
+    );
   }
 
   private async getAssignableGroupsOrThrow(d: {
@@ -780,6 +926,17 @@ class ConsumerProfileServiceImpl {
             let shouldActivate =
               (d.aresUserId && existingProfile.inviteStatus == 'invited') ||
               (nextInviteStatus == 'accepted' && existingProfile.inviteStatus != 'accepted');
+
+            let organizationIdentity = await this.resolveOrganizationIdentity({
+              consumerProfile: existingProfile,
+              surface: d.surface,
+              organization,
+              instanceConsumer,
+              member: d.member,
+              name: d.name,
+              email
+            });
+
             let consumerProfile = await db.consumerProfile.update({
               where: {
                 oid: existingProfile.oid
@@ -791,15 +948,14 @@ class ConsumerProfileServiceImpl {
                 name: d.name,
                 inviteStatus: shouldActivate ? existingProfile.inviteStatus : nextInviteStatus,
                 consumerOid: instanceConsumer.consumerOid,
-                organizationMemberOid: d.member?.oid ?? instanceConsumer.organizationMemberOid,
-                organizationActorOid:
-                  d.member?.actorOid ?? instanceConsumer.organizationActorOid,
+                ...organizationIdentity,
                 deletedAt: null,
                 ssoGroupIds,
                 ssoRoles
               },
               include
             });
+
             return {
               lifecycleAction: 'updated' as const,
               instanceConsumer,
@@ -812,10 +968,17 @@ class ConsumerProfileServiceImpl {
             surface: d.surface
           });
 
+          let organizationIdentity = await this.resolveOrganizationIdentity({
+            surface: d.surface,
+            organization,
+            instanceConsumer,
+            member: d.member,
+            name: d.name,
+            email
+          });
+
           let accessTag = await db.accessTag.create({
-            data: {
-              instanceOid: d.surface.instanceOid
-            }
+            data: { instanceOid: d.surface.instanceOid }
           });
 
           let personalConsumerGroup = await db.consumerGroup.create({
@@ -849,9 +1012,7 @@ class ConsumerProfileServiceImpl {
                 instanceOid: d.surface.instanceOid,
                 surfaceOid: d.surface.oid,
                 consumerOid: instanceConsumer.consumerOid,
-                organizationMemberOid: d.member?.oid ?? instanceConsumer.organizationMemberOid,
-                organizationActorOid:
-                  d.member?.actorOid ?? instanceConsumer.organizationActorOid,
+                ...organizationIdentity,
                 accessTagOid: accessTag.oid,
                 personalConsumerGroupOid: personalConsumerGroup.oid
               },

--- a/src/metorial/modules/consumer/test/consumerProfileOrganizationActor.test.ts
+++ b/src/metorial/modules/consumer/test/consumerProfileOrganizationActor.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => {
+  let db = {
+    accessTag: { create: vi.fn() },
+    consumer: { findUnique: vi.fn() },
+    consumerGroup: { create: vi.fn() },
+    consumerProfile: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn()
+    },
+    instance: {
+      findFirstOrThrow: vi.fn(),
+      findMany: vi.fn()
+    },
+    instanceConsumer: {
+      findMany: vi.fn(),
+      findUnique: vi.fn()
+    },
+    organization: { findFirstOrThrow: vi.fn() },
+    organizationActor: { findUnique: vi.fn() },
+    organizationMember: { findUnique: vi.fn() }
+  };
+
+  return {
+    db,
+    createOrganizationActor: vi.fn(),
+    getSystemActor: vi.fn(),
+    upsertConsumer: vi.fn(),
+    profileCreatedAdd: vi.fn(),
+    profileUpdatedAdd: vi.fn(),
+    fire: vi.fn()
+  };
+});
+
+vi.mock('@metorial/db', () => ({
+  db: mocks.db,
+  ID: { generateId: vi.fn(async prefix => `${prefix}_generated`) },
+  withTransaction: vi.fn(async callback => await callback(mocks.db))
+}));
+
+vi.mock('@metorial/consumer-auth', () => ({
+  getEffectiveConsumerGroups: vi.fn(),
+  normalizeStringList: vi.fn(values => values ?? [])
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_: string, factory: () => unknown) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: { fire: mocks.fire }
+}));
+
+vi.mock('@metorial/lock', () => ({
+  createLock: vi.fn(() => ({
+    usingLock: vi.fn(async (_key, callback) => await callback())
+  }))
+}));
+
+vi.mock('@metorial/module-organization', () => ({
+  namespaceService: {},
+  organizationActorService: {
+    createOrganizationActor: mocks.createOrganizationActor,
+    getSystemActor: mocks.getSystemActor
+  }
+}));
+
+vi.mock('@metorial/module-search', () => ({
+  searchConsumerIds: vi.fn()
+}));
+
+vi.mock('../src/queues/lifecycle/consumerInvite', () => ({
+  consumerInviteUpdatedQueue: { addMany: vi.fn() }
+}));
+
+vi.mock('../src/queues/lifecycle/consumerProfile', () => ({
+  consumerProfileCreatedQueue: { add: mocks.profileCreatedAdd },
+  consumerProfileUpdatedQueue: { add: mocks.profileUpdatedAdd }
+}));
+
+vi.mock('../src/queues/reconcileUserConsumer', () => ({
+  reconcileUserConsumersQueue: { add: vi.fn() }
+}));
+
+vi.mock('../src/queues/syncUserConsumer', () => ({
+  syncUserConsumersQueue: { add: vi.fn() }
+}));
+
+vi.mock('../src/services/consumers/consumer', () => ({
+  consumerService: { upsertConsumer: mocks.upsertConsumer }
+}));
+
+vi.mock('../src/services/consumers/consumerSurface', () => ({
+  consumerSurfaceInclude: {},
+  consumerSurfaceService: {
+    enrichConsumerSurfaces: vi.fn(async ({ consumerSurfaces }) => consumerSurfaces)
+  }
+}));
+
+import { consumerProfileService } from '../src/services/consumers/consumerProfile';
+
+let organization = { id: 'org_1', oid: 1n };
+let systemActor = { id: 'oac_system', oid: 2n, type: 'system' };
+let instanceConsumer = {
+  id: 'inc_1',
+  oid: 3n,
+  instanceOid: 4n,
+  consumerOid: 5n,
+  organizationMemberOid: null,
+  organizationActorOid: null
+};
+let portalSurface = {
+  id: 'csf_portal',
+  oid: 6n,
+  instanceOid: 4n,
+  organizationOid: 1n,
+  type: 'portal',
+  isInternal: false
+};
+
+let profile = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: 'cop_1',
+    oid: 7n,
+    status: 'active',
+    name: 'Consumer',
+    email: 'consumer@example.com',
+    organizationOid: 1n,
+    instanceOid: 4n,
+    surfaceOid: 6n,
+    consumerOid: 5n,
+    organizationMemberOid: null,
+    organizationActorOid: null,
+    organization,
+    surface: portalSurface,
+    ...overrides
+  }) as any;
+
+describe('consumer profile organization actors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSystemActor.mockResolvedValue(systemActor);
+    mocks.createOrganizationActor.mockResolvedValue({
+      id: 'oac_profile',
+      oid: 8n,
+      type: 'consumer_profile'
+    });
+    mocks.db.instanceConsumer.findUnique.mockResolvedValue(instanceConsumer);
+  });
+
+  it('creates a dedicated actor and clears inherited member links', async () => {
+    let consumerProfile = profile({
+      organizationMemberOid: 20n,
+      organizationActorOid: 21n
+    });
+    mocks.db.consumerProfile.findUnique.mockResolvedValue(consumerProfile);
+    mocks.db.organizationActor.findUnique.mockResolvedValue({
+      oid: 21n,
+      type: 'member',
+      consumerProfiles: [{ oid: 7n }]
+    });
+    mocks.db.consumerProfile.update.mockImplementation(async ({ data }) => ({
+      ...consumerProfile,
+      ...data
+    }));
+
+    await consumerProfileService.reconcileConsumerProfileOrganizationActor({
+      consumerProfile
+    });
+
+    expect(mocks.createOrganizationActor).toHaveBeenCalledWith({
+      input: {
+        type: 'consumer_profile',
+        name: 'Consumer',
+        email: 'consumer@example.com'
+      },
+      organization,
+      performedBy: { type: 'actor', actor: systemActor }
+    });
+    expect(mocks.db.consumerProfile.update).toHaveBeenCalledWith({
+      where: { oid: 7n },
+      data: {
+        organizationMemberOid: null,
+        organizationActorOid: 8n
+      }
+    });
+    expect(mocks.db.consumer).not.toHaveProperty('update');
+    expect(mocks.db.instanceConsumer).not.toHaveProperty('update');
+  });
+
+  it('keeps an actor that belongs only to the profile', async () => {
+    let consumerProfile = profile({ organizationActorOid: 8n });
+    mocks.db.consumerProfile.findUnique.mockResolvedValue(consumerProfile);
+    mocks.db.organizationActor.findUnique.mockResolvedValue({
+      oid: 8n,
+      type: 'consumer_profile',
+      consumerProfiles: [{ oid: 7n }]
+    });
+
+    await consumerProfileService.reconcileConsumerProfileOrganizationActor({
+      consumerProfile
+    });
+
+    expect(mocks.createOrganizationActor).not.toHaveBeenCalled();
+    expect(mocks.db.consumerProfile.update).not.toHaveBeenCalled();
+  });
+
+  it('replaces a consumer profile actor shared by another profile', async () => {
+    let consumerProfile = profile({ organizationActorOid: 8n });
+    mocks.db.consumerProfile.findUnique.mockResolvedValue(consumerProfile);
+    mocks.createOrganizationActor.mockResolvedValue({
+      id: 'oac_profile_replacement',
+      oid: 9n,
+      type: 'consumer_profile'
+    });
+    mocks.db.organizationActor.findUnique.mockResolvedValue({
+      oid: 8n,
+      type: 'consumer_profile',
+      consumerProfiles: [{ oid: 7n }, { oid: 9n }]
+    });
+
+    await consumerProfileService.reconcileConsumerProfileOrganizationActor({
+      consumerProfile
+    });
+
+    expect(mocks.createOrganizationActor).toHaveBeenCalledOnce();
+    expect(mocks.db.consumerProfile.update).toHaveBeenCalledWith({
+      where: { oid: 7n },
+      data: {
+        organizationMemberOid: null,
+        organizationActorOid: 9n
+      }
+    });
+  });
+
+  it.each([
+    {
+      source: 'profile',
+      profileMemberOid: 20n,
+      instanceMemberOid: 30n,
+      consumerMemberOid: 40n,
+      expectedMemberOid: 20n
+    },
+    {
+      source: 'instance consumer',
+      profileMemberOid: null,
+      instanceMemberOid: 30n,
+      consumerMemberOid: 40n,
+      expectedMemberOid: 30n
+    },
+    {
+      source: 'consumer',
+      profileMemberOid: null,
+      instanceMemberOid: null,
+      consumerMemberOid: 40n,
+      expectedMemberOid: 40n
+    }
+  ])('uses the organization member from the $source', async testCase => {
+    let memberSurface = { ...portalSurface, type: 'organization_members' };
+    let consumerProfile = profile({
+      surface: memberSurface,
+      organizationMemberOid: testCase.profileMemberOid
+    });
+    mocks.db.consumerProfile.findUnique.mockResolvedValue(consumerProfile);
+    mocks.db.instanceConsumer.findUnique.mockResolvedValue({
+      ...instanceConsumer,
+      organizationMemberOid: testCase.instanceMemberOid
+    });
+    mocks.db.consumer.findUnique.mockResolvedValue({
+      organizationMemberOid: testCase.consumerMemberOid
+    });
+    mocks.db.organizationMember.findUnique.mockResolvedValue({
+      oid: testCase.expectedMemberOid,
+      actorOid: 50n
+    });
+
+    await consumerProfileService.reconcileConsumerProfileOrganizationActor({
+      consumerProfile
+    });
+
+    expect(mocks.db.consumerProfile.update).toHaveBeenCalledWith({
+      where: { oid: 7n },
+      data: {
+        organizationMemberOid: testCase.expectedMemberOid,
+        organizationActorOid: 50n
+      }
+    });
+    expect(mocks.createOrganizationActor).not.toHaveBeenCalled();
+  });
+
+  it('clears unresolved organization member profiles for a later retry', async () => {
+    let memberSurface = { ...portalSurface, type: 'organization_members' };
+    let consumerProfile = profile({
+      surface: memberSurface,
+      organizationActorOid: 21n
+    });
+    mocks.db.consumerProfile.findUnique.mockResolvedValue(consumerProfile);
+    mocks.db.consumer.findUnique.mockResolvedValue({ organizationMemberOid: null });
+
+    await consumerProfileService.reconcileConsumerProfileOrganizationActor({
+      consumerProfile
+    });
+
+    expect(mocks.db.consumerProfile.update).toHaveBeenCalledWith({
+      where: { oid: 7n },
+      data: {
+        organizationMemberOid: null,
+        organizationActorOid: null
+      }
+    });
+  });
+
+  it('gives a newly created portal profile its own actor', async () => {
+    let instance = { id: 'ins_1', oid: 4n };
+    let createdProfile = profile({
+      organizationActorOid: 8n,
+      surface: portalSurface
+    });
+    mocks.db.organization.findFirstOrThrow.mockResolvedValue(organization);
+    mocks.db.instance.findFirstOrThrow.mockResolvedValue(instance);
+    mocks.db.instance.findMany.mockResolvedValue([instance]);
+    mocks.upsertConsumer.mockResolvedValue(instanceConsumer);
+    mocks.db.consumerProfile.findFirst.mockResolvedValue(null);
+    mocks.db.accessTag.create.mockResolvedValue({ oid: 60n });
+    mocks.db.consumerGroup.create.mockResolvedValue({ oid: 61n });
+    mocks.db.consumerProfile.create.mockResolvedValue(createdProfile);
+
+    await consumerProfileService.ensureConsumerProfile({
+      surface: portalSurface as any,
+      name: 'Consumer',
+      email: 'consumer@example.com'
+    });
+
+    expect(mocks.db.consumerProfile.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organizationMemberOid: null,
+          organizationActorOid: 8n
+        })
+      })
+    );
+    expect(mocks.profileCreatedAdd).toHaveBeenCalledWith({
+      consumerProfileId: 'cop_1'
+    });
+  });
+});

--- a/src/metorial/modules/consumer/test/consumerProfileOrganizationActor.test.ts
+++ b/src/metorial/modules/consumer/test/consumerProfileOrganizationActor.test.ts
@@ -5,6 +5,7 @@ let mocks = vi.hoisted(() => {
     accessTag: { create: vi.fn() },
     consumer: { findUnique: vi.fn() },
     consumerGroup: { create: vi.fn() },
+    consumerOrganizationActor: { upsert: vi.fn() },
     consumerProfile: {
       create: vi.fn(),
       findFirst: vi.fn(),
@@ -183,6 +184,19 @@ describe('consumer profile organization actors', () => {
       },
       organization,
       performedBy: { type: 'actor', actor: systemActor }
+    });
+    expect(mocks.db.consumerOrganizationActor.upsert).toHaveBeenCalledWith({
+      where: {
+        consumerOid_organizationActorOid: {
+          consumerOid: 5n,
+          organizationActorOid: 8n
+        }
+      },
+      create: {
+        consumerOid: 5n,
+        organizationActorOid: 8n
+      },
+      update: {}
     });
     expect(mocks.db.consumerProfile.update).toHaveBeenCalledWith({
       where: { oid: 7n },

--- a/src/metorial/modules/consumer/test/reconcileConsumerProfileOrganizationActorsQueue.test.ts
+++ b/src/metorial/modules/consumer/test/reconcileConsumerProfileOrganizationActorsQueue.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  consumerProfileFindMany: vi.fn(),
+  consumerProfileFindUnique: vi.fn(),
+  reconcileProfile: vi.fn(),
+  queueAdds: new Map<string, ReturnType<typeof vi.fn>>(),
+  queueAddMany: new Map<string, ReturnType<typeof vi.fn>>(),
+  queueProcessors: new Map<string, (data: any) => Promise<unknown>>()
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    consumerProfile: {
+      findMany: mocks.consumerProfileFindMany,
+      findUnique: mocks.consumerProfileFindUnique
+    }
+  }
+}));
+
+vi.mock('@metorial/cron', () => ({
+  createCron: vi.fn((_config, handler) => handler)
+}));
+
+vi.mock('@metorial/queue', () => ({
+  combineQueueProcessors: vi.fn(processors => processors),
+  createQueue: vi.fn(config => {
+    let add = vi.fn();
+    let addManyWithOps = vi.fn();
+    mocks.queueAdds.set(config.name, add);
+    mocks.queueAddMany.set(config.name, addManyWithOps);
+
+    return {
+      add,
+      addManyWithOps,
+      process: vi.fn(handler => {
+        mocks.queueProcessors.set(config.name, handler);
+        return handler;
+      })
+    };
+  })
+}));
+
+vi.mock('../src/services', () => ({
+  consumerProfileService: {
+    reconcileConsumerProfileOrganizationActor: mocks.reconcileProfile
+  }
+}));
+
+describe('reconcile consumer profile organization actors queue', () => {
+  beforeAll(async () => {
+    vi.useFakeTimers();
+    await import('../src/queues/reconcileConsumerProfileOrganizationActors');
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('paginates profiles and fans out deduplicated jobs', async () => {
+    mocks.consumerProfileFindMany.mockResolvedValue([{ id: 'cop_1' }, { id: 'cop_2' }]);
+    let processor = mocks.queueProcessors.get('cons/profileOrgActor/rec/search')!;
+
+    await processor({ cursor: 'cop_0' });
+
+    expect(mocks.consumerProfileFindMany).toHaveBeenCalledWith({
+      where: { id: { gt: 'cop_0' } },
+      orderBy: { id: 'asc' },
+      take: 500,
+      select: { id: true }
+    });
+    expect(mocks.queueAddMany.get('cons/profileOrgActor/rec/single')).toHaveBeenCalledWith([
+      {
+        data: { consumerProfileId: 'cop_1' },
+        opts: { id: 'cop_1' }
+      },
+      {
+        data: { consumerProfileId: 'cop_2' },
+        opts: { id: 'cop_2' }
+      }
+    ]);
+    expect(mocks.queueAdds.get('cons/profileOrgActor/rec/search')).toHaveBeenCalledWith({
+      cursor: 'cop_2'
+    });
+  });
+
+  it('stops pagination when no profiles remain', async () => {
+    mocks.consumerProfileFindMany.mockResolvedValue([]);
+    let processor = mocks.queueProcessors.get('cons/profileOrgActor/rec/search')!;
+
+    await processor({ cursor: 'cop_2' });
+
+    expect(mocks.queueAddMany.get('cons/profileOrgActor/rec/single')).not.toHaveBeenCalled();
+    expect(mocks.queueAdds.get('cons/profileOrgActor/rec/search')).not.toHaveBeenCalled();
+  });
+
+  it('reloads and reconciles each profile', async () => {
+    let consumerProfile = { id: 'cop_1', oid: 1n };
+    mocks.consumerProfileFindUnique.mockResolvedValue(consumerProfile);
+    let processor = mocks.queueProcessors.get('cons/profileOrgActor/rec/single')!;
+
+    await processor({ consumerProfileId: 'cop_1' });
+
+    expect(mocks.reconcileProfile).toHaveBeenCalledWith({ consumerProfile });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes identity linkage on consumer profiles and org actors across create, update, and a full backfill—important for authorization attribution but scoped to consumer module logic with tests.
> 
> **Overview**
> This PR fixes how **consumer profiles** attach to **organization actors**, instead of inheriting member/instance-consumer actor IDs.
> 
> For **portal** (and other non–org-member) surfaces, profile create/update now creates a **`consumer_profile`** `OrganizationActor` (new enum value), records the link in **`ConsumerOrganizationActor`**, and stores that actor on the profile while clearing stray member links. **`organization_members`** surfaces still resolve the org member (profile → instance consumer → consumer) and use that member’s actor.
> 
> **`ensureConsumerProfile`** and profile updates call shared **`resolveOrganizationIdentity`** logic; **`reconcileConsumerProfileOrganizationActor`** backfills mismatches (including replacing shared or member-type actors). A **daily cron** plus an **on-startup** paginated queue walks all profiles and runs reconciliation in batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f1c3cfe568a243ac9f7d5410c5089a92761567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->