### PR TITLE
Make org actors required for consumer

### DIFF
--- a/src/metorial/db/prisma/schema/consumer/consumer.prisma
+++ b/src/metorial/db/prisma/schema/consumer/consumer.prisma
@@ -123,8 +123,8 @@ model ConsumerProfile {
   organizationMemberOid BigInt?
   organizationMember    OrganizationMember? @relation(fields: [organizationMemberOid], references: [oid], onDelete: SetNull)
 
-  organizationActorOid BigInt?
-  organizationActor    OrganizationActor? @relation(fields: [organizationActorOid], references: [oid], onDelete: SetNull)
+  organizationActorOid BigInt
+  organizationActor    OrganizationActor @relation(fields: [organizationActorOid], references: [oid], onDelete: Cascade)
 
   personalConsumerGroupOid BigInt        @unique
   personalConsumerGroup    ConsumerGroup @relation("ConsumerProfilePersonalGroup", fields: [personalConsumerGroupOid], references: [oid], onDelete: Cascade)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema tightening and FK delete behavior change can break migrations if profiles lack actors and may delete profiles when org actors are removed; creation paths must always set `organizationActorOid`.
> 
> **Overview**
> **`ConsumerProfile`** now **requires** an `organizationActor` link: `organizationActorOid` is non-nullable and the relation is required instead of optional.
> 
> Deleting an **`OrganizationActor`** **cascades** to linked consumer profiles (**`onDelete: Cascade`**), replacing the previous **`SetNull`** behavior when the actor was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a728482d50154abe351df868e295bc8af3deec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->