### PR TITLE
Harden subspace reconcile

### DIFF
--- a/src/metorial/subspace/db/prisma/schema/tenant/legacy.prisma
+++ b/src/metorial/subspace/db/prisma/schema/tenant/legacy.prisma
@@ -41,6 +41,8 @@ model Tenant {
 
   collectOperationDescriptionForToolCalls Boolean @default(true)
 
+  retiredAt DateTime?
+
   providers                                Provider[]
   providerListingGroups                    ProviderListingGroup[]
   providerListings                         ProviderListing[]
@@ -138,6 +140,8 @@ model Tenant {
   monitors                                 Monitor[]
   monitorAlerts                            MonitorAlert[]
   projects                                 Project[]
+
+  @@index([retiredAt])
 }
 
 enum EnvironmentType {

--- a/src/metorial/subspace/modules/tenant/src/lib/legacyScope.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/legacyScope.test.ts
@@ -1,0 +1,427 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  instanceFindUnique: vi.fn(),
+  instanceFindFirst: vi.fn(),
+  projectFindUnique: vi.fn(),
+  projectFindFirst: vi.fn(),
+  projectFindMany: vi.fn(),
+  organizationFindUnique: vi.fn(),
+  environmentFindMany: vi.fn(),
+  environmentFindUnique: vi.fn(),
+  tenantFindUnique: vi.fn()
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: {
+    environment: {
+      findMany: mocks.environmentFindMany,
+      findUnique: mocks.environmentFindUnique
+    },
+    tenant: { findUnique: mocks.tenantFindUnique }
+  }
+}));
+
+vi.mock('./metorialDb', () => ({
+  metorialDb: {
+    instance: {
+      findUnique: mocks.instanceFindUnique,
+      findFirst: mocks.instanceFindFirst
+    },
+    project: {
+      findUnique: mocks.projectFindUnique,
+      findFirst: mocks.projectFindFirst,
+      findMany: mocks.projectFindMany
+    },
+    organization: { findUnique: mocks.organizationFindUnique }
+  }
+}));
+
+import {
+  getProjectScopeDrift,
+  isCanonicalEnvironmentIdentifier,
+  isCanonicalProjectIdentifier,
+  parseCanonicalInstanceOid,
+  parseCanonicalProjectOid,
+  parseLegacyEnvironmentInstanceId,
+  parseLegacyTenantInstanceId,
+  parseLegacyTenantOrganizationId,
+  resolveInstanceForEnvironment,
+  resolveProjectForTenant
+} from './legacyScope';
+
+let instance = { oid: 3n, projectOid: 2n };
+
+let makeEnvironment = (overrides: Record<string, unknown> = {}) => ({
+  id: 'ken_1',
+  identifier: 'mtei-ins_legacy',
+  resourceGroupIdentifier: null,
+  instanceOid: null,
+  ...overrides
+});
+
+let makeTenant = (overrides: Record<string, unknown> = {}) => ({
+  id: 'ktn_1',
+  identifier: 'mte-ins_legacy',
+  resourceTenantIdentifier: null,
+  projectOid: null,
+  ...overrides
+});
+
+describe('identifier parsing', () => {
+  it('separates canonical identifiers from the legacy ones they resemble', () => {
+    expect(isCanonicalProjectIdentifier('mte-pro-2')).toBe(true);
+    expect(isCanonicalProjectIdentifier('mteo-org_1')).toBe(false);
+    expect(isCanonicalProjectIdentifier(null)).toBe(false);
+
+    expect(isCanonicalEnvironmentIdentifier('mte-ins-3')).toBe(true);
+    // The legacy per-instance tenant uses an underscore where the canonical one uses a dash.
+    expect(isCanonicalEnvironmentIdentifier('mte-ins_0mlz')).toBe(false);
+    expect(isCanonicalEnvironmentIdentifier('mtei-ins_0mlz')).toBe(false);
+  });
+
+  it('reads oids out of canonical identifiers only', () => {
+    expect(parseCanonicalProjectOid('mte-pro-48526066642506752')).toBe(48526066642506752n);
+    expect(parseCanonicalInstanceOid('mte-ins-48526066661381120')).toBe(48526066661381120n);
+    expect(parseCanonicalInstanceOid('mte-ins_0mlzkn8h5vDpg9CRUBSlP0')).toBeNull();
+    expect(parseCanonicalProjectOid('mte-org-1')).toBeNull();
+  });
+
+  it('reads Metorial ids out of legacy identifiers', () => {
+    expect(parseLegacyTenantInstanceId('mte-ins_0mlzkn8h5vDpg9CRUBSlP0')).toBe(
+      'ins_0mlzkn8h5vDpg9CRUBSlP0'
+    );
+    expect(parseLegacyTenantOrganizationId('mteo-org_0mm27g7m5kd8d860A3Gv2d')).toBe(
+      'org_0mm27g7m5kd8d860A3Gv2d'
+    );
+    expect(parseLegacyEnvironmentInstanceId('mtei-ins_0mlzkn8h5vDpg9CRUBSlP0')).toBe(
+      'ins_0mlzkn8h5vDpg9CRUBSlP0'
+    );
+
+    expect(parseLegacyTenantInstanceId('mte-pro-2')).toBeNull();
+    expect(parseLegacyTenantOrganizationId('mte-ins_1')).toBeNull();
+  });
+});
+
+describe('resolveInstanceForEnvironment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.instanceFindUnique.mockResolvedValue(null);
+    mocks.instanceFindFirst.mockResolvedValue(null);
+  });
+
+  it('trusts the mirror reference first', async () => {
+    mocks.instanceFindUnique.mockResolvedValue(instance);
+
+    let resolution = await resolveInstanceForEnvironment(makeEnvironment({ instanceOid: 3n }));
+
+    expect(resolution).toEqual({
+      status: 'resolved',
+      value: instance,
+      source: 'mirrorInstanceOid'
+    });
+    expect(mocks.instanceFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the Metorial pointer', async () => {
+    mocks.instanceFindFirst.mockResolvedValue(instance);
+
+    let resolution = await resolveInstanceForEnvironment(makeEnvironment());
+
+    expect(resolution).toMatchObject({ status: 'resolved', source: 'subspaceEnvironmentId' });
+    expect(mocks.instanceFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { subspaceEnvironmentId: 'ken_1' } })
+    );
+  });
+
+  it('reads the instance id out of the legacy identifier', async () => {
+    mocks.instanceFindUnique.mockResolvedValue(instance);
+
+    let resolution = await resolveInstanceForEnvironment(
+      makeEnvironment({ identifier: 'mtei-ins_legacy' })
+    );
+
+    expect(resolution).toMatchObject({ status: 'resolved', source: 'legacyIdentifier' });
+    expect(mocks.instanceFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'ins_legacy' } })
+    );
+  });
+
+  it('falls back to the resource group identifier', async () => {
+    mocks.instanceFindUnique.mockImplementation(async ({ where }: any) =>
+      where.oid === 3n ? instance : null
+    );
+
+    let resolution = await resolveInstanceForEnvironment(
+      makeEnvironment({ identifier: 'legacy-nonsense', resourceGroupIdentifier: 'mte-ins-3' })
+    );
+
+    expect(resolution).toMatchObject({ status: 'resolved', source: 'canonicalIdentifier' });
+  });
+
+  it('reports an environment it cannot place', async () => {
+    let resolution = await resolveInstanceForEnvironment(
+      makeEnvironment({ identifier: 'legacy-nonsense' })
+    );
+
+    expect(resolution).toEqual({
+      status: 'unresolved',
+      reason: expect.stringContaining('No Metorial instance resolves')
+    });
+  });
+});
+
+describe('resolveProjectForTenant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.instanceFindUnique.mockResolvedValue(null);
+    mocks.projectFindUnique.mockResolvedValue(null);
+    mocks.projectFindFirst.mockResolvedValue(null);
+    mocks.projectFindMany.mockResolvedValue([]);
+    mocks.organizationFindUnique.mockResolvedValue(null);
+    mocks.environmentFindMany.mockResolvedValue([]);
+  });
+
+  it('trusts the mirror reference first', async () => {
+    mocks.projectFindUnique.mockResolvedValue({ oid: 2n });
+
+    let resolution = await resolveProjectForTenant(makeTenant({ projectOid: 2n }));
+
+    expect(resolution).toEqual({ status: 'resolved', value: 2n, source: 'mirrorProjectOid' });
+  });
+
+  it('uses the resource tenant identifier the partial migration left behind', async () => {
+    mocks.projectFindUnique.mockResolvedValue({ oid: 48526066642506752n });
+
+    let resolution = await resolveProjectForTenant(
+      makeTenant({ resourceTenantIdentifier: 'mte-pro-48526066642506752' })
+    );
+
+    expect(resolution).toEqual({
+      status: 'resolved',
+      value: 48526066642506752n,
+      source: 'canonicalIdentifier'
+    });
+  });
+
+  it('resolves a per-instance legacy tenant through its instance', async () => {
+    mocks.instanceFindUnique.mockResolvedValue(instance);
+
+    let resolution = await resolveProjectForTenant(
+      makeTenant({ identifier: 'mte-ins_legacy' })
+    );
+
+    expect(resolution).toEqual({
+      status: 'resolved',
+      value: 2n,
+      source: 'legacyInstanceIdentifier'
+    });
+  });
+
+  it('resolves a per-organization legacy tenant when the org has a single project', async () => {
+    mocks.organizationFindUnique.mockResolvedValue({ oid: 1n });
+    mocks.projectFindMany.mockResolvedValue([{ oid: 2n }]);
+
+    let resolution = await resolveProjectForTenant(
+      makeTenant({ identifier: 'mteo-org_legacy' })
+    );
+
+    expect(resolution).toEqual({
+      status: 'resolved',
+      value: 2n,
+      source: 'legacyOrganizationIdentifier'
+    });
+  });
+
+  it('refuses to guess when the organization owns several projects', async () => {
+    mocks.organizationFindUnique.mockResolvedValue({ oid: 1n });
+    mocks.projectFindMany.mockResolvedValue([{ oid: 2n }, { oid: 5n }]);
+
+    let resolution = await resolveProjectForTenant(
+      makeTenant({ identifier: 'mteo-org_legacy' })
+    );
+
+    expect(resolution).toEqual({
+      status: 'unresolved',
+      reason: expect.stringContaining('more than one active project')
+    });
+  });
+
+  it('falls back to the projects behind its environments', async () => {
+    mocks.environmentFindMany.mockResolvedValue([
+      {
+        id: 'ken_1',
+        identifier: 'mtei-ins_legacy',
+        resourceGroupIdentifier: null,
+        instanceOid: 3n
+      }
+    ]);
+    mocks.instanceFindUnique.mockResolvedValue(instance);
+
+    let resolution = await resolveProjectForTenant(makeTenant({ identifier: 'nonsense' }));
+
+    expect(resolution).toEqual({ status: 'resolved', value: 2n, source: 'environments' });
+  });
+
+  it('reports a tenant it cannot place', async () => {
+    let resolution = await resolveProjectForTenant(makeTenant({ identifier: 'nonsense' }));
+
+    expect(resolution).toEqual({
+      status: 'unresolved',
+      reason: expect.stringContaining('No Metorial project resolves')
+    });
+  });
+});
+
+describe('getProjectScopeDrift', () => {
+  let makeScopedProject = (overrides: Record<string, unknown> = {}) => ({
+    oid: 2n,
+    id: 'pro_1',
+    subspaceTenantId: 'ktn_1',
+    internalTenantIdentifier: 'mte-pro-2',
+    instances: [
+      {
+        oid: 3n,
+        id: 'ins_1',
+        subspaceTenantId: 'ktn_1',
+        internalTenantIdentifier: 'mte-pro-2',
+        subspaceEnvironmentId: 'ken_1',
+        internalEnvironmentIdentifier: 'mte-ins-3'
+      }
+    ],
+    ...overrides
+  });
+
+  beforeEach(() => {
+    mocks.projectFindUnique.mockResolvedValue(makeScopedProject());
+    mocks.tenantFindUnique.mockResolvedValue({
+      oid: 20n,
+      identifier: 'mte-pro-2',
+      retiredAt: null
+    });
+    mocks.environmentFindUnique.mockResolvedValue({
+      identifier: 'mte-ins-3',
+      tenantOid: 20n
+    });
+  });
+
+  it('sees no drift when both sides are canonical', async () => {
+    expect(await getProjectScopeDrift({ projectOid: 2n })).toEqual({
+      hasDrift: false,
+      reasons: [],
+      notes: []
+    });
+  });
+
+  it('flags a project still pointing at a legacy tenant', async () => {
+    mocks.tenantFindUnique.mockResolvedValue({
+      oid: 20n,
+      identifier: 'mteo-org_legacy',
+      retiredAt: null
+    });
+
+    let drift = await getProjectScopeDrift({ projectOid: 2n });
+
+    expect(drift.hasDrift).toBe(true);
+    expect(drift.reasons).toContainEqual(expect.stringContaining('expected mte-pro-2'));
+  });
+
+  it('flags pointers to tenants that are gone or retired', async () => {
+    mocks.tenantFindUnique.mockResolvedValue(null);
+    expect((await getProjectScopeDrift({ projectOid: 2n })).reasons).toContainEqual(
+      expect.stringContaining('missing tenant')
+    );
+
+    mocks.tenantFindUnique.mockResolvedValue({
+      oid: 20n,
+      identifier: 'mte-pro-2',
+      retiredAt: new Date()
+    });
+    expect((await getProjectScopeDrift({ projectOid: 2n })).reasons).toContainEqual(
+      expect.stringContaining('retired tenant')
+    );
+  });
+
+  it('flags an instance whose environment kept its legacy identifier', async () => {
+    mocks.environmentFindUnique.mockResolvedValue({
+      identifier: 'mtei-ins_legacy',
+      tenantOid: 20n
+    });
+
+    let drift = await getProjectScopeDrift({ projectOid: 2n });
+
+    expect(drift.hasDrift).toBe(true);
+    expect(drift.reasons).toContainEqual(expect.stringContaining('expected mte-ins-3'));
+  });
+
+  it('flags an environment parked under a different tenant', async () => {
+    mocks.environmentFindUnique.mockResolvedValue({
+      identifier: 'mte-ins-3',
+      tenantOid: 99n
+    });
+
+    expect((await getProjectScopeDrift({ projectOid: 2n })).reasons).toContainEqual(
+      expect.stringContaining('different tenant')
+    );
+  });
+
+  it('flags stale internal identifiers even when the rows are canonical', async () => {
+    mocks.projectFindUnique.mockResolvedValue(
+      makeScopedProject({ internalTenantIdentifier: 'mteo-org_legacy' })
+    );
+
+    expect((await getProjectScopeDrift({ projectOid: 2n })).reasons).toContainEqual(
+      expect.stringContaining('is labelled mteo-org_legacy')
+    );
+  });
+
+  it('treats an unprovisioned project as clean', async () => {
+    mocks.projectFindUnique.mockResolvedValue(
+      makeScopedProject({
+        subspaceTenantId: null,
+        internalTenantIdentifier: null,
+        instances: []
+      })
+    );
+
+    expect(await getProjectScopeDrift({ projectOid: 2n })).toEqual({
+      hasDrift: false,
+      reasons: [],
+      notes: []
+    });
+  });
+
+  it('does not defer a project whose tenant names a different project', async () => {
+    mocks.tenantFindUnique.mockResolvedValue({
+      oid: 20n,
+      identifier: 'mte-pro-777',
+      retiredAt: null
+    });
+
+    let drift = await getProjectScopeDrift({ projectOid: 2n });
+
+    // Reporting drift here would exclude the project from every other reconciler forever.
+    expect(drift.hasDrift).toBe(false);
+    expect(drift.notes).toContainEqual(expect.stringContaining('names another project'));
+  });
+
+  it("does not defer an instance pointing at another instance's environment", async () => {
+    mocks.environmentFindUnique.mockResolvedValue({
+      identifier: 'mte-ins-999',
+      tenantOid: 20n
+    });
+
+    let drift = await getProjectScopeDrift({ projectOid: 2n });
+
+    expect(drift.hasDrift).toBe(false);
+    expect(drift.notes).toContainEqual(expect.stringContaining('names another instance'));
+  });
+
+  it('flags a label that is missing entirely', async () => {
+    mocks.projectFindUnique.mockResolvedValue(
+      makeScopedProject({ internalTenantIdentifier: null })
+    );
+
+    expect((await getProjectScopeDrift({ projectOid: 2n })).hasDrift).toBe(true);
+  });
+});

--- a/src/metorial/subspace/modules/tenant/src/lib/legacyScope.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/legacyScope.test.ts
@@ -391,6 +391,39 @@ describe('getProjectScopeDrift', () => {
     });
   });
 
+  it('flags a project whose legacy links only exist on its instances', async () => {
+    // The legacy model linked tenants per instance, so the project itself often has no link. The
+    // regular scope path would provision a canonical tenant next to these rows.
+    mocks.projectFindUnique.mockResolvedValue(
+      makeScopedProject({
+        subspaceTenantId: null,
+        internalTenantIdentifier: null,
+        instances: [
+          {
+            oid: 3n,
+            id: 'ins_1',
+            subspaceTenantId: 'ktn_legacy',
+            internalTenantIdentifier: 'mtei-ins_legacy',
+            subspaceEnvironmentId: 'ken_1',
+            internalEnvironmentIdentifier: 'mtei-ins_legacy'
+          }
+        ]
+      })
+    );
+    mocks.environmentFindUnique.mockResolvedValue({
+      identifier: 'mtei-ins_legacy',
+      tenantOid: 21n
+    });
+
+    let drift = await getProjectScopeDrift({ projectOid: 2n });
+
+    expect(drift.hasDrift).toBe(true);
+    expect(drift.reasons).toContainEqual(
+      expect.stringContaining('points at a different tenant than its project')
+    );
+    expect(drift.reasons).toContainEqual(expect.stringContaining('expected mte-ins-3'));
+  });
+
   it('does not defer a project whose tenant names a different project', async () => {
     mocks.tenantFindUnique.mockResolvedValue({
       oid: 20n,

--- a/src/metorial/subspace/modules/tenant/src/lib/legacyScope.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/legacyScope.ts
@@ -270,41 +270,50 @@ export let getProjectScopeDrift = async (d: {
 
   let tenantIdentifier = `${CANONICAL_TENANT_PREFIX}${project.oid}`;
 
-  if (!project.subspaceTenantId) return result();
+  let tenant = project.subspaceTenantId
+    ? await subspaceDb.tenant.findUnique({
+        where: { id: project.subspaceTenantId },
+        select: { oid: true, identifier: true, retiredAt: true }
+      })
+    : null;
 
-  let tenant = await subspaceDb.tenant.findUnique({
-    where: { id: project.subspaceTenantId },
-    select: { oid: true, identifier: true, retiredAt: true }
-  });
+  // The legacy model linked tenants per instance, so a project can carry no tenant link at all
+  // while its instances point at legacy rows. Only the project's own link is settled here; the
+  // instance links below are inspected either way.
+  if (project.subspaceTenantId) {
+    if (!tenant) {
+      reasons.push(
+        `Project ${project.id} points at missing tenant ${project.subspaceTenantId}`
+      );
+      return result();
+    }
+    if (tenant.retiredAt) {
+      reasons.push(
+        `Project ${project.id} points at retired tenant ${project.subspaceTenantId}`
+      );
+      return result();
+    }
 
-  if (!tenant) {
-    reasons.push(`Project ${project.id} points at missing tenant ${project.subspaceTenantId}`);
-    return result();
-  }
-  if (tenant.retiredAt) {
-    reasons.push(`Project ${project.id} points at retired tenant ${project.subspaceTenantId}`);
-    return result();
-  }
+    if (
+      isCanonicalProjectIdentifier(tenant.identifier) &&
+      tenant.identifier !== tenantIdentifier
+    ) {
+      notes.push(
+        `Project ${project.id} points at tenant ${tenant.identifier}, which names another project`
+      );
+      return result();
+    }
 
-  if (
-    isCanonicalProjectIdentifier(tenant.identifier) &&
-    tenant.identifier !== tenantIdentifier
-  ) {
-    notes.push(
-      `Project ${project.id} points at tenant ${tenant.identifier}, which names another project`
-    );
-    return result();
-  }
-
-  if (tenant.identifier !== tenantIdentifier) {
-    reasons.push(
-      `Project ${project.id} resolves to tenant ${tenant.identifier}, expected ${tenantIdentifier}`
-    );
-  }
-  if (project.internalTenantIdentifier !== tenantIdentifier) {
-    reasons.push(
-      `Project ${project.id} is labelled ${project.internalTenantIdentifier}, expected ${tenantIdentifier}`
-    );
+    if (tenant.identifier !== tenantIdentifier) {
+      reasons.push(
+        `Project ${project.id} resolves to tenant ${tenant.identifier}, expected ${tenantIdentifier}`
+      );
+    }
+    if (project.internalTenantIdentifier !== tenantIdentifier) {
+      reasons.push(
+        `Project ${project.id} is labelled ${project.internalTenantIdentifier}, expected ${tenantIdentifier}`
+      );
+    }
   }
 
   for (let instance of project.instances) {
@@ -351,7 +360,7 @@ export let getProjectScopeDrift = async (d: {
         `Instance ${instance.id} resolves to environment ${environment.identifier}, expected ${environmentIdentifier}`
       );
     }
-    if (environment.tenantOid !== tenant.oid) {
+    if (tenant && environment.tenantOid !== tenant.oid) {
       reasons.push(`Instance ${instance.id} environment sits under a different tenant`);
     }
     if (instance.internalEnvironmentIdentifier !== environmentIdentifier) {

--- a/src/metorial/subspace/modules/tenant/src/lib/legacyScope.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/legacyScope.ts
@@ -1,0 +1,365 @@
+import { db as subspaceDb } from '@metorial-subspace/db';
+import { metorialDb } from './metorialDb';
+
+export let CANONICAL_TENANT_PREFIX = 'mte-pro-';
+export let CANONICAL_ENVIRONMENT_PREFIX = 'mte-ins-';
+
+let LEGACY_TENANT_INSTANCE_PREFIX = 'mte-';
+let LEGACY_TENANT_ORGANIZATION_PREFIX = 'mteo-';
+let LEGACY_ENVIRONMENT_INSTANCE_PREFIX = 'mtei-';
+
+let METORIAL_INSTANCE_ID_PREFIX = 'ins_';
+let METORIAL_ORGANIZATION_ID_PREFIX = 'org_';
+
+export let isCanonicalProjectIdentifier = (identifier: string | null | undefined) =>
+  identifier?.startsWith(CANONICAL_TENANT_PREFIX) ?? false;
+
+export let isCanonicalEnvironmentIdentifier = (identifier: string | null | undefined) =>
+  identifier?.startsWith(CANONICAL_ENVIRONMENT_PREFIX) ?? false;
+
+let parseOid = (identifier: string | null | undefined, prefix: string) => {
+  if (!identifier?.startsWith(prefix)) return null;
+
+  let raw = identifier.slice(prefix.length);
+  if (!/^[0-9]+$/.test(raw)) return null;
+
+  return BigInt(raw);
+};
+
+export let parseCanonicalProjectOid = (identifier: string | null | undefined) =>
+  parseOid(identifier, CANONICAL_TENANT_PREFIX);
+
+export let parseCanonicalInstanceOid = (identifier: string | null | undefined) =>
+  parseOid(identifier, CANONICAL_ENVIRONMENT_PREFIX);
+
+/**
+ * Legacy identifiers embed the Metorial string id rather than the oid, and use an underscore
+ * where the canonical identifiers use a dash: `mte-ins_0mlz...` is a legacy per-instance tenant,
+ * `mte-ins-48526066661381120` is a canonical environment.
+ */
+let parseLegacyMetorialId = (
+  identifier: string | null | undefined,
+  prefix: string,
+  idPrefix: string
+) => {
+  if (!identifier?.startsWith(prefix)) return null;
+
+  let raw = identifier.slice(prefix.length);
+  return raw.startsWith(idPrefix) ? raw : null;
+};
+
+export let parseLegacyTenantInstanceId = (identifier: string | null | undefined) =>
+  parseLegacyMetorialId(
+    identifier,
+    LEGACY_TENANT_INSTANCE_PREFIX,
+    METORIAL_INSTANCE_ID_PREFIX
+  );
+
+export let parseLegacyTenantOrganizationId = (identifier: string | null | undefined) =>
+  parseLegacyMetorialId(
+    identifier,
+    LEGACY_TENANT_ORGANIZATION_PREFIX,
+    METORIAL_ORGANIZATION_ID_PREFIX
+  );
+
+export let parseLegacyEnvironmentInstanceId = (identifier: string | null | undefined) =>
+  parseLegacyMetorialId(
+    identifier,
+    LEGACY_ENVIRONMENT_INSTANCE_PREFIX,
+    METORIAL_INSTANCE_ID_PREFIX
+  );
+
+export type ScopeResolution<T> =
+  | { status: 'resolved'; value: T; source: string }
+  | { status: 'unresolved'; reason: string };
+
+export type LegacyEnvironmentCandidate = {
+  id: string;
+  identifier: string;
+  resourceGroupIdentifier: string | null;
+  instanceOid: bigint | null;
+};
+
+export type LegacyTenantCandidate = {
+  id: string;
+  identifier: string;
+  resourceTenantIdentifier: string | null;
+  projectOid: bigint | null;
+};
+
+export type ResolvedInstance = {
+  oid: bigint;
+  projectOid: bigint;
+};
+
+let loadInstance = async (where: { oid: bigint } | { id: string }) =>
+  await metorialDb.instance.findUnique({
+    where: where as any,
+    select: { oid: true, projectOid: true }
+  });
+
+export let resolveInstanceForEnvironment = async (
+  environment: LegacyEnvironmentCandidate
+): Promise<ScopeResolution<ResolvedInstance>> => {
+  if (environment.instanceOid !== null) {
+    let instance = await loadInstance({ oid: environment.instanceOid });
+    if (instance) return { status: 'resolved', value: instance, source: 'mirrorInstanceOid' };
+  }
+
+  let linked = await metorialDb.instance.findFirst({
+    where: { subspaceEnvironmentId: environment.id },
+    select: { oid: true, projectOid: true }
+  });
+  if (linked) return { status: 'resolved', value: linked, source: 'subspaceEnvironmentId' };
+
+  let legacyInstanceId = parseLegacyEnvironmentInstanceId(environment.identifier);
+  if (legacyInstanceId) {
+    let instance = await loadInstance({ id: legacyInstanceId });
+    if (instance) return { status: 'resolved', value: instance, source: 'legacyIdentifier' };
+  }
+
+  let canonicalOid =
+    parseCanonicalInstanceOid(environment.identifier) ??
+    parseCanonicalInstanceOid(environment.resourceGroupIdentifier);
+  if (canonicalOid !== null) {
+    let instance = await loadInstance({ oid: canonicalOid });
+    if (instance) {
+      return { status: 'resolved', value: instance, source: 'canonicalIdentifier' };
+    }
+  }
+
+  return {
+    status: 'unresolved',
+    reason: `No Metorial instance resolves for subspace environment ${environment.id} (${environment.identifier})`
+  };
+};
+
+let projectExists = async (projectOid: bigint) =>
+  !!(await metorialDb.project.findUnique({
+    where: { oid: projectOid },
+    select: { oid: true }
+  }));
+
+export let resolveProjectForTenant = async (
+  tenant: LegacyTenantCandidate
+): Promise<ScopeResolution<bigint>> => {
+  if (tenant.projectOid !== null && (await projectExists(tenant.projectOid))) {
+    return { status: 'resolved', value: tenant.projectOid, source: 'mirrorProjectOid' };
+  }
+
+  let linked = await metorialDb.project.findFirst({
+    where: { subspaceTenantId: tenant.id },
+    select: { oid: true }
+  });
+  if (linked) return { status: 'resolved', value: linked.oid, source: 'subspaceTenantId' };
+
+  let canonicalOid =
+    parseCanonicalProjectOid(tenant.identifier) ??
+    parseCanonicalProjectOid(tenant.resourceTenantIdentifier);
+  if (canonicalOid !== null && (await projectExists(canonicalOid))) {
+    return { status: 'resolved', value: canonicalOid, source: 'canonicalIdentifier' };
+  }
+
+  let legacyInstanceId = parseLegacyTenantInstanceId(tenant.identifier);
+  if (legacyInstanceId) {
+    let instance = await loadInstance({ id: legacyInstanceId });
+    if (instance) {
+      return {
+        status: 'resolved',
+        value: instance.projectOid,
+        source: 'legacyInstanceIdentifier'
+      };
+    }
+  }
+
+  let legacyOrganizationId = parseLegacyTenantOrganizationId(tenant.identifier);
+  if (legacyOrganizationId) {
+    let organization = await metorialDb.organization.findUnique({
+      where: { id: legacyOrganizationId },
+      select: { oid: true }
+    });
+
+    if (organization) {
+      let projects = await metorialDb.project.findMany({
+        where: { organizationOid: organization.oid, status: 'active' },
+        select: { oid: true },
+        orderBy: { oid: 'asc' },
+        take: 2
+      });
+
+      let project = projects[0];
+      if (projects.length === 1 && project) {
+        return {
+          status: 'resolved',
+          value: project.oid,
+          source: 'legacyOrganizationIdentifier'
+        };
+      }
+
+      return {
+        status: 'unresolved',
+        reason: `Organization ${legacyOrganizationId} behind tenant ${tenant.id} has ${projects.length === 0 ? 'no' : 'more than one'} active project`
+      };
+    }
+  }
+
+  let environments = await subspaceDb.environment.findMany({
+    where: { tenant: { id: tenant.id } },
+    select: {
+      id: true,
+      identifier: true,
+      resourceGroupIdentifier: true,
+      instanceOid: true
+    }
+  });
+
+  let projectOids = new Set<bigint>();
+  for (let environment of environments) {
+    let resolution = await resolveInstanceForEnvironment(environment);
+    if (resolution.status === 'resolved') projectOids.add(resolution.value.projectOid);
+  }
+
+  if (projectOids.size === 1) {
+    return {
+      status: 'resolved',
+      value: [...projectOids][0]!,
+      source: 'environments'
+    };
+  }
+
+  return {
+    status: 'unresolved',
+    reason: `No Metorial project resolves for subspace tenant ${tenant.id} (${tenant.identifier})`
+  };
+};
+
+export type ProjectScopeDrift = {
+  hasDrift: boolean;
+  reasons: string[];
+  notes: string[];
+};
+
+export let getProjectScopeDrift = async (d: {
+  projectOid: bigint;
+}): Promise<ProjectScopeDrift> => {
+  let project = await metorialDb.project.findUnique({
+    where: { oid: d.projectOid },
+    select: {
+      oid: true,
+      id: true,
+      subspaceTenantId: true,
+      internalTenantIdentifier: true,
+      instances: {
+        select: {
+          oid: true,
+          id: true,
+          subspaceTenantId: true,
+          internalTenantIdentifier: true,
+          subspaceEnvironmentId: true,
+          internalEnvironmentIdentifier: true
+        }
+      }
+    }
+  });
+
+  let reasons: string[] = [];
+  let notes: string[] = [];
+  let result = () => ({ hasDrift: reasons.length > 0, reasons, notes });
+
+  if (!project) return result();
+
+  let tenantIdentifier = `${CANONICAL_TENANT_PREFIX}${project.oid}`;
+
+  if (!project.subspaceTenantId) return result();
+
+  let tenant = await subspaceDb.tenant.findUnique({
+    where: { id: project.subspaceTenantId },
+    select: { oid: true, identifier: true, retiredAt: true }
+  });
+
+  if (!tenant) {
+    reasons.push(`Project ${project.id} points at missing tenant ${project.subspaceTenantId}`);
+    return result();
+  }
+  if (tenant.retiredAt) {
+    reasons.push(`Project ${project.id} points at retired tenant ${project.subspaceTenantId}`);
+    return result();
+  }
+
+  if (
+    isCanonicalProjectIdentifier(tenant.identifier) &&
+    tenant.identifier !== tenantIdentifier
+  ) {
+    notes.push(
+      `Project ${project.id} points at tenant ${tenant.identifier}, which names another project`
+    );
+    return result();
+  }
+
+  if (tenant.identifier !== tenantIdentifier) {
+    reasons.push(
+      `Project ${project.id} resolves to tenant ${tenant.identifier}, expected ${tenantIdentifier}`
+    );
+  }
+  if (project.internalTenantIdentifier !== tenantIdentifier) {
+    reasons.push(
+      `Project ${project.id} is labelled ${project.internalTenantIdentifier}, expected ${tenantIdentifier}`
+    );
+  }
+
+  for (let instance of project.instances) {
+    let environmentIdentifier = `${CANONICAL_ENVIRONMENT_PREFIX}${instance.oid}`;
+
+    if (
+      instance.internalTenantIdentifier &&
+      instance.internalTenantIdentifier !== tenantIdentifier
+    ) {
+      reasons.push(
+        `Instance ${instance.id} is labelled ${instance.internalTenantIdentifier}, expected ${tenantIdentifier}`
+      );
+    }
+    if (instance.subspaceTenantId && instance.subspaceTenantId !== project.subspaceTenantId) {
+      reasons.push(`Instance ${instance.id} points at a different tenant than its project`);
+    }
+
+    if (!instance.subspaceEnvironmentId) continue;
+
+    let environment = await subspaceDb.environment.findUnique({
+      where: { id: instance.subspaceEnvironmentId },
+      select: { identifier: true, tenantOid: true }
+    });
+
+    if (!environment) {
+      reasons.push(
+        `Instance ${instance.id} points at missing environment ${instance.subspaceEnvironmentId}`
+      );
+      continue;
+    }
+
+    if (
+      isCanonicalEnvironmentIdentifier(environment.identifier) &&
+      environment.identifier !== environmentIdentifier
+    ) {
+      notes.push(
+        `Instance ${instance.id} points at environment ${environment.identifier}, which names another instance`
+      );
+      continue;
+    }
+
+    if (environment.identifier !== environmentIdentifier) {
+      reasons.push(
+        `Instance ${instance.id} resolves to environment ${environment.identifier}, expected ${environmentIdentifier}`
+      );
+    }
+    if (environment.tenantOid !== tenant.oid) {
+      reasons.push(`Instance ${instance.id} environment sits under a different tenant`);
+    }
+    if (instance.internalEnvironmentIdentifier !== environmentIdentifier) {
+      reasons.push(
+        `Instance ${instance.id} environment is labelled ${instance.internalEnvironmentIdentifier}, expected ${environmentIdentifier}`
+      );
+    }
+  }
+
+  return result();
+};

--- a/src/metorial/subspace/modules/tenant/src/lib/mirrorReferences.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/mirrorReferences.ts
@@ -1,16 +1,11 @@
 import { db as subspaceDb } from '@metorial-subspace/db';
+import {
+  getModelsByScalarFields,
+  type RuntimeField,
+  type ScopedClient
+} from './tenantScopedReferences';
 
-type RuntimeField = {
-  name: string;
-  kind: string;
-  type: string;
-  isList?: boolean;
-};
-
-export type MirrorClient = {
-  _runtimeDataModel?: { models?: Record<string, { fields?: RuntimeField[] }> };
-  [key: string]: any;
-};
+export type MirrorClient = ScopedClient;
 
 export type MirrorReference = {
   model: string;
@@ -30,28 +25,6 @@ let MIRROR_TARGETS = {
   tenantOid: 'Project',
   environmentOid: 'Instance'
 } as const;
-
-let getModelsByScalarFields = (client: MirrorClient) => {
-  let byModel = new Map<string, { delegate: string; scalars: Set<string> }>();
-
-  for (let key of Object.keys(client)) {
-    if (key.startsWith('$') || key.startsWith('_') || key === 'constructor') continue;
-
-    let fields = client[key]?.fields;
-    if (!fields || typeof fields !== 'object') continue;
-
-    let refs = Object.values(fields) as { modelName?: string; name?: string }[];
-    let model = refs.find(ref => ref.modelName)?.modelName;
-    if (!model) continue;
-
-    byModel.set(model, {
-      delegate: key,
-      scalars: new Set(refs.map(ref => ref.name).filter((name): name is string => !!name))
-    });
-  }
-
-  return byModel;
-};
 
 let resolveMirrorField = (d: {
   model: string;

--- a/src/metorial/subspace/modules/tenant/src/lib/tenantScopedReferences.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/tenantScopedReferences.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The generated client validates its env at import time, and imports are hoisted.
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/scoped-plan-test';
+  process.env.INTEGRATIONS_API_URL ??= 'http://localhost';
+});
+
+import { buildScopedModelPlan, type ScopedClient } from './tenantScopedReferences';
+
+type FieldSpec = { name: string; kind?: string; type?: string };
+
+let fakeClient = (
+  models: Record<string, FieldSpec[]>,
+  includeRuntime = true
+): ScopedClient => {
+  let client: any = { $connect: () => {}, notAModel: { someOtherProperty: true } };
+
+  if (includeRuntime) {
+    client._runtimeDataModel = {
+      models: Object.fromEntries(
+        Object.entries(models).map(([model, fields]) => [
+          model,
+          {
+            fields: fields.map(field => ({
+              name: field.name,
+              kind: field.kind ?? 'scalar',
+              type: field.type ?? 'BigInt',
+              isList: false
+            }))
+          }
+        ])
+      )
+    };
+  }
+
+  for (let [model, fields] of Object.entries(models)) {
+    let delegate = model[0]!.toLowerCase() + model.slice(1);
+    client[delegate] = {
+      fields: Object.fromEntries(
+        fields
+          .filter(field => (field.kind ?? 'scalar') !== 'object')
+          .map(field => [field.name, { modelName: model, name: field.name }])
+      )
+    };
+  }
+
+  return client as ScopedClient;
+};
+
+describe('buildScopedModelPlan', () => {
+  it('splits models by how they are scoped', () => {
+    let plan = buildScopedModelPlan(
+      fakeClient({
+        Session: [{ name: 'oid' }, { name: 'tenantOid' }, { name: 'environmentOid' }],
+        Brand: [{ name: 'oid' }, { name: 'tenantOid' }],
+        Callback: [{ name: 'oid' }, { name: 'environmentOid' }],
+        SkillItem: [{ name: 'oid' }, { name: 'skillOid' }]
+      })
+    );
+
+    expect(plan.environmentScoped).toEqual([
+      { model: 'Callback', delegate: 'callback', hasTenantOid: false },
+      { model: 'Session', delegate: 'session', hasTenantOid: true }
+    ]);
+    expect(plan.tenantScopedOnly).toEqual([
+      { model: 'Brand', delegate: 'brand', hasTenantOid: true }
+    ]);
+  });
+
+  it('leaves the scopes and their mirrors out of both lists', () => {
+    let plan = buildScopedModelPlan(
+      fakeClient({
+        Tenant: [{ name: 'oid' }],
+        Environment: [{ name: 'oid' }, { name: 'tenantOid' }],
+        Project: [{ name: 'oid' }, { name: 'tenantOid' }],
+        Instance: [{ name: 'oid' }, { name: 'environmentOid' }]
+      })
+    );
+
+    expect(plan.environmentScoped).toEqual([]);
+    expect(plan.tenantScopedOnly).toEqual([]);
+  });
+
+  it('refuses to run when the relation metadata is unavailable', () => {
+    expect(() =>
+      buildScopedModelPlan(
+        fakeClient({ Session: [{ name: 'oid' }, { name: 'tenantOid' }] }, false)
+      )
+    ).toThrow(/runtime data model is unavailable/);
+  });
+});
+
+describe('buildScopedModelPlan against the generated client', () => {
+  it('finds the scoped models of the real schema', async () => {
+    let { db } = await import('@metorial-subspace/db');
+
+    let plan = buildScopedModelPlan(db as unknown as ScopedClient);
+
+    expect(plan.environmentScoped.length).toBeGreaterThan(40);
+    expect(plan.tenantScopedOnly.length).toBeGreaterThan(20);
+
+    let models = plan.environmentScoped.map(entry => entry.model);
+    expect(models).toContain('Session');
+    expect(models).not.toContain('Instance');
+
+    // Everything that would have to move with an environment carries the denormalized tenantOid.
+    expect(plan.environmentScoped.find(entry => entry.model === 'Session')?.hasTenantOid).toBe(
+      true
+    );
+
+    let tenantOnly = plan.tenantScopedOnly.map(entry => entry.model);
+    expect(tenantOnly).toContain('Brand');
+    expect(tenantOnly).not.toContain('Session');
+    expect(tenantOnly).not.toContain('Project');
+  });
+});

--- a/src/metorial/subspace/modules/tenant/src/lib/tenantScopedReferences.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/tenantScopedReferences.ts
@@ -1,0 +1,85 @@
+import { db as subspaceDb } from '@metorial-subspace/db';
+
+export type RuntimeField = {
+  name: string;
+  kind: string;
+  type: string;
+  isList?: boolean;
+};
+
+export type ScopedClient = {
+  _runtimeDataModel?: { models?: Record<string, { fields?: RuntimeField[] }> };
+  [key: string]: any;
+};
+
+export let getModelsByScalarFields = (client: ScopedClient) => {
+  let byModel = new Map<string, { delegate: string; scalars: Set<string> }>();
+
+  for (let key of Object.keys(client)) {
+    if (key.startsWith('$') || key.startsWith('_') || key === 'constructor') continue;
+
+    let fields = client[key]?.fields;
+    if (!fields || typeof fields !== 'object') continue;
+
+    let refs = Object.values(fields) as { modelName?: string; name?: string }[];
+    let model = refs.find(ref => ref.modelName)?.modelName;
+    if (!model) continue;
+
+    byModel.set(model, {
+      delegate: key,
+      scalars: new Set(refs.map(ref => ref.name).filter((name): name is string => !!name))
+    });
+  }
+
+  return byModel;
+};
+
+export type ScopedModel = {
+  model: string;
+  delegate: string;
+  hasTenantOid: boolean;
+};
+
+export type ScopedModelPlan = {
+  environmentScoped: ScopedModel[];
+  tenantScopedOnly: ScopedModel[];
+};
+
+let EXCLUDED_MODELS = new Set(['Project', 'Instance', 'Tenant', 'Environment']);
+
+export let buildScopedModelPlan = (client: ScopedClient): ScopedModelPlan => {
+  if (!client._runtimeDataModel?.models) {
+    throw new Error(
+      'Prisma runtime data model is unavailable, so scoped models cannot be enumerated. ' +
+        'Refusing to move tenant-scoped rows.'
+    );
+  }
+
+  let plan: ScopedModelPlan = { environmentScoped: [], tenantScopedOnly: [] };
+
+  for (let [model, { delegate, scalars }] of getModelsByScalarFields(client)) {
+    if (EXCLUDED_MODELS.has(model)) continue;
+
+    let hasTenantOid = scalars.has('tenantOid');
+    let hasEnvironmentOid = scalars.has('environmentOid');
+
+    if (hasEnvironmentOid) plan.environmentScoped.push({ model, delegate, hasTenantOid });
+    else if (hasTenantOid) plan.tenantScopedOnly.push({ model, delegate, hasTenantOid });
+  }
+
+  plan.environmentScoped.sort((a, b) => a.model.localeCompare(b.model));
+  plan.tenantScopedOnly.sort((a, b) => a.model.localeCompare(b.model));
+
+  return plan;
+};
+
+let cachedPlan: ScopedModelPlan | undefined;
+
+let getScopedModelPlan = () => {
+  cachedPlan ??= buildScopedModelPlan(subspaceDb as unknown as ScopedClient);
+  return cachedPlan;
+};
+
+export let getEnvironmentScopedModels = () => getScopedModelPlan().environmentScoped;
+
+export let getTenantScopedOnlyModels = () => getScopedModelPlan().tenantScopedOnly;

--- a/src/metorial/subspace/modules/tenant/src/queues.ts
+++ b/src/metorial/subspace/modules/tenant/src/queues.ts
@@ -1,4 +1,5 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
+import { legacyScopeQueues } from './queues/legacyScope';
 import { metorialResourceQueues } from './queues/metorialResource';
 import { mirrorReferenceQueues } from './queues/mirrorReference';
 import { resourceLinkQueues } from './queues/resourceLink';
@@ -8,5 +9,6 @@ export let tenantQueueProcessors = combineQueueProcessors([
   retentionQueues,
   resourceLinkQueues,
   mirrorReferenceQueues,
-  metorialResourceQueues
+  metorialResourceQueues,
+  legacyScopeQueues
 ]);

--- a/src/metorial/subspace/modules/tenant/src/queues/legacyScope/index.ts
+++ b/src/metorial/subspace/modules/tenant/src/queues/legacyScope/index.ts
@@ -135,6 +135,14 @@ export let reconcileLegacyScopeProjectQueueProcessor =
       return;
     }
 
+    if (report.warnings.length > 0) {
+      console.warn(
+        `[subspace] legacy scope reconciled project ${report.projectOid} with warnings: ${report.warnings.join('; ')}`,
+        report
+      );
+      return;
+    }
+
     console.log(`[subspace] legacy scope reconciled`, report);
   });
 

--- a/src/metorial/subspace/modules/tenant/src/queues/legacyScope/index.ts
+++ b/src/metorial/subspace/modules/tenant/src/queues/legacyScope/index.ts
@@ -1,0 +1,146 @@
+import { createCron } from '@lowerdeck/cron';
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import { db as subspaceDb } from '@metorial-subspace/db';
+import { env } from '../../env';
+import {
+  CANONICAL_ENVIRONMENT_PREFIX,
+  CANONICAL_TENANT_PREFIX,
+  resolveInstanceForEnvironment,
+  resolveProjectForTenant
+} from '../../lib/legacyScope';
+import { reconcileLegacyScopeService } from '../../services/reconcileLegacyScope';
+import {
+  enqueueLegacyScopeRepair,
+  reconcileLegacyScopeEnvironmentSearchQueue,
+  reconcileLegacyScopeProjectQueue,
+  reconcileLegacyScopeTenantSearchQueue
+} from './queues';
+
+let BATCH_SIZE = 500;
+
+export * from './queues';
+
+export let reconcileLegacyScopeCron = createCron(
+  {
+    name: 'sub/ten/legacy/scope/cron',
+    redisUrl: env.service.REDIS_URL,
+    cron: '30 * * * *'
+  },
+  async () => {
+    await reconcileLegacyScopeTenantSearchQueue.add(
+      {},
+      { id: 'subspace-legacy-scope-tenant-search' }
+    );
+    await reconcileLegacyScopeEnvironmentSearchQueue.add(
+      {},
+      { id: 'subspace-legacy-scope-environment-search' }
+    );
+  }
+);
+
+export let reconcileLegacyScopeTenantSearchQueueProcessor =
+  reconcileLegacyScopeTenantSearchQueue.process(async data => {
+    let tenants = await subspaceDb.tenant.findMany({
+      where: {
+        retiredAt: null,
+        NOT: { identifier: { startsWith: CANONICAL_TENANT_PREFIX } },
+        oid: data.cursor ? { gt: BigInt(data.cursor) } : undefined
+      },
+      orderBy: { oid: 'asc' },
+      take: BATCH_SIZE,
+      select: {
+        oid: true,
+        id: true,
+        identifier: true,
+        resourceTenantIdentifier: true,
+        projectOid: true
+      }
+    });
+    if (tenants.length === 0) return;
+
+    for (let tenant of tenants) {
+      let resolution = await resolveProjectForTenant(tenant);
+
+      if (resolution.status === 'unresolved') {
+        console.warn(`[subspace] legacy tenant not reconciled: ${resolution.reason}`);
+        continue;
+      }
+
+      await enqueueLegacyScopeRepair({ projectOid: resolution.value });
+    }
+
+    let lastTenant = tenants[tenants.length - 1];
+    if (!lastTenant) return;
+
+    await reconcileLegacyScopeTenantSearchQueue.add({ cursor: lastTenant.oid.toString() });
+  });
+
+export let reconcileLegacyScopeEnvironmentSearchQueueProcessor =
+  reconcileLegacyScopeEnvironmentSearchQueue.process(async data => {
+    let environments = await subspaceDb.environment.findMany({
+      where: {
+        NOT: { identifier: { startsWith: CANONICAL_ENVIRONMENT_PREFIX } },
+        oid: data.cursor ? { gt: BigInt(data.cursor) } : undefined
+      },
+      orderBy: { oid: 'asc' },
+      take: BATCH_SIZE,
+      select: {
+        oid: true,
+        id: true,
+        identifier: true,
+        resourceGroupIdentifier: true,
+        instanceOid: true
+      }
+    });
+    if (environments.length === 0) return;
+
+    for (let environment of environments) {
+      let resolution = await resolveInstanceForEnvironment(environment);
+
+      if (resolution.status === 'unresolved') {
+        console.warn(`[subspace] legacy environment not reconciled: ${resolution.reason}`);
+        continue;
+      }
+
+      await enqueueLegacyScopeRepair({ projectOid: resolution.value.projectOid });
+    }
+
+    let lastEnvironment = environments[environments.length - 1];
+    if (!lastEnvironment) return;
+
+    await reconcileLegacyScopeEnvironmentSearchQueue.add({
+      cursor: lastEnvironment.oid.toString()
+    });
+  });
+
+export let reconcileLegacyScopeProjectQueueProcessor =
+  reconcileLegacyScopeProjectQueue.process(async data => {
+    let report = await reconcileLegacyScopeService.reconcileLegacyProjectScope({
+      projectOid: BigInt(data.projectOid)
+    });
+
+    if (report.status === 'aborted') {
+      console.error(
+        `[subspace] legacy scope reconcile aborted for project ${report.projectOid}: ${report.reason}`
+      );
+      return;
+    }
+
+    if (report.status === 'noop') {
+      if (report.warnings.length > 0) {
+        console.warn(
+          `[subspace] legacy scope left project ${report.projectOid} untouched: ${report.warnings.join('; ')}`
+        );
+      }
+      return;
+    }
+
+    console.log(`[subspace] legacy scope reconciled`, report);
+  });
+
+export let legacyScopeQueues = combineQueueProcessors([
+  reconcileLegacyScopeCron,
+  reconcileLegacyScopeTenantSearchQueueProcessor,
+  reconcileLegacyScopeEnvironmentSearchQueueProcessor,
+  reconcileLegacyScopeProjectQueueProcessor
+]);

--- a/src/metorial/subspace/modules/tenant/src/queues/legacyScope/queues.ts
+++ b/src/metorial/subspace/modules/tenant/src/queues/legacyScope/queues.ts
@@ -1,0 +1,36 @@
+import { createQueue } from '@lowerdeck/queue';
+import { env } from '../../env';
+import { getProjectScopeDrift } from '../../lib/legacyScope';
+
+export let reconcileLegacyScopeProjectQueue = createQueue<{ projectOid: string }>({
+  name: 'sub/ten/legacy/scope/project',
+  redisUrl: env.service.REDIS_URL,
+  workerOpts: { concurrency: 1 }
+});
+
+export let reconcileLegacyScopeTenantSearchQueue = createQueue<{ cursor?: string }>({
+  name: 'sub/ten/legacy/scope/tenant/search',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let reconcileLegacyScopeEnvironmentSearchQueue = createQueue<{ cursor?: string }>({
+  name: 'sub/ten/legacy/scope/environment/search',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueLegacyScopeRepair = async (d: { projectOid: bigint | string }) => {
+  let projectOid = d.projectOid.toString();
+
+  await reconcileLegacyScopeProjectQueue.add(
+    { projectOid },
+    { id: `subspace-legacy-scope:${projectOid}` }
+  );
+};
+
+export let deferToLegacyScopeReconciler = async (d: { projectOid: bigint }) => {
+  let drift = await getProjectScopeDrift(d);
+  if (!drift.hasDrift) return false;
+
+  await enqueueLegacyScopeRepair({ projectOid: d.projectOid });
+  return true;
+};

--- a/src/metorial/subspace/modules/tenant/src/services/index.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/index.ts
@@ -2,6 +2,7 @@ export * from './actor';
 export * from './brand';
 export * from './environment';
 export * from './metorialResource';
+export * from './reconcileLegacyScope';
 export * from './resourceCount';
 export * from './solution';
 export * from './subspaceScope';

--- a/src/metorial/subspace/modules/tenant/src/services/metorialResource.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/metorialResource.test.ts
@@ -19,7 +19,9 @@ let mocks = vi.hoisted(() => ({
   consumerProfileFindMany: vi.fn(),
   consumerProfileUpsert: vi.fn(),
   metorialOrganizationFind: vi.fn(),
+  metorialOrganizationUpdate: vi.fn(),
   metorialProjectFind: vi.fn(),
+  metorialProjectFindMany: vi.fn(),
   tenantFindUnique: vi.fn(),
   tenantActorFindMany: vi.fn(),
   metorialActorFind: vi.fn(),
@@ -33,7 +35,8 @@ let mocks = vi.hoisted(() => ({
   ensureForOrganizationActor: vi.fn(),
   ensureNetworksForTenant: vi.fn(),
   backfillTenantReferences: vi.fn(),
-  backfillEnvironmentReferences: vi.fn()
+  backfillEnvironmentReferences: vi.fn(),
+  deferToLegacyScopeReconciler: vi.fn()
 }));
 
 vi.mock('@lowerdeck/service', () => ({
@@ -90,8 +93,14 @@ vi.mock('@metorial-subspace/db', () => ({
 
 vi.mock('../lib/metorialDb', () => ({
   metorialDb: {
-    organization: { findUniqueOrThrow: mocks.metorialOrganizationFind },
-    project: { findUniqueOrThrow: mocks.metorialProjectFind },
+    organization: {
+      findUniqueOrThrow: mocks.metorialOrganizationFind,
+      update: mocks.metorialOrganizationUpdate
+    },
+    project: {
+      findUniqueOrThrow: mocks.metorialProjectFind,
+      findMany: mocks.metorialProjectFindMany
+    },
     instance: { findUniqueOrThrow: mocks.metorialInstanceFind },
     organizationActor: {
       findUniqueOrThrow: mocks.metorialActorFind,
@@ -115,6 +124,10 @@ vi.mock('./tenant', () => ({
   tenantService: {
     ensureNetworksForTenant: mocks.ensureNetworksForTenant
   }
+}));
+
+vi.mock('../queues/legacyScope/queues', () => ({
+  deferToLegacyScopeReconciler: mocks.deferToLegacyScopeReconciler
 }));
 
 vi.mock('./backfillMirrorReferences', () => ({
@@ -157,6 +170,37 @@ describe('Metorial resource synchronization', () => {
     mocks.tenantFindUnique.mockResolvedValue(null);
     mocks.tenantActorFindMany.mockResolvedValue([]);
     mocks.ensureForOrganizationActor.mockResolvedValue({ oid: 40n, id: 'act_40' });
+    mocks.deferToLegacyScopeReconciler.mockResolvedValue(false);
+    mocks.metorialProjectFindMany.mockResolvedValue([]);
+  });
+
+  describe('reconcileOrganization', () => {
+    let project = { oid: 2n, id: 'pro_1', organizationOid: 1n, instances: [] };
+
+    beforeEach(() => {
+      mocks.metorialOrganizationFind.mockResolvedValue({
+        ...organization,
+        projects: [project]
+      });
+      mocks.organizationUpsert.mockResolvedValue({ oid: 1n, id: 'org_1' });
+      mocks.ensureForProject.mockResolvedValue({ tenant: { oid: 20n, id: 'ktn_1' } });
+      mocks.projectUpsert.mockResolvedValue({ oid: 2n, id: 'pro_1' });
+    });
+
+    it('leaves a project with a legacy scope to the legacy reconciler', async () => {
+      mocks.deferToLegacyScopeReconciler.mockResolvedValue(true);
+
+      await metorialResourceService.reconcileOrganization('org_1');
+
+      expect(mocks.deferToLegacyScopeReconciler).toHaveBeenCalledWith({ projectOid: 2n });
+      expect(mocks.ensureForProject).not.toHaveBeenCalled();
+    });
+
+    it('syncs a project whose scope is already canonical', async () => {
+      await metorialResourceService.reconcileOrganization('org_1');
+
+      expect(mocks.ensureForProject).toHaveBeenCalledWith(project);
+    });
   });
 
   it('creates the organization mirror with the exact Metorial oid and id', async () => {
@@ -339,7 +383,11 @@ describe('Metorial resource synchronization', () => {
     mocks.metorialOrganizationFind.mockResolvedValue(organization);
     mocks.organizationUpsert.mockResolvedValue(organization);
     mocks.organizationActorUpsert.mockResolvedValue(actor);
-    mocks.projectFindMany.mockResolvedValue([{ tenantOid: 20n }, { tenantOid: 20n }, { tenantOid: 21n }]);
+    mocks.projectFindMany.mockResolvedValue([
+      { tenantOid: 20n },
+      { tenantOid: 20n },
+      { tenantOid: 21n }
+    ]);
     mocks.tenantFindUnique.mockImplementation(async ({ where }: { where: { oid: bigint } }) =>
       where.oid === 20n ? tenantA : tenantB
     );

--- a/src/metorial/subspace/modules/tenant/src/services/metorialResource.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/metorialResource.ts
@@ -1,4 +1,5 @@
 import { Service } from '@lowerdeck/service';
+import { db, type Tenant } from '@metorial-subspace/db';
 import type {
   Consumer as MetorialConsumer,
   ConsumerProfile as MetorialConsumerProfile,
@@ -9,7 +10,6 @@ import type {
   OrganizationMember as MetorialOrganizationMember,
   Project as MetorialProject
 } from '@metorial/db';
-import { db, type Tenant } from '@metorial-subspace/db';
 import { metorialDb } from '../lib/metorialDb';
 import {
   assertMirrorIdentity,
@@ -19,6 +19,7 @@ import {
   upsertProjectMirror
 } from '../lib/mirrorRecords';
 import { getOrganizationActorInternalActorIdentifier } from '../lib/scopeIds';
+import { deferToLegacyScopeReconciler } from '../queues/legacyScope/queues';
 import { backfillMirrorReferencesService } from './backfillMirrorReferences';
 import { subspaceScopeService } from './subspaceScope';
 import { tenantService } from './tenant';
@@ -337,6 +338,10 @@ class metorialResourceServiceImpl {
 
     await this.syncOrganization(organization);
     for (let project of organization.projects) {
+      // Provisioning a project whose scope is still legacy is what produced duplicate canonical
+      // environments, so the promotion runs instead and syncs the project itself afterwards.
+      if (await deferToLegacyScopeReconciler({ projectOid: project.oid })) continue;
+
       await this.syncProject(project);
       for (let instance of project.instances) {
         await this.syncInstance(instance);

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
@@ -545,6 +545,11 @@ describe('reconcileLegacyProjectScope', () => {
     expect(update).not.toHaveProperty('subspaceEnvironmentId');
     expect(update).not.toHaveProperty('internalEnvironmentIdentifier');
     expect(h.state.environments[0]).toMatchObject({ id: 'ken_30', tenantOid: 21n });
+
+    // Syncing the instance would provision a canonical environment and repoint the instance at it,
+    // abandoning the one we just kept.
+    expect(h.state.handoff).not.toContainEqual(['syncInstance', 3n]);
+    expect(h.state.handoff).toContainEqual(['reconcileProjectLinks', 2n]);
   });
 
   it('repairs the Metorial pointers when only they have drifted', async () => {

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
@@ -74,6 +74,12 @@ let h = vi.hoisted(() => {
         Object.assign(environment, data);
         return environment;
       },
+      updateMany: async ({ where, data }: any) => {
+        let rows = state.environments.filter(row => matches(row, where));
+        state.opLog.push({ op: 'updateEnvironments', where, data });
+        for (let row of rows) Object.assign(row, data);
+        return { count: rows.length };
+      },
       delete: async ({ where }: any) => {
         state.opLog.push({ op: 'deleteEnvironment', oid: where.oid });
         state.environments = state.environments.filter(row => row.oid !== where.oid);
@@ -167,6 +173,10 @@ vi.mock('../lib/metorialDb', () => ({
         h.state.projects
           .flatMap(project => project.instances)
           .find(row => h.matches(row, where)) ?? null,
+      count: async ({ where }: any) =>
+        h.state.projects
+          .flatMap(project => project.instances)
+          .filter(row => h.matches(row, where)).length,
       update: async ({ where, data }: any) => {
         h.state.metorialInstanceUpdates.push({ where, data });
         let instance = h.state.projects
@@ -184,6 +194,11 @@ vi.mock('../lib/metorialDb', () => ({
     },
     resourceGroup: { findUnique: async () => null }
   }
+}));
+
+vi.mock('../lib/mirrorRecords', () => ({
+  // Mirror rows carry the oid of the Metorial row they mirror.
+  ensureInstanceMirror: async (d: any) => d.instanceOid
 }));
 
 vi.mock('./metorialResource', () => ({
@@ -547,9 +562,116 @@ describe('reconcileLegacyProjectScope', () => {
     expect(h.state.environments[0]).toMatchObject({ id: 'ken_30', tenantOid: 21n });
 
     // Syncing the instance would provision a canonical environment and repoint the instance at it,
-    // abandoning the one we just kept.
+    // abandoning the one we just kept. Link reconciliation would only defer back into this queue.
     expect(h.state.handoff).not.toContainEqual(['syncInstance', 3n]);
-    expect(h.state.handoff).toContainEqual(['reconcileProjectLinks', 2n]);
+    expect(h.state.handoff).not.toContainEqual(['reconcileProjectLinks', 2n]);
+  });
+
+  it('will not promote an environment that names another instance of the same project', async () => {
+    // A stale mirror points instance 3 at instance 4's canonical environment. Promoting it would
+    // rename a correct row onto the wrong instance.
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [
+          makeInstance({ subspaceEnvironmentId: 'ken_40' }),
+          makeInstance({ oid: 4n, id: 'ins_4' })
+        ]
+      })
+    ];
+    h.state.tenants = [makeTenant()];
+    h.state.environments = [
+      makeEnvironment({ oid: 40n, id: 'ken_40', identifier: 'mte-ins-4', instanceOid: 3n })
+    ];
+
+    let report = await reconcile();
+
+    expect(report.warnings).toContainEqual(
+      expect.stringContaining('names instance 4 but resolves to instance 3')
+    );
+    expect(report.renamedEnvironments).toEqual([]);
+    expect(report.deletedEnvironments).toEqual([]);
+    expect(h.state.environments[0]).toMatchObject({
+      identifier: 'mte-ins-4',
+      tenantOid: 20n,
+      instanceOid: 3n
+    });
+  });
+
+  it('will not repoint the mirror of an environment that names another instance', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [
+          makeInstance({ subspaceEnvironmentId: 'ken_40' }),
+          makeInstance({ oid: 4n, id: 'ins_4' })
+        ]
+      })
+    ];
+    h.state.tenants = [makeTenant()];
+    h.state.environments = [
+      makeEnvironment({ oid: 40n, id: 'ken_40', identifier: 'mte-ins-4', instanceOid: 4n })
+    ];
+
+    let report = await reconcile();
+
+    expect(report.warnings).toContainEqual(
+      expect.stringContaining('names instance 4, leaving its mirror alone')
+    );
+    expect(h.state.environments[0]).toMatchObject({ instanceOid: 4n });
+  });
+
+  it('repoints a kept environment mirror so the next run can promote it', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      }),
+      makeProject({
+        oid: 9n,
+        id: 'prj_9',
+        instances: [makeInstance({ oid: 5n, id: 'ins_5', projectOid: 9n })]
+      })
+    ];
+    h.state.tenants = [makeTenant(), makeTenant({ oid: 21n, id: 'ktn_21' })];
+    h.state.environments = [makeEnvironment({ tenantOid: 21n, instanceOid: 5n })];
+
+    let report = await reconcile();
+
+    expect(report.warnings).toContainEqual(
+      expect.stringContaining('Repointed environment ken_30 at instance ins_1')
+    );
+    expect(h.state.environments[0]).toMatchObject({ id: 'ken_30', instanceOid: 3n });
+  });
+
+  it('leaves the mirror alone when two instances claim one environment', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      }),
+      makeProject({
+        oid: 9n,
+        id: 'prj_9',
+        instances: [
+          makeInstance({
+            oid: 5n,
+            id: 'ins_5',
+            projectOid: 9n,
+            subspaceEnvironmentId: 'ken_30'
+          })
+        ]
+      })
+    ];
+    h.state.tenants = [makeTenant(), makeTenant({ oid: 21n, id: 'ktn_21' })];
+    h.state.environments = [makeEnvironment({ tenantOid: 21n, instanceOid: 5n })];
+
+    let report = await reconcile();
+
+    expect(report.warnings).toContainEqual(
+      expect.stringContaining('claimed by 2 instances, leaving its mirror alone')
+    );
+    expect(h.state.environments[0]).toMatchObject({ instanceOid: 5n });
   });
 
   it('repairs the Metorial pointers when only they have drifted', async () => {

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
@@ -596,9 +596,20 @@ describe('reconcileLegacyProjectScope', () => {
       tenantOid: 20n,
       instanceOid: 3n
     });
+
+    // The link is the stale side, so it is dropped and the instance provisions its own environment
+    // through the regular path rather than being held back while a sibling provisions one for it.
+    expect(report.warnings).toContainEqual(
+      expect.stringContaining('dropped its link to ken_40, which names another instance')
+    );
+    expect(h.state.metorialInstanceUpdates[0]?.data).toMatchObject({
+      subspaceEnvironmentId: null,
+      internalEnvironmentIdentifier: null
+    });
+    expect(h.state.handoff).toContainEqual(['syncInstance', 3n]);
   });
 
-  it('will not repoint the mirror of an environment that names another instance', async () => {
+  it('drops a link to a sibling environment whose own mirror is correct', async () => {
     h.state.projects = [
       makeProject({
         subspaceTenantId: 'ktn_20',
@@ -615,10 +626,18 @@ describe('reconcileLegacyProjectScope', () => {
 
     let report = await reconcile();
 
+    // Instance 4 owns ken_40 on both sides, so instance 3's link is the only wrong thing here.
     expect(report.warnings).toContainEqual(
-      expect.stringContaining('names instance 4, leaving its mirror alone')
+      expect.stringContaining('dropped its link to ken_40, which names another instance')
     );
-    expect(h.state.environments[0]).toMatchObject({ instanceOid: 4n });
+    expect(h.state.environments[0]).toMatchObject({
+      identifier: 'mte-ins-4',
+      instanceOid: 4n
+    });
+    expect(h.state.metorialInstanceUpdates[0]?.data).toMatchObject({
+      subspaceEnvironmentId: null,
+      internalEnvironmentIdentifier: null
+    });
   });
 
   it('repoints a kept environment mirror so the next run can promote it', async () => {

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.test.ts
@@ -1,0 +1,615 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let h = vi.hoisted(() => {
+  let matchValue = (value: any, filter: any): boolean => {
+    if (filter === undefined) return true;
+
+    if (
+      filter !== null &&
+      typeof filter === 'object' &&
+      !Array.isArray(filter) &&
+      !(filter instanceof Date)
+    ) {
+      if ('in' in filter) return (filter.in ?? []).some((entry: any) => entry === value);
+      if ('not' in filter) return !matchValue(value, filter.not);
+      if ('startsWith' in filter) {
+        return typeof value === 'string' && value.startsWith(filter.startsWith);
+      }
+      if ('gt' in filter) return value > filter.gt;
+      return false;
+    }
+
+    return value === filter;
+  };
+
+  let matches = (row: any, where: any = {}): boolean =>
+    Object.entries(where ?? {}).every(([key, filter]) => {
+      if (key === 'OR') return (filter as any[]).some(sub => matches(row, sub));
+      if (key === 'NOT') return !matches(row, filter);
+      return matchValue(row[key], filter);
+    });
+
+  let state = {
+    tenants: [] as any[],
+    environments: [] as any[],
+    projects: [] as any[],
+    mirrorProject: null as any,
+    mirrorInstances: [] as any[],
+    childRows: new Map<string, number>(),
+    // Rows that appear only once planning has already counted the environment.
+    childRowsOnRecheck: new Map<string, number>(),
+    childRowCalls: new Map<string, number>(),
+    opLog: [] as any[],
+    metorialProjectUpdates: [] as any[],
+    metorialInstanceUpdates: [] as any[],
+    organizationUpdates: [] as any[],
+    handoff: [] as any[]
+  };
+
+  let subspaceDb = {
+    tenant: {
+      findUnique: async ({ where }: any) =>
+        state.tenants.find(row => (where.oid ? row.oid === where.oid : row.id === where.id)) ??
+        null,
+      findMany: async ({ where }: any) => state.tenants.filter(row => matches(row, where)),
+      update: async ({ where, data }: any) => {
+        let tenant = state.tenants.find(row => row.oid === where.oid);
+        state.opLog.push({ op: 'updateTenant', oid: where.oid, data });
+        Object.assign(tenant, data);
+        return tenant;
+      }
+    },
+    environment: {
+      findUnique: async ({ where }: any) =>
+        state.environments.find(row =>
+          where.oid ? row.oid === where.oid : row.id === where.id
+        ) ?? null,
+      findMany: async ({ where }: any) =>
+        state.environments.filter(row => matches(row, where)),
+      count: async ({ where }: any) =>
+        state.environments.filter(row => matches(row, where)).length,
+      update: async ({ where, data }: any) => {
+        let environment = state.environments.find(row => row.oid === where.oid);
+        state.opLog.push({ op: 'updateEnvironment', oid: where.oid, data });
+        Object.assign(environment, data);
+        return environment;
+      },
+      delete: async ({ where }: any) => {
+        state.opLog.push({ op: 'deleteEnvironment', oid: where.oid });
+        state.environments = state.environments.filter(row => row.oid !== where.oid);
+      }
+    },
+    project: {
+      updateMany: async ({ where, data }: any) => {
+        state.opLog.push({ op: 'mirrorProject', oid: where.oid, data });
+        if (state.mirrorProject) Object.assign(state.mirrorProject, data);
+      }
+    },
+    instance: {
+      updateMany: async ({ where, data }: any) => {
+        state.opLog.push({ op: 'mirrorInstance', oid: where.oid, data });
+        let mirror = state.mirrorInstances.find(row => row.oid === where.oid);
+        if (mirror) Object.assign(mirror, data);
+      },
+      count: async ({ where }: any) =>
+        state.mirrorInstances.filter(row => matches(row, where)).length
+    },
+    providerAuthCredentials: { findMany: async () => [] },
+    managedProviderAuthCredentialsBacking: { updateMany: async () => {} },
+    session: {
+      count: async ({ where }: any) => {
+        let key = String(where.environmentOid);
+        let calls = (state.childRowCalls.get(key) ?? 0) + 1;
+        state.childRowCalls.set(key, calls);
+
+        if (calls > 1 && state.childRowsOnRecheck.has(key)) {
+          return state.childRowsOnRecheck.get(key)!;
+        }
+
+        return state.childRows.get(key) ?? 0;
+      },
+      updateMany: async ({ where, data }: any) => {
+        state.opLog.push({ op: 'moveScopedRows', where, data });
+      }
+    },
+    brand: { count: async () => 0 },
+    monitorAlert: { findMany: async () => [] },
+    monitorAlertEvent: { findMany: async () => [], updateMany: async () => {} },
+    monitorAlertRecipient: {
+      findMany: async () => [],
+      updateMany: async () => {},
+      deleteMany: async () => {}
+    },
+    tenantActor: { findMany: async () => [] }
+  };
+
+  return { matches, state, subspaceDb };
+});
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: { create: vi.fn((_name, factory) => ({ build: () => factory() })) }
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: h.subspaceDb,
+  withTransaction: async (cb: any) => await cb(h.subspaceDb)
+}));
+
+vi.mock('../lib/tenantScopedReferences', () => ({
+  getEnvironmentScopedModels: () => [
+    { model: 'Session', delegate: 'session', hasTenantOid: true }
+  ],
+  getTenantScopedOnlyModels: () => [{ model: 'Brand', delegate: 'brand', hasTenantOid: true }]
+}));
+
+vi.mock('../lib/metorialDb', () => ({
+  metorialDb: {
+    project: {
+      findUnique: async ({ where }: any) =>
+        h.state.projects.find(row => row.oid === where.oid) ?? null,
+      findFirst: async ({ where }: any) =>
+        h.state.projects.find(row => h.matches(row, where)) ?? null,
+      findMany: async ({ where }: any) =>
+        h.state.projects.filter(row => h.matches(row, where)),
+      update: async ({ where, data }: any) => {
+        h.state.metorialProjectUpdates.push({ where, data });
+        let project = h.state.projects.find(row => row.oid === where.oid);
+        Object.assign(project, data);
+        return project;
+      }
+    },
+    instance: {
+      findUnique: async ({ where }: any) =>
+        h.state.projects
+          .flatMap(project => project.instances)
+          .find(row => (where.oid ? row.oid === where.oid : row.id === where.id)) ?? null,
+      findFirst: async ({ where }: any) =>
+        h.state.projects
+          .flatMap(project => project.instances)
+          .find(row => h.matches(row, where)) ?? null,
+      update: async ({ where, data }: any) => {
+        h.state.metorialInstanceUpdates.push({ where, data });
+        let instance = h.state.projects
+          .flatMap(project => project.instances)
+          .find(row => row.oid === where.oid);
+        Object.assign(instance, data);
+        return instance;
+      }
+    },
+    organization: {
+      findUnique: async () => null,
+      update: async (args: any) => {
+        h.state.organizationUpdates.push(args);
+      }
+    },
+    resourceGroup: { findUnique: async () => null }
+  }
+}));
+
+vi.mock('./metorialResource', () => ({
+  metorialResourceService: {
+    syncProject: async (project: any) => h.state.handoff.push(['syncProject', project.oid]),
+    syncInstance: async (instance: any) => h.state.handoff.push(['syncInstance', instance.oid])
+  }
+}));
+
+vi.mock('./reconcileResourceLinks', () => ({
+  reconcileResourceLinksService: {
+    reconcileProjectLinks: async (d: any) =>
+      h.state.handoff.push(['reconcileProjectLinks', d.projectOid])
+  }
+}));
+
+import { reconcileLegacyScopeService } from './reconcileLegacyScope';
+
+let makeInstance = (overrides: Record<string, unknown> = {}) => ({
+  oid: 3n,
+  id: 'ins_1',
+  projectOid: 2n,
+  resourceGroupOid: null,
+  subspaceTenantId: null,
+  subspaceEnvironmentId: null,
+  internalTenantIdentifier: null,
+  internalEnvironmentIdentifier: null,
+  ...overrides
+});
+
+let makeProject = (overrides: Record<string, unknown> = {}) => ({
+  oid: 2n,
+  id: 'prj_1',
+  subspaceTenantId: null,
+  internalTenantIdentifier: null,
+  resourceTenant: null,
+  organization: { id: 'org_1', subspaceTenantIds: [] as string[] },
+  instances: [makeInstance()],
+  ...overrides
+});
+
+let makeTenant = (overrides: Record<string, unknown> = {}) => ({
+  oid: 20n,
+  id: 'ktn_20',
+  identifier: 'mte-ins_1',
+  resourceTenantId: null,
+  resourceTenantIdentifier: null,
+  projectOid: null,
+  retiredAt: null,
+  ...overrides
+});
+
+let makeEnvironment = (overrides: Record<string, unknown> = {}) => ({
+  oid: 30n,
+  id: 'ken_30',
+  identifier: 'mtei-ins_1',
+  tenantOid: 20n,
+  resourceGroupId: null,
+  resourceGroupIdentifier: null,
+  instanceOid: null,
+  ...overrides
+});
+
+let reconcile = () =>
+  reconcileLegacyScopeService.reconcileLegacyProjectScope({ projectOid: 2n });
+
+beforeEach(() => {
+  h.state.tenants = [];
+  h.state.environments = [];
+  h.state.projects = [];
+  h.state.mirrorProject = { oid: 2n, tenantOid: 0n };
+  h.state.mirrorInstances = [{ oid: 3n, environmentOid: 0n }];
+  h.state.childRows = new Map();
+  h.state.childRowsOnRecheck = new Map();
+  h.state.childRowCalls = new Map();
+  h.state.opLog = [];
+  h.state.metorialProjectUpdates = [];
+  h.state.metorialInstanceUpdates = [];
+  h.state.organizationUpdates = [];
+  h.state.handoff = [];
+});
+
+describe('reconcileLegacyProjectScope', () => {
+  it('promotes a single legacy tenant and its environment', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      })
+    ];
+    h.state.tenants = [makeTenant()];
+    h.state.environments = [makeEnvironment()];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('reconciled');
+    expect(report.renamedTenant).toBe(true);
+    expect(report.deletedEnvironments).toEqual([]);
+    expect(h.state.tenants[0]).toMatchObject({
+      identifier: 'mte-pro-2',
+      projectOid: 2n
+    });
+    expect(h.state.environments[0]).toMatchObject({
+      identifier: 'mte-ins-3',
+      tenantOid: 20n,
+      instanceOid: 3n
+    });
+
+    expect(h.state.metorialProjectUpdates[0]?.data).toEqual({
+      internalTenantIdentifier: 'mte-pro-2',
+      subspaceTenantId: 'ktn_20'
+    });
+    expect(h.state.metorialInstanceUpdates[0]?.data).toMatchObject({
+      internalTenantIdentifier: 'mte-pro-2',
+      subspaceTenantId: 'ktn_20',
+      internalEnvironmentIdentifier: 'mte-ins-3',
+      subspaceEnvironmentId: 'ken_30'
+    });
+    expect(h.state.organizationUpdates[0]?.data).toEqual({
+      subspaceTenantIds: ['ktn_20']
+    });
+    expect(h.state.handoff).toEqual([
+      ['syncInstance', 3n],
+      ['reconcileProjectLinks', 2n]
+    ]);
+  });
+
+  it('collapses two per-instance tenants onto the project', async () => {
+    h.state.projects = [
+      makeProject({
+        instances: [
+          makeInstance({ subspaceEnvironmentId: 'ken_30' }),
+          makeInstance({ oid: 4n, id: 'ins_2', subspaceEnvironmentId: 'ken_31' })
+        ]
+      })
+    ];
+    h.state.mirrorInstances = [
+      { oid: 3n, environmentOid: 0n },
+      { oid: 4n, environmentOid: 0n }
+    ];
+    h.state.tenants = [
+      makeTenant(),
+      makeTenant({ oid: 21n, id: 'ktn_21', identifier: 'mte-ins_2' })
+    ];
+    h.state.environments = [
+      makeEnvironment(),
+      makeEnvironment({
+        oid: 31n,
+        id: 'ken_31',
+        identifier: 'mtei-ins_2',
+        tenantOid: 21n
+      })
+    ];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('reconciled');
+    expect(report.promotedTenantId).toBe('ktn_20');
+    expect(report.movedEnvironments).toEqual(['ken_31']);
+    expect(report.retiredTenantIds).toEqual(['ktn_21']);
+
+    expect(h.state.environments.map(row => [row.identifier, row.tenantOid])).toEqual([
+      ['mte-ins-3', 20n],
+      ['mte-ins-4', 20n]
+    ]);
+    expect(h.state.tenants[1].retiredAt).toBeInstanceOf(Date);
+
+    // The moved environment takes its scoped rows with it.
+    expect(h.state.opLog).toContainEqual({
+      op: 'moveScopedRows',
+      where: { environmentOid: 31n, tenantOid: { not: 20n } },
+      data: { tenantOid: 20n }
+    });
+  });
+
+  it('keeps the populated legacy environment and drops the empty canonical duplicate', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      })
+    ];
+    h.state.tenants = [makeTenant()];
+    h.state.environments = [
+      makeEnvironment(),
+      makeEnvironment({ oid: 31n, id: 'ken_31', identifier: 'mte-ins-3', instanceOid: 3n })
+    ];
+    h.state.childRows.set('30', 12);
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('reconciled');
+    expect(report.deletedEnvironments).toEqual(['ken_31']);
+    expect(h.state.environments).toHaveLength(1);
+    expect(h.state.environments[0]).toMatchObject({ id: 'ken_30', identifier: 'mte-ins-3' });
+
+    // Deleting cascades, so the mirror has to be moved off the duplicate first.
+    let repoint = h.state.opLog.findIndex(entry => entry.op === 'mirrorInstance');
+    let remove = h.state.opLog.findIndex(entry => entry.op === 'deleteEnvironment');
+    expect(repoint).toBeGreaterThanOrEqual(0);
+    expect(repoint).toBeLessThan(remove);
+    expect(h.state.mirrorInstances[0].environmentOid).toBe(30n);
+  });
+
+  it('aborts without writing when both environments hold rows', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      })
+    ];
+    h.state.tenants = [makeTenant()];
+    h.state.environments = [
+      makeEnvironment(),
+      makeEnvironment({ oid: 31n, id: 'ken_31', identifier: 'mte-ins-3', instanceOid: 3n })
+    ];
+    h.state.childRows.set('30', 12);
+    h.state.childRows.set('31', 4);
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('aborted');
+    expect(report.reason).toContain('all hold rows for mte-ins-3');
+    expect(h.state.opLog).toEqual([]);
+    expect(h.state.metorialProjectUpdates).toEqual([]);
+    expect(h.state.handoff).toEqual([]);
+  });
+
+  it('leaves an already canonical project alone', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        internalTenantIdentifier: 'mte-pro-2',
+        instances: [
+          makeInstance({
+            subspaceTenantId: 'ktn_20',
+            internalTenantIdentifier: 'mte-pro-2',
+            subspaceEnvironmentId: 'ken_30',
+            internalEnvironmentIdentifier: 'mte-ins-3'
+          })
+        ]
+      })
+    ];
+    h.state.tenants = [makeTenant({ identifier: 'mte-pro-2', projectOid: 2n })];
+    h.state.environments = [makeEnvironment({ identifier: 'mte-ins-3', instanceOid: 3n })];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('noop');
+    expect(h.state.opLog).toEqual([]);
+    expect(h.state.metorialProjectUpdates).toEqual([]);
+    expect(h.state.handoff).toEqual([]);
+  });
+
+  it('will not promote a tenant shared with another project', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      }),
+      makeProject({
+        oid: 9n,
+        id: 'prj_9',
+        instances: [makeInstance({ oid: 5n, id: 'ins_5', projectOid: 9n })]
+      })
+    ];
+    h.state.tenants = [makeTenant({ identifier: 'mteo-org_1' })];
+    h.state.environments = [
+      makeEnvironment(),
+      // A second project's environment still sits under the shared per-organization tenant.
+      makeEnvironment({ oid: 50n, id: 'ken_50', identifier: 'mtei-ins_5', instanceOid: 5n })
+    ];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('aborted');
+    expect(report.reason).toContain('belongs to another project');
+    expect(h.state.opLog).toEqual([]);
+    expect(h.state.metorialProjectUpdates).toEqual([]);
+  });
+
+  it('refuses to delete a duplicate that gained rows since planning', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      })
+    ];
+    h.state.tenants = [makeTenant()];
+    h.state.environments = [
+      makeEnvironment(),
+      makeEnvironment({ oid: 31n, id: 'ken_31', identifier: 'mte-ins-3', instanceOid: 3n })
+    ];
+    h.state.childRows.set('30', 12);
+    // Live traffic writes into the empty duplicate after planning read it as empty.
+    h.state.childRowsOnRecheck.set('31', 3);
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('aborted');
+    expect(report.reason).toContain('gained rows');
+    expect(h.state.environments).toHaveLength(2);
+    expect(h.state.opLog.some(entry => entry.op === 'deleteEnvironment')).toBe(false);
+  });
+
+  it('refuses to delete a duplicate that still backs another instance mirror', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      })
+    ];
+    h.state.tenants = [makeTenant()];
+    h.state.environments = [
+      makeEnvironment(),
+      makeEnvironment({ oid: 31n, id: 'ken_31', identifier: 'mte-ins-3', instanceOid: 3n })
+    ];
+    h.state.childRows.set('30', 12);
+    // Instance mirrors cascade from Environment but carry no environmentOid, so the row count
+    // cannot see them. This one belongs to an instance outside the plan.
+    h.state.mirrorInstances = [
+      { oid: 3n, environmentOid: 0n },
+      { oid: 7n, environmentOid: 31n }
+    ];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('aborted');
+    expect(report.reason).toContain('instance mirrors');
+    expect(h.state.environments).toHaveLength(2);
+    expect(h.state.opLog.some(entry => entry.op === 'deleteEnvironment')).toBe(false);
+  });
+
+  it('keeps an environment link that no candidate resolved to', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      }),
+      makeProject({
+        oid: 9n,
+        id: 'prj_9',
+        instances: [makeInstance({ oid: 5n, id: 'ins_5', projectOid: 9n })]
+      })
+    ];
+    h.state.tenants = [makeTenant(), makeTenant({ oid: 21n, id: 'ktn_21' })];
+    // A stale mirror points this environment at another project's instance, so it never becomes a
+    // plan for instance 3. Its tenant is not the survivor, so the shared-tenant check stays quiet.
+    h.state.environments = [makeEnvironment({ tenantOid: 21n, instanceOid: 5n })];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('reconciled');
+    expect(report.warnings).toContainEqual(
+      expect.stringContaining('keeps its existing environment link ken_30')
+    );
+
+    let update = h.state.metorialInstanceUpdates[0]?.data;
+    expect(update).not.toHaveProperty('subspaceEnvironmentId');
+    expect(update).not.toHaveProperty('internalEnvironmentIdentifier');
+    expect(h.state.environments[0]).toMatchObject({ id: 'ken_30', tenantOid: 21n });
+  });
+
+  it('repairs the Metorial pointers when only they have drifted', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_20',
+        internalTenantIdentifier: 'mteo-org_1',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_30' })]
+      })
+    ];
+    h.state.tenants = [makeTenant({ identifier: 'mte-pro-2', projectOid: 2n })];
+    h.state.environments = [makeEnvironment({ identifier: 'mte-ins-3', instanceOid: 3n })];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('reconciled');
+    expect(h.state.metorialProjectUpdates[0]?.data).toEqual({
+      internalTenantIdentifier: 'mte-pro-2',
+      subspaceTenantId: 'ktn_20'
+    });
+    expect(h.state.metorialInstanceUpdates[0]?.data).toMatchObject({
+      internalEnvironmentIdentifier: 'mte-ins-3',
+      subspaceEnvironmentId: 'ken_30'
+    });
+  });
+
+  it('clears pointers into a tenant that no longer exists', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_gone',
+        internalTenantIdentifier: 'mte-pro-2',
+        instances: [makeInstance({ subspaceEnvironmentId: 'ken_gone' })]
+      })
+    ];
+
+    let report = await reconcile();
+
+    expect(report.status).toBe('reconciled');
+    expect(h.state.metorialProjectUpdates[0]?.data).toEqual({
+      internalTenantIdentifier: null,
+      subspaceTenantId: null
+    });
+    expect(h.state.metorialInstanceUpdates[0]?.data).toEqual({
+      internalEnvironmentIdentifier: null,
+      subspaceEnvironmentId: null
+    });
+    // Cleared pointers let the regular scope path provision from scratch.
+    expect(h.state.handoff).toContainEqual(['syncInstance', 3n]);
+  });
+
+  it('will not repurpose a tenant that belongs to another project', async () => {
+    h.state.projects = [
+      makeProject({
+        subspaceTenantId: 'ktn_99',
+        instances: [makeInstance({ subspaceEnvironmentId: null })]
+      })
+    ];
+    h.state.tenants = [makeTenant({ oid: 99n, id: 'ktn_99', identifier: 'mte-pro-777' })];
+
+    let report = await reconcile();
+
+    // Silently reporting a no-op would hide a project whose scope belongs to another project.
+    expect(report.status).toBe('aborted');
+    expect(report.reason).toContain('names another project');
+    expect(h.state.opLog).toEqual([]);
+    expect(h.state.metorialProjectUpdates).toEqual([]);
+  });
+});

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
@@ -3,9 +3,11 @@ import { db as subspaceDb, withTransaction, type TransactionDB } from '@metorial
 import {
   getProjectScopeDrift,
   isCanonicalProjectIdentifier,
+  parseCanonicalInstanceOid,
   resolveInstanceForEnvironment
 } from '../lib/legacyScope';
 import { metorialDb } from '../lib/metorialDb';
+import { ensureInstanceMirror } from '../lib/mirrorRecords';
 import {
   getInstanceInternalEnvironmentIdentifier,
   getProjectInternalTenantIdentifier
@@ -505,6 +507,8 @@ class ReconcileLegacyScopeServiceImpl {
       report
     });
 
+    await this.repairKeptEnvironmentMirrors({ project, keptExistingLink, report });
+
     await this.handOffToRegularReconciliation({
       projectOid,
       skipInstanceOids: keptExistingLink
@@ -582,6 +586,17 @@ class ReconcileLegacyScopeServiceImpl {
       }
 
       if (resolution.value.projectOid !== d.project.oid) continue;
+
+      // A canonical identifier names the instance it belongs to, and resolution trusts the mirror
+      // before the identifier. When the two disagree the row is another instance's environment
+      // reached through a stale pointer, so promoting it would rename or delete a correct row.
+      let namedInstanceOid = parseCanonicalInstanceOid(candidate.identifier);
+      if (namedInstanceOid !== null && namedInstanceOid !== resolution.value.oid) {
+        d.report.warnings.push(
+          `Environment ${candidate.id} names instance ${namedInstanceOid} but resolves to instance ${resolution.value.oid}, leaving it alone`
+        );
+        continue;
+      }
 
       byInstance.set(resolution.value.oid, [
         ...(byInstance.get(resolution.value.oid) ?? []),
@@ -850,6 +865,58 @@ class ReconcileLegacyScopeServiceImpl {
     return keptExistingLink;
   }
 
+  private async repairKeptEnvironmentMirrors(d: {
+    project: ScopeProject;
+    keptExistingLink: Set<bigint>;
+    report: LegacyScopeReport;
+  }) {
+    for (let instance of d.project.instances) {
+      if (!d.keptExistingLink.has(instance.oid) || !instance.subspaceEnvironmentId) continue;
+
+      let environment = await subspaceDb.environment.findUnique({
+        where: { id: instance.subspaceEnvironmentId },
+        select: { oid: true, identifier: true, tenantOid: true, instanceOid: true }
+      });
+      if (!environment) continue;
+
+      let namedInstanceOid = parseCanonicalInstanceOid(environment.identifier);
+      if (namedInstanceOid !== null && namedInstanceOid !== instance.oid) {
+        d.report.warnings.push(
+          `Environment ${instance.subspaceEnvironmentId} names instance ${namedInstanceOid}, leaving its mirror alone`
+        );
+        continue;
+      }
+
+      let claimants = await metorialDb.instance.count({
+        where: { subspaceEnvironmentId: instance.subspaceEnvironmentId }
+      });
+      if (claimants !== 1) {
+        d.report.warnings.push(
+          `Environment ${instance.subspaceEnvironmentId} is claimed by ${claimants} instances, leaving its mirror alone`
+        );
+        continue;
+      }
+
+      let mirroredInstanceOid = await ensureInstanceMirror({
+        instanceOid: instance.oid,
+        environmentOid: environment.oid,
+        tenantOid: environment.tenantOid
+      });
+      if (mirroredInstanceOid === null || environment.instanceOid === mirroredInstanceOid) {
+        continue;
+      }
+
+      await subspaceDb.environment.updateMany({
+        where: { id: instance.subspaceEnvironmentId },
+        data: { instanceOid: mirroredInstanceOid }
+      });
+
+      d.report.warnings.push(
+        `Repointed environment ${instance.subspaceEnvironmentId} at instance ${instance.id}, the next run can promote it`
+      );
+    }
+  }
+
   private async handOffToRegularReconciliation(d: {
     projectOid: bigint;
     skipInstanceOids?: Set<bigint>;
@@ -860,9 +927,6 @@ class ReconcileLegacyScopeServiceImpl {
     });
     if (!project) return;
 
-    // An instance whose environment link was left as it was must not be synced: the link is still
-    // non-canonical, so persistInstanceScope would provision a fresh environment and repoint the
-    // instance at it, orphaning the populated one this run deliberately kept.
     let instances = project.instances.filter(
       instance => !d.skipInstanceOids?.has(instance.oid)
     );
@@ -875,8 +939,8 @@ class ReconcileLegacyScopeServiceImpl {
       }
     }
 
-    // Link reconciliation is still safe for the skipped instances, and repairing their mirror
-    // references is what lets the next run resolve them properly.
+    if (d.skipInstanceOids?.size) return;
+
     await reconcileResourceLinksService.reconcileProjectLinks({ projectOid: d.projectOid });
   }
 }

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
@@ -497,7 +497,7 @@ class ReconcileLegacyScopeServiceImpl {
 
     report.committedAt = new Date();
 
-    await this.persistMetorialLinks({
+    let keptExistingLink = await this.persistMetorialLinks({
       project,
       tenantIdentifier,
       survivorTenant,
@@ -505,7 +505,10 @@ class ReconcileLegacyScopeServiceImpl {
       report
     });
 
-    await this.handOffToRegularReconciliation({ projectOid });
+    await this.handOffToRegularReconciliation({
+      projectOid,
+      skipInstanceOids: keptExistingLink
+    });
 
     return { ...report, status: 'reconciled' as const };
   }
@@ -792,11 +795,16 @@ class ReconcileLegacyScopeServiceImpl {
     });
 
     let planByInstance = new Map(d.environmentPlans.map(plan => [plan.instanceOid, plan]));
+    let keptExistingLink = new Set<bigint>();
 
     for (let instance of d.project.instances) {
       let plan = planByInstance.get(instance.oid);
 
+      // An instance can end up without a plan because its environment resolved elsewhere. Clearing
+      // the link would orphan whatever that environment holds, so it is kept and the instance is
+      // held back from the handoff, which would otherwise provision a replacement for it.
       if (!plan && instance.subspaceEnvironmentId) {
+        keptExistingLink.add(instance.oid);
         d.report.warnings.push(
           `Instance ${instance.id} keeps its existing environment link ${instance.subspaceEnvironmentId}, no candidate resolved to it`
         );
@@ -825,7 +833,7 @@ class ReconcileLegacyScopeServiceImpl {
       })
     )?.organization;
 
-    if (!organization) return;
+    if (!organization) return keptExistingLink;
 
     let retired = new Set(d.report.retiredTenantIds);
     let subspaceTenantIds = [
@@ -838,23 +846,37 @@ class ReconcileLegacyScopeServiceImpl {
       where: { id: organization.id },
       data: { subspaceTenantIds }
     });
+
+    return keptExistingLink;
   }
 
-  private async handOffToRegularReconciliation(d: { projectOid: bigint }) {
+  private async handOffToRegularReconciliation(d: {
+    projectOid: bigint;
+    skipInstanceOids?: Set<bigint>;
+  }) {
     let project = await metorialDb.project.findUnique({
       where: { oid: d.projectOid },
       include: { instances: true }
     });
     if (!project) return;
 
-    if (project.instances.length === 0) {
+    // An instance whose environment link was left as it was must not be synced: the link is still
+    // non-canonical, so persistInstanceScope would provision a fresh environment and repoint the
+    // instance at it, orphaning the populated one this run deliberately kept.
+    let instances = project.instances.filter(
+      instance => !d.skipInstanceOids?.has(instance.oid)
+    );
+
+    if (instances.length === 0) {
       await metorialResourceService.syncProject(project);
     } else {
-      for (let instance of project.instances) {
+      for (let instance of instances) {
         await metorialResourceService.syncInstance(instance);
       }
     }
 
+    // Link reconciliation is still safe for the skipped instances, and repairing their mirror
+    // references is what lets the next run resolve them properly.
     await reconcileResourceLinksService.reconcileProjectLinks({ projectOid: d.projectOid });
   }
 }

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
@@ -1,0 +1,865 @@
+import { Service } from '@lowerdeck/service';
+import { db as subspaceDb, withTransaction, type TransactionDB } from '@metorial-subspace/db';
+import {
+  getProjectScopeDrift,
+  isCanonicalProjectIdentifier,
+  resolveInstanceForEnvironment
+} from '../lib/legacyScope';
+import { metorialDb } from '../lib/metorialDb';
+import {
+  getInstanceInternalEnvironmentIdentifier,
+  getProjectInternalTenantIdentifier
+} from '../lib/scopeIds';
+import {
+  getEnvironmentScopedModels,
+  getTenantScopedOnlyModels
+} from '../lib/tenantScopedReferences';
+import { metorialResourceService } from './metorialResource';
+import { reconcileResourceLinksService } from './reconcileResourceLinks';
+
+let TRANSACTION_TIMEOUT_MS = 120_000;
+let TRANSACTION_MAX_WAIT_MS = 30_000;
+
+/** Thrown when the legacy state is too ambiguous to repair without losing data. */
+export class LegacyScopeAbort extends Error {}
+
+type TenantCandidate = {
+  oid: bigint;
+  id: string;
+  identifier: string;
+  resourceTenantId: string | null;
+  resourceTenantIdentifier: string | null;
+  projectOid: bigint | null;
+  retiredAt: Date | null;
+};
+
+type EnvironmentCandidate = {
+  oid: bigint;
+  id: string;
+  identifier: string;
+  tenantOid: bigint;
+  resourceGroupId: string | null;
+  resourceGroupIdentifier: string | null;
+  instanceOid: bigint | null;
+};
+
+type EnvironmentPlan = {
+  instanceOid: bigint;
+  instanceId: string;
+  identifier: string;
+  survivor: EnvironmentCandidate;
+  duplicates: EnvironmentCandidate[];
+  resourceGroupId: string | null;
+  resourceGroupIdentifier: string | null;
+};
+
+type ScopeProject = {
+  oid: bigint;
+  id: string;
+  subspaceTenantId: string | null;
+  resourceTenant: { id: string; identifier: string } | null;
+  instances: {
+    oid: bigint;
+    id: string;
+    subspaceTenantId: string | null;
+    subspaceEnvironmentId: string | null;
+    resourceGroupOid: bigint | null;
+  }[];
+};
+
+export type LegacyScopeReport = {
+  projectOid: string;
+  status: 'reconciled' | 'noop' | 'aborted';
+  reason?: string;
+  tenantIdentifier?: string;
+  promotedTenantId?: string;
+  renamedTenant: boolean;
+  movedEnvironments: string[];
+  renamedEnvironments: string[];
+  deletedEnvironments: string[];
+  retiredTenantIds: string[];
+  strandedRows: { tenantId: string; model: string; count: number }[];
+  warnings: string[];
+  /** Set once the subspace transaction commits, after which failures must not be swallowed. */
+  committedAt?: Date;
+};
+
+let tenantSelect = {
+  oid: true,
+  id: true,
+  identifier: true,
+  resourceTenantId: true,
+  resourceTenantIdentifier: true,
+  projectOid: true,
+  retiredAt: true
+};
+
+let environmentSelect = {
+  oid: true,
+  id: true,
+  identifier: true,
+  tenantOid: true,
+  resourceGroupId: true,
+  resourceGroupIdentifier: true,
+  instanceOid: true
+};
+
+let countEnvironmentChildRows = async (
+  environmentOid: bigint,
+  client: TransactionDB | typeof subspaceDb = subspaceDb
+) => {
+  for (let model of getEnvironmentScopedModels()) {
+    let count = await (client as any)[model.delegate].count({
+      where: { environmentOid }
+    });
+    if (count > 0) return count;
+  }
+
+  return 0;
+};
+
+let countTenantScopedOnlyRows = async (tdb: TransactionDB, tenantOid: bigint) => {
+  let counts: { model: string; count: number }[] = [];
+
+  for (let model of getTenantScopedOnlyModels()) {
+    let count = await (tdb as any)[model.delegate].count({ where: { tenantOid } });
+    if (count > 0) counts.push({ model: model.model, count });
+  }
+
+  return counts;
+};
+
+let collectEnvironmentCandidates = async (instances: ScopeProject['instances']) => {
+  let canonicalIdentifiers = instances.map(instance =>
+    getInstanceInternalEnvironmentIdentifier(instance)
+  );
+
+  return await subspaceDb.environment.findMany({
+    where: {
+      OR: [
+        { identifier: { in: canonicalIdentifiers } },
+        { identifier: { in: instances.map(instance => `mtei-${instance.id}`) } },
+        {
+          id: {
+            in: instances.flatMap(instance =>
+              instance.subspaceEnvironmentId ? [instance.subspaceEnvironmentId] : []
+            )
+          }
+        },
+        { instanceOid: { in: instances.map(instance => instance.oid) } },
+        { resourceGroupIdentifier: { in: canonicalIdentifiers } }
+      ]
+    },
+    select: environmentSelect
+  });
+};
+
+let collectTenantCandidates = async (d: {
+  projectOid: bigint;
+  tenantIdentifier: string;
+  subspaceTenantIds: string[];
+  instanceIds: string[];
+  environmentTenantOids: bigint[];
+}) =>
+  await subspaceDb.tenant.findMany({
+    where: {
+      OR: [
+        { identifier: d.tenantIdentifier },
+        { identifier: { in: d.instanceIds.map(instanceId => `mte-${instanceId}`) } },
+        { id: { in: d.subspaceTenantIds } },
+        { resourceTenantIdentifier: d.tenantIdentifier },
+        { projectOid: d.projectOid },
+        { oid: { in: d.environmentTenantOids } }
+      ]
+    },
+    select: tenantSelect
+  });
+
+let pickSurvivorEnvironment = async (d: {
+  candidates: EnvironmentCandidate[];
+  identifier: string;
+}) => {
+  if (d.candidates.length === 1) {
+    return { survivor: d.candidates[0]!, duplicates: [] as EnvironmentCandidate[] };
+  }
+
+  let counted = await Promise.all(
+    d.candidates.map(async candidate => ({
+      candidate,
+      childRows: await countEnvironmentChildRows(candidate.oid)
+    }))
+  );
+
+  let populated = counted.filter(entry => entry.childRows > 0);
+  if (populated.length > 1) {
+    throw new LegacyScopeAbort(
+      `Environments ${populated
+        .map(entry => entry.candidate.id)
+        .join(', ')} all hold rows for ${d.identifier}`
+    );
+  }
+
+  let survivor =
+    populated[0]?.candidate ??
+    counted.find(entry => entry.candidate.identifier === d.identifier)?.candidate ??
+    [...counted].sort((a, b) => (a.candidate.oid < b.candidate.oid ? -1 : 1))[0]!.candidate;
+
+  return {
+    survivor,
+    duplicates: d.candidates.filter(candidate => candidate.oid !== survivor.oid)
+  };
+};
+
+let pickSurvivorTenant = (d: {
+  candidates: TenantCandidate[];
+  identifier: string;
+  environmentPlans: EnvironmentPlan[];
+}) => {
+  let canonical = d.candidates.find(candidate => candidate.identifier === d.identifier);
+  if (canonical) return canonical;
+
+  let ownedEnvironments = new Map<bigint, number>();
+  for (let plan of d.environmentPlans) {
+    ownedEnvironments.set(
+      plan.survivor.tenantOid,
+      (ownedEnvironments.get(plan.survivor.tenantOid) ?? 0) + 1
+    );
+  }
+
+  return [...d.candidates].sort((a, b) => {
+    let owned = (ownedEnvironments.get(b.oid) ?? 0) - (ownedEnvironments.get(a.oid) ?? 0);
+    if (owned !== 0) return owned;
+    return a.oid < b.oid ? -1 : 1;
+  })[0];
+};
+
+let assertTenantHoldsNoForeignEnvironments = async (d: {
+  tdb: TransactionDB;
+  project: ScopeProject;
+  survivorTenant: TenantCandidate;
+  environmentPlans: EnvironmentPlan[];
+  warnings: string[];
+}) => {
+  let planned = new Set(d.environmentPlans.map(plan => plan.survivor.oid));
+
+  let environments = await d.tdb.environment.findMany({
+    where: { tenantOid: d.survivorTenant.oid },
+    select: environmentSelect
+  });
+
+  for (let environment of environments) {
+    if (planned.has(environment.oid)) continue;
+
+    let resolution = await resolveInstanceForEnvironment(environment);
+    if (resolution.status === 'unresolved') {
+      d.warnings.push(resolution.reason);
+      continue;
+    }
+
+    if (resolution.value.projectOid !== d.project.oid) {
+      throw new LegacyScopeAbort(
+        `Tenant ${d.survivorTenant.id} also holds environment ${environment.id}, which belongs to another project`
+      );
+    }
+  }
+};
+
+let moveEnvironmentScopedRows = async (d: {
+  tdb: TransactionDB;
+  environmentOid: bigint;
+  tenantOid: bigint;
+}) => {
+  for (let model of getEnvironmentScopedModels()) {
+    if (!model.hasTenantOid) continue;
+
+    try {
+      await (d.tdb as any)[model.delegate].updateMany({
+        where: { environmentOid: d.environmentOid, tenantOid: { not: d.tenantOid } },
+        data: { tenantOid: d.tenantOid }
+      });
+    } catch (error: any) {
+      if (error?.code !== 'P2002') throw error;
+
+      throw new LegacyScopeAbort(
+        `Moving ${model.model} rows collides with existing rows under the target tenant (${error.meta?.target ?? 'unknown constraint'})`
+      );
+    }
+  }
+
+  let movedCredentials = await d.tdb.providerAuthCredentials.findMany({
+    where: { environmentOid: d.environmentOid },
+    select: { oid: true }
+  });
+
+  if (movedCredentials.length > 0) {
+    await d.tdb.managedProviderAuthCredentialsBacking.updateMany({
+      where: {
+        providerAuthCredentialsOid: { in: movedCredentials.map(row => row.oid) },
+        tenantOid: { not: d.tenantOid }
+      },
+      data: { tenantOid: d.tenantOid }
+    });
+  }
+};
+
+let remapEnvironmentActors = async (d: {
+  tdb: TransactionDB;
+  environmentOid: bigint;
+  fromTenantOid: bigint;
+  toTenantOid: bigint;
+  warnings: string[];
+}) => {
+  let alerts = await d.tdb.monitorAlert.findMany({
+    where: { environmentOid: d.environmentOid },
+    select: { oid: true }
+  });
+  if (alerts.length === 0) return;
+
+  let monitorAlertOids = alerts.map(alert => alert.oid);
+
+  let events = await d.tdb.monitorAlertEvent.findMany({
+    where: { monitorAlertOid: { in: monitorAlertOids }, actorOid: { not: null } },
+    select: { actorOid: true },
+    distinct: ['actorOid']
+  });
+  let recipients = await d.tdb.monitorAlertRecipient.findMany({
+    where: { monitorAlertOid: { in: monitorAlertOids } },
+    select: { recipientOid: true },
+    distinct: ['recipientOid']
+  });
+
+  let referenced = [
+    ...new Set([
+      ...events.flatMap(event => (event.actorOid === null ? [] : [event.actorOid])),
+      ...recipients.map(recipient => recipient.recipientOid)
+    ])
+  ];
+  if (referenced.length === 0) return;
+
+  let actors = await d.tdb.tenantActor.findMany({
+    where: { tenantOid: d.fromTenantOid, oid: { in: referenced } },
+    select: { oid: true, identifier: true }
+  });
+  if (actors.length === 0) return;
+
+  let replacements = await d.tdb.tenantActor.findMany({
+    where: {
+      tenantOid: d.toTenantOid,
+      identifier: { in: actors.map(actor => actor.identifier) }
+    },
+    select: { oid: true, identifier: true }
+  });
+  let replacementByIdentifier = new Map(
+    replacements.map(actor => [actor.identifier, actor.oid])
+  );
+
+  for (let actor of actors) {
+    let replacement = replacementByIdentifier.get(actor.identifier);
+
+    if (replacement === undefined) {
+      d.warnings.push(
+        `Actor ${actor.identifier} has no counterpart under tenant ${d.toTenantOid}, monitor alert references left in place`
+      );
+      continue;
+    }
+
+    await d.tdb.monitorAlertEvent.updateMany({
+      where: { monitorAlertOid: { in: monitorAlertOids }, actorOid: actor.oid },
+      data: { actorOid: replacement }
+    });
+
+    let alreadyPresent = await d.tdb.monitorAlertRecipient.findMany({
+      where: { monitorAlertOid: { in: monitorAlertOids }, recipientOid: replacement },
+      select: { monitorAlertOid: true }
+    });
+
+    if (alreadyPresent.length > 0) {
+      await d.tdb.monitorAlertRecipient.deleteMany({
+        where: {
+          monitorAlertOid: { in: alreadyPresent.map(entry => entry.monitorAlertOid) },
+          recipientOid: actor.oid
+        }
+      });
+    }
+
+    await d.tdb.monitorAlertRecipient.updateMany({
+      where: { monitorAlertOid: { in: monitorAlertOids }, recipientOid: actor.oid },
+      data: { recipientOid: replacement }
+    });
+  }
+};
+
+class ReconcileLegacyScopeServiceImpl {
+  async reconcileLegacyProjectScope(d: { projectOid: bigint }): Promise<LegacyScopeReport> {
+    let report: LegacyScopeReport = {
+      projectOid: d.projectOid.toString(),
+      status: 'noop',
+      renamedTenant: false,
+      movedEnvironments: [],
+      renamedEnvironments: [],
+      deletedEnvironments: [],
+      retiredTenantIds: [],
+      strandedRows: [],
+      warnings: []
+    };
+
+    try {
+      return await this.run(d.projectOid, report);
+    } catch (error: any) {
+      if (report.committedAt) throw error;
+
+      if (error instanceof LegacyScopeAbort) {
+        return { ...report, status: 'aborted', reason: error.message };
+      }
+
+      if (error?.code === 'P2002') {
+        return {
+          ...report,
+          status: 'aborted',
+          reason: `Canonical identifier collision: ${error.meta?.target ?? 'unknown constraint'}`
+        };
+      }
+
+      throw error;
+    }
+  }
+
+  private async run(projectOid: bigint, report: LegacyScopeReport) {
+    let project = await metorialDb.project.findUnique({
+      where: { oid: projectOid },
+      include: {
+        instances: true,
+        resourceTenant: { select: { id: true, identifier: true } }
+      }
+    });
+
+    if (!project) {
+      return { ...report, status: 'aborted' as const, reason: 'Project no longer exists' };
+    }
+
+    let tenantIdentifier = getProjectInternalTenantIdentifier(project);
+    report.tenantIdentifier = tenantIdentifier;
+
+    let drift = await getProjectScopeDrift({ projectOid });
+    report.warnings.push(...drift.reasons, ...drift.notes);
+
+    let environmentPlans = await this.planEnvironments({ project, report });
+    let tenantCandidates = await this.planTenants({
+      project,
+      tenantIdentifier,
+      environmentPlans
+    });
+
+    let survivorTenant = pickSurvivorTenant({
+      candidates: tenantCandidates,
+      identifier: tenantIdentifier,
+      environmentPlans
+    });
+
+    if (!survivorTenant) {
+      if (drift.hasDrift) return await this.clearDanglingLinks({ project, report });
+
+      if (drift.notes.length > 0) {
+        return { ...report, status: 'aborted' as const, reason: drift.notes.join('; ') };
+      }
+
+      return report;
+    }
+
+    let needsWork =
+      drift.hasDrift ||
+      survivorTenant.identifier !== tenantIdentifier ||
+      tenantCandidates.length > 1 ||
+      environmentPlans.some(
+        plan =>
+          plan.survivor.identifier !== plan.identifier ||
+          plan.survivor.tenantOid !== survivorTenant.oid ||
+          plan.duplicates.length > 0
+      );
+
+    if (!needsWork) return report;
+
+    report.promotedTenantId = survivorTenant.id;
+
+    await withTransaction(
+      async tdb =>
+        await this.apply({
+          tdb,
+          project,
+          tenantIdentifier,
+          survivorTenant,
+          tenantCandidates,
+          environmentPlans,
+          report
+        }),
+      { timeout: TRANSACTION_TIMEOUT_MS, maxWait: TRANSACTION_MAX_WAIT_MS }
+    );
+
+    report.committedAt = new Date();
+
+    await this.persistMetorialLinks({
+      project,
+      tenantIdentifier,
+      survivorTenant,
+      environmentPlans,
+      report
+    });
+
+    await this.handOffToRegularReconciliation({ projectOid });
+
+    return { ...report, status: 'reconciled' as const };
+  }
+
+  private async clearDanglingLinks(d: { project: ScopeProject; report: LegacyScopeReport }) {
+    let isDangling = async (subspaceTenantId: string | null) => {
+      if (!subspaceTenantId) return false;
+
+      let tenant = await subspaceDb.tenant.findUnique({
+        where: { id: subspaceTenantId },
+        select: { retiredAt: true }
+      });
+
+      return !tenant || !!tenant.retiredAt;
+    };
+
+    let cleared = 0;
+
+    if (await isDangling(d.project.subspaceTenantId)) {
+      await metorialDb.project.update({
+        where: { oid: d.project.oid },
+        data: { internalTenantIdentifier: null, subspaceTenantId: null }
+      });
+      cleared++;
+    }
+
+    for (let instance of d.project.instances) {
+      let tenantDangling = await isDangling(instance.subspaceTenantId);
+
+      let environmentDangling =
+        !!instance.subspaceEnvironmentId &&
+        !(await subspaceDb.environment.findUnique({
+          where: { id: instance.subspaceEnvironmentId },
+          select: { oid: true }
+        }));
+
+      if (!tenantDangling && !environmentDangling) continue;
+
+      await metorialDb.instance.update({
+        where: { oid: instance.oid },
+        data: {
+          ...(tenantDangling
+            ? { internalTenantIdentifier: null, subspaceTenantId: null }
+            : {}),
+          ...(environmentDangling
+            ? { internalEnvironmentIdentifier: null, subspaceEnvironmentId: null }
+            : {})
+        }
+      });
+      cleared++;
+    }
+
+    if (cleared === 0) return d.report;
+
+    d.report.warnings.push(`Cleared ${cleared} dangling subspace links`);
+    await this.handOffToRegularReconciliation({ projectOid: d.project.oid });
+
+    return { ...d.report, status: 'reconciled' as const };
+  }
+
+  private async planEnvironments(d: { project: ScopeProject; report: LegacyScopeReport }) {
+    let candidates = await collectEnvironmentCandidates(d.project.instances);
+
+    let byInstance = new Map<bigint, EnvironmentCandidate[]>();
+    for (let candidate of candidates) {
+      let resolution = await resolveInstanceForEnvironment(candidate);
+
+      if (resolution.status === 'unresolved') {
+        d.report.warnings.push(resolution.reason);
+        continue;
+      }
+
+      if (resolution.value.projectOid !== d.project.oid) continue;
+
+      byInstance.set(resolution.value.oid, [
+        ...(byInstance.get(resolution.value.oid) ?? []),
+        candidate
+      ]);
+    }
+
+    let plans: EnvironmentPlan[] = [];
+
+    for (let instance of d.project.instances) {
+      let instanceCandidates = byInstance.get(instance.oid) ?? [];
+      if (instanceCandidates.length === 0) continue;
+
+      if (instanceCandidates.length > 2) {
+        throw new LegacyScopeAbort(
+          `Instance ${instance.id} has ${instanceCandidates.length} subspace environments`
+        );
+      }
+
+      let identifier = getInstanceInternalEnvironmentIdentifier(instance);
+      let { survivor, duplicates } = await pickSurvivorEnvironment({
+        candidates: instanceCandidates,
+        identifier
+      });
+
+      let resourceGroup = instance.resourceGroupOid
+        ? await metorialDb.resourceGroup.findUnique({
+            where: { oid: instance.resourceGroupOid },
+            select: { id: true, identifier: true }
+          })
+        : null;
+
+      plans.push({
+        instanceOid: instance.oid,
+        instanceId: instance.id,
+        identifier,
+        survivor,
+        duplicates,
+        resourceGroupId: resourceGroup?.id ?? survivor.resourceGroupId,
+        resourceGroupIdentifier: resourceGroup?.identifier ?? survivor.resourceGroupIdentifier
+      });
+    }
+
+    return plans;
+  }
+
+  private async planTenants(d: {
+    project: ScopeProject;
+    tenantIdentifier: string;
+    environmentPlans: EnvironmentPlan[];
+  }) {
+    let subspaceTenantIds = [
+      d.project.subspaceTenantId,
+      ...d.project.instances.map(instance => instance.subspaceTenantId)
+    ].filter((id): id is string => !!id);
+
+    let candidates = await collectTenantCandidates({
+      projectOid: d.project.oid,
+      tenantIdentifier: d.tenantIdentifier,
+      subspaceTenantIds,
+      instanceIds: d.project.instances.map(instance => instance.id),
+      environmentTenantOids: d.environmentPlans.map(plan => plan.survivor.tenantOid)
+    });
+
+    return candidates.filter(candidate => {
+      if (candidate.retiredAt) return false;
+
+      return (
+        candidate.identifier === d.tenantIdentifier ||
+        !isCanonicalProjectIdentifier(candidate.identifier)
+      );
+    });
+  }
+
+  private async apply(d: {
+    tdb: TransactionDB;
+    project: ScopeProject;
+    tenantIdentifier: string;
+    survivorTenant: TenantCandidate;
+    tenantCandidates: TenantCandidate[];
+    environmentPlans: EnvironmentPlan[];
+    report: LegacyScopeReport;
+  }) {
+    await assertTenantHoldsNoForeignEnvironments({
+      tdb: d.tdb,
+      project: d.project,
+      survivorTenant: d.survivorTenant,
+      environmentPlans: d.environmentPlans,
+      warnings: d.report.warnings
+    });
+
+    await d.tdb.project.updateMany({
+      where: { oid: d.project.oid },
+      data: { tenantOid: d.survivorTenant.oid }
+    });
+
+    for (let plan of d.environmentPlans) {
+      await d.tdb.instance.updateMany({
+        where: { oid: plan.instanceOid },
+        data: { environmentOid: plan.survivor.oid }
+      });
+
+      for (let duplicate of plan.duplicates) {
+        let childRows = await countEnvironmentChildRows(duplicate.oid, d.tdb);
+        if (childRows > 0) {
+          throw new LegacyScopeAbort(
+            `Environment ${duplicate.id} gained rows while reconciling ${plan.identifier}`
+          );
+        }
+
+        let attachedMirrors = await d.tdb.instance.count({
+          where: { environmentOid: duplicate.oid }
+        });
+        if (attachedMirrors > 0) {
+          throw new LegacyScopeAbort(
+            `Environment ${duplicate.id} still backs ${attachedMirrors} instance mirrors, refusing to delete it`
+          );
+        }
+
+        await d.tdb.environment.delete({ where: { oid: duplicate.oid } });
+        d.report.deletedEnvironments.push(duplicate.id);
+      }
+    }
+
+    for (let plan of d.environmentPlans) {
+      if (plan.survivor.tenantOid !== d.survivorTenant.oid) {
+        await moveEnvironmentScopedRows({
+          tdb: d.tdb,
+          environmentOid: plan.survivor.oid,
+          tenantOid: d.survivorTenant.oid
+        });
+        await remapEnvironmentActors({
+          tdb: d.tdb,
+          environmentOid: plan.survivor.oid,
+          fromTenantOid: plan.survivor.tenantOid,
+          toTenantOid: d.survivorTenant.oid,
+          warnings: d.report.warnings
+        });
+        d.report.movedEnvironments.push(plan.survivor.id);
+      }
+
+      if (plan.survivor.identifier !== plan.identifier) {
+        d.report.renamedEnvironments.push(plan.survivor.id);
+      }
+
+      await d.tdb.environment.update({
+        where: { oid: plan.survivor.oid },
+        data: {
+          identifier: plan.identifier,
+          tenantOid: d.survivorTenant.oid,
+          instanceOid: plan.instanceOid,
+          resourceGroupId: plan.resourceGroupId,
+          resourceGroupIdentifier: plan.resourceGroupIdentifier
+        }
+      });
+    }
+
+    d.report.renamedTenant = d.survivorTenant.identifier !== d.tenantIdentifier;
+
+    await d.tdb.tenant.update({
+      where: { oid: d.survivorTenant.oid },
+      data: {
+        identifier: d.tenantIdentifier,
+        projectOid: d.project.oid,
+        resourceTenantId: d.project.resourceTenant?.id ?? d.survivorTenant.resourceTenantId,
+        resourceTenantIdentifier:
+          d.project.resourceTenant?.identifier ?? d.survivorTenant.resourceTenantIdentifier
+      }
+    });
+
+    for (let candidate of d.tenantCandidates) {
+      if (candidate.oid === d.survivorTenant.oid) continue;
+
+      let remainingEnvironments = await d.tdb.environment.count({
+        where: { tenantOid: candidate.oid }
+      });
+
+      if (remainingEnvironments > 0) {
+        d.report.warnings.push(
+          `Tenant ${candidate.id} still owns ${remainingEnvironments} environments, leaving it alone`
+        );
+        continue;
+      }
+
+      let stranded = await countTenantScopedOnlyRows(d.tdb, candidate.oid);
+      d.report.strandedRows.push(
+        ...stranded.map(entry => ({ tenantId: candidate.id, ...entry }))
+      );
+
+      await d.tdb.tenant.update({
+        where: { oid: candidate.oid },
+        data: { retiredAt: new Date() }
+      });
+      d.report.retiredTenantIds.push(candidate.id);
+    }
+  }
+
+  private async persistMetorialLinks(d: {
+    project: ScopeProject;
+    tenantIdentifier: string;
+    survivorTenant: TenantCandidate;
+    environmentPlans: EnvironmentPlan[];
+    report: LegacyScopeReport;
+  }) {
+    await metorialDb.project.update({
+      where: { oid: d.project.oid },
+      data: {
+        internalTenantIdentifier: d.tenantIdentifier,
+        subspaceTenantId: d.survivorTenant.id
+      }
+    });
+
+    let planByInstance = new Map(d.environmentPlans.map(plan => [plan.instanceOid, plan]));
+
+    for (let instance of d.project.instances) {
+      let plan = planByInstance.get(instance.oid);
+
+      if (!plan && instance.subspaceEnvironmentId) {
+        d.report.warnings.push(
+          `Instance ${instance.id} keeps its existing environment link ${instance.subspaceEnvironmentId}, no candidate resolved to it`
+        );
+      }
+
+      await metorialDb.instance.update({
+        where: { oid: instance.oid },
+        data: {
+          internalTenantIdentifier: d.tenantIdentifier,
+          subspaceTenantId: d.survivorTenant.id,
+          ...(plan
+            ? {
+                internalEnvironmentIdentifier: plan.identifier,
+                subspaceEnvironmentId: plan.survivor.id
+              }
+            : {}),
+          lastSubspaceSyncAt: new Date()
+        }
+      });
+    }
+
+    let organization = (
+      await metorialDb.project.findUnique({
+        where: { oid: d.project.oid },
+        select: { organization: { select: { id: true, subspaceTenantIds: true } } }
+      })
+    )?.organization;
+
+    if (!organization) return;
+
+    let retired = new Set(d.report.retiredTenantIds);
+    let subspaceTenantIds = [
+      ...new Set(
+        [...organization.subspaceTenantIds, d.survivorTenant.id].filter(id => !retired.has(id))
+      )
+    ];
+
+    await metorialDb.organization.update({
+      where: { id: organization.id },
+      data: { subspaceTenantIds }
+    });
+  }
+
+  private async handOffToRegularReconciliation(d: { projectOid: bigint }) {
+    let project = await metorialDb.project.findUnique({
+      where: { oid: d.projectOid },
+      include: { instances: true }
+    });
+    if (!project) return;
+
+    if (project.instances.length === 0) {
+      await metorialResourceService.syncProject(project);
+    } else {
+      for (let instance of project.instances) {
+        await metorialResourceService.syncInstance(instance);
+      }
+    }
+
+    await reconcileResourceLinksService.reconcileProjectLinks({ projectOid: d.projectOid });
+  }
+}
+
+export let reconcileLegacyScopeService = Service.create(
+  'reconcileLegacyScopeService',
+  () => new ReconcileLegacyScopeServiceImpl()
+).build();

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileLegacyScope.ts
@@ -445,7 +445,10 @@ class ReconcileLegacyScopeServiceImpl {
     let drift = await getProjectScopeDrift({ projectOid });
     report.warnings.push(...drift.reasons, ...drift.notes);
 
-    let environmentPlans = await this.planEnvironments({ project, report });
+    let { plans: environmentPlans, foreignEnvironmentIds } = await this.planEnvironments({
+      project,
+      report
+    });
     let tenantCandidates = await this.planTenants({
       project,
       tenantIdentifier,
@@ -468,8 +471,19 @@ class ReconcileLegacyScopeServiceImpl {
       return report;
     }
 
+    // A link to an environment named for another instance reads as a note rather than drift, so
+    // nothing else defers on it. Left alone it would keep this instance pointing at a sibling's
+    // environment while the regular path provisions a replacement behind it.
+    let hasForeignLink = project.instances.some(
+      instance =>
+        instance.subspaceEnvironmentId &&
+        foreignEnvironmentIds.has(instance.subspaceEnvironmentId) &&
+        !environmentPlans.some(plan => plan.instanceOid === instance.oid)
+    );
+
     let needsWork =
       drift.hasDrift ||
+      hasForeignLink ||
       survivorTenant.identifier !== tenantIdentifier ||
       tenantCandidates.length > 1 ||
       environmentPlans.some(
@@ -504,6 +518,7 @@ class ReconcileLegacyScopeServiceImpl {
       tenantIdentifier,
       survivorTenant,
       environmentPlans,
+      foreignEnvironmentIds,
       report
     });
 
@@ -576,7 +591,25 @@ class ReconcileLegacyScopeServiceImpl {
   private async planEnvironments(d: { project: ScopeProject; report: LegacyScopeReport }) {
     let candidates = await collectEnvironmentCandidates(d.project.instances);
 
+    // A canonical identifier names the instance that owns the environment, so an instance linking
+    // to one that names a sibling is holding a link the identifier itself contradicts.
+    let foreignEnvironmentIds = new Set(
+      candidates
+        .filter(candidate => {
+          let namedInstanceOid = parseCanonicalInstanceOid(candidate.identifier);
+          if (namedInstanceOid === null) return false;
+
+          return d.project.instances.some(
+            instance =>
+              instance.subspaceEnvironmentId === candidate.id &&
+              instance.oid !== namedInstanceOid
+          );
+        })
+        .map(candidate => candidate.id)
+    );
+
     let byInstance = new Map<bigint, EnvironmentCandidate[]>();
+
     for (let candidate of candidates) {
       let resolution = await resolveInstanceForEnvironment(candidate);
 
@@ -640,7 +673,7 @@ class ReconcileLegacyScopeServiceImpl {
       });
     }
 
-    return plans;
+    return { plans, foreignEnvironmentIds };
   }
 
   private async planTenants(d: {
@@ -799,6 +832,7 @@ class ReconcileLegacyScopeServiceImpl {
     tenantIdentifier: string;
     survivorTenant: TenantCandidate;
     environmentPlans: EnvironmentPlan[];
+    foreignEnvironmentIds: Set<string>;
     report: LegacyScopeReport;
   }) {
     await metorialDb.project.update({
@@ -811,18 +845,28 @@ class ReconcileLegacyScopeServiceImpl {
 
     let planByInstance = new Map(d.environmentPlans.map(plan => [plan.instanceOid, plan]));
     let keptExistingLink = new Set<bigint>();
+    let clearedForeignLink = new Set<bigint>();
 
     for (let instance of d.project.instances) {
       let plan = planByInstance.get(instance.oid);
 
-      // An instance can end up without a plan because its environment resolved elsewhere. Clearing
-      // the link would orphan whatever that environment holds, so it is kept and the instance is
-      // held back from the handoff, which would otherwise provision a replacement for it.
+      // The environment carries another instance's canonical name, so this link is the stale side
+      // of the disagreement. Dropping it lets the regular path provision this instance its own
+      // environment instead of leaving it pointing at a row that belongs to a sibling.
       if (!plan && instance.subspaceEnvironmentId) {
-        keptExistingLink.add(instance.oid);
-        d.report.warnings.push(
-          `Instance ${instance.id} keeps its existing environment link ${instance.subspaceEnvironmentId}, no candidate resolved to it`
-        );
+        if (d.foreignEnvironmentIds.has(instance.subspaceEnvironmentId)) {
+          clearedForeignLink.add(instance.oid);
+          d.report.warnings.push(
+            `Instance ${instance.id} dropped its link to ${instance.subspaceEnvironmentId}, which names another instance`
+          );
+        } else {
+          // Nothing names this environment, so it may well hold this instance's data. Clearing the
+          // link would orphan it, so the link stays and the instance is held back from the handoff.
+          keptExistingLink.add(instance.oid);
+          d.report.warnings.push(
+            `Instance ${instance.id} keeps its existing environment link ${instance.subspaceEnvironmentId}, no candidate resolved to it`
+          );
+        }
       }
 
       await metorialDb.instance.update({
@@ -835,6 +879,9 @@ class ReconcileLegacyScopeServiceImpl {
                 internalEnvironmentIdentifier: plan.identifier,
                 subspaceEnvironmentId: plan.survivor.id
               }
+            : {}),
+          ...(clearedForeignLink.has(instance.oid)
+            ? { internalEnvironmentIdentifier: null, subspaceEnvironmentId: null }
             : {}),
           lastSubspaceSyncAt: new Date()
         }

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileResourceLinks.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileResourceLinks.test.ts
@@ -7,7 +7,8 @@ let mocks = vi.hoisted(() => ({
   environmentFind: vi.fn(),
   environmentUpdateMany: vi.fn(),
   ensureProjectMirror: vi.fn(),
-  ensureInstanceMirror: vi.fn()
+  ensureInstanceMirror: vi.fn(),
+  deferToLegacyScopeReconciler: vi.fn()
 }));
 
 vi.mock('@lowerdeck/service', () => ({
@@ -46,6 +47,10 @@ vi.mock('../lib/metorialDb', () => ({
 vi.mock('../lib/mirrorRecords', () => ({
   ensureProjectMirror: mocks.ensureProjectMirror,
   ensureInstanceMirror: mocks.ensureInstanceMirror
+}));
+
+vi.mock('../queues/legacyScope/queues', () => ({
+  deferToLegacyScopeReconciler: mocks.deferToLegacyScopeReconciler
 }));
 
 import { reconcileResourceLinksService } from './reconcileResourceLinks';
@@ -91,6 +96,20 @@ describe('Resource link reconciliation', () => {
     mocks.environmentUpdateMany.mockResolvedValue({ count: 1 });
     mocks.ensureProjectMirror.mockResolvedValue(2n);
     mocks.ensureInstanceMirror.mockResolvedValue(3n);
+    mocks.deferToLegacyScopeReconciler.mockResolvedValue(false);
+  });
+
+  it('hands a project with a legacy scope to the legacy reconciler', async () => {
+    mocks.deferToLegacyScopeReconciler.mockResolvedValue(true);
+
+    let result = await reconcileResourceLinksService.reconcileProjectLinks({
+      projectOid: 2n
+    });
+
+    expect(result).toEqual({ linkedTenants: 0, linkedEnvironments: 0, deferred: true });
+    expect(mocks.metorialProjectFind).not.toHaveBeenCalled();
+    expect(mocks.tenantUpdateMany).not.toHaveBeenCalled();
+    expect(mocks.environmentUpdateMany).not.toHaveBeenCalled();
   });
 
   it('backfills the project and instance references when they are missing', async () => {
@@ -119,7 +138,7 @@ describe('Resource link reconciliation', () => {
       where: { id: 'ken_1' },
       data: { instanceOid: 3n }
     });
-    expect(result).toEqual({ linkedTenants: 1, linkedEnvironments: 1 });
+    expect(result).toEqual({ linkedTenants: 1, linkedEnvironments: 1, deferred: false });
   });
 
   it('writes nothing when every reference is already correct', async () => {
@@ -133,7 +152,7 @@ describe('Resource link reconciliation', () => {
 
     expect(mocks.tenantUpdateMany).not.toHaveBeenCalled();
     expect(mocks.environmentUpdateMany).not.toHaveBeenCalled();
-    expect(result).toEqual({ linkedTenants: 0, linkedEnvironments: 0 });
+    expect(result).toEqual({ linkedTenants: 0, linkedEnvironments: 0, deferred: false });
   });
 
   it('still repairs the mirrors of references that are already linked', async () => {
@@ -160,7 +179,7 @@ describe('Resource link reconciliation', () => {
 
     expect(mocks.tenantUpdateMany).not.toHaveBeenCalled();
     expect(mocks.environmentUpdateMany).not.toHaveBeenCalled();
-    expect(result).toEqual({ linkedTenants: 0, linkedEnvironments: 0 });
+    expect(result).toEqual({ linkedTenants: 0, linkedEnvironments: 0, deferred: false });
   });
 
   it('repoints a reference that drifted to the wrong oid', async () => {

--- a/src/metorial/subspace/modules/tenant/src/services/reconcileResourceLinks.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/reconcileResourceLinks.ts
@@ -1,7 +1,8 @@
-import { db as subspaceDb } from '@metorial-subspace/db';
 import { Service } from '@lowerdeck/service';
+import { db as subspaceDb } from '@metorial-subspace/db';
 import { metorialDb } from '../lib/metorialDb';
 import { ensureInstanceMirror, ensureProjectMirror } from '../lib/mirrorRecords';
+import { deferToLegacyScopeReconciler } from '../queues/legacyScope/queues';
 
 let shouldUpdateTenantLink = (d: {
   currentResourceTenantId: string | null;
@@ -35,6 +36,10 @@ let shouldUpdateOidReference = (d: { current: bigint | null; expected: bigint })
 
 class ReconcileResourceLinksServiceImpl {
   async reconcileProjectLinks(d: { projectOid: bigint }) {
+    if (await deferToLegacyScopeReconciler({ projectOid: d.projectOid })) {
+      return { linkedTenants: 0, linkedEnvironments: 0, deferred: true };
+    }
+
     let project = await metorialDb.project.findUnique({
       where: {
         oid: d.projectOid
@@ -66,7 +71,8 @@ class ReconcileResourceLinksServiceImpl {
     if (!project?.subspaceTenantId) {
       return {
         linkedTenants: 0,
-        linkedEnvironments: 0
+        linkedEnvironments: 0,
+        deferred: false
       };
     }
 
@@ -199,7 +205,8 @@ class ReconcileResourceLinksServiceImpl {
 
     return {
       linkedTenants,
-      linkedEnvironments
+      linkedEnvironments,
+      deferred: false
     };
   }
 

--- a/src/metorial/subspace/modules/tenant/src/services/subspaceScope.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/subspaceScope.test.ts
@@ -18,7 +18,8 @@ let mocks = vi.hoisted(() => ({
   solutionUpsert: vi.fn(),
   findActorForOrganizationActor: vi.fn(),
   upsertActor: vi.fn(),
-  generateId: vi.fn()
+  generateId: vi.fn(),
+  enqueueLegacyScopeRepair: vi.fn()
 }));
 
 vi.mock('@lowerdeck/service', () => ({
@@ -92,6 +93,10 @@ vi.mock('./actor', () => ({
     findActorForOrganizationActor: mocks.findActorForOrganizationActor,
     upsertActor: mocks.upsertActor
   }
+}));
+
+vi.mock('../queues/legacyScope/queues', () => ({
+  enqueueLegacyScopeRepair: mocks.enqueueLegacyScopeRepair
 }));
 
 import { subspaceScopeService } from './subspaceScope';
@@ -220,6 +225,20 @@ describe('Subspace canonical scope reconciliation', () => {
     );
     expect(mocks.tenantUpsert).not.toHaveBeenCalled();
     expect(mocks.projectUpdate).not.toHaveBeenCalled();
+  });
+
+  it('schedules a legacy scope repair when a canonical tenant link does not resolve', async () => {
+    let project = makeProject({
+      internalTenantIdentifier: 'mte-pro-2',
+      subspaceTenantId: 'ktn_legacy'
+    });
+    mocks.tenantFind.mockResolvedValue({ identifier: 'mte-ins_0mlzkn8h5vDpg9CRUBSlP0' });
+
+    await expect(subspaceScopeService.ensureForProject(project)).rejects.toThrow(
+      'canonical tenant link does not resolve to mte-pro-2'
+    );
+    expect(mocks.enqueueLegacyScopeRepair).toHaveBeenCalledWith({ projectOid: 2n });
+    expect(mocks.tenantUpsert).not.toHaveBeenCalled();
   });
 
   it('replaces legacy project and instance links with new canonical scope links', async () => {

--- a/src/metorial/subspace/modules/tenant/src/services/subspaceScope.ts
+++ b/src/metorial/subspace/modules/tenant/src/services/subspaceScope.ts
@@ -1,6 +1,13 @@
 import { ProgrammablePromise } from '@lowerdeck/programmable-promise';
 import { Service } from '@lowerdeck/service';
 import {
+  db as subspaceDb,
+  type Environment,
+  type Solution,
+  type Tenant,
+  type TenantActor
+} from '@metorial-subspace/db';
+import {
   ID,
   type Instance,
   type Organization,
@@ -8,20 +15,18 @@ import {
   type Prisma,
   type Project
 } from '@metorial/db';
-import {
-  db as subspaceDb,
-  type Environment,
-  type Solution,
-  type Tenant,
-  type TenantActor
-} from '@metorial-subspace/db';
 import { env } from '../env';
+import {
+  isCanonicalEnvironmentIdentifier,
+  isCanonicalProjectIdentifier
+} from '../lib/legacyScope';
 import { metorialDb } from '../lib/metorialDb';
 import {
   getInstanceInternalEnvironmentIdentifier,
   getOrganizationActorInternalActorIdentifier,
   getProjectInternalTenantIdentifier
 } from '../lib/scopeIds';
+import { enqueueLegacyScopeRepair } from '../queues/legacyScope/queues';
 import { actorService } from './actor';
 import { environmentService } from './environment';
 import { solutionService } from './solution';
@@ -61,11 +66,10 @@ let hasUpdates = (update: Record<string, unknown>) =>
 let solutionProm = new ProgrammablePromise<Solution>();
 let solutionBootStarted = false;
 
-let isCanonicalProjectIdentifier = (identifier: string | null | undefined) =>
-  identifier?.startsWith('mte-pro-') ?? false;
-
-let isCanonicalEnvironmentIdentifier = (identifier: string | null | undefined) =>
-  identifier?.startsWith('mte-ins-') ?? false;
+let failCanonicalScope = async (d: { projectOid: bigint; message: string }) => {
+  await enqueueLegacyScopeRepair({ projectOid: d.projectOid });
+  throw new Error(d.message);
+};
 
 let ensureSolutionBoot = () => {
   if (solutionBootStarted) return;
@@ -176,9 +180,10 @@ let assertCanonicalProjectScope = async (project: LoadedProject) => {
 
   let expectedIdentifier = getProjectTenantIdentifier(project);
   if (!project.subspaceTenantId) {
-    throw new Error(
-      `Project ${project.id} has canonical tenant identifier but no subspace tenant id`
-    );
+    return await failCanonicalScope({
+      projectOid: project.oid,
+      message: `Project ${project.id} has canonical tenant identifier but no subspace tenant id`
+    });
   }
 
   let tenant = await subspaceDb.tenant.findUnique({
@@ -186,9 +191,10 @@ let assertCanonicalProjectScope = async (project: LoadedProject) => {
     select: { identifier: true }
   });
   if (tenant?.identifier !== expectedIdentifier) {
-    throw new Error(
-      `Project ${project.id} canonical tenant link does not resolve to ${expectedIdentifier}`
-    );
+    return await failCanonicalScope({
+      projectOid: project.oid,
+      message: `Project ${project.id} canonical tenant link does not resolve to ${expectedIdentifier}`
+    });
   }
 };
 
@@ -204,14 +210,16 @@ let assertCanonicalInstanceScope = async (instance: Instance, project: LoadedPro
 
   if (hasCanonicalTenant) {
     if (instance.internalTenantIdentifier !== expectedTenantIdentifier) {
-      throw new Error(
-        `Instance ${instance.id} canonical tenant identifier does not match project ${project.id}`
-      );
+      return await failCanonicalScope({
+        projectOid: project.oid,
+        message: `Instance ${instance.id} canonical tenant identifier does not match project ${project.id}`
+      });
     }
     if (!instance.subspaceTenantId) {
-      throw new Error(
-        `Instance ${instance.id} has canonical tenant identifier but no subspace tenant id`
-      );
+      return await failCanonicalScope({
+        projectOid: project.oid,
+        message: `Instance ${instance.id} has canonical tenant identifier but no subspace tenant id`
+      });
     }
 
     let tenant = await subspaceDb.tenant.findUnique({
@@ -219,16 +227,18 @@ let assertCanonicalInstanceScope = async (instance: Instance, project: LoadedPro
       select: { oid: true, identifier: true }
     });
     if (tenant?.identifier !== expectedTenantIdentifier) {
-      throw new Error(
-        `Instance ${instance.id} canonical tenant link does not resolve to ${expectedTenantIdentifier}`
-      );
+      return await failCanonicalScope({
+        projectOid: project.oid,
+        message: `Instance ${instance.id} canonical tenant link does not resolve to ${expectedTenantIdentifier}`
+      });
     }
 
     if (hasCanonicalEnvironment) {
       if (!instance.subspaceEnvironmentId) {
-        throw new Error(
-          `Instance ${instance.id} has canonical environment identifier but no subspace environment id`
-        );
+        return await failCanonicalScope({
+          projectOid: project.oid,
+          message: `Instance ${instance.id} has canonical environment identifier but no subspace environment id`
+        });
       }
 
       let environment = await subspaceDb.environment.findUnique({
@@ -239,15 +249,17 @@ let assertCanonicalInstanceScope = async (instance: Instance, project: LoadedPro
         environment?.identifier !== expectedEnvironmentIdentifier ||
         environment.tenantOid !== tenant.oid
       ) {
-        throw new Error(
-          `Instance ${instance.id} canonical environment link does not resolve beneath its canonical tenant`
-        );
+        return await failCanonicalScope({
+          projectOid: project.oid,
+          message: `Instance ${instance.id} canonical environment link does not resolve beneath its canonical tenant`
+        });
       }
     }
   } else if (hasCanonicalEnvironment) {
-    throw new Error(
-      `Instance ${instance.id} has a canonical environment linked to a legacy tenant`
-    );
+    return await failCanonicalScope({
+      projectOid: project.oid,
+      message: `Instance ${instance.id} has a canonical environment linked to a legacy tenant`
+    });
   }
 };
 

--- a/src/shuttle/service/prisma/schema/oauthRemote.prisma
+++ b/src/shuttle/service/prisma/schema/oauthRemote.prisma
@@ -141,7 +141,6 @@ model RemoteOAuthConnection {
   registrationOid BigInt?
   registration    RemoteOAuthAutoRegistration? @relation(fields: [registrationOid], references: [oid])
 
-  // Set when this connection was created to replace the client of another one.
   rotatedFromOid BigInt?
   rotatedFrom    RemoteOAuthConnection?  @relation("remoteOAuthConnectionRotation", fields: [rotatedFromOid], references: [oid], onDelete: SetNull)
   rotatedTo      RemoteOAuthConnection[] @relation("remoteOAuthConnectionRotation")

--- a/src/shuttle/service/prisma/schema/oauthRemote.prisma
+++ b/src/shuttle/service/prisma/schema/oauthRemote.prisma
@@ -143,7 +143,7 @@ model RemoteOAuthConnection {
 
   // Set when this connection was created to replace the client of another one.
   rotatedFromOid BigInt?
-  rotatedFrom    RemoteOAuthConnection?  @relation("remoteOAuthConnectionRotation", fields: [rotatedFromOid], references: [oid])
+  rotatedFrom    RemoteOAuthConnection?  @relation("remoteOAuthConnectionRotation", fields: [rotatedFromOid], references: [oid], onDelete: SetNull)
   rotatedTo      RemoteOAuthConnection[] @relation("remoteOAuthConnectionRotation")
 
   tenantOid BigInt

--- a/src/shuttle/service/src/lib/oauth/clientRegistrationMetadata.ts
+++ b/src/shuttle/service/src/lib/oauth/clientRegistrationMetadata.ts
@@ -1,9 +1,5 @@
 import type { OAuthConfiguration } from './types';
 
-// Authorization servers advertise every grant/response type they implement, but a
-// registration endpoint only accepts the ones a client is allowed to register for.
-// We therefore register for the authorization code flow only, and never for extras
-// like device code or jwt-bearer that we never run.
 let usableGrantTypes = ['authorization_code', 'refresh_token'];
 let usableResponseTypes = ['code'];
 let authMethodPreference = ['client_secret_basic', 'client_secret_post', 'none'];
@@ -16,10 +12,6 @@ let supportedSubset = (usable: string[], supported: string[] | undefined) => {
   return subset.length ? subset : undefined;
 };
 
-/**
- * Builds the flow-related client metadata for a dynamic client registration
- * request. Omitted values fall back to the authorization server's defaults.
- */
 export let buildClientRegistrationMetadata = (config: OAuthConfiguration) => ({
   grant_types: supportedSubset(usableGrantTypes, config.grant_types_supported),
   response_types: supportedSubset(usableResponseTypes, config.response_types_supported),

--- a/src/shuttle/service/src/lib/oauth/registrationRetry.ts
+++ b/src/shuttle/service/src/lib/oauth/registrationRetry.ts
@@ -1,16 +1,13 @@
-import { addHours, addDays } from 'date-fns';
+import { addDays, addHours } from 'date-fns';
 import type {
   RemoteOAuthConnectionDiscoveryStatus,
   RemoteOAuthConnectionStatus
 } from '../../../prisma/generated/client';
 
-/** Auto-registration is retried once per cron run until this many attempts failed. */
 export let MAX_REGISTRATION_ATTEMPTS = 10;
 
-/** Slightly below 24h so a daily cron never skips a connection because of drift. */
 export let REGISTRATION_RETRY_INTERVAL_HOURS = 20;
 
-/** Age at which an auto-registered client is replaced on the next deployment. */
 export let STALE_REGISTRATION_DAYS = 3;
 
 export let getRegistrationRetryCutoff = (now = new Date()) =>
@@ -22,10 +19,6 @@ export let getStaleRegistrationCutoff = (now = new Date()) =>
 export let isStaleRegistration = (registration: { createdAt: Date }, now = new Date()) =>
   registration.createdAt.getTime() < getStaleRegistrationCutoff(now).getTime();
 
-/**
- * Transient failures are worth retrying, permanent ones (invalid client
- * metadata, unsupported registration) will fail the same way every time.
- */
 export let isTransientRegistrationError = (d: { status?: number | null }) => {
   if (d.status == null) return true;
   if (d.status == 408 || d.status == 425 || d.status == 429) return true;
@@ -40,11 +33,6 @@ export type RegistrationBlocker =
   | 'has_bound_credentials'
   | 'attempts_exhausted';
 
-/**
- * Re-registering a connection swaps the client the provider knows about, which
- * would break every token that was issued to the previous client. Only
- * connections without any bound credentials may be registered.
- */
 export let getRegistrationBlocker = (d: {
   connection: {
     status: RemoteOAuthConnectionStatus;

--- a/src/shuttle/service/src/queues/discovery/remoteOAuthConnection.ts
+++ b/src/shuttle/service/src/queues/discovery/remoteOAuthConnection.ts
@@ -14,10 +14,9 @@ export let discoverRemoteOAuthConnectionQueueProcessor =
       connectionId: data.oauthConnectionId
     });
 
-    if (res.ok) {
-      await enqueuePromotion({ connection: res.connection });
-      return;
-    }
+    await enqueuePromotion({ connectionId: data.oauthConnectionId });
+
+    if (res.ok) return;
 
     if (res.reason == 'not_found') throw new QueueRetryError();
     if (res.reason == 'failed' && res.isTransient) throw new QueueRetryError();

--- a/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.test.ts
+++ b/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { queues, dbMock, runAutoRegistration, QueueRetryError } = vi.hoisted(() => ({
+  queues: {} as Record<string, any>,
+  QueueRetryError: class QueueRetryError extends Error {},
+  dbMock: {
+    serverOAuthCredentials: {
+      findFirst: vi.fn()
+    },
+    remoteOAuthConnection: {
+      findMany: vi.fn()
+    }
+  },
+  runAutoRegistration: vi.fn()
+}));
+
+vi.mock('@lowerdeck/queue', () => ({
+  QueueRetryError,
+  createQueue: (opts: { name: string }) => {
+    let queue = {
+      add: vi.fn(),
+      addManyWithOps: vi.fn(),
+      process: vi.fn((processor: unknown) => {
+        queue.processor = processor;
+        return { name: opts.name };
+      }),
+      processor: undefined as any
+    };
+    queues[opts.name] = queue;
+    return queue;
+  }
+}));
+
+vi.mock('@lowerdeck/cron', () => ({ createCron: () => ({}) }));
+
+vi.mock('@lowerdeck/lock', () => ({
+  createLock: () => ({ usingLock: (_key: string, fn: () => Promise<unknown>) => fn() })
+}));
+
+vi.mock('../../db', () => ({ db: dbMock }));
+
+vi.mock('../../env', () => ({
+  env: { service: { REDIS_URL: 'redis://localhost:6379' } }
+}));
+
+vi.mock('../../id', () => ({ getId: () => ({ oid: 1n, id: 'event_id' }) }));
+
+vi.mock('../../transaction', () => ({
+  withTransaction: (cb: (db: unknown) => Promise<unknown>) => cb(dbMock)
+}));
+
+vi.mock('../../services/oauth/remote/connection', () => ({
+  remoteOAuthConnectionService: { createConnection: vi.fn() }
+}));
+
+vi.mock('../../services/oauth/remote/registration', () => ({
+  remoteOAuthRegistrationService: { runAutoRegistration }
+}));
+
+import './retryRemoteOAuthConnections';
+
+let retryProcessor = () => queues['shut/rem-oaconn/retry/single'].processor;
+let promoteQueue = () => queues['shut/rem-oaconn/rotate/promote'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('retryRegistrationQueueProcessor', () => {
+  it('promotes a replacement that was registered by an earlier run of the job', async () => {
+    // The job crashed after registering, so this run only sees the connection
+    // as already registered.
+    runAutoRegistration.mockResolvedValue({
+      ok: false,
+      reason: 'skipped',
+      blocker: 'already_succeeded'
+    });
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({ id: 'soc_replacement' });
+
+    await retryProcessor()({ oauthConnectionId: 'cso_replacement' });
+
+    expect(promoteQueue().add).toHaveBeenCalledWith(
+      { newCredentialsId: 'soc_replacement' },
+      expect.objectContaining({ delay: 5000 })
+    );
+  });
+
+  it('promotes a replacement right after a successful registration', async () => {
+    runAutoRegistration.mockResolvedValue({ ok: true });
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue({ id: 'soc_replacement' });
+
+    await retryProcessor()({ oauthConnectionId: 'cso_replacement' });
+
+    expect(promoteQueue().add).toHaveBeenCalledWith(
+      { newCredentialsId: 'soc_replacement' },
+      expect.objectContaining({ delay: 5000 })
+    );
+  });
+
+  it('does not promote connections that are not replacements', async () => {
+    runAutoRegistration.mockResolvedValue({ ok: true });
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue(null);
+
+    await retryProcessor()({ oauthConnectionId: 'cso_plain' });
+
+    expect(promoteQueue().add).not.toHaveBeenCalled();
+  });
+
+  it('retries transient registration failures', async () => {
+    runAutoRegistration.mockResolvedValue({ ok: false, reason: 'failed', isTransient: true });
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue(null);
+
+    await expect(
+      retryProcessor()({ oauthConnectionId: 'cso_replacement' })
+    ).rejects.toBeInstanceOf(QueueRetryError);
+  });
+});

--- a/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
+++ b/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
@@ -42,8 +42,6 @@ export let retryFailedRegistrationsSearchQueueProcessor =
         status: 'active',
         discoveryStatus: 'failed',
 
-        // Connections with their own client must never be re-registered, doing
-        // so would swap the client out from under any token issued to it.
         registrationOid: null,
         secretOid: null,
 
@@ -91,7 +89,5 @@ export let retryRegistrationQueueProcessor = retryRegistrationQueue.process(asyn
 
   if (res.ok) return;
 
-  // A connection that is gone or no longer eligible is not an error, the next
-  // cron run reconsiders it.
   if (res.reason == 'failed' && res.isTransient) throw new QueueRetryError();
 });

--- a/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
+++ b/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.ts
@@ -87,10 +87,9 @@ export let retryRegistrationQueueProcessor = retryRegistrationQueue.process(asyn
     connectionId: data.oauthConnectionId
   });
 
-  if (res.ok) {
-    await enqueuePromotion({ connection: res.connection });
-    return;
-  }
+  await enqueuePromotion({ connectionId: data.oauthConnectionId });
+
+  if (res.ok) return;
 
   // A connection that is gone or no longer eligible is not an error, the next
   // cron run reconsiders it.

--- a/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.ts
+++ b/src/shuttle/service/src/queues/oauth/rotateRemoteCredentials.ts
@@ -45,7 +45,7 @@ export let rotateStaleCredentialsSearchQueueProcessor =
         remoteConnection: {
           status: 'active',
           discoveryStatus: 'succeeded',
-          // Only clients Metorial registered itself may be replaced.
+
           secretOid: null,
           registrationOid: { not: null },
           registration: { createdAt: { lt: staleCutoff } }
@@ -97,8 +97,6 @@ export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.pr
     await rotationLock.usingLock(
       `${credentials.tenantOid}-${credentials.serverOid}`,
       async () => {
-        // Everything is re-read inside the lock, a concurrent rotation or a
-        // manual credential change may have happened since the job was queued.
         let current = await db.serverOAuthCredentials.findUnique({
           where: { oid: credentials.oid },
           include: { remoteConnection: { include: { registration: true } } }
@@ -111,9 +109,6 @@ export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.pr
         if (connection.secretOid != null) return;
         if (!isStaleRegistration(connection.registration)) return;
 
-        // An earlier rotation may have left a replacement behind, for example
-        // when its promotion job ran out of attempts. Those are picked up again
-        // instead of registering yet another client.
         let existingReplacement = await db.remoteOAuthConnection.findFirst({
           where: {
             rotatedFromOid: connection.oid,
@@ -125,15 +120,16 @@ export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.pr
 
         if (existingReplacement) {
           if (existingReplacement.discoveryStatus != 'failed') {
-            await enqueuePromotion({ connection: existingReplacement });
+            await enqueuePromotion({ connectionId: existingReplacement.id });
             return;
           }
 
-          // The replacement can still be registered by the retry queue, which
-          // enqueues the promotion itself once it succeeds.
           if (existingReplacement.registrationAttemptCount < MAX_REGISTRATION_ATTEMPTS) return;
 
-          await retireReplacement({ connection: existingReplacement, previousConnection: connection });
+          await retireReplacement({
+            connection: existingReplacement,
+            previousConnection: connection
+          });
         }
 
         let config = await db.remoteOAuthConfig.findUniqueOrThrow({
@@ -151,7 +147,7 @@ export let rotateStaleCredentialsQueueProcessor = rotateStaleCredentialsQueue.pr
         });
         if (!replacement.serverOAuthCredentials) return;
 
-        await enqueuePromotion({ connection: replacement });
+        await enqueuePromotion({ connectionId: replacement.id });
       }
     );
   }
@@ -177,18 +173,12 @@ export let promoteRotatedCredentialsQueueProcessor = promoteRotatedCredentialsQu
     let newConnection = newCredentials.remoteConnection;
     let previousConnection = newConnection.rotatedFrom;
 
-    // Only connections created by a rotation are ever promoted, credentials the
-    // tenant created itself must keep the role it gave them.
     if (!previousConnection) return;
     if (newConnection.status != 'active') return;
 
-    // Registration is still running, wait for it with the queue's backoff.
     if (newConnection.discoveryStatus == 'discovering') throw new QueueRetryError();
 
     if (newConnection.discoveryStatus == 'failed') {
-      // The retry queue keeps working on the replacement until its budget is
-      // spent, and enqueues this job again once registration succeeds. Waiting
-      // here instead would outlive the job's own attempts.
       if (newConnection.registrationAttemptCount < MAX_REGISTRATION_ATTEMPTS) return;
 
       await retireReplacement({ connection: newConnection, previousConnection });
@@ -196,8 +186,9 @@ export let promoteRotatedCredentialsQueueProcessor = promoteRotatedCredentialsQu
       return;
     }
 
-    await rotationLock.usingLock(`${newCredentials.tenantOid}-${newCredentials.serverOid}`, () =>
-      promoteCredentials({ newCredentials, newConnection, previousConnection })
+    await rotationLock.usingLock(
+      `${newCredentials.tenantOid}-${newCredentials.serverOid}`,
+      () => promoteCredentials({ newCredentials, newConnection, previousConnection })
     );
   }
 );
@@ -219,8 +210,6 @@ let promoteCredentials = async (d: {
   });
   if (currentDefault?.oid == newCredentials.oid) return;
 
-  // The default moved on while the replacement was being registered, so the
-  // rotation is obsolete and its client must not take over.
   if (currentDefault?.remoteConnectionOid != previousConnection.oid) {
     await retireReplacement({ connection: newConnection, previousConnection: null });
 
@@ -244,8 +233,6 @@ let promoteCredentials = async (d: {
     });
   });
 
-  // Existing auth configs stay bound to the previous connection and keep
-  // refreshing with the client they were authorized against.
   await recordRotationEvent({
     connectionOid: newConnection.oid,
     discriminator: previousConnection.id,
@@ -268,29 +255,34 @@ let promoteCredentials = async (d: {
   });
 };
 
-// Called whenever a connection finishes registering, so a replacement is still
-// promoted when its original promotion job ran out of attempts.
-export let enqueuePromotion = async (d: {
-  connection: { oid: bigint; rotatedFromOid: bigint | null };
-}) => {
-  if (!d.connection.rotatedFromOid) return;
-
+export let enqueuePromotion = async (d: { connectionId: string }) => {
   let credentials = await db.serverOAuthCredentials.findFirst({
-    where: { remoteConnectionOid: d.connection.oid, isDefault: false },
+    where: {
+      isDefault: false,
+      remoteConnection: {
+        id: d.connectionId,
+        status: 'active',
+        rotatedFromOid: { not: null },
+        discoveryStatus: { in: ['discovering', 'succeeded'] }
+      }
+    },
     select: { id: true }
   });
   if (!credentials) return;
 
-  // Deliberately without a job id: a permanently failed promotion stays in the
-  // failed set for a day and would swallow the job that is meant to replace it.
-  // Promotion is idempotent, so duplicates are harmless.
-  await promoteRotatedCredentialsQueue.add({ newCredentialsId: credentials.id }, { delay: 5000 });
+  await promoteRotatedCredentialsQueue.add(
+    { newCredentialsId: credentials.id },
+    { delay: 5000 }
+  );
 };
 
-// The previous credentials keep working, so a failed rotation is not an error.
-// The replacement is retired so nothing can pick it up later.
 let retireReplacement = async (d: {
-  connection: { oid: bigint; id: string; errorCode?: string | null; errorMessage?: string | null };
+  connection: {
+    oid: bigint;
+    id: string;
+    errorCode?: string | null;
+    errorMessage?: string | null;
+  };
   previousConnection: { oid: bigint } | null;
 }) => {
   await db.remoteOAuthConnection.updateMany({

--- a/src/shuttle/service/src/queues/remote/startDeployment.ts
+++ b/src/shuttle/service/src/queues/remote/startDeployment.ts
@@ -142,14 +142,11 @@ export let deployRemoteServerStartQueueProcessor = deployRemoteServerStartQueue.
           deployingStep.log(`Name: ${oauthConfig.providerName}`);
           deployingStep.log(`URL: ${oauthConfig.providerUrl}`);
 
-          // If the discovery succeeded, we can update the server to point to the new OAuth config
           await db.server.updateMany({
             where: { oid: server.oid },
             data: { remoteOauthConfigOid: oauthConfig.oid }
           });
 
-          // For backwards compatibility, we need to update all existing
-          // remote connections to use the new config
           await db.remoteOAuthConnection.updateMany({
             where: {
               serverOid: server.oid,
@@ -159,9 +156,6 @@ export let deployRemoteServerStartQueueProcessor = deployRemoteServerStartQueue.
             data: { configOid: oauthConfig.oid }
           });
 
-          // Connections that never got a client registered are moved to the new
-          // config as well, and get a fresh retry budget because the newly
-          // discovered config may be what makes registration work.
           let repointed = await db.remoteOAuthConnection.updateMany({
             where: {
               serverOid: server.oid,

--- a/src/shuttle/service/src/services/oauth/remote/registration.ts
+++ b/src/shuttle/service/src/services/oauth/remote/registration.ts
@@ -5,10 +5,6 @@ import { OAuthUtils } from '../../../lib/oauth/oauthUtils';
 import { getRegistrationBlocker } from '../../../lib/oauth/registrationRetry';
 
 class remoteOAuthRegistrationServiceImpl {
-  /**
-   * Registers an OAuth client for a connection that does not have one yet. Used
-   * both for the initial registration and for retries of failed registrations.
-   */
   async runAutoRegistration(d: { connectionId: string }) {
     let connection = await db.remoteOAuthConnection.findFirst({
       where: { id: d.connectionId },
@@ -42,8 +38,6 @@ class remoteOAuthRegistrationServiceImpl {
       return { ok: false as const, reason: 'unsupported' as const };
     }
 
-    // Counted before calling the provider so a crashing or hanging registration
-    // cannot be retried indefinitely.
     let attempt = connection.registrationAttemptCount + 1;
     await db.remoteOAuthConnection.update({
       where: { oid: connection.oid },
@@ -106,7 +100,6 @@ class remoteOAuthRegistrationServiceImpl {
         discoveryStatus: 'failed',
         errorCode: 'auto_registration_failed',
         errorMessage: `Failed to auto-register OAuth client for connection: ${jsonInner}`,
-        // Provider outages should not use up the connection's retry budget.
         registrationAttemptCount: isTransient ? connection.registrationAttemptCount : attempt
       }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Subspace changes mutate tenant/environment identity, move scoped rows, and delete duplicate environments with transactional aborts; incorrect reconciliation could mis-scope customer data. OAuth promotion behavior change affects default credential cutover after auto-registration.
> 
> **Overview**
> Adds a **legacy subspace scope reconciliation** path so projects stuck on per-instance/org tenant identifiers can be promoted to canonical `mte-pro-*` / `mte-ins-*` scope without the regular sync path creating duplicate environments.
> 
> **Subspace:** `Tenant` gains optional `retiredAt` (indexed). New `legacyScope` helpers distinguish canonical vs legacy identifiers, resolve Metorial projects/instances from subspace rows, and report **scope drift**. `reconcileLegacyScopeService` plans and applies repairs in a transaction (tenant promotion, environment rename/move, duplicate environment deletion when safe, scoped row moves, tenant retirement) with **abort** when ambiguity would lose data; it then updates Metorial pointers and hands off to normal sync/link reconciliation. Hourly cron plus tenant/environment search queues enqueue per-project repair; `metorialResource`, `reconcileResourceLinks`, and `subspaceScope` **defer** to this flow when drift is detected or canonical links do not resolve (enqueue repair instead of provisioning).
> 
> **Shuttle:** Remote OAuth `rotatedFrom` relation uses `onDelete: SetNull`. **Credential rotation promotion** is enqueued by `connectionId` after every registration attempt (success or skip), so replacements still promote if a prior job registered then crashed; new tests cover that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a716406c441855e7a710b99b9762515290211cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->