### PR TITLE
Fix queue spans

### DIFF
--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
@@ -1,13 +1,57 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+type FakeScope = {
+  setTransactionName: (name: string) => void;
+  setTag: (key: string, value: string) => void;
+};
+
 let mocks = vi.hoisted(() => ({
   queueConstructed: vi.fn(),
   queueAdd: vi.fn(),
   workerConstructed: vi.fn(),
   workerWaitUntilReady: vi.fn(),
   workerRun: vi.fn(),
-  workerClose: vi.fn()
+  workerClose: vi.fn(),
+  captureException: vi.fn(),
+  openScopes: [] as { transactionName?: string; tags: Record<string, string> }[],
+  scopeDuringCapture: [] as (string | undefined)[]
 }));
+
+vi.mock('@lowerdeck/sentry', () => {
+  let current: { transactionName?: string; tags: Record<string, string> } | null = null;
+
+  // The driver is not the only consumer of this module, and what the others reach for is
+  // beside the point here, so anything unnamed is a no-op.
+  let asSentry = (sentry: Record<string, unknown>) =>
+    new Proxy(sentry, { get: (target, key) => Reflect.get(target, key) ?? (() => {}) });
+
+  return {
+    getSentry: () =>
+      asSentry({
+        captureException: (...args: unknown[]) => {
+          mocks.scopeDuringCapture.push(current?.transactionName);
+          return mocks.captureException(...args);
+        },
+        withIsolationScope: async (cb: (scope: FakeScope) => Promise<unknown>) => {
+          let opened: { transactionName?: string; tags: Record<string, string> } = {
+            tags: {}
+          };
+          let previous = current;
+          current = opened;
+          mocks.openScopes.push(opened);
+
+          try {
+            return await cb({
+              setTransactionName: name => (opened.transactionName = name),
+              setTag: (key, value) => (opened.tags[key] = value)
+            });
+          } finally {
+            current = previous;
+          }
+        }
+      })
+  };
+});
 
 vi.mock('bullmq', () => ({
   Queue: class Queue {
@@ -20,8 +64,8 @@ vi.mock('bullmq', () => ({
   },
   QueueEvents: class QueueEvents {},
   Worker: class Worker {
-    constructor() {
-      mocks.workerConstructed();
+    constructor(_name: string, handler: (job: unknown) => Promise<unknown>) {
+      mocks.workerConstructed(handler);
     }
 
     waitUntilReady = mocks.workerWaitUntilReady;
@@ -32,9 +76,17 @@ vi.mock('bullmq', () => ({
 
 import { createBullMqQueue } from './bullmq';
 
+let startWorker = async (name: string, cb: (payload: any) => Promise<void>) => {
+  await createBullMqQueue({ name, redisUrl: 'redis://localhost:6379' }).process(cb).start();
+
+  return mocks.workerConstructed.mock.calls.at(-1)![0] as (job: unknown) => Promise<unknown>;
+};
+
 describe('createBullMqQueue', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.openScopes = [];
+    mocks.scopeDuringCapture = [];
     mocks.queueAdd.mockResolvedValue({});
     mocks.workerWaitUntilReady.mockResolvedValue(undefined);
     mocks.workerRun.mockResolvedValue(undefined);
@@ -71,5 +123,38 @@ describe('createBullMqQueue', () => {
     resolveReady();
     await starting;
     expect(mocks.workerRun).toHaveBeenCalledOnce();
+  });
+
+  // Concurrent jobs share the process scope, so without a scope of its own a job inherits the
+  // transaction of whichever job ran before it and reports its failures under that name.
+  it('gives every job a scope naming the queue it came from', async () => {
+    let handler = await startWorker('scoped-queue', async () => {});
+
+    await handler({ id: 'job_1', data: { payload: { value: 1 } }, attemptsMade: 0 });
+    await handler({ id: 'job_2', data: { payload: { value: 2 } }, attemptsMade: 0 });
+
+    expect(mocks.openScopes).toEqual([
+      {
+        transactionName: 'queue process: scoped-queue',
+        tags: { queue: 'scoped-queue', 'queue.job_id': 'job_1' }
+      },
+      {
+        transactionName: 'queue process: scoped-queue',
+        tags: { queue: 'scoped-queue', 'queue.job_id': 'job_2' }
+      }
+    ]);
+  });
+
+  it('reports a failed job from inside the scope of that job', async () => {
+    let handler = await startWorker('failing-queue', async () => {
+      throw new Error('job failed');
+    });
+
+    await expect(
+      handler({ id: 'job_1', data: { payload: {} }, attemptsMade: 0 })
+    ).rejects.toThrow('job failed');
+
+    expect(mocks.captureException).toHaveBeenCalledOnce();
+    expect(mocks.scopeDuringCapture).toEqual(['queue process: failing-queue']);
   });
 });

--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
@@ -1,10 +1,10 @@
 import { delay } from '@lowerdeck/delay';
+import type { ExecutionContext } from '@lowerdeck/execution-context';
 import {
   createExecutionContext,
   provideExecutionContext,
   withExecutionContextOptional
 } from '@lowerdeck/execution-context';
-import type { ExecutionContext } from '@lowerdeck/execution-context';
 import { generateSnowflakeId } from '@lowerdeck/id';
 import { memo } from '@lowerdeck/memo';
 import { parseRedisUrl } from '@lowerdeck/redis';
@@ -16,8 +16,14 @@ import {
   SpanStatusCode,
   trace
 } from '@lowerdeck/telemetry';
+import type {
+  DeduplicationOptions,
+  Job,
+  JobsOptions,
+  QueueOptions,
+  WorkerOptions
+} from 'bullmq';
 import { Queue, QueueEvents, Worker } from 'bullmq';
-import type { DeduplicationOptions, JobsOptions, QueueOptions, WorkerOptions } from 'bullmq';
 import { QueueRetryError } from '../lib/queueRetryError';
 import type { IQueue } from '../types';
 
@@ -258,65 +264,74 @@ export let createBullMqQueue = <JobData>(
           staredRef.started = true;
           anyQueueStartedRef.started = true;
 
+          let runJob = async (job: Job<JobData>) => {
+            try {
+              let data = job.data as any;
+
+              let payload: any;
+
+              try {
+                payload = SuperJson.deserialize(data.payload);
+              } catch (e: any) {
+                payload = data.payload;
+              }
+
+              let parentExecutionContext = (data as any)
+                .$$execution_context$$ as ExecutionContext;
+              while (
+                parentExecutionContext &&
+                parentExecutionContext.type == 'job' &&
+                parentExecutionContext.parent
+              )
+                parentExecutionContext = parentExecutionContext.parent;
+
+              let jobExecutionContext = createExecutionContext({
+                type: 'job',
+                contextId: job.id ?? generateSnowflakeId(),
+                queue: opts.name,
+                parent: parentExecutionContext
+              });
+
+              await provideExecutionContext(
+                jobExecutionContext,
+                async () =>
+                  await withQueueSpan(
+                    {
+                      name: `queue process: ${opts.name}`,
+                      kind: SpanKind.CONSUMER,
+                      queueName: opts.name,
+                      operation: 'process',
+                      createSpan: true,
+                      attributes: {
+                        'messaging.message.id': job.id ? String(job.id) : undefined,
+                        'messaging.message.retry.count': job.attemptsMade
+                      }
+                    },
+                    async () => await cb(payload as any, job)
+                  )
+              );
+            } catch (e: any) {
+              if (e instanceof QueueRetryError) {
+                await delay(1000);
+                throw e;
+              } else {
+                Sentry.captureException(e);
+                console.error(e);
+                throw e;
+              }
+            }
+          };
+
           let worker = new Worker<JobData>(
             opts.name,
-            async job => {
-              try {
-                let data = job.data as any;
+            async job =>
+              await Sentry.withIsolationScope(async scope => {
+                scope.setTransactionName(`queue process: ${opts.name}`);
+                scope.setTag('queue', opts.name);
+                if (job.id) scope.setTag('queue.job_id', String(job.id));
 
-                let payload: any;
-
-                try {
-                  payload = SuperJson.deserialize(data.payload);
-                } catch (e: any) {
-                  payload = data.payload;
-                }
-
-                let parentExecutionContext = (data as any)
-                  .$$execution_context$$ as ExecutionContext;
-                while (
-                  parentExecutionContext &&
-                  parentExecutionContext.type == 'job' &&
-                  parentExecutionContext.parent
-                )
-                  parentExecutionContext = parentExecutionContext.parent;
-
-                let jobExecutionContext = createExecutionContext({
-                  type: 'job',
-                  contextId: job.id ?? generateSnowflakeId(),
-                  queue: opts.name,
-                  parent: parentExecutionContext
-                });
-
-                await provideExecutionContext(
-                  jobExecutionContext,
-                  async () =>
-                    await withQueueSpan(
-                      {
-                        name: `queue process: ${opts.name}`,
-                        kind: SpanKind.CONSUMER,
-                        queueName: opts.name,
-                        operation: 'process',
-                        createSpan: true,
-                        attributes: {
-                          'messaging.message.id': job.id ? String(job.id) : undefined,
-                          'messaging.message.retry.count': job.attemptsMade
-                        }
-                      },
-                      async () => await cb(payload as any, job)
-                    )
-                );
-              } catch (e: any) {
-                if (e instanceof QueueRetryError) {
-                  await delay(1000);
-                  throw e;
-                } else {
-                  Sentry.captureException(e);
-                  console.error(e);
-                  throw e;
-                }
-              }
-            },
+                return await runJob(job);
+              }),
             {
               concurrency: 50,
               ...opts.workerOpts,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the shared queue worker error/observability path for all BullMQ processors; behavior is scoped to Sentry metadata, but mis-scoping would affect incident triage.
> 
> **Overview**
> **BullMQ workers now run each job inside its own Sentry isolation scope** so concurrent jobs no longer inherit another job’s transaction name and failures show up under the correct queue.
> 
> For every processed job, the worker sets the transaction to `queue process: <queue name>` and tags `queue` plus `queue.job_id` before running the existing payload/execution-context/telemetry path. Job logic is unchanged; processing is just factored into `runJob` and invoked from the scoped worker callback.
> 
> Tests mock Sentry’s `withIsolationScope` / `captureException` and assert two jobs get separate scopes with the right names/tags, and that `captureException` runs while that job’s scope is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5227de062bcbc6a9c27e625868a88d8930803fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->