### PR TITLE
Add instance tenancy

### DIFF
--- a/src/metorial/db/prisma/schema/file/document.prisma
+++ b/src/metorial/db/prisma/schema/file/document.prisma
@@ -25,6 +25,12 @@ model Document {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   contentOid BigInt
   content    DocumentContent @relation(fields: [contentOid], references: [oid], onDelete: Cascade)
 
@@ -56,6 +62,8 @@ model Document {
 
   @@index([resourceTenantOid, resourceGroupOid])
   @@index([resourceTenantOid, resourceGroupOid, isTemplateBacking])
+  @@index([instanceOid])
+  @@index([instanceOid, isTemplateBacking])
   @@index([isContentOwner])
   @@index([draftVersionExpiresAt])
 }
@@ -99,6 +107,12 @@ model DocumentVersion {
 
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
+
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 
   documentOid BigInt
   document    Document @relation(fields: [documentOid], references: [oid], onDelete: Cascade)

--- a/src/metorial/db/prisma/schema/file/file.prisma
+++ b/src/metorial/db/prisma/schema/file/file.prisma
@@ -95,6 +95,12 @@ model FileLink {
   resourceGroupOid BigInt?
   resourceGroup    ResourceGroup? @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   createdByResourceActorOid BigInt?
   createdByResourceActor    ResourceActor? @relation("FileLinkCreator", fields: [createdByResourceActorOid], references: [oid], onDelete: SetNull)
 
@@ -119,6 +125,12 @@ model FileReference {
 
   resourceGroupOid BigInt?
   resourceGroup    ResourceGroup? @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
+
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 
   entityType String
   entityId   String

--- a/src/metorial/db/prisma/schema/file/store.prisma
+++ b/src/metorial/db/prisma/schema/file/store.prisma
@@ -52,6 +52,12 @@ model Store {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   parentStoreOid BigInt?
   parentStore    Store?  @relation("StoreHierarchy", fields: [parentStoreOid], references: [oid], onDelete: Cascade)
   childStores    Store[] @relation("StoreHierarchy")
@@ -72,6 +78,8 @@ model Store {
 
   @@index([resourceTenantOid, resourceGroupOid, dirtyAt])
   @@index([resourceTenantOid, resourceGroupOid, isTemplateBacking])
+  @@index([instanceOid, dirtyAt])
+  @@index([instanceOid, isTemplateBacking])
 }
 
 model StoreTemplate {
@@ -88,6 +96,12 @@ model StoreTemplate {
   resourceGroupOid BigInt?
   resourceGroup    ResourceGroup? @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   sourceStoreOid BigInt?
   sourceStore    Store?  @relation("StoreTemplateSource", fields: [sourceStoreOid], references: [oid], onDelete: Cascade)
 
@@ -100,6 +114,7 @@ model StoreTemplate {
   backingStores      StoreTemplateBacking[]
 
   @@index([resourceTenantOid, resourceGroupOid])
+  @@index([projectOid, instanceOid])
   @@index([sourceStoreOid])
   @@index([hash])
 }
@@ -143,6 +158,12 @@ model StoreTemplateBacking {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   storeOid BigInt @unique
   store    Store  @relation(fields: [storeOid], references: [oid], onDelete: Cascade)
 
@@ -153,6 +174,7 @@ model StoreTemplateBacking {
 
   @@unique([storeTemplateOid, resourceTenantOid, resourceGroupOid])
   @@index([resourceTenantOid, resourceGroupOid])
+  @@index([instanceOid])
 }
 
 model StoreItem {

--- a/src/metorial/db/prisma/schema/organization/instance.prisma
+++ b/src/metorial/db/prisma/schema/organization/instance.prisma
@@ -147,6 +147,24 @@ model Instance {
   auditLogs                            AuditLog[]
   events                               Event[]
 
+  fileLinks             FileLink[]
+  fileReferences        FileReference[]
+  documents             Document[]
+  documentVersions      DocumentVersion[]
+  stores                Store[]
+  storeTemplates        StoreTemplate[]
+  storeTemplateBackings StoreTemplateBacking[]
+  skillConfigurations   SkillConfiguration[]
+  skillRepositories     SkillRepository[]
+  skillExports          SkillExport[]
+  skillExportRefs       SkillExportRef[]
+  skillImports          SkillImport[]
+  skillMergeRequests    SkillMergeRequest[]
+  skillForkSyncs        SkillForkSync[]
+
+  productAssistantConversations          ProductAssistantConversation[]
+  productAssistantSubspaceMcpConnections ProductAssistantSubspaceMcpConnection[]
+
   @@index([previousSlugs])
   @@index([oldSlug])
   @@index([slug])

--- a/src/metorial/db/prisma/schema/organization/project.prisma
+++ b/src/metorial/db/prisma/schema/organization/project.prisma
@@ -47,5 +47,32 @@ model Project {
   brand                ProjectBrand?
   teams                TeamProject[]
 
+  resourceActors        ResourceActor[]
+  fileLinks             FileLink[]
+  fileReferences        FileReference[]
+  documents             Document[]
+  documentVersions      DocumentVersion[]
+  stores                Store[]
+  storeTemplates        StoreTemplate[]
+  storeTemplateBackings StoreTemplateBacking[]
+  skills                Skill[]
+  skillConfigurations   SkillConfiguration[]
+  skillTemplates        SkillTemplate[]
+  skillMarketplaces     SkillMarketplace[]
+  skillPlugins          SkillPlugin[]
+  skillRepositories     SkillRepository[]
+  skillExports          SkillExport[]
+  skillExportRefs       SkillExportRef[]
+  skillImports          SkillImport[]
+  skillMergeRequests    SkillMergeRequest[]
+  skillForkSyncs        SkillForkSync[]
+
+  productAssistants                      ProductAssistant[]
+  productAssistantConfig                 ProductAssistantConfig?
+  productAssistantInstances              ProductAssistantInstance[]
+  productAssistantConversations          ProductAssistantConversation[]
+  productAssistantModelRuns              ProductAssistantModelRun[]
+  productAssistantSubspaceMcpConnections ProductAssistantSubspaceMcpConnection[]
+
   @@index([previousSlugs])
 }

--- a/src/metorial/db/prisma/schema/product-assistant/assistant.prisma
+++ b/src/metorial/db/prisma/schema/product-assistant/assistant.prisma
@@ -25,6 +25,9 @@ model ProductAssistant {
   resourceTenantOid BigInt?
   resourceTenant    ResourceTenant? @relation(fields: [resourceTenantOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   implementationOid BigInt
   implementation    ProductAssistantImplementation @relation(fields: [implementationOid], references: [oid], onDelete: Cascade)
 
@@ -42,6 +45,7 @@ model ProductAssistant {
   modelRuns              ProductAssistantModelRun[]
 
   @@index([resourceTenantOid])
+  @@index([projectOid])
   @@index([implementationOid])
 }
 
@@ -49,8 +53,11 @@ model ProductAssistantConfig {
   oid BigInt @id @default(autoincrement())
   id  String @unique
 
-  resourceTenantOid BigInt @unique
+  resourceTenantOid BigInt         @unique
   resourceTenant    ResourceTenant @relation(fields: [resourceTenantOid], references: [oid], onDelete: Cascade)
+
+  projectOid BigInt?  @unique
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
@@ -66,6 +73,9 @@ model ProductAssistantInstance {
   resourceTenantOid BigInt
   resourceTenant    ResourceTenant @relation(fields: [resourceTenantOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -75,5 +85,7 @@ model ProductAssistantInstance {
   modelRuns              ProductAssistantModelRun[]
 
   @@unique([assistantOid, resourceTenantOid])
+  @@unique([assistantOid, projectOid])
   @@index([resourceTenantOid])
+  @@index([projectOid])
 }

--- a/src/metorial/db/prisma/schema/product-assistant/conversation.prisma
+++ b/src/metorial/db/prisma/schema/product-assistant/conversation.prisma
@@ -19,6 +19,12 @@ model ProductAssistantConversation {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   createdByResourceActorOid BigInt
   createdByResourceActor    ResourceActor @relation("ProductAssistantConversationCreator", fields: [createdByResourceActorOid], references: [oid], onDelete: Cascade)
 
@@ -34,6 +40,7 @@ model ProductAssistantConversation {
   assistantConversationParticipants ProductAssistantConversationParticipant[]
 
   @@index([resourceTenantOid, resourceGroupOid])
+  @@index([projectOid, instanceOid])
   @@index([assistantOid, assistantInstanceOid])
   @@index([createdByResourceActorOid])
 }

--- a/src/metorial/db/prisma/schema/product-assistant/model.prisma
+++ b/src/metorial/db/prisma/schema/product-assistant/model.prisma
@@ -55,6 +55,9 @@ model ProductAssistantModelRun {
   resourceTenantOid BigInt
   resourceTenant    ResourceTenant @relation(fields: [resourceTenantOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   requestOid BigInt?
   request    ProductAssistantRequest? @relation(fields: [requestOid], references: [oid], onDelete: Cascade)
 
@@ -85,4 +88,5 @@ model ProductAssistantModelRun {
   @@index([conversationOid, status])
   @@index([assistantInstanceOid])
   @@index([resourceTenantOid])
+  @@index([projectOid])
 }

--- a/src/metorial/db/prisma/schema/product-assistant/subspace.prisma
+++ b/src/metorial/db/prisma/schema/product-assistant/subspace.prisma
@@ -15,11 +15,19 @@ model ProductAssistantSubspaceMcpConnection {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
   @@unique([resourceTenantOid, resourceGroupOid, sessionId])
+  @@unique([instanceOid, sessionId])
   @@index([resourceTenantOid, resourceGroupOid])
+  @@index([projectOid, instanceOid])
   @@index([lastUsedAt])
   @@index([createdAt])
 }

--- a/src/metorial/db/prisma/schema/skill/configuration.prisma
+++ b/src/metorial/db/prisma/schema/skill/configuration.prisma
@@ -15,6 +15,12 @@ model SkillConfiguration {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   deletedAt DateTime?
   createdAt DateTime  @default(now())
   updatedAt DateTime  @default(now()) @updatedAt
@@ -28,4 +34,6 @@ model SkillConfiguration {
   @@unique([resourceGroupOid, isDefault])
   @@index([resourceTenantOid, resourceGroupOid, deletedAt])
   @@index([resourceTenantOid, resourceGroupOid, isInternal])
+  @@index([instanceOid, deletedAt])
+  @@index([instanceOid, isInternal])
 }

--- a/src/metorial/db/prisma/schema/skill/export.prisma
+++ b/src/metorial/db/prisma/schema/skill/export.prisma
@@ -48,6 +48,12 @@ model SkillExportRef {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   createdAt DateTime @default(now())
 
   skillExports SkillExport[]
@@ -82,6 +88,12 @@ model SkillExport {
 
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
+
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 
   createdAt   DateTime  @default(now())
   startedAt   DateTime?

--- a/src/metorial/db/prisma/schema/skill/import.prisma
+++ b/src/metorial/db/prisma/schema/skill/import.prisma
@@ -55,6 +55,12 @@ model SkillImport {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   creatorResourceActorOid BigInt?
   creatorResourceActor    ResourceActor? @relation("SkillImportCreator", fields: [creatorResourceActorOid], references: [oid], onDelete: SetNull)
 
@@ -66,6 +72,7 @@ model SkillImport {
   items SkillImportItem[]
 
   @@index([resourceTenantOid, resourceGroupOid, createdAt])
+  @@index([instanceOid, createdAt])
   @@index([creatorResourceActorOid, createdAt])
   @@index([status, updatedAt])
 }

--- a/src/metorial/db/prisma/schema/skill/marketplace.prisma
+++ b/src/metorial/db/prisma/schema/skill/marketplace.prisma
@@ -46,6 +46,9 @@ model SkillMarketplace {
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   instanceOid BigInt
   instance    Instance @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 

--- a/src/metorial/db/prisma/schema/skill/mergeRequest.prisma
+++ b/src/metorial/db/prisma/schema/skill/mergeRequest.prisma
@@ -80,6 +80,12 @@ model SkillMergeRequest {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   sourceSkillOid BigInt
   sourceSkill    Skill  @relation("SkillMergeRequestSource", fields: [sourceSkillOid], references: [oid], onDelete: Cascade)
 
@@ -135,6 +141,7 @@ model SkillMergeRequest {
   generatedForkSync SkillForkSync?             @relation("SkillForkSyncMergeRequest")
 
   @@index([resourceTenantOid, resourceGroupOid, status, createdAt])
+  @@index([instanceOid, status, createdAt])
   @@index([sourceSkillOid, status, createdAt])
   @@index([targetSkillOid, status, createdAt])
   @@index([baseSourceSkillVersionOid])
@@ -165,6 +172,12 @@ model SkillForkSync {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   forkSkillOid BigInt
   forkSkill    Skill  @relation("SkillForkSyncFork", fields: [forkSkillOid], references: [oid], onDelete: Cascade)
 
@@ -186,6 +199,7 @@ model SkillForkSync {
   updatedAt           DateTime  @default(now()) @updatedAt
 
   @@index([resourceTenantOid, resourceGroupOid, status, createdAt])
+  @@index([instanceOid, status, createdAt])
   @@index([forkSkillOid, status, createdAt])
   @@index([upstreamSkillOid, status, createdAt])
   @@index([createdByResourceActorOid, createdAt])

--- a/src/metorial/db/prisma/schema/skill/plugin.prisma
+++ b/src/metorial/db/prisma/schema/skill/plugin.prisma
@@ -41,6 +41,9 @@ model SkillPlugin {
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   instanceOid BigInt
   instance    Instance @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 

--- a/src/metorial/db/prisma/schema/skill/repository.prisma
+++ b/src/metorial/db/prisma/schema/skill/repository.prisma
@@ -11,6 +11,12 @@ model SkillRepository {
   resourceGroupOid BigInt
   resourceGroup    ResourceGroup @relation(fields: [resourceGroupOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt?
+  instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -20,4 +26,6 @@ model SkillRepository {
 
   @@index([resourceTenantOid])
   @@index([resourceGroupOid])
+  @@index([projectOid])
+  @@index([instanceOid])
 }

--- a/src/metorial/db/prisma/schema/skill/skill.prisma
+++ b/src/metorial/db/prisma/schema/skill/skill.prisma
@@ -37,6 +37,9 @@ model Skill {
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   instanceOid BigInt
   instance    Instance @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 

--- a/src/metorial/db/prisma/schema/skill/template.prisma
+++ b/src/metorial/db/prisma/schema/skill/template.prisma
@@ -38,6 +38,9 @@ model SkillTemplate {
   organizationOid BigInt?
   organization    Organization? @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   instanceOid BigInt?
   instance    Instance? @relation(fields: [instanceOid], references: [oid], onDelete: Cascade)
 

--- a/src/metorial/db/prisma/schema/tenant/resource.prisma
+++ b/src/metorial/db/prisma/schema/tenant/resource.prisma
@@ -116,6 +116,9 @@ model ResourceActor {
   resourceTenantOid BigInt
   resourceTenant    ResourceTenant @relation(fields: [resourceTenantOid], references: [oid], onDelete: Cascade)
 
+  projectOid BigInt?
+  project    Project? @relation(fields: [projectOid], references: [oid], onDelete: Cascade)
+
   organizationActorOid BigInt?
   organizationActor    OrganizationActor? @relation(fields: [organizationActorOid], references: [oid], onDelete: SetNull)
 
@@ -157,6 +160,9 @@ model ResourceActor {
   @@unique([resourceTenantOid, identifier])
   @@unique([resourceTenantOid, consumerProfileOid])
   @@unique([resourceTenantOid, organizationActorOid])
+  @@unique([projectOid, identifier])
+  @@unique([projectOid, consumerProfileOid])
+  @@unique([projectOid, organizationActorOid])
   @@index([consumerOid])
   @@index([consumerProfileOid])
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Broad schema migration touching tenancy on many tables; nullable columns require backfill and application writes to avoid inconsistent scoping, and new uniques on ResourceActor/ProductAssistant can fail if duplicates exist per project or instance.
> 
> **Overview**
> Extends the data model so **project** and **instance** can scope resources that were previously tied mainly to `resourceTenant` / `resourceGroup`.
> 
> Optional `projectOid` and `instanceOid` foreign keys (with cascade delete) are added across files, documents, stores, skills (config, export/import, merge requests, fork sync, repositories, templates, marketplaces, plugins), product assistant entities, and `ResourceActor`. **Project** and **Instance** gain the corresponding inverse relation lists for these entities.
> 
> Query support is added via new indexes (often `instanceOid`-centric, plus `projectOid` / `projectOid, instanceOid` composites). **ResourceActor** gets project-scoped uniques parallel to the tenant ones. Product assistant changes include optional `projectOid` on assistants/config/instances/runs, `@@unique([assistantOid, projectOid])` on instances, and `@@unique([instanceOid, sessionId])` on Subspace MCP connections alongside the existing tenant/group constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2944b5dc3a02ba709052b34c245aa07bd33e6691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->