### PR TITLE
Fix sse connections

### DIFF
--- a/src/metorial/apis/connection/src/mcp.ts
+++ b/src/metorial/apis/connection/src/mcp.ts
@@ -72,11 +72,14 @@ let applyConnectionHeaders = (
     connection?: { id: string; token: string } | null;
   }
 ) => {
-  c.header('Metorial-Session-Id', connection.session.id);
+  // Mutate the live response headers in place. `c.header()` after streamSSE
+  // returns recreates the Response from `.body`, which steals the stream and
+  // closes the SSE connection with Content-Length: 0.
+  c.res.headers.set('Metorial-Session-Id', connection.session.id);
   if (connection.connection) {
-    c.header('Mcp-Session-Id', connection.connection.token);
-    c.header('Metorial-Connection-Id', connection.connection.id);
-    c.header('Metorial-Connection-Token', connection.connection.token);
+    c.res.headers.set('Mcp-Session-Id', connection.connection.token);
+    c.res.headers.set('Metorial-Connection-Id', connection.connection.id);
+    c.res.headers.set('Metorial-Connection-Token', connection.connection.token);
   }
 };
 

--- a/src/metorial/apis/connection/test/mcp.test.ts
+++ b/src/metorial/apis/connection/test/mcp.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+let { create } = vi.hoisted(() => ({ create: vi.fn() }));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: { fire: vi.fn() }
+}));
+
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  subspaceScopeService: {
+    ensureForInstance: vi.fn(async () => ({
+      tenant: { id: 'ten_1' },
+      solution: { id: 'sol_1' }
+    }))
+  }
+}));
+
+vi.mock('@metorial-subspace/module-connection', () => ({
+  McpConnection: { create },
+  handleMcpRequest: vi.fn()
+}));
+
+import { handleMcpRequest } from '../src/mcp';
+
+let neverEndingIterator = async function* () {
+  await new Promise(() => {});
+};
+
+let readSseWithCurl = async (url: string) => {
+  let proc = Bun.spawn(
+    ['curl', '-sS', '-N', '-D', '-', '--max-time', '1', url, '-H', 'Accept: text/event-stream'],
+    { stdout: 'pipe', stderr: 'pipe' }
+  );
+  let stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  return stdout;
+};
+
+describe.skipIf(typeof Bun === 'undefined')('handleMcpRequest SSE', () => {
+  beforeEach(() => {
+    create.mockReset();
+  });
+
+  it('writes the endpoint event and keeps the stream open', async () => {
+    let connection = {
+      session: { id: 'ses_1' },
+      connection: null as { id: string; token: string } | null,
+      listener: vi.fn(async () => ({
+        close: vi.fn(),
+        iterator: neverEndingIterator
+      })),
+      createConnection: vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 30));
+        connection.connection = { id: 'scon_1', token: 'tok_1' };
+        return connection.connection;
+      })
+    };
+    create.mockResolvedValue(connection);
+
+    let app = new Hono()
+      .use(async (c, next) => {
+        c.res.headers.set('Access-Control-Allow-Origin', '*');
+        await next();
+      })
+      .all('/connect/mcp/:sessionId', c =>
+        handleMcpRequest(c, {
+          instance: { id: 'ins_1' } as any,
+          sessionId: 'ses_1'
+        })
+      );
+
+    let server = Bun.serve({ port: 0, fetch: app.fetch, idleTimeout: 255 });
+
+    try {
+      let stdout = await readSseWithCurl(`http://127.0.0.1:${server.port}/connect/mcp/ses_1`);
+      let [rawHeaders, ...bodyParts] = stdout.split('\r\n\r\n');
+      let body = bodyParts.join('\r\n\r\n');
+
+      expect(rawHeaders).toContain('HTTP/1.1 200');
+      expect(rawHeaders).toContain('text/event-stream');
+      expect(rawHeaders).not.toMatch(/content-length: 0/i);
+      expect(body).toContain('event: endpoint');
+      expect(body).toContain('connection_token=tok_1');
+    } finally {
+      server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, targeted fix to header mutation on the connection API’s SSE path, with regression coverage and no auth or data-model changes.
> 
> **Overview**
> Fixes MCP **SSE** connections that were closing immediately because connection/session headers were applied with Hono’s `c.header()` **after** `streamSSE` had started.
> 
> `applyConnectionHeaders` now mutates **`c.res.headers` in place** (`headers.set`) so the live streaming response is not replaced (which was yielding `Content-Length: 0` and killing the stream). Session and connection tokens (`Metorial-Session-Id`, `Mcp-Session-Id`, etc.) are unchanged; only how they are written on SSE paths differs.
> 
> Adds a **Bun-only** integration test that serves the MCP route, curls the SSE GET, and asserts `text/event-stream`, no zero content-length, and an `endpoint` event with `connection_token`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0906b99529f29f7553bbe65d19dcfb2aa7511f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->