### PR TITLE
Fix document version check

### DIFF
--- a/src/metorial/cargo/modules/doc/src/internal/documentContent.ts
+++ b/src/metorial/cargo/modules/doc/src/internal/documentContent.ts
@@ -71,7 +71,7 @@ class InternalDocumentContentServiceImpl {
     return await withTransaction(async db => {
       let now = new Date();
       let shouldCreateNewVersion =
-        internalDocumentVersioningService.shouldCreateNewVersionForWrite(d.document, now);
+        await internalDocumentVersioningService.shouldCreateNewVersionForWrite(d.document, now);
 
       let liveContentOid = d.document.contentOid;
       let activeVersion = d.document.currentVersion;
@@ -296,7 +296,7 @@ class InternalDocumentContentServiceImpl {
         isContentOwner: d.document.isContentOwner || !shouldKeepParentSync,
         didCreateVersion,
         draftVersionExpiresAt:
-          internalDocumentVersioningService.getNextDraftVersionExpiresAt(now)
+          await internalDocumentVersioningService.getNextDraftVersionExpiresAt(now)
       };
     });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches document versioning on write paths; the change is small but incorrect version logic can affect stored content and version history.
> 
> **Overview**
> **Fixes document version decisions during content writes** by `await`ing `internalDocumentVersioningService.shouldCreateNewVersionForWrite` and `getNextDraftVersionExpiresAt` inside `writeDocumentContent`.
> 
> Without awaiting, those calls would treat unresolved promises as values—skewing whether a new version is created and what `draftVersionExpiresAt` is persisted when drafts are saved to the document.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cfb924486597bb0b96f149bb0f73540cc63ff92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->