### PR TITLE
Harden remote oauth

### DIFF
--- a/src/shuttle/service/prisma/schema/oauthRemote.prisma
+++ b/src/shuttle/service/prisma/schema/oauthRemote.prisma
@@ -141,6 +141,11 @@ model RemoteOAuthConnection {
   registrationOid BigInt?
   registration    RemoteOAuthAutoRegistration? @relation(fields: [registrationOid], references: [oid])
 
+  // Set when this connection was created to replace the client of another one.
+  rotatedFromOid BigInt?
+  rotatedFrom    RemoteOAuthConnection?  @relation("remoteOAuthConnectionRotation", fields: [rotatedFromOid], references: [oid])
+  rotatedTo      RemoteOAuthConnection[] @relation("remoteOAuthConnectionRotation")
+
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid])
 
@@ -163,6 +168,7 @@ model RemoteOAuthConnection {
   serverAuthConfigs               ServerAuthConfig[]
 
   @@index([discoveryStatus, status, lastRegistrationAttemptAt])
+  @@index([rotatedFromOid, status])
 }
 
 enum RemoteOAuthConnectionEventType {

--- a/src/shuttle/service/prisma/schema/oauthRemote.prisma
+++ b/src/shuttle/service/prisma/schema/oauthRemote.prisma
@@ -147,6 +147,9 @@ model RemoteOAuthConnection {
   serverOid BigInt
   server    Server @relation(fields: [serverOid], references: [oid])
 
+  registrationAttemptCount  Int       @default(0)
+  lastRegistrationAttemptAt DateTime?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -158,6 +161,8 @@ model RemoteOAuthConnection {
   remoteOAuthConnectionAuthTokens RemoteOAuthConnectionAuthToken[]
   remoteOAuthRegistrationErrors   RemoteOAuthRegistrationError[]
   serverAuthConfigs               ServerAuthConfig[]
+
+  @@index([discoveryStatus, status, lastRegistrationAttemptAt])
 }
 
 enum RemoteOAuthConnectionEventType {
@@ -166,6 +171,7 @@ enum RemoteOAuthConnectionEventType {
   auto_registration_failed
   config_auto_discovered
   config_auto_updated
+  credentials_rotated
 }
 
 model RemoteOAuthConnectionEvent {

--- a/src/shuttle/service/src/lib/oauth/clientRegistrationMetadata.test.ts
+++ b/src/shuttle/service/src/lib/oauth/clientRegistrationMetadata.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildClientRegistrationMetadata } from './clientRegistrationMetadata';
+import type { OAuthConfiguration } from './types';
+
+let config = (partial: Partial<OAuthConfiguration> = {}): OAuthConfiguration => ({
+  authorization_endpoint: 'https://example.com/oauth2/authorize',
+  token_endpoint: 'https://example.com/oauth2/token',
+  registration_endpoint: 'https://example.com/oauth2/register',
+  ...partial
+});
+
+describe('buildClientRegistrationMetadata', () => {
+  it('drops grant types we never use', () => {
+    let metadata = buildClientRegistrationMetadata(
+      config({
+        grant_types_supported: [
+          'authorization_code',
+          'refresh_token',
+          'urn:ietf:params:oauth:grant-type:device_code',
+          'urn:ietf:params:oauth:grant-type:jwt-bearer'
+        ],
+        response_types_supported: ['code'],
+        token_endpoint_auth_methods_supported: ['none', 'client_secret_post', 'client_secret_basic']
+      })
+    );
+
+    expect(metadata).toEqual({
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'client_secret_basic'
+    });
+  });
+
+  it('drops response types we never use', () => {
+    let metadata = buildClientRegistrationMetadata(
+      config({ response_types_supported: ['code', 'token', 'id_token'] })
+    );
+
+    expect(metadata.response_types).toEqual(['code']);
+  });
+
+  it('omits flows the server does not advertise', () => {
+    let metadata = buildClientRegistrationMetadata(
+      config({ grant_types_supported: ['authorization_code'] })
+    );
+
+    expect(metadata.grant_types).toEqual(['authorization_code']);
+    expect(metadata.response_types).toBeUndefined();
+  });
+
+  it('falls back to server defaults when nothing overlaps', () => {
+    let metadata = buildClientRegistrationMetadata(
+      config({ grant_types_supported: ['client_credentials'] })
+    );
+
+    expect(metadata.grant_types).toBeUndefined();
+  });
+
+  it('registers as a public client when secrets are unsupported', () => {
+    let metadata = buildClientRegistrationMetadata(
+      config({ token_endpoint_auth_methods_supported: ['none'] })
+    );
+
+    expect(metadata.token_endpoint_auth_method).toBe('none');
+  });
+
+  it('keeps client_secret_basic when the server advertises no auth methods', () => {
+    expect(buildClientRegistrationMetadata(config()).token_endpoint_auth_method).toBe(
+      'client_secret_basic'
+    );
+  });
+});

--- a/src/shuttle/service/src/lib/oauth/clientRegistrationMetadata.ts
+++ b/src/shuttle/service/src/lib/oauth/clientRegistrationMetadata.ts
@@ -1,0 +1,30 @@
+import type { OAuthConfiguration } from './types';
+
+// Authorization servers advertise every grant/response type they implement, but a
+// registration endpoint only accepts the ones a client is allowed to register for.
+// We therefore register for the authorization code flow only, and never for extras
+// like device code or jwt-bearer that we never run.
+let usableGrantTypes = ['authorization_code', 'refresh_token'];
+let usableResponseTypes = ['code'];
+let authMethodPreference = ['client_secret_basic', 'client_secret_post', 'none'];
+
+let supportedSubset = (usable: string[], supported: string[] | undefined) => {
+  if (!supported?.length) return undefined;
+
+  let subset = usable.filter(value => supported.includes(value));
+
+  return subset.length ? subset : undefined;
+};
+
+/**
+ * Builds the flow-related client metadata for a dynamic client registration
+ * request. Omitted values fall back to the authorization server's defaults.
+ */
+export let buildClientRegistrationMetadata = (config: OAuthConfiguration) => ({
+  grant_types: supportedSubset(usableGrantTypes, config.grant_types_supported),
+  response_types: supportedSubset(usableResponseTypes, config.response_types_supported),
+  token_endpoint_auth_method:
+    authMethodPreference.find(method =>
+      config.token_endpoint_auth_methods_supported?.includes(method)
+    ) ?? 'client_secret_basic'
+});

--- a/src/shuttle/service/src/lib/oauth/oauthUtils.ts
+++ b/src/shuttle/service/src/lib/oauth/oauthUtils.ts
@@ -14,7 +14,9 @@ import { db } from '../../db';
 import { getId } from '../../id';
 import { getAxiosSsrfFilter } from '../http/axiosSsrf';
 import { assertUrlAllowedByEgressPolicy } from '../network/egressPolicy';
+import { buildClientRegistrationMetadata } from './clientRegistrationMetadata';
 import { normalizeAuthorizationUrl } from './normalizeAuthorizationUrl';
+import { isTransientRegistrationError } from './registrationRetry';
 import {
   type OAuthConfiguration,
   type RegistrationResponse,
@@ -352,7 +354,8 @@ export class OAuthUtils {
   static async registerClient({
     tenant,
     config,
-    owner
+    owner,
+    captureErrors = true
   }: {
     tenant: Tenant;
     config: OAuthConfiguration;
@@ -360,6 +363,7 @@ export class OAuthUtils {
       connection?: RemoteOAuthConnection;
       config?: RemoteOAuthConfig;
     };
+    captureErrors?: boolean;
   }) {
     if (!config.registration_endpoint) return null;
 
@@ -371,9 +375,7 @@ export class OAuthUtils {
         {
           client_name: clientName,
           redirect_uris: [oauthCallbackUrl],
-          grant_types: config.grant_types_supported,
-          response_types: config.response_types_supported,
-          token_endpoint_auth_method: 'client_secret_basic'
+          ...buildClientRegistrationMetadata(config)
         },
         {
           headers: {
@@ -433,6 +435,8 @@ export class OAuthUtils {
         registration: reg
       };
     } catch (error: any) {
+      let status = typeof error?.response?.status == 'number' ? error.response.status : null;
+
       let err = await db.remoteOAuthRegistrationError.create({
         data: {
           ...getId('remoteOAuthRegistrationError'),
@@ -446,16 +450,21 @@ export class OAuthUtils {
         }
       });
 
-      Sentry.captureException(error, {
-        extra: {
-          registrationEndpoint: config.registration_endpoint,
-          tenantId: tenant.id
-        }
-      });
+      if (captureErrors) {
+        Sentry.captureException(error, {
+          extra: {
+            registrationEndpoint: config.registration_endpoint,
+            tenantId: tenant.id,
+            status
+          }
+        });
+      }
 
       return {
         ok: false as const,
-        error: err
+        error: err,
+        status,
+        isTransient: isTransientRegistrationError({ status })
       };
     }
   }

--- a/src/shuttle/service/src/lib/oauth/registrationRetry.test.ts
+++ b/src/shuttle/service/src/lib/oauth/registrationRetry.test.ts
@@ -1,0 +1,85 @@
+import { subDays, subHours } from 'date-fns';
+import { describe, expect, it } from 'vitest';
+import {
+  getRegistrationBlocker,
+  isStaleRegistration,
+  isTransientRegistrationError,
+  MAX_REGISTRATION_ATTEMPTS
+} from './registrationRetry';
+
+let connection = (partial: Partial<Parameters<typeof getRegistrationBlocker>[0]['connection']> = {}) => ({
+  status: 'active' as const,
+  discoveryStatus: 'failed' as const,
+  registrationOid: null,
+  secretOid: null,
+  registrationAttemptCount: 0,
+  ...partial
+});
+
+let blocker = (
+  partial: Partial<Parameters<typeof getRegistrationBlocker>[0]['connection']> = {},
+  counts: { boundTokenCount?: number; boundAuthConfigCount?: number } = {}
+) =>
+  getRegistrationBlocker({
+    connection: connection(partial),
+    boundTokenCount: counts.boundTokenCount ?? 0,
+    boundAuthConfigCount: counts.boundAuthConfigCount ?? 0
+  });
+
+describe('getRegistrationBlocker', () => {
+  it('allows a failed connection without credentials', () => {
+    expect(blocker()).toBeNull();
+  });
+
+  it('refuses connections that already have a registered client', () => {
+    expect(blocker({ registrationOid: 1n })).toBe('already_registered');
+  });
+
+  it('refuses connections using manually provided credentials', () => {
+    expect(blocker({ secretOid: 1n })).toBe('manual_credentials');
+  });
+
+  it('refuses connections that already have tokens or auth configs bound', () => {
+    expect(blocker({}, { boundTokenCount: 1 })).toBe('has_bound_credentials');
+    expect(blocker({}, { boundAuthConfigCount: 1 })).toBe('has_bound_credentials');
+  });
+
+  it('refuses inactive and already succeeded connections', () => {
+    expect(blocker({ status: 'inactive' })).toBe('connection_inactive');
+    expect(blocker({ discoveryStatus: 'succeeded' })).toBe('already_succeeded');
+  });
+
+  it('stops once the attempt budget is used up', () => {
+    expect(blocker({ registrationAttemptCount: MAX_REGISTRATION_ATTEMPTS - 1 })).toBeNull();
+    expect(blocker({ registrationAttemptCount: MAX_REGISTRATION_ATTEMPTS })).toBe(
+      'attempts_exhausted'
+    );
+  });
+});
+
+describe('isStaleRegistration', () => {
+  it('treats registrations older than three days as stale', () => {
+    expect(isStaleRegistration({ createdAt: subDays(new Date(), 4) })).toBe(true);
+  });
+
+  it('keeps recent registrations', () => {
+    expect(isStaleRegistration({ createdAt: subHours(new Date(), 12) })).toBe(false);
+    expect(isStaleRegistration({ createdAt: subDays(new Date(), 2) })).toBe(false);
+  });
+});
+
+describe('isTransientRegistrationError', () => {
+  it('treats missing responses, rate limits and server errors as transient', () => {
+    expect(isTransientRegistrationError({ status: null })).toBe(true);
+    expect(isTransientRegistrationError({})).toBe(true);
+    expect(isTransientRegistrationError({ status: 429 })).toBe(true);
+    expect(isTransientRegistrationError({ status: 500 })).toBe(true);
+    expect(isTransientRegistrationError({ status: 503 })).toBe(true);
+  });
+
+  it('treats provider validation errors as permanent', () => {
+    expect(isTransientRegistrationError({ status: 400 })).toBe(false);
+    expect(isTransientRegistrationError({ status: 401 })).toBe(false);
+    expect(isTransientRegistrationError({ status: 404 })).toBe(false);
+  });
+});

--- a/src/shuttle/service/src/lib/oauth/registrationRetry.ts
+++ b/src/shuttle/service/src/lib/oauth/registrationRetry.ts
@@ -1,0 +1,68 @@
+import { addHours, addDays } from 'date-fns';
+import type {
+  RemoteOAuthConnectionDiscoveryStatus,
+  RemoteOAuthConnectionStatus
+} from '../../../prisma/generated/client';
+
+/** Auto-registration is retried once per cron run until this many attempts failed. */
+export let MAX_REGISTRATION_ATTEMPTS = 10;
+
+/** Slightly below 24h so a daily cron never skips a connection because of drift. */
+export let REGISTRATION_RETRY_INTERVAL_HOURS = 20;
+
+/** Age at which an auto-registered client is replaced on the next deployment. */
+export let STALE_REGISTRATION_DAYS = 3;
+
+export let getRegistrationRetryCutoff = (now = new Date()) =>
+  addHours(now, -REGISTRATION_RETRY_INTERVAL_HOURS);
+
+export let getStaleRegistrationCutoff = (now = new Date()) =>
+  addDays(now, -STALE_REGISTRATION_DAYS);
+
+export let isStaleRegistration = (registration: { createdAt: Date }, now = new Date()) =>
+  registration.createdAt.getTime() < getStaleRegistrationCutoff(now).getTime();
+
+/**
+ * Transient failures are worth retrying, permanent ones (invalid client
+ * metadata, unsupported registration) will fail the same way every time.
+ */
+export let isTransientRegistrationError = (d: { status?: number | null }) => {
+  if (d.status == null) return true;
+  if (d.status == 408 || d.status == 425 || d.status == 429) return true;
+  return d.status >= 500;
+};
+
+export type RegistrationBlocker =
+  | 'connection_inactive'
+  | 'already_succeeded'
+  | 'already_registered'
+  | 'manual_credentials'
+  | 'has_bound_credentials'
+  | 'attempts_exhausted';
+
+/**
+ * Re-registering a connection swaps the client the provider knows about, which
+ * would break every token that was issued to the previous client. Only
+ * connections without any bound credentials may be registered.
+ */
+export let getRegistrationBlocker = (d: {
+  connection: {
+    status: RemoteOAuthConnectionStatus;
+    discoveryStatus: RemoteOAuthConnectionDiscoveryStatus;
+    registrationOid: bigint | null;
+    secretOid: bigint | null;
+    registrationAttemptCount: number;
+  };
+  boundTokenCount: number;
+  boundAuthConfigCount: number;
+}): RegistrationBlocker | null => {
+  if (d.connection.status != 'active') return 'connection_inactive';
+  if (d.connection.discoveryStatus == 'succeeded') return 'already_succeeded';
+  if (d.connection.registrationOid != null) return 'already_registered';
+  if (d.connection.secretOid != null) return 'manual_credentials';
+  if (d.boundTokenCount > 0 || d.boundAuthConfigCount > 0) return 'has_bound_credentials';
+  if (d.connection.registrationAttemptCount >= MAX_REGISTRATION_ATTEMPTS)
+    return 'attempts_exhausted';
+
+  return null;
+};

--- a/src/shuttle/service/src/queues/discovery/remoteOAuthConnection.ts
+++ b/src/shuttle/service/src/queues/discovery/remoteOAuthConnection.ts
@@ -1,6 +1,7 @@
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { env } from '../../env';
 import { remoteOAuthRegistrationService } from '../../services/oauth/remote/registration';
+import { enqueuePromotion } from '../oauth/rotateRemoteCredentials';
 
 export let discoverRemoteOAuthConnectionQueue = createQueue<{ oauthConnectionId: string }>({
   name: 'shut/rem-oaconn/discover',
@@ -13,7 +14,10 @@ export let discoverRemoteOAuthConnectionQueueProcessor =
       connectionId: data.oauthConnectionId
     });
 
-    if (res.ok) return;
+    if (res.ok) {
+      await enqueuePromotion({ connection: res.connection });
+      return;
+    }
 
     if (res.reason == 'not_found') throw new QueueRetryError();
     if (res.reason == 'failed' && res.isTransient) throw new QueueRetryError();

--- a/src/shuttle/service/src/queues/discovery/remoteOAuthConnection.ts
+++ b/src/shuttle/service/src/queues/discovery/remoteOAuthConnection.ts
@@ -1,8 +1,6 @@
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
-import { db } from '../../db';
 import { env } from '../../env';
-import { getId } from '../../id';
-import { OAuthUtils } from '../../lib/oauth/oauthUtils';
+import { remoteOAuthRegistrationService } from '../../services/oauth/remote/registration';
 
 export let discoverRemoteOAuthConnectionQueue = createQueue<{ oauthConnectionId: string }>({
   name: 'shut/rem-oaconn/discover',
@@ -11,75 +9,12 @@ export let discoverRemoteOAuthConnectionQueue = createQueue<{ oauthConnectionId:
 
 export let discoverRemoteOAuthConnectionQueueProcessor =
   discoverRemoteOAuthConnectionQueue.process(async data => {
-    let oauthConnection = await db.remoteOAuthConnection.findFirst({
-      where: { id: data.oauthConnectionId },
-      include: { config: true, tenant: true }
+    let res = await remoteOAuthRegistrationService.runAutoRegistration({
+      connectionId: data.oauthConnectionId
     });
-    if (!oauthConnection) throw new QueueRetryError();
 
-    if (oauthConnection.discoveryStatus == 'succeeded') return;
+    if (res.ok) return;
 
-    if (await OAuthUtils.supportsAuthRegistration(oauthConnection.config.config)) {
-      let reg = await OAuthUtils.registerClient({
-        tenant: oauthConnection.tenant,
-        config: oauthConnection.config.config,
-        owner: {
-          config: oauthConnection.config,
-          connection: oauthConnection
-        }
-      });
-
-      if (reg?.ok) {
-        await db.remoteOAuthConnection.update({
-          where: { id: oauthConnection.id },
-          data: {
-            registrationOid: reg.registration.oid,
-            clientId: reg.registration.clientId,
-            discoveryStatus: 'succeeded'
-          }
-        });
-
-        await db.remoteOAuthConnectionEvent.create({
-          data: {
-            ...getId('remoteOAuthConnectionEvent'),
-            connectionOid: oauthConnection.oid,
-            type: 'auto_registration_succeeded',
-            metadata: {
-              clientId: reg.registration.clientId
-            }
-          }
-        });
-      } else {
-        let inner = (reg?.error.payload as any)?.error || 'unknown_error';
-
-        await db.remoteOAuthConnection.update({
-          where: { id: oauthConnection.id },
-          data: {
-            discoveryStatus: 'failed',
-            errorCode: 'auto_registration_failed',
-            errorMessage: `Failed to auto-register OAuth client for connection: ${inner}`
-          }
-        });
-
-        await db.remoteOAuthConnectionEvent.create({
-          data: {
-            ...getId('remoteOAuthConnectionEvent'),
-            connectionOid: oauthConnection.oid,
-            type: 'auto_registration_failed',
-            metadata: {
-              error: inner
-            }
-          }
-        });
-      }
-    } else {
-      await db.remoteOAuthConnection.update({
-        where: { id: oauthConnection.id },
-        data: {
-          discoveryStatus: 'failed',
-          errorCode: 'auto_registration_unsupported',
-          errorMessage: `OAuth provider does not support auto-registration.`
-        }
-      });
-    }
+    if (res.reason == 'not_found') throw new QueueRetryError();
+    if (res.reason == 'failed' && res.isTransient) throw new QueueRetryError();
   });

--- a/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
+++ b/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
@@ -1,0 +1,94 @@
+import { createCron } from '@lowerdeck/cron';
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '../../db';
+import { env } from '../../env';
+import {
+  getRegistrationRetryCutoff,
+  MAX_REGISTRATION_ATTEMPTS
+} from '../../lib/oauth/registrationRetry';
+import { remoteOAuthRegistrationService } from '../../services/oauth/remote/registration';
+
+let RETRY_BATCH_SIZE = 250;
+
+export let retryFailedRegistrationsCron = createCron(
+  {
+    name: 'shut/rem-oaconn/retry/cron',
+    redisUrl: env.service.REDIS_URL,
+    cron: '0 3 * * *'
+  },
+  async () => {
+    await retryFailedRegistrationsSearchQueue.add({});
+  }
+);
+
+export let retryFailedRegistrationsSearchQueue = createQueue<{
+  cursor?: string;
+  serverId?: string;
+}>({
+  name: 'shut/rem-oaconn/retry/search',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let retryFailedRegistrationsSearchQueueProcessor =
+  retryFailedRegistrationsSearchQueue.process(async data => {
+    let retryCutoff = getRegistrationRetryCutoff();
+
+    let connections = await db.remoteOAuthConnection.findMany({
+      where: {
+        id: data.cursor ? { gt: data.cursor } : undefined,
+        server: data.serverId ? { id: data.serverId } : undefined,
+
+        status: 'active',
+        discoveryStatus: 'failed',
+
+        // Connections with their own client must never be re-registered, doing
+        // so would swap the client out from under any token issued to it.
+        registrationOid: null,
+        secretOid: null,
+
+        registrationAttemptCount: { lt: MAX_REGISTRATION_ATTEMPTS },
+        OR: [
+          { lastRegistrationAttemptAt: null },
+          { lastRegistrationAttemptAt: { lt: retryCutoff } }
+        ],
+
+        config: { discoverStatus: 'supports_auto_registration' }
+      },
+      orderBy: { id: 'asc' },
+      take: RETRY_BATCH_SIZE,
+      select: { id: true }
+    });
+    if (connections.length === 0) return;
+
+    await retryRegistrationQueue.addManyWithOps(
+      connections.map(connection => ({
+        data: { oauthConnectionId: connection.id },
+        opts: { id: `rereg-${connection.id}` }
+      }))
+    );
+
+    if (connections.length < RETRY_BATCH_SIZE) return;
+
+    await retryFailedRegistrationsSearchQueue.add({
+      cursor: connections[connections.length - 1]?.id,
+      serverId: data.serverId
+    });
+  });
+
+export let retryRegistrationQueue = createQueue<{ oauthConnectionId: string }>({
+  name: 'shut/rem-oaconn/retry/single',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: { concurrency: 5, limiter: { max: 10, duration: 1000 } }
+});
+
+export let retryRegistrationQueueProcessor = retryRegistrationQueue.process(async data => {
+  let res = await remoteOAuthRegistrationService.runAutoRegistration({
+    connectionId: data.oauthConnectionId
+  });
+
+  if (res.ok) return;
+
+  // A connection that is gone or no longer eligible is not an error, the next
+  // cron run reconsiders it.
+  if (res.reason == 'failed' && res.isTransient) throw new QueueRetryError();
+});

--- a/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
+++ b/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
@@ -7,6 +7,7 @@ import {
   MAX_REGISTRATION_ATTEMPTS
 } from '../../lib/oauth/registrationRetry';
 import { remoteOAuthRegistrationService } from '../../services/oauth/remote/registration';
+import { enqueuePromotion } from '../oauth/rotateRemoteCredentials';
 
 let RETRY_BATCH_SIZE = 250;
 
@@ -86,7 +87,10 @@ export let retryRegistrationQueueProcessor = retryRegistrationQueue.process(asyn
     connectionId: data.oauthConnectionId
   });
 
-  if (res.ok) return;
+  if (res.ok) {
+    await enqueuePromotion({ connection: res.connection });
+    return;
+  }
 
   // A connection that is gone or no longer eligible is not an error, the next
   // cron run reconsiders it.

--- a/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.test.ts
+++ b/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.test.ts
@@ -1,0 +1,273 @@
+import { subDays, subHours } from 'date-fns';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { queues, dbMock, createConnection, QueueRetryError } = vi.hoisted(() => ({
+  queues: {} as Record<string, any>,
+  QueueRetryError: class QueueRetryError extends Error {},
+  dbMock: {
+    serverOAuthCredentials: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn()
+    },
+    remoteOAuthConnection: {
+      findFirst: vi.fn(),
+      updateMany: vi.fn()
+    },
+    remoteOAuthConfig: {
+      findUniqueOrThrow: vi.fn()
+    },
+    remoteOAuthConnectionEvent: {
+      upsert: vi.fn()
+    }
+  },
+  createConnection: vi.fn()
+}));
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError,
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      addManyWithOps: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as any
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('@lowerdeck/lock', () => ({
+  createLock: () => ({
+    usingLock: (_key: string, fn: (controller: { passForNow: () => void }) => Promise<unknown>) =>
+      fn({ passForNow: () => {} })
+  })
+}));
+
+vi.mock('../../db', () => ({ db: dbMock }));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+vi.mock('../../id', () => ({
+  getId: () => ({ oid: 1n, id: 'event_id' })
+}));
+
+vi.mock('../../transaction', () => ({
+  withTransaction: (cb: (db: unknown) => Promise<unknown>) => cb(dbMock)
+}));
+
+vi.mock('../../services/oauth/remote/connection', () => ({
+  remoteOAuthConnectionService: { createConnection }
+}));
+
+import './rotateRemoteCredentials';
+
+let rotateProcessor = () => queues['shut/rem-oaconn/rotate/single'].processor;
+let promoteProcessor = () => queues['shut/rem-oaconn/rotate/promote'].processor;
+let promoteQueue = () => queues['shut/rem-oaconn/rotate/promote'];
+
+let previousCredentials = (registrationCreatedAt: Date) => ({
+  oid: 100n,
+  id: 'soc_previous',
+  isDefault: true,
+  tenantOid: 2n,
+  serverOid: 3n,
+  tenant: { oid: 2n, id: 'ten_test' },
+  server: { oid: 3n, id: 'srv_test', remoteOauthConfigOid: 4n },
+  remoteConnection: {
+    oid: 10n,
+    id: 'cso_previous',
+    status: 'active',
+    discoveryStatus: 'succeeded',
+    secretOid: null,
+    registrationOid: 20n,
+    scopes: ['openid'],
+    registration: { oid: 20n, createdAt: registrationCreatedAt }
+  }
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('rotateStaleCredentialsQueueProcessor', () => {
+  it('replaces a stale registration with a new connection', async () => {
+    let credentials = previousCredentials(subDays(new Date(), 5));
+
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(credentials)
+      .mockResolvedValueOnce(credentials);
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(null);
+    dbMock.remoteOAuthConfig.findUniqueOrThrow.mockResolvedValue({
+      oid: 4n,
+      discoverStatus: 'supports_auto_registration'
+    });
+    createConnection.mockResolvedValue({
+      oid: 11n,
+      id: 'cso_replacement',
+      serverOAuthCredentials: { oid: 101n, id: 'soc_replacement' }
+    });
+
+    await rotateProcessor()({ credentialsId: 'soc_previous' });
+
+    expect(createConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ scopes: ['openid'] })
+      })
+    );
+    expect(promoteQueue().add).toHaveBeenCalledWith(
+      { newCredentialsId: 'soc_replacement', previousCredentialsId: 'soc_previous' },
+      expect.objectContaining({ delay: 5000 })
+    );
+  });
+
+  it('leaves recent registrations alone', async () => {
+    let credentials = previousCredentials(subHours(new Date(), 6));
+
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(credentials)
+      .mockResolvedValueOnce(credentials);
+
+    await rotateProcessor()({ credentialsId: 'soc_previous' });
+
+    expect(createConnection).not.toHaveBeenCalled();
+    expect(promoteQueue().add).not.toHaveBeenCalled();
+  });
+
+  it('skips when a replacement is already in flight', async () => {
+    let credentials = previousCredentials(subDays(new Date(), 5));
+
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(credentials)
+      .mockResolvedValueOnce(credentials);
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue({ oid: 11n });
+
+    await rotateProcessor()({ credentialsId: 'soc_previous' });
+
+    expect(createConnection).not.toHaveBeenCalled();
+  });
+
+  it('does not replace manually configured credentials', async () => {
+    let credentials = previousCredentials(subDays(new Date(), 5));
+    credentials.remoteConnection.secretOid = 9n as any;
+
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(credentials)
+      .mockResolvedValueOnce(credentials);
+
+    await rotateProcessor()({ credentialsId: 'soc_previous' });
+
+    expect(createConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('promoteRotatedCredentialsQueueProcessor', () => {
+  let newCredentials = (discoveryStatus: string, registrationAttemptCount = 1) => ({
+    oid: 101n,
+    id: 'soc_replacement',
+    tenantOid: 2n,
+    serverOid: 3n,
+    remoteConnection: {
+      oid: 11n,
+      id: 'cso_replacement',
+      status: 'active',
+      discoveryStatus,
+      registrationAttemptCount,
+      clientId: 'new-client-id',
+      errorCode: 'auto_registration_failed',
+      errorMessage: 'nope'
+    }
+  });
+
+  it('waits while the replacement is still registering', async () => {
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(newCredentials('discovering'))
+      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+
+    await expect(
+      promoteProcessor()({
+        newCredentialsId: 'soc_replacement',
+        previousCredentialsId: 'soc_previous'
+      })
+    ).rejects.toBeInstanceOf(QueueRetryError);
+
+    expect(dbMock.serverOAuthCredentials.update).not.toHaveBeenCalled();
+    expect(dbMock.serverOAuthCredentials.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('keeps waiting while only transient failures were recorded', async () => {
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(newCredentials('failed', 0))
+      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+
+    await expect(
+      promoteProcessor()({
+        newCredentialsId: 'soc_replacement',
+        previousCredentialsId: 'soc_previous'
+      })
+    ).rejects.toBeInstanceOf(QueueRetryError);
+
+    expect(dbMock.remoteOAuthConnection.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('promotes the replacement once registration succeeded', async () => {
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(newCredentials('succeeded'))
+      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+
+    await promoteProcessor()({
+      newCredentialsId: 'soc_replacement',
+      previousCredentialsId: 'soc_previous'
+    });
+
+    expect(dbMock.serverOAuthCredentials.updateMany).toHaveBeenCalledWith({
+      where: {
+        tenantOid: 2n,
+        serverOid: 3n,
+        isDefault: true,
+        oid: { not: 101n }
+      },
+      data: { isDefault: false }
+    });
+    expect(dbMock.serverOAuthCredentials.update).toHaveBeenCalledWith({
+      where: { oid: 101n },
+      data: { isDefault: true }
+    });
+    // The replaced connection stays active so its auth configs keep refreshing.
+    expect(dbMock.remoteOAuthConnection.updateMany).not.toHaveBeenCalled();
+    expect(dbMock.remoteOAuthConnectionEvent.upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the previous default when the replacement fails to register', async () => {
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(newCredentials('failed'))
+      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+
+    await promoteProcessor()({
+      newCredentialsId: 'soc_replacement',
+      previousCredentialsId: 'soc_previous'
+    });
+
+    expect(dbMock.serverOAuthCredentials.update).not.toHaveBeenCalled();
+    expect(dbMock.serverOAuthCredentials.updateMany).not.toHaveBeenCalled();
+    expect(dbMock.remoteOAuthConnection.updateMany).toHaveBeenCalledWith({
+      where: { oid: 11n, status: 'active' },
+      data: { status: 'inactive' }
+    });
+    expect(dbMock.remoteOAuthConnectionEvent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          connectionOid: 10n,
+          type: 'credentials_rotated'
+        })
+      })
+    );
+  });
+});

--- a/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.test.ts
+++ b/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.test.ts
@@ -7,6 +7,7 @@ let { queues, dbMock, createConnection, QueueRetryError } = vi.hoisted(() => ({
   dbMock: {
     serverOAuthCredentials: {
       findMany: vi.fn(),
+      findFirst: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn()
@@ -93,6 +94,21 @@ let previousCredentials = (registrationCreatedAt: Date) => ({
   }
 });
 
+let replacementConnection = (d: {
+  discoveryStatus: string;
+  registrationAttemptCount?: number;
+}) => ({
+  oid: 11n,
+  id: 'cso_replacement',
+  status: 'active',
+  discoveryStatus: d.discoveryStatus,
+  registrationAttemptCount: d.registrationAttemptCount ?? 0,
+  rotatedFromOid: 10n,
+  errorCode: null,
+  errorMessage: null,
+  serverOAuthCredentials: { oid: 101n, id: 'soc_replacement' }
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -112,18 +128,91 @@ describe('rotateStaleCredentialsQueueProcessor', () => {
     createConnection.mockResolvedValue({
       oid: 11n,
       id: 'cso_replacement',
+      rotatedFromOid: 10n,
       serverOAuthCredentials: { oid: 101n, id: 'soc_replacement' }
     });
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({ id: 'soc_replacement' });
 
     await rotateProcessor()({ credentialsId: 'soc_previous' });
 
     expect(createConnection).toHaveBeenCalledWith(
       expect.objectContaining({
-        input: expect.objectContaining({ scopes: ['openid'] })
+        input: expect.objectContaining({ scopes: ['openid'], rotatedFromOid: 10n })
       })
     );
     expect(promoteQueue().add).toHaveBeenCalledWith(
-      { newCredentialsId: 'soc_replacement', previousCredentialsId: 'soc_previous' },
+      { newCredentialsId: 'soc_replacement' },
+      expect.objectContaining({ delay: 5000 })
+    );
+  });
+
+  it('promotes a replacement that was left behind instead of registering another client', async () => {
+    let credentials = previousCredentials(subDays(new Date(), 5));
+
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(credentials)
+      .mockResolvedValueOnce(credentials);
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
+      replacementConnection({ discoveryStatus: 'succeeded' })
+    );
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({ id: 'soc_replacement' });
+
+    await rotateProcessor()({ credentialsId: 'soc_previous' });
+
+    expect(createConnection).not.toHaveBeenCalled();
+    expect(promoteQueue().add).toHaveBeenCalledWith(
+      { newCredentialsId: 'soc_replacement' },
+      expect.objectContaining({ delay: 5000 })
+    );
+  });
+
+  it('waits for a failed replacement that still has retries left', async () => {
+    let credentials = previousCredentials(subDays(new Date(), 5));
+
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(credentials)
+      .mockResolvedValueOnce(credentials);
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
+      replacementConnection({ discoveryStatus: 'failed', registrationAttemptCount: 3 })
+    );
+
+    await rotateProcessor()({ credentialsId: 'soc_previous' });
+
+    expect(createConnection).not.toHaveBeenCalled();
+    expect(promoteQueue().add).not.toHaveBeenCalled();
+    expect(dbMock.remoteOAuthConnection.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('retires an exhausted replacement and registers a new one', async () => {
+    let credentials = previousCredentials(subDays(new Date(), 5));
+
+    dbMock.serverOAuthCredentials.findUnique
+      .mockResolvedValueOnce(credentials)
+      .mockResolvedValueOnce(credentials);
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
+      replacementConnection({ discoveryStatus: 'failed', registrationAttemptCount: 10 })
+    );
+    dbMock.remoteOAuthConfig.findUniqueOrThrow.mockResolvedValue({
+      oid: 4n,
+      discoverStatus: 'supports_auto_registration'
+    });
+    createConnection.mockResolvedValue({
+      oid: 12n,
+      id: 'cso_replacement_2',
+      rotatedFromOid: 10n,
+      serverOAuthCredentials: { oid: 102n, id: 'soc_replacement_2' }
+    });
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({ id: 'soc_replacement_2' });
+
+    await rotateProcessor()({ credentialsId: 'soc_previous' });
+
+    expect(dbMock.remoteOAuthConnection.updateMany).toHaveBeenCalledWith({
+      where: { oid: 11n, status: 'active' },
+      data: { status: 'inactive' }
+    });
+    expect(createConnection).toHaveBeenCalledTimes(1);
+    expect(promoteQueue().add).toHaveBeenCalledWith(
+      { newCredentialsId: 'soc_replacement_2' },
       expect.objectContaining({ delay: 5000 })
     );
   });
@@ -147,7 +236,10 @@ describe('rotateStaleCredentialsQueueProcessor', () => {
     dbMock.serverOAuthCredentials.findUnique
       .mockResolvedValueOnce(credentials)
       .mockResolvedValueOnce(credentials);
-    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue({ oid: 11n });
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
+      replacementConnection({ discoveryStatus: 'discovering' })
+    );
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({ id: 'soc_replacement' });
 
     await rotateProcessor()({ credentialsId: 'soc_previous' });
 
@@ -169,9 +261,10 @@ describe('rotateStaleCredentialsQueueProcessor', () => {
 });
 
 describe('promoteRotatedCredentialsQueueProcessor', () => {
-  let newCredentials = (discoveryStatus: string, registrationAttemptCount = 1) => ({
+  let newCredentials = (discoveryStatus: string, registrationAttemptCount = 10) => ({
     oid: 101n,
     id: 'soc_replacement',
+    isDefault: false,
     tenantOid: 2n,
     serverOid: 3n,
     remoteConnection: {
@@ -182,50 +275,72 @@ describe('promoteRotatedCredentialsQueueProcessor', () => {
       registrationAttemptCount,
       clientId: 'new-client-id',
       errorCode: 'auto_registration_failed',
-      errorMessage: 'nope'
+      errorMessage: 'nope',
+      rotatedFromOid: 10n,
+      rotatedFrom: { oid: 10n, id: 'cso_previous' }
     }
   });
 
+  let currentDefaultIsPrevious = () =>
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({
+      oid: 100n,
+      remoteConnectionOid: 10n
+    });
+
   it('waits while the replacement is still registering', async () => {
-    dbMock.serverOAuthCredentials.findUnique
-      .mockResolvedValueOnce(newCredentials('discovering'))
-      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+    dbMock.serverOAuthCredentials.findUnique.mockResolvedValueOnce(newCredentials('discovering'));
 
     await expect(
-      promoteProcessor()({
-        newCredentialsId: 'soc_replacement',
-        previousCredentialsId: 'soc_previous'
-      })
+      promoteProcessor()({ newCredentialsId: 'soc_replacement' })
     ).rejects.toBeInstanceOf(QueueRetryError);
 
     expect(dbMock.serverOAuthCredentials.update).not.toHaveBeenCalled();
     expect(dbMock.serverOAuthCredentials.updateMany).not.toHaveBeenCalled();
   });
 
-  it('keeps waiting while only transient failures were recorded', async () => {
-    dbMock.serverOAuthCredentials.findUnique
-      .mockResolvedValueOnce(newCredentials('failed', 0))
-      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+  it('leaves a failed replacement to the retry queue while it has retries left', async () => {
+    dbMock.serverOAuthCredentials.findUnique.mockResolvedValueOnce(newCredentials('failed', 3));
 
-    await expect(
-      promoteProcessor()({
-        newCredentialsId: 'soc_replacement',
-        previousCredentialsId: 'soc_previous'
-      })
-    ).rejects.toBeInstanceOf(QueueRetryError);
+    await promoteProcessor()({ newCredentialsId: 'soc_replacement' });
 
     expect(dbMock.remoteOAuthConnection.updateMany).not.toHaveBeenCalled();
+    expect(dbMock.serverOAuthCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('does not promote credentials the tenant created itself', async () => {
+    let credentials = newCredentials('succeeded');
+    credentials.remoteConnection.rotatedFromOid = null as any;
+    credentials.remoteConnection.rotatedFrom = null as any;
+
+    dbMock.serverOAuthCredentials.findUnique.mockResolvedValueOnce(credentials);
+
+    await promoteProcessor()({ newCredentialsId: 'soc_replacement' });
+
+    expect(dbMock.serverOAuthCredentials.update).not.toHaveBeenCalled();
+    expect(dbMock.serverOAuthCredentials.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('retires the replacement when the default moved on in the meantime', async () => {
+    dbMock.serverOAuthCredentials.findUnique.mockResolvedValueOnce(newCredentials('succeeded'));
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({
+      oid: 200n,
+      remoteConnectionOid: 30n
+    });
+
+    await promoteProcessor()({ newCredentialsId: 'soc_replacement' });
+
+    expect(dbMock.serverOAuthCredentials.update).not.toHaveBeenCalled();
+    expect(dbMock.remoteOAuthConnection.updateMany).toHaveBeenCalledWith({
+      where: { oid: 11n, status: 'active' },
+      data: { status: 'inactive' }
+    });
   });
 
   it('promotes the replacement once registration succeeded', async () => {
-    dbMock.serverOAuthCredentials.findUnique
-      .mockResolvedValueOnce(newCredentials('succeeded'))
-      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+    dbMock.serverOAuthCredentials.findUnique.mockResolvedValueOnce(newCredentials('succeeded'));
+    currentDefaultIsPrevious();
 
-    await promoteProcessor()({
-      newCredentialsId: 'soc_replacement',
-      previousCredentialsId: 'soc_previous'
-    });
+    await promoteProcessor()({ newCredentialsId: 'soc_replacement' });
 
     expect(dbMock.serverOAuthCredentials.updateMany).toHaveBeenCalledWith({
       where: {
@@ -246,14 +361,9 @@ describe('promoteRotatedCredentialsQueueProcessor', () => {
   });
 
   it('keeps the previous default when the replacement fails to register', async () => {
-    dbMock.serverOAuthCredentials.findUnique
-      .mockResolvedValueOnce(newCredentials('failed'))
-      .mockResolvedValueOnce(previousCredentials(subDays(new Date(), 5)));
+    dbMock.serverOAuthCredentials.findUnique.mockResolvedValueOnce(newCredentials('failed'));
 
-    await promoteProcessor()({
-      newCredentialsId: 'soc_replacement',
-      previousCredentialsId: 'soc_previous'
-    });
+    await promoteProcessor()({ newCredentialsId: 'soc_replacement' });
 
     expect(dbMock.serverOAuthCredentials.update).not.toHaveBeenCalled();
     expect(dbMock.serverOAuthCredentials.updateMany).not.toHaveBeenCalled();

--- a/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.ts
+++ b/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.ts
@@ -1,12 +1,12 @@
 import { createLock } from '@lowerdeck/lock';
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
-import { subHours } from 'date-fns';
 import { db } from '../../db';
 import { env } from '../../env';
 import { getId } from '../../id';
 import {
   getStaleRegistrationCutoff,
-  isStaleRegistration
+  isStaleRegistration,
+  MAX_REGISTRATION_ATTEMPTS
 } from '../../lib/oauth/registrationRetry';
 import { remoteOAuthConnectionService } from '../../services/oauth/remote/connection';
 import { withTransaction } from '../../transaction';
@@ -111,20 +111,30 @@ export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.pr
         if (connection.secretOid != null) return;
         if (!isStaleRegistration(connection.registration)) return;
 
-        let pendingReplacement = await db.remoteOAuthConnection.findFirst({
+        // An earlier rotation may have left a replacement behind, for example
+        // when its promotion job ran out of attempts. Those are picked up again
+        // instead of registering yet another client.
+        let existingReplacement = await db.remoteOAuthConnection.findFirst({
           where: {
-            oid: { not: connection.oid },
-            serverOid: credentials.serverOid,
-            tenantOid: credentials.tenantOid,
-            status: 'active',
-            secretOid: null,
-            discoveryStatus: { in: ['discovering', 'succeeded'] },
-            createdAt: { gt: subHours(new Date(), 1) },
-            serverOAuthCredentials: { isDefault: false }
+            rotatedFromOid: connection.oid,
+            status: 'active'
           },
-          select: { oid: true }
+          include: { serverOAuthCredentials: true },
+          orderBy: { oid: 'desc' }
         });
-        if (pendingReplacement) return;
+
+        if (existingReplacement) {
+          if (existingReplacement.discoveryStatus != 'failed') {
+            await enqueuePromotion({ connection: existingReplacement });
+            return;
+          }
+
+          // The replacement can still be registered by the retry queue, which
+          // enqueues the promotion itself once it succeeds.
+          if (existingReplacement.registrationAttemptCount < MAX_REGISTRATION_ATTEMPTS) return;
+
+          await retireReplacement({ connection: existingReplacement, previousConnection: connection });
+        }
 
         let config = await db.remoteOAuthConfig.findUniqueOrThrow({
           where: { oid: credentials.server.remoteOauthConfigOid! }
@@ -135,18 +145,13 @@ export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.pr
           tenant: credentials.tenant,
           input: {
             config,
-            scopes: connection.scopes
+            scopes: connection.scopes,
+            rotatedFromOid: connection.oid
           }
         });
         if (!replacement.serverOAuthCredentials) return;
 
-        await promoteRotatedCredentialsQueue.add(
-          {
-            newCredentialsId: replacement.serverOAuthCredentials.id,
-            previousCredentialsId: current.id
-          },
-          { delay: 5000, id: `prom-${replacement.serverOAuthCredentials.id}` }
-        );
+        await enqueuePromotion({ connection: replacement });
       }
     );
   }
@@ -154,7 +159,6 @@ export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.pr
 
 export let promoteRotatedCredentialsQueue = createQueue<{
   newCredentialsId: string;
-  previousCredentialsId: string;
 }>({
   name: 'shut/rem-oaconn/rotate/promote',
   redisUrl: env.service.REDIS_URL,
@@ -165,92 +169,148 @@ export let promoteRotatedCredentialsQueueProcessor = promoteRotatedCredentialsQu
   async data => {
     let newCredentials = await db.serverOAuthCredentials.findUnique({
       where: { id: data.newCredentialsId },
-      include: { remoteConnection: true }
+      include: { remoteConnection: { include: { rotatedFrom: true } } }
     });
     if (!newCredentials?.remoteConnection) return;
-
-    let previousCredentials = await db.serverOAuthCredentials.findUnique({
-      where: { id: data.previousCredentialsId },
-      include: { remoteConnection: true }
-    });
+    if (newCredentials.isDefault) return;
 
     let newConnection = newCredentials.remoteConnection;
-    let previousConnection = previousCredentials?.remoteConnection;
+    let previousConnection = newConnection.rotatedFrom;
+
+    // Only connections created by a rotation are ever promoted, credentials the
+    // tenant created itself must keep the role it gave them.
+    if (!previousConnection) return;
+    if (newConnection.status != 'active') return;
 
     // Registration is still running, wait for it with the queue's backoff.
     if (newConnection.discoveryStatus == 'discovering') throw new QueueRetryError();
 
     if (newConnection.discoveryStatus == 'failed') {
-      // Transient provider failures do not spend the retry budget, so a
-      // replacement without a counted attempt is still being retried.
-      if (newConnection.registrationAttemptCount == 0) throw new QueueRetryError();
+      // The retry queue keeps working on the replacement until its budget is
+      // spent, and enqueues this job again once registration succeeds. Waiting
+      // here instead would outlive the job's own attempts.
+      if (newConnection.registrationAttemptCount < MAX_REGISTRATION_ATTEMPTS) return;
 
-      // The previous credentials keep working, so a failed rotation is not an
-      // error. The replacement is retired so nothing can pick it up later.
-      await db.remoteOAuthConnection.updateMany({
-        where: { oid: newConnection.oid, status: 'active' },
-        data: { status: 'inactive' }
-      });
-
-      if (previousConnection) {
-        await recordRotationEvent({
-          connectionOid: previousConnection.oid,
-          discriminator: newConnection.id,
-          metadata: {
-            status: 'failed',
-            replacementConnectionId: newConnection.id,
-            errorCode: newConnection.errorCode,
-            errorMessage: newConnection.errorMessage
-          }
-        });
-      }
+      await retireReplacement({ connection: newConnection, previousConnection });
 
       return;
     }
 
-    await withTransaction(async db => {
-      await db.serverOAuthCredentials.updateMany({
-        where: {
-          tenantOid: newCredentials.tenantOid,
-          serverOid: newCredentials.serverOid,
-          isDefault: true,
-          oid: { not: newCredentials.oid }
-        },
-        data: { isDefault: false }
-      });
-
-      await db.serverOAuthCredentials.update({
-        where: { oid: newCredentials.oid },
-        data: { isDefault: true }
-      });
-    });
-
-    // Existing auth configs stay bound to the previous connection and keep
-    // refreshing with the client they were authorized against.
-    await recordRotationEvent({
-      connectionOid: newConnection.oid,
-      discriminator: previousConnection?.id ?? newConnection.id,
-      metadata: {
-        status: 'succeeded',
-        role: 'replacement',
-        previousConnectionId: previousConnection?.id ?? null,
-        clientId: newConnection.clientId
-      }
-    });
-
-    if (previousConnection) {
-      await recordRotationEvent({
-        connectionOid: previousConnection.oid,
-        discriminator: newConnection.id,
-        metadata: {
-          status: 'succeeded',
-          role: 'replaced',
-          replacementConnectionId: newConnection.id
-        }
-      });
-    }
+    await rotationLock.usingLock(`${newCredentials.tenantOid}-${newCredentials.serverOid}`, () =>
+      promoteCredentials({ newCredentials, newConnection, previousConnection })
+    );
   }
 );
+
+let promoteCredentials = async (d: {
+  newCredentials: { oid: bigint; tenantOid: bigint; serverOid: bigint };
+  newConnection: { oid: bigint; id: string; clientId: string | null };
+  previousConnection: { oid: bigint; id: string };
+}) => {
+  let { newCredentials, newConnection, previousConnection } = d;
+
+  let currentDefault = await db.serverOAuthCredentials.findFirst({
+    where: {
+      tenantOid: newCredentials.tenantOid,
+      serverOid: newCredentials.serverOid,
+      isDefault: true
+    },
+    select: { oid: true, remoteConnectionOid: true }
+  });
+  if (currentDefault?.oid == newCredentials.oid) return;
+
+  // The default moved on while the replacement was being registered, so the
+  // rotation is obsolete and its client must not take over.
+  if (currentDefault?.remoteConnectionOid != previousConnection.oid) {
+    await retireReplacement({ connection: newConnection, previousConnection: null });
+
+    return;
+  }
+
+  await withTransaction(async db => {
+    await db.serverOAuthCredentials.updateMany({
+      where: {
+        tenantOid: newCredentials.tenantOid,
+        serverOid: newCredentials.serverOid,
+        isDefault: true,
+        oid: { not: newCredentials.oid }
+      },
+      data: { isDefault: false }
+    });
+
+    await db.serverOAuthCredentials.update({
+      where: { oid: newCredentials.oid },
+      data: { isDefault: true }
+    });
+  });
+
+  // Existing auth configs stay bound to the previous connection and keep
+  // refreshing with the client they were authorized against.
+  await recordRotationEvent({
+    connectionOid: newConnection.oid,
+    discriminator: previousConnection.id,
+    metadata: {
+      status: 'succeeded',
+      role: 'replacement',
+      previousConnectionId: previousConnection.id,
+      clientId: newConnection.clientId
+    }
+  });
+
+  await recordRotationEvent({
+    connectionOid: previousConnection.oid,
+    discriminator: newConnection.id,
+    metadata: {
+      status: 'succeeded',
+      role: 'replaced',
+      replacementConnectionId: newConnection.id
+    }
+  });
+};
+
+// Called whenever a connection finishes registering, so a replacement is still
+// promoted when its original promotion job ran out of attempts.
+export let enqueuePromotion = async (d: {
+  connection: { oid: bigint; rotatedFromOid: bigint | null };
+}) => {
+  if (!d.connection.rotatedFromOid) return;
+
+  let credentials = await db.serverOAuthCredentials.findFirst({
+    where: { remoteConnectionOid: d.connection.oid, isDefault: false },
+    select: { id: true }
+  });
+  if (!credentials) return;
+
+  // Deliberately without a job id: a permanently failed promotion stays in the
+  // failed set for a day and would swallow the job that is meant to replace it.
+  // Promotion is idempotent, so duplicates are harmless.
+  await promoteRotatedCredentialsQueue.add({ newCredentialsId: credentials.id }, { delay: 5000 });
+};
+
+// The previous credentials keep working, so a failed rotation is not an error.
+// The replacement is retired so nothing can pick it up later.
+let retireReplacement = async (d: {
+  connection: { oid: bigint; id: string; errorCode?: string | null; errorMessage?: string | null };
+  previousConnection: { oid: bigint } | null;
+}) => {
+  await db.remoteOAuthConnection.updateMany({
+    where: { oid: d.connection.oid, status: 'active' },
+    data: { status: 'inactive' }
+  });
+
+  if (!d.previousConnection) return;
+
+  await recordRotationEvent({
+    connectionOid: d.previousConnection.oid,
+    discriminator: d.connection.id,
+    metadata: {
+      status: 'failed',
+      replacementConnectionId: d.connection.id,
+      errorCode: d.connection.errorCode ?? null,
+      errorMessage: d.connection.errorMessage ?? null
+    }
+  });
+};
 
 let recordRotationEvent = async (d: {
   connectionOid: bigint;

--- a/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.ts
+++ b/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.ts
@@ -1,0 +1,277 @@
+import { createLock } from '@lowerdeck/lock';
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { subHours } from 'date-fns';
+import { db } from '../../db';
+import { env } from '../../env';
+import { getId } from '../../id';
+import {
+  getStaleRegistrationCutoff,
+  isStaleRegistration
+} from '../../lib/oauth/registrationRetry';
+import { remoteOAuthConnectionService } from '../../services/oauth/remote/connection';
+import { withTransaction } from '../../transaction';
+
+let ROTATE_BATCH_SIZE = 100;
+
+let rotationLock = createLock({
+  name: 'shut/rem-oaconn/rotate/lock',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let rotateStaleCredentialsSearchQueue = createQueue<{
+  serverId: string;
+  cursor?: string;
+}>({
+  name: 'shut/rem-oaconn/rotate/search',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let rotateStaleCredentialsSearchQueueProcessor =
+  rotateStaleCredentialsSearchQueue.process(async data => {
+    let staleCutoff = getStaleRegistrationCutoff();
+
+    let credentials = await db.serverOAuthCredentials.findMany({
+      where: {
+        id: data.cursor ? { gt: data.cursor } : undefined,
+
+        type: 'remote',
+        isDefault: true,
+
+        server: {
+          id: data.serverId,
+          remoteOauthConfig: { discoverStatus: 'supports_auto_registration' }
+        },
+
+        remoteConnection: {
+          status: 'active',
+          discoveryStatus: 'succeeded',
+          // Only clients Metorial registered itself may be replaced.
+          secretOid: null,
+          registrationOid: { not: null },
+          registration: { createdAt: { lt: staleCutoff } }
+        }
+      },
+      orderBy: { id: 'asc' },
+      take: ROTATE_BATCH_SIZE,
+      select: { id: true }
+    });
+    if (credentials.length === 0) return;
+
+    await rotateStaleCredentialsQueue.addManyWithOps(
+      credentials.map(credential => ({
+        data: { credentialsId: credential.id },
+        opts: { id: `rot-${credential.id}` }
+      }))
+    );
+
+    if (credentials.length < ROTATE_BATCH_SIZE) return;
+
+    await rotateStaleCredentialsSearchQueue.add({
+      serverId: data.serverId,
+      cursor: credentials[credentials.length - 1]?.id
+    });
+  });
+
+export let rotateStaleCredentialsQueue = createQueue<{ credentialsId: string }>({
+  name: 'shut/rem-oaconn/rotate/single',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: { concurrency: 3, limiter: { max: 5, duration: 1000 } }
+});
+
+export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.process(
+  async data => {
+    let credentials = await db.serverOAuthCredentials.findUnique({
+      where: { id: data.credentialsId },
+      include: {
+        tenant: true,
+        server: true,
+        remoteConnection: { include: { registration: true } }
+      }
+    });
+    if (!credentials) return;
+
+    let previousConnection = credentials.remoteConnection;
+    if (!previousConnection?.registration) return;
+    if (!credentials.server.remoteOauthConfigOid) return;
+
+    await rotationLock.usingLock(
+      `${credentials.tenantOid}-${credentials.serverOid}`,
+      async () => {
+        // Everything is re-read inside the lock, a concurrent rotation or a
+        // manual credential change may have happened since the job was queued.
+        let current = await db.serverOAuthCredentials.findUnique({
+          where: { oid: credentials.oid },
+          include: { remoteConnection: { include: { registration: true } } }
+        });
+        if (!current?.isDefault) return;
+
+        let connection = current.remoteConnection;
+        if (!connection?.registration) return;
+        if (connection.status != 'active' || connection.discoveryStatus != 'succeeded') return;
+        if (connection.secretOid != null) return;
+        if (!isStaleRegistration(connection.registration)) return;
+
+        let pendingReplacement = await db.remoteOAuthConnection.findFirst({
+          where: {
+            oid: { not: connection.oid },
+            serverOid: credentials.serverOid,
+            tenantOid: credentials.tenantOid,
+            status: 'active',
+            secretOid: null,
+            discoveryStatus: { in: ['discovering', 'succeeded'] },
+            createdAt: { gt: subHours(new Date(), 1) },
+            serverOAuthCredentials: { isDefault: false }
+          },
+          select: { oid: true }
+        });
+        if (pendingReplacement) return;
+
+        let config = await db.remoteOAuthConfig.findUniqueOrThrow({
+          where: { oid: credentials.server.remoteOauthConfigOid! }
+        });
+        if (config.discoverStatus != 'supports_auto_registration') return;
+
+        let replacement = await remoteOAuthConnectionService.createConnection({
+          tenant: credentials.tenant,
+          input: {
+            config,
+            scopes: connection.scopes
+          }
+        });
+        if (!replacement.serverOAuthCredentials) return;
+
+        await promoteRotatedCredentialsQueue.add(
+          {
+            newCredentialsId: replacement.serverOAuthCredentials.id,
+            previousCredentialsId: current.id
+          },
+          { delay: 5000, id: `prom-${replacement.serverOAuthCredentials.id}` }
+        );
+      }
+    );
+  }
+);
+
+export let promoteRotatedCredentialsQueue = createQueue<{
+  newCredentialsId: string;
+  previousCredentialsId: string;
+}>({
+  name: 'shut/rem-oaconn/rotate/promote',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: { concurrency: 5 }
+});
+
+export let promoteRotatedCredentialsQueueProcessor = promoteRotatedCredentialsQueue.process(
+  async data => {
+    let newCredentials = await db.serverOAuthCredentials.findUnique({
+      where: { id: data.newCredentialsId },
+      include: { remoteConnection: true }
+    });
+    if (!newCredentials?.remoteConnection) return;
+
+    let previousCredentials = await db.serverOAuthCredentials.findUnique({
+      where: { id: data.previousCredentialsId },
+      include: { remoteConnection: true }
+    });
+
+    let newConnection = newCredentials.remoteConnection;
+    let previousConnection = previousCredentials?.remoteConnection;
+
+    // Registration is still running, wait for it with the queue's backoff.
+    if (newConnection.discoveryStatus == 'discovering') throw new QueueRetryError();
+
+    if (newConnection.discoveryStatus == 'failed') {
+      // Transient provider failures do not spend the retry budget, so a
+      // replacement without a counted attempt is still being retried.
+      if (newConnection.registrationAttemptCount == 0) throw new QueueRetryError();
+
+      // The previous credentials keep working, so a failed rotation is not an
+      // error. The replacement is retired so nothing can pick it up later.
+      await db.remoteOAuthConnection.updateMany({
+        where: { oid: newConnection.oid, status: 'active' },
+        data: { status: 'inactive' }
+      });
+
+      if (previousConnection) {
+        await recordRotationEvent({
+          connectionOid: previousConnection.oid,
+          discriminator: newConnection.id,
+          metadata: {
+            status: 'failed',
+            replacementConnectionId: newConnection.id,
+            errorCode: newConnection.errorCode,
+            errorMessage: newConnection.errorMessage
+          }
+        });
+      }
+
+      return;
+    }
+
+    await withTransaction(async db => {
+      await db.serverOAuthCredentials.updateMany({
+        where: {
+          tenantOid: newCredentials.tenantOid,
+          serverOid: newCredentials.serverOid,
+          isDefault: true,
+          oid: { not: newCredentials.oid }
+        },
+        data: { isDefault: false }
+      });
+
+      await db.serverOAuthCredentials.update({
+        where: { oid: newCredentials.oid },
+        data: { isDefault: true }
+      });
+    });
+
+    // Existing auth configs stay bound to the previous connection and keep
+    // refreshing with the client they were authorized against.
+    await recordRotationEvent({
+      connectionOid: newConnection.oid,
+      discriminator: previousConnection?.id ?? newConnection.id,
+      metadata: {
+        status: 'succeeded',
+        role: 'replacement',
+        previousConnectionId: previousConnection?.id ?? null,
+        clientId: newConnection.clientId
+      }
+    });
+
+    if (previousConnection) {
+      await recordRotationEvent({
+        connectionOid: previousConnection.oid,
+        discriminator: newConnection.id,
+        metadata: {
+          status: 'succeeded',
+          role: 'replaced',
+          replacementConnectionId: newConnection.id
+        }
+      });
+    }
+  }
+);
+
+let recordRotationEvent = async (d: {
+  connectionOid: bigint;
+  discriminator: string;
+  metadata: Record<string, any>;
+}) => {
+  await db.remoteOAuthConnectionEvent.upsert({
+    where: {
+      connectionOid_type_discriminator: {
+        connectionOid: d.connectionOid,
+        type: 'credentials_rotated',
+        discriminator: d.discriminator
+      }
+    },
+    update: { metadata: d.metadata },
+    create: {
+      ...getId('remoteOAuthConnectionEvent'),
+      connectionOid: d.connectionOid,
+      type: 'credentials_rotated',
+      discriminator: d.discriminator,
+      metadata: d.metadata
+    }
+  });
+};

--- a/src/shuttle/service/src/queues/remote/startDeployment.ts
+++ b/src/shuttle/service/src/queues/remote/startDeployment.ts
@@ -19,7 +19,9 @@ import { remoteOAuthDiscoveryService } from '../../services';
 import { deployServerFailedQueue } from '../deployment/failed';
 import { deployServerSucceededQueue } from '../deployment/succeeded';
 import { discoverRemoteOAuthConfigQueue } from '../discovery/remoteOAuthConfig';
+import { retryFailedRegistrationsSearchQueue } from '../discovery/retryRemoteOAuthConnections';
 import { serverVersionCreatedQueue } from '../lifecycle/serverVersion';
+import { rotateStaleCredentialsSearchQueue } from '../oauth/rotateRemoteCredentials';
 
 export let deployRemoteServerStartQueue = createQueue<{
   serverDeploymentId: string;
@@ -156,6 +158,35 @@ export let deployRemoteServerStartQueueProcessor = deployRemoteServerStartQueue.
             },
             data: { configOid: oauthConfig.oid }
           });
+
+          // Connections that never got a client registered are moved to the new
+          // config as well, and get a fresh retry budget because the newly
+          // discovered config may be what makes registration work.
+          let repointed = await db.remoteOAuthConnection.updateMany({
+            where: {
+              serverOid: server.oid,
+              status: { not: 'inactive' },
+              discoveryStatus: 'failed',
+              registrationOid: null,
+              secretOid: null,
+              configOid: { not: oauthConfig.oid }
+            },
+            data: {
+              configOid: oauthConfig.oid,
+              registrationAttemptCount: 0,
+              lastRegistrationAttemptAt: null
+            }
+          });
+
+          if (repointed.count > 0) {
+            deployingStep.log(
+              `Retrying client registration for ${repointed.count} connection(s) that previously failed.`
+            );
+          }
+
+          await retryFailedRegistrationsSearchQueue.add({ serverId: server.id });
+
+          await rotateStaleCredentialsSearchQueue.add({ serverId: server.id });
 
           deployingStep.log(encode(oauthConfig.config));
         }

--- a/src/shuttle/service/src/services/oauth/remote/authorization.ts
+++ b/src/shuttle/service/src/services/oauth/remote/authorization.ts
@@ -6,10 +6,10 @@ import { subMinutes } from 'date-fns';
 import type {
   RemoteOAuthConfig,
   RemoteOAuthConnection,
+  RemoteOAuthConnectionProfile,
   RemoteOAuthConnectionSetup,
   ServerOAuthSetup,
-  Tenant,
-  RemoteOAuthConnectionProfile
+  Tenant
 } from '../../../../prisma/generated/client';
 import { oauthCallbackUrl } from '../../../config';
 import { db } from '../../../db';

--- a/src/shuttle/service/src/services/oauth/remote/connection.ts
+++ b/src/shuttle/service/src/services/oauth/remote/connection.ts
@@ -65,6 +65,9 @@ class remoteOAuthConnectionServiceImpl {
       clientId?: string;
       clientSecret?: string;
       scopes?: string[];
+
+      // Set when this connection replaces the client of an existing connection.
+      rotatedFromOid?: bigint;
     };
   }) {
     let config = await this.waitForConfig({ config: d.input.config });
@@ -107,7 +110,8 @@ class remoteOAuthConnectionServiceImpl {
           configOid: config.oid,
           secretOid: secret?.oid,
           tenantOid: d.tenant.oid,
-          serverOid: config.serverOid
+          serverOid: config.serverOid,
+          rotatedFromOid: d.input.rotatedFromOid
         }
       });
 

--- a/src/shuttle/service/src/services/oauth/remote/index.ts
+++ b/src/shuttle/service/src/services/oauth/remote/index.ts
@@ -2,3 +2,4 @@ export * from './authorization';
 export * from './authToken';
 export * from './connection';
 export * from './discovery';
+export * from './registration';

--- a/src/shuttle/service/src/services/oauth/remote/registration.test.ts
+++ b/src/shuttle/service/src/services/oauth/remote/registration.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { dbMock, oauthUtilsMock } = vi.hoisted(() => ({
+  dbMock: {
+    remoteOAuthConnection: {
+      findFirst: vi.fn(),
+      update: vi.fn()
+    },
+    remoteOAuthConnectionEvent: {
+      create: vi.fn()
+    }
+  },
+  oauthUtilsMock: {
+    supportsAuthRegistration: vi.fn(),
+    registerClient: vi.fn()
+  }
+}));
+
+vi.mock('../../../db', () => ({ db: dbMock }));
+
+vi.mock('../../../id', () => ({
+  getId: () => ({ oid: 1n, id: 'test_id' })
+}));
+
+vi.mock('../../../lib/oauth/oauthUtils', () => ({
+  OAuthUtils: oauthUtilsMock
+}));
+
+import { remoteOAuthRegistrationService } from './registration';
+
+let connection = (partial: Record<string, any> = {}) => ({
+  oid: 10n,
+  id: 'cso_test',
+  status: 'active',
+  discoveryStatus: 'failed',
+  registrationOid: null,
+  secretOid: null,
+  registrationAttemptCount: 0,
+  tenant: { oid: 2n, id: 'ten_test', name: 'Test' },
+  config: { oid: 3n, config: { registration_endpoint: 'https://provider.example.com/register' } },
+  _count: { remoteOAuthConnectionAuthTokens: 0, serverAuthConfigs: 0 },
+  ...partial
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  oauthUtilsMock.supportsAuthRegistration.mockReturnValue(true);
+});
+
+describe('runAutoRegistration', () => {
+  it('never re-registers a connection that already has tokens bound to it', async () => {
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
+      connection({
+        _count: { remoteOAuthConnectionAuthTokens: 1, serverAuthConfigs: 1 }
+      })
+    );
+
+    let res = await remoteOAuthRegistrationService.runAutoRegistration({
+      connectionId: 'cso_test'
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'skipped', blocker: 'has_bound_credentials' });
+    expect(oauthUtilsMock.registerClient).not.toHaveBeenCalled();
+    expect(dbMock.remoteOAuthConnection.update).not.toHaveBeenCalled();
+  });
+
+  it('stores the registration and clears the error on success', async () => {
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(connection());
+    oauthUtilsMock.registerClient.mockResolvedValue({
+      ok: true,
+      registration: { oid: 20n, clientId: 'client-id' }
+    });
+
+    let res = await remoteOAuthRegistrationService.runAutoRegistration({
+      connectionId: 'cso_test'
+    });
+
+    expect(res.ok).toBe(true);
+    expect(dbMock.remoteOAuthConnection.update).toHaveBeenLastCalledWith({
+      where: { oid: 10n },
+      data: expect.objectContaining({
+        registrationOid: 20n,
+        clientId: 'client-id',
+        discoveryStatus: 'succeeded',
+        errorCode: null,
+        errorMessage: null,
+        registrationAttemptCount: 0
+      })
+    });
+  });
+
+  it('counts an attempt for provider validation errors', async () => {
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(connection());
+    oauthUtilsMock.registerClient.mockResolvedValue({
+      ok: false,
+      error: { payload: { error: { message: 'Validation failed' } } },
+      status: 400,
+      isTransient: false
+    });
+
+    let res = await remoteOAuthRegistrationService.runAutoRegistration({
+      connectionId: 'cso_test'
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'failed', isTransient: false });
+    expect(dbMock.remoteOAuthConnection.update).toHaveBeenLastCalledWith({
+      where: { oid: 10n },
+      data: expect.objectContaining({
+        discoveryStatus: 'failed',
+        errorCode: 'auto_registration_failed',
+        registrationAttemptCount: 1
+      })
+    });
+  });
+
+  it('does not spend the retry budget on transient provider failures', async () => {
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
+      connection({ registrationAttemptCount: 3 })
+    );
+    oauthUtilsMock.registerClient.mockResolvedValue({
+      ok: false,
+      error: { payload: { error: 'gateway timeout' } },
+      status: 504,
+      isTransient: true
+    });
+
+    let res = await remoteOAuthRegistrationService.runAutoRegistration({
+      connectionId: 'cso_test'
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'failed', isTransient: true });
+    expect(dbMock.remoteOAuthConnection.update).toHaveBeenLastCalledWith({
+      where: { oid: 10n },
+      data: expect.objectContaining({ registrationAttemptCount: 3 })
+    });
+  });
+
+  it('only reports the first failure of a connection to Sentry', async () => {
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
+      connection({ registrationAttemptCount: 2 })
+    );
+    oauthUtilsMock.registerClient.mockResolvedValue({
+      ok: false,
+      error: { payload: { error: 'nope' } },
+      status: 400,
+      isTransient: false
+    });
+
+    await remoteOAuthRegistrationService.runAutoRegistration({ connectionId: 'cso_test' });
+
+    expect(oauthUtilsMock.registerClient).toHaveBeenCalledWith(
+      expect.objectContaining({ captureErrors: false })
+    );
+  });
+
+  it('marks providers without a registration endpoint as unsupported', async () => {
+    dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(connection());
+    oauthUtilsMock.supportsAuthRegistration.mockReturnValue(false);
+
+    let res = await remoteOAuthRegistrationService.runAutoRegistration({
+      connectionId: 'cso_test'
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'unsupported' });
+    expect(dbMock.remoteOAuthConnection.update).toHaveBeenCalledWith({
+      where: { oid: 10n },
+      data: expect.objectContaining({ errorCode: 'auto_registration_unsupported' })
+    });
+    expect(oauthUtilsMock.registerClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/shuttle/service/src/services/oauth/remote/registration.ts
+++ b/src/shuttle/service/src/services/oauth/remote/registration.ts
@@ -1,0 +1,134 @@
+import { Service } from '@lowerdeck/service';
+import { db } from '../../../db';
+import { getId } from '../../../id';
+import { OAuthUtils } from '../../../lib/oauth/oauthUtils';
+import { getRegistrationBlocker } from '../../../lib/oauth/registrationRetry';
+
+class remoteOAuthRegistrationServiceImpl {
+  /**
+   * Registers an OAuth client for a connection that does not have one yet. Used
+   * both for the initial registration and for retries of failed registrations.
+   */
+  async runAutoRegistration(d: { connectionId: string }) {
+    let connection = await db.remoteOAuthConnection.findFirst({
+      where: { id: d.connectionId },
+      include: {
+        config: true,
+        tenant: true,
+        _count: {
+          select: { remoteOAuthConnectionAuthTokens: true, serverAuthConfigs: true }
+        }
+      }
+    });
+    if (!connection) return { ok: false as const, reason: 'not_found' as const };
+
+    let blocker = getRegistrationBlocker({
+      connection,
+      boundTokenCount: connection._count.remoteOAuthConnectionAuthTokens,
+      boundAuthConfigCount: connection._count.serverAuthConfigs
+    });
+    if (blocker) return { ok: false as const, reason: 'skipped' as const, blocker };
+
+    if (!OAuthUtils.supportsAuthRegistration(connection.config.config)) {
+      await db.remoteOAuthConnection.update({
+        where: { oid: connection.oid },
+        data: {
+          discoveryStatus: 'failed',
+          errorCode: 'auto_registration_unsupported',
+          errorMessage: `OAuth provider does not support auto-registration.`
+        }
+      });
+
+      return { ok: false as const, reason: 'unsupported' as const };
+    }
+
+    // Counted before calling the provider so a crashing or hanging registration
+    // cannot be retried indefinitely.
+    let attempt = connection.registrationAttemptCount + 1;
+    await db.remoteOAuthConnection.update({
+      where: { oid: connection.oid },
+      data: {
+        registrationAttemptCount: attempt,
+        lastRegistrationAttemptAt: new Date()
+      }
+    });
+
+    let reg = await OAuthUtils.registerClient({
+      tenant: connection.tenant,
+      config: connection.config.config,
+      owner: {
+        config: connection.config,
+        connection
+      },
+      captureErrors: connection.registrationAttemptCount == 0
+    });
+
+    if (reg?.ok) {
+      await db.remoteOAuthConnection.update({
+        where: { oid: connection.oid },
+        data: {
+          registrationOid: reg.registration.oid,
+          clientId: reg.registration.clientId,
+          discoveryStatus: 'succeeded',
+          errorCode: null,
+          errorMessage: null,
+          registrationAttemptCount: 0
+        }
+      });
+
+      await db.remoteOAuthConnectionEvent.create({
+        data: {
+          ...getId('remoteOAuthConnectionEvent'),
+          connectionOid: connection.oid,
+          type: 'auto_registration_succeeded',
+          metadata: {
+            clientId: reg.registration.clientId,
+            attempt
+          }
+        }
+      });
+
+      return { ok: true as const, connection, registration: reg.registration };
+    }
+
+    let inner = (reg?.error.payload as any)?.error || 'unknown_error';
+
+    let jsonInner = inner;
+    try {
+      jsonInner = JSON.stringify(inner);
+    } catch (e) {}
+
+    let isTransient = reg?.isTransient ?? false;
+
+    await db.remoteOAuthConnection.update({
+      where: { oid: connection.oid },
+      data: {
+        discoveryStatus: 'failed',
+        errorCode: 'auto_registration_failed',
+        errorMessage: `Failed to auto-register OAuth client for connection: ${jsonInner}`,
+        // Provider outages should not use up the connection's retry budget.
+        registrationAttemptCount: isTransient ? connection.registrationAttemptCount : attempt
+      }
+    });
+
+    await db.remoteOAuthConnectionEvent.create({
+      data: {
+        ...getId('remoteOAuthConnectionEvent'),
+        connectionOid: connection.oid,
+        type: 'auto_registration_failed',
+        metadata: {
+          error: inner,
+          attempt,
+          status: reg?.status ?? null
+        }
+      }
+    });
+
+    return { ok: false as const, reason: 'failed' as const, isTransient };
+  }
+}
+
+export let remoteOAuthRegistrationService = Service.create(
+  'remoteOAuthRegistration',
+  () => new remoteOAuthRegistrationServiceImpl()
+).build();

--- a/src/shuttle/service/src/worker.ts
+++ b/src/shuttle/service/src/worker.ts
@@ -17,6 +17,11 @@ import {
 } from './queues/deployment/timeout';
 import { discoverRemoteOAuthConfigQueueProcessor } from './queues/discovery/remoteOAuthConfig';
 import { discoverRemoteOAuthConnectionQueueProcessor } from './queues/discovery/remoteOAuthConnection';
+import {
+  retryFailedRegistrationsCron,
+  retryFailedRegistrationsSearchQueueProcessor,
+  retryRegistrationQueueProcessor
+} from './queues/discovery/retryRemoteOAuthConnections';
 import { discoverServerQueueProcessor } from './queues/discovery/server';
 import { deployFunctionServerDiscoverQueueProcessor } from './queues/function/discover';
 import { deployFunctionServerWatchQueueProcessor } from './queues/function/monitor';
@@ -30,6 +35,11 @@ import { serverVersionCreatedQueueProcessor } from './queues/lifecycle/serverVer
 import { repositoryTagCreatedQueueProcessor } from './queues/lifecycle/tag';
 import { delegatedOAuthErrorCheckQueueProcessor } from './queues/oauth/delegatedErrorCheck';
 import { remoteOAuthErrorCheckQueueProcessor } from './queues/oauth/remoteErrorCheck';
+import {
+  promoteRotatedCredentialsQueueProcessor,
+  rotateStaleCredentialsQueueProcessor,
+  rotateStaleCredentialsSearchQueueProcessor
+} from './queues/oauth/rotateRemoteCredentials';
 import { retentionQueues } from './queues/retention';
 import { deployRemoteServerStartQueueProcessor } from './queues/remote/startDeployment';
 import {
@@ -58,6 +68,14 @@ await runQueueProcessors([
 
   discoverRemoteOAuthConfigQueueProcessor,
   discoverRemoteOAuthConnectionQueueProcessor,
+
+  retryFailedRegistrationsCron,
+  retryFailedRegistrationsSearchQueueProcessor,
+  retryRegistrationQueueProcessor,
+
+  rotateStaleCredentialsSearchQueueProcessor,
+  rotateStaleCredentialsQueueProcessor,
+  promoteRotatedCredentialsQueueProcessor,
 
   delegatedOAuthErrorCheckQueueProcessor,
   remoteOAuthErrorCheckQueueProcessor,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes default OAuth credential selection, rotation timing, and when re-registration is allowed—mistakes could break auth or swap clients under live tokens despite explicit blockers.
> 
> **Overview**
> Hardens **remote OAuth dynamic client registration** by centralizing auto-registration in `remoteOAuthRegistrationService`, tightening what gets sent to providers, and adding **scheduled retries** plus **stale-client rotation** without breaking existing tokens.
> 
> **Registration behavior:** Dynamic registration now uses `buildClientRegistrationMetadata` so only supported authorization-code flows and preferred token auth methods are advertised (instead of forwarding the provider’s full grant/response lists). `OAuthUtils.registerClient` can skip repeat Sentry noise, classifies HTTP failures as transient vs permanent, and surfaces that to callers.
> 
> **Retries:** `RemoteOAuthConnection` gains `registrationAttemptCount`, `lastRegistrationAttemptAt`, and guards (`getRegistrationBlocker`) so connections with manual secrets, an existing registration, or bound tokens/auth configs are never re-registered. A daily cron and batched queues re-run eligible **failed** connections on a ~20h interval, up to 10 permanent-failure attempts; transient errors do not consume the budget. Discovery queue logic delegates to the shared service and retries on transient failures.
> 
> **Credential rotation:** Schema adds `rotatedFromOid` and `credentials_rotated` events. After deploy (and via search/single/promote queues), auto-registered default credentials older than **3 days** spawn a replacement connection; on success the new credentials become default while the **previous connection stays active** so existing auth configs keep refreshing against the old client. Promotion is idempotent and re-enqueued when registration completes after a failed promotion job.
> 
> **Deploy hook:** When OAuth config is rediscovered, still-failed connections without a client are repointed to the new config with a reset retry budget, then registration retry and stale rotation searches are kicked off for that server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d66c837aecd5adb400b6207fd1cc6cdc98b858e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->