### PR TITLE
Fix setup urls

### DIFF
--- a/src/metorial/apis/core/src/controllers/consumer/provider.ts
+++ b/src/metorial/apis/core/src/controllers/consumer/provider.ts
@@ -13,10 +13,6 @@ import {
   consumerSurfaceProviderGroupService
 } from '@metorial/module-consumer';
 import { magicMcpServerService } from '@metorial/module-magic';
-import { Controller } from '@metorial/rest';
-import { normalizeArrayParam } from '../../lib/normalizeArrayParam';
-import { consumerGroup, consumerPath } from '../../middleware/consumerGroup';
-import { hasFlags } from '../../middleware/hasFlags';
 import {
   consumerAccessRequestPresenter,
   consumerProviderPresenter,
@@ -26,6 +22,10 @@ import {
   portalOAuthAuthorizationPresenter,
   portalOAuthClientPresenter
 } from '@metorial/presenters';
+import { Controller } from '@metorial/rest';
+import { normalizeArrayParam } from '../../lib/normalizeArrayParam';
+import { consumerGroup, consumerPath } from '../../middleware/consumerGroup';
+import { hasFlags } from '../../middleware/hasFlags';
 
 let consumerProviderItemGroup = consumerGroup.use(async ctx => {
   if (!ctx.params.catalogItemId) {
@@ -413,6 +413,7 @@ export let consumerProviderController = Controller.create(
           consumerSurface: ctx.consumerSurface,
           consumerProfile: ctx.consumerProfile,
           providerTemplateId: consumerProvider.providerTemplate.id,
+          requestOrigin: ctx.headers['origin'],
           input: {
             providerAuthMethodId: ctx.body.provider_auth_method_id
           }

--- a/src/metorial/modules/consumer/src/services/consumerEntities/consumerProviderSetupSession.ts
+++ b/src/metorial/modules/consumer/src/services/consumerEntities/consumerProviderSetupSession.ts
@@ -5,6 +5,10 @@ import {
   unauthorizedError
 } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
+import {
+  integrationService,
+  integrationSetupSessionService
+} from '@metorial-subspace/module-integration';
 import { Context } from '@metorial/context';
 import {
   ConsumerProfile,
@@ -12,35 +16,31 @@ import {
   ConsumerSurface,
   db,
   ID,
+  Portal,
   ProviderTemplate,
   type Instance
 } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import { type AnyAccessTagSelector } from '@metorial/module-access';
 import { providerTemplateService } from '@metorial/module-magic';
-import {
-  integrationService,
-  integrationSetupSessionService
-} from '@metorial-subspace/module-integration';
+import { portalService } from '../portal';
 
-let buildProviderSetupRedirectUrl = (portalSlug: string) => {
-  let template = process.env.PORTAL_HOST_TEMPLATE;
-  if (!template) {
-    throw new Error('PORTAL_HOST_TEMPLATE is required');
-  }
+let buildProviderSetupRedirectUrl = async (d: {
+  portal: Pick<Portal, 'oid' | 'slug'>;
+  requestOrigin?: string | null;
+}) => {
+  let url = new URL(
+    await portalService.getPortalUrlForOrigin({
+      portal: d.portal,
+      origin: d.requestOrigin
+    })
+  );
+  let basePath = url.pathname.replace(/\/+$/, '');
+  url.pathname = `${basePath}/provider-setup-complete`.replace(/\/{2,}/g, '/');
+  url.search = '';
+  url.hash = '';
 
-  let raw = template.replace(/\/+$/, '');
-
-  if (!raw.includes('{portalId}')) {
-    let url = new URL(raw);
-    let pathname = `${url.pathname.replace(/\/+$/, '')}/p/{portalId}`.replace(/\/{2,}/g, '/');
-
-    raw = `${url.origin}${pathname}${url.search}${url.hash}`.replace(/\/+$/, '');
-  }
-
-  let baseUrl = raw.replace('{portalId}', portalSlug).replace(/\/+$/, '');
-
-  return `${baseUrl}/provider-setup-complete`;
+  return url.toString();
 };
 
 let getSetupSessionBindingMetadata = (d: {
@@ -124,6 +124,7 @@ class ConsumerProviderSetupSessionServiceImpl {
     consumerSurface: ConsumerSurface;
     consumerProfile: ConsumerProfile;
     providerTemplateId: string;
+    requestOrigin?: string | null;
     input: {
       providerAuthMethodId?: string;
     };
@@ -140,6 +141,7 @@ class ConsumerProviderSetupSessionServiceImpl {
         surfaceOid: d.consumerSurface.oid
       },
       select: {
+        oid: true,
         slug: true
       }
     });
@@ -182,7 +184,10 @@ class ConsumerProviderSetupSessionServiceImpl {
         }),
         identityActorId: consumerIdentity.identityActorId,
         identityId: consumerIdentity.identityId,
-        redirectUrl: buildProviderSetupRedirectUrl(portal.slug),
+        redirectUrl: await buildProviderSetupRedirectUrl({
+          portal,
+          requestOrigin: d.requestOrigin
+        }),
         configuration: {
           ui: {
             layout: 'box'

--- a/src/metorial/modules/consumer/src/services/portal.ts
+++ b/src/metorial/modules/consumer/src/services/portal.ts
@@ -76,6 +76,16 @@ let buildPortalUrlFromId = (portalId: string) => {
   return buildPortalUrlFromTemplate(env.portal.PORTAL_HOST_TEMPLATE, portalId);
 };
 
+let toOrigin = (value: string | null | undefined) => {
+  if (!value) return null;
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+};
+
 type PortalSurface = ConsumerSurfaceWithPublishableApiKey;
 type EnrichedPortalSurface = EnrichedConsumerSurface;
 type PortalRecord = Prisma.PortalGetPayload<{
@@ -469,6 +479,26 @@ class PortalServiceImpl {
     let urls = await this.getPrimaryPortalUrls({ portals: [d.portal] });
 
     return urls.get(d.portal.oid) ?? this.getPortalHost({ portal: d.portal }).host;
+  }
+
+  async getPortalUrlForOrigin(d: {
+    portal: Pick<Portal, 'oid' | 'slug'>;
+    origin?: string | null;
+  }) {
+    let namespacesByPortalOid = await namespaceService.getNamespacePropertiesByPortalOid({
+      portals: [d.portal]
+    });
+    let urls = this.getPortalUrls({
+      portal: d.portal,
+      namespaces: namespacesByPortalOid.get(d.portal.oid) ?? []
+    });
+
+    let requestOrigin = toOrigin(d.origin);
+    let match = requestOrigin
+      ? urls.find(({ url }) => toOrigin(url) == requestOrigin)
+      : undefined;
+
+    return match?.url ?? urls[0]?.url ?? this.getPortalHost({ portal: d.portal }).host;
   }
 
   parsePortalIdFromHost(d: { url: string }) {

--- a/src/metorial/modules/consumer/test/portalNamespaceUrls.test.ts
+++ b/src/metorial/modules/consumer/test/portalNamespaceUrls.test.ts
@@ -198,6 +198,62 @@ describe('portalService.getPrimaryPortalUrls', () => {
     expect(urls.get(other.oid)).toBe('https://portals.metorial.test/globex');
   });
 
+  describe('getPortalUrlForOrigin', () => {
+    let namespaces = [
+      namespaceProperty({
+        value: 'acme',
+        compartment: 'portals.metorial.com',
+        purposes: ['metorial_portal']
+      }),
+      namespaceProperty({
+        value: 'acme-portal',
+        compartment: 'portals.metorial.com',
+        purposes: ['metorial_portal_single']
+      })
+    ];
+
+    it('keeps the request on the host it came from', async () => {
+      mockNamespaces(namespaces);
+
+      expect(
+        await portalService.getPortalUrlForOrigin({
+          portal,
+          origin: 'https://acme-portal.portals.metorial.com'
+        })
+      ).toBe('https://acme-portal.portals.metorial.com');
+    });
+
+    it('falls back to the primary URL for an unknown origin', async () => {
+      mockNamespaces(namespaces);
+
+      expect(
+        await portalService.getPortalUrlForOrigin({
+          portal,
+          origin: 'https://somewhere.else.com'
+        })
+      ).toBe('https://acme.portals.metorial.com/p/acme');
+    });
+
+    it('falls back to the primary URL when there is no origin', async () => {
+      mockNamespaces(namespaces);
+
+      expect(await portalService.getPortalUrlForOrigin({ portal })).toBe(
+        'https://acme.portals.metorial.com/p/acme'
+      );
+    });
+
+    it('falls back to the configured host when the portal has no namespace', async () => {
+      mockNamespaces([]);
+
+      expect(
+        await portalService.getPortalUrlForOrigin({
+          portal,
+          origin: 'https://acme.portals.metorial.com'
+        })
+      ).toBe('https://portals.metorial.test/acme');
+    });
+  });
+
   describe('in development', () => {
     beforeEach(() => {
       config.env = 'development';

--- a/src/metorial/modules/consumer/test/providerSetupRedirect.test.ts
+++ b/src/metorial/modules/consumer/test/providerSetupRedirect.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_: string, factory: () => unknown) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    portal: {
+      findFirst: vi.fn(async () => ({ oid: 1n, slug: 'acme' }))
+    },
+    instanceConsumer: {
+      findFirst: vi.fn(async () => null)
+    },
+    consumerProviderSetupSessionBinding: {
+      create: vi.fn(async () => ({}))
+    }
+  },
+  ID: { generateId: vi.fn(async () => 'cpssb_1') }
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: { fire: vi.fn() }
+}));
+
+vi.mock('@metorial/module-magic', () => ({
+  providerTemplateService: {
+    getProviderTemplateById: vi.fn(async () => ({
+      oid: 2n,
+      id: 'prvtpl_1',
+      name: 'Acme',
+      description: null,
+      metadata: null,
+      subspaceIntegrationId: 'itg_1'
+    }))
+  }
+}));
+
+vi.mock('@metorial-subspace/module-integration', () => ({
+  integrationService: {
+    getIntegrationById: vi.fn(async () => ({ id: 'itg_1' }))
+  },
+  integrationSetupSessionService: {
+    createIntegrationSetupSession: vi.fn(async () => ({ id: 'itgss_1' }))
+  }
+}));
+
+vi.mock('../src/services/portal', () => ({
+  portalService: {
+    getPortalUrlForOrigin: vi.fn()
+  }
+}));
+
+import { integrationSetupSessionService } from '@metorial-subspace/module-integration';
+import { consumerProviderSetupSessionService } from '../src/services/consumerEntities/consumerProviderSetupSession';
+import { portalService } from '../src/services/portal';
+
+let startSetup = async (portalUrl: string, requestOrigin?: string) => {
+  vi.mocked(portalService.getPortalUrlForOrigin).mockResolvedValue(portalUrl);
+
+  await consumerProviderSetupSessionService.startSetupSession({
+    instance: { oid: 1n } as any,
+    context: { ip: '127.0.0.1', ua: 'test' },
+    accessTags: null as any,
+    consumerSurface: { oid: 1n } as any,
+    consumerProfile: { oid: 1n, consumerOid: 1n } as any,
+    providerTemplateId: 'prvtpl_1',
+    requestOrigin,
+    input: {}
+  });
+
+  return vi.mocked(integrationSetupSessionService.createIntegrationSetupSession).mock
+    .calls[0]![0].input.redirectUrl;
+};
+
+describe('consumer provider setup redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('appends the completion path to a portal-specific namespace host', async () => {
+    expect(await startSetup('https://acme-portal.portals.metorial.com')).toBe(
+      'https://acme-portal.portals.metorial.com/provider-setup-complete'
+    );
+  });
+
+  it('keeps the slug prefix of a shared namespace host', async () => {
+    expect(await startSetup('https://acme.portals.metorial.com/p/acme')).toBe(
+      'https://acme.portals.metorial.com/p/acme/provider-setup-complete'
+    );
+  });
+
+  it('drops any query and hash the portal URL carries', async () => {
+    expect(await startSetup('https://acme.portals.metorial.com/p/acme?a=1#b')).toBe(
+      'https://acme.portals.metorial.com/p/acme/provider-setup-complete'
+    );
+  });
+
+  it('does not double up slashes on a trailing-slash portal URL', async () => {
+    expect(await startSetup('https://acme-portal.portals.metorial.com/')).toBe(
+      'https://acme-portal.portals.metorial.com/provider-setup-complete'
+    );
+  });
+
+  it('resolves the portal URL against the origin the setup was started from', async () => {
+    await startSetup(
+      'https://acme-portal.portals.metorial.com',
+      'https://acme-portal.portals.metorial.com'
+    );
+
+    expect(portalService.getPortalUrlForOrigin).toHaveBeenCalledWith({
+      portal: { oid: 1n, slug: 'acme' },
+      origin: 'https://acme-portal.portals.metorial.com'
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to OAuth/setup redirect URL generation with fallbacks to existing primary portal URLs; no auth or data-model changes.
> 
> **Overview**
> Fixes **provider setup completion redirects** so users return to the same portal host they started from (shared vs dedicated namespace URLs), instead of a URL built only from `PORTAL_HOST_TEMPLATE`.
> 
> The consumer **start setup** endpoint forwards `Origin` into `startSetupSession`. Redirect construction now calls new **`portalService.getPortalUrlForOrigin`**, which picks the portal URL whose origin matches the request and otherwise uses the primary namespace URL, then appends `/provider-setup-complete` (preserving path prefixes like `/p/{slug}`, stripping query/hash, normalizing slashes).
> 
> Tests cover origin matching, fallbacks, and redirect path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e1c5cf8e5e1c9cd75bbf3dc0af0ede155ed9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->