### PR TITLE
Fix menu overflow

### DIFF
--- a/src/metorial-frontend/packages/ui/src/menu/index.tsx
+++ b/src/metorial-frontend/packages/ui/src/menu/index.tsx
@@ -5,6 +5,7 @@ import { css, keyframes, styled } from 'styled-components';
 import { theme } from '..';
 import { markOverlayPointerDismiss, useDialogZIndex } from '../dialog/state';
 import { OverlayOpenProvider, useSuppressTooltipWhileOpen } from '../tooltip/state';
+import { MENU_VIEWPORT_PADDING, useConstrainedMenuHeight } from './useConstrainedMenuHeight';
 
 let fadeInBottom = keyframes`
   from { opacity: 0; transform: translateY(-10px) scale(0.99); }
@@ -52,7 +53,11 @@ let contentStyles = css<{
 }>`
   display: flex;
   flex-direction: column;
-  transition: all 0.3s ease;
+  transition:
+    background 0.3s ease,
+    box-shadow 0.3s ease,
+    color 0.3s ease,
+    border-color 0.3s ease;
   padding: 5px;
   color: ${({ $lightMode }) =>
     $lightMode ? theme.colors.foreground : theme.colors.background};
@@ -63,9 +68,17 @@ let contentStyles = css<{
     ${({ $lightMode }) => ($lightMode ? theme.colors.gray400 : theme.colors.foreground)};
   border-radius: 10px;
   min-width: 200px;
+  min-height: 0;
   width: ${({ $matchTriggerWidth }) =>
     $matchTriggerWidth ? 'var(--radix-dropdown-menu-trigger-width)' : undefined};
   gap: 5px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  max-height: calc(
+    var(--radix-dropdown-menu-content-available-height, 100dvh) - ${MENU_VIEWPORT_PADDING}px
+  );
+
   &[data-state='open'][data-side='top'] {
     animation: ${fadeInTop} 0.2s ease forwards;
   }
@@ -109,6 +122,16 @@ let Content = styled(RadixMenu.Content)<{
 let SubContent = styled(RadixMenu.SubContent)<{ $lightMode?: boolean }>`
   ${contentStyles}
 `;
+
+let ConstrainedContent = (props: React.ComponentProps<typeof Content>) => {
+  let ref = useConstrainedMenuHeight();
+  return <Content {...props} ref={ref} />;
+};
+
+let ConstrainedSubContent = (props: React.ComponentProps<typeof SubContent>) => {
+  let ref = useConstrainedMenuHeight();
+  return <SubContent {...props} ref={ref} />;
+};
 
 let Separator = styled(RadixMenu.Separator)<{ $lightMode?: boolean }>`
   height: 1px;
@@ -338,7 +361,7 @@ export let Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
               </SubTrigger>
 
               <RadixMenu.Portal>
-                <SubContent
+                <ConstrainedSubContent
                   $lightMode={lightMode}
                   data-metorial-menu-content="true"
                   sideOffset={2}
@@ -346,7 +369,7 @@ export let Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
                   style={{ zIndex: zIndex + 1 }}
                 >
                   {renderItems(item.items)}
-                </SubContent>
+                </ConstrainedSubContent>
               </RadixMenu.Portal>
             </RadixMenu.Sub>
           );
@@ -398,7 +421,7 @@ export let Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
         </OverlayOpenProvider>
 
         <RadixMenu.Portal>
-          <Content
+          <ConstrainedContent
             $lightMode={lightMode}
             $matchTriggerWidth={matchTriggerWidth}
             data-metorial-menu-content="true"
@@ -414,7 +437,7 @@ export let Menu = React.forwardRef<HTMLButtonElement, MenuProps>(
             )}
 
             {renderItems(items)}
-          </Content>
+          </ConstrainedContent>
         </RadixMenu.Portal>
       </RadixMenu.Root>
     );

--- a/src/metorial-frontend/packages/ui/src/menu/useConstrainedMenuHeight.ts
+++ b/src/metorial-frontend/packages/ui/src/menu/useConstrainedMenuHeight.ts
@@ -1,0 +1,184 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+export let MENU_VIEWPORT_PADDING = 20;
+
+type MenuHeightConstraint = {
+  apply: () => void;
+  detach: () => void;
+};
+
+let getViewportBottom = () => {
+  if (typeof window == 'undefined') return 0;
+
+  try {
+    let visualViewport = window.visualViewport;
+    if (visualViewport && Number.isFinite(visualViewport.height)) {
+      let offsetTop = Number.isFinite(visualViewport.offsetTop) ? visualViewport.offsetTop : 0;
+      return offsetTop + visualViewport.height;
+    }
+  } catch {}
+
+  let clientHeight = document.documentElement?.clientHeight;
+  if (Number.isFinite(clientHeight) && clientHeight > 0) return clientHeight;
+
+  return Number.isFinite(window.innerHeight) ? window.innerHeight : 0;
+};
+
+export let measureMenuMaxHeight = (element: HTMLElement) => {
+  if (!element.isConnected) return null;
+
+  let rect = element.getBoundingClientRect();
+  if (!Number.isFinite(rect.top)) return null;
+  if (rect.width == 0 && rect.height == 0) return null;
+
+  let topOffset = rect.top;
+  let viewportBottom = getViewportBottom();
+  if (!Number.isFinite(viewportBottom) || viewportBottom <= 0) return null;
+
+  let maxHeight = Math.floor(viewportBottom - topOffset - MENU_VIEWPORT_PADDING);
+  if (!Number.isFinite(maxHeight)) return null;
+
+  return Math.max(0, maxHeight);
+};
+
+let addListener = (
+  target: EventTarget,
+  type: string,
+  listener: EventListener,
+  options?: AddEventListenerOptions
+) => {
+  try {
+    target.addEventListener(type, listener, options);
+    return () => {
+      try {
+        target.removeEventListener(type, listener, options);
+      } catch {}
+    };
+  } catch {
+    return () => {};
+  }
+};
+
+export let attachMenuHeightConstraint = (element: HTMLElement): MenuHeightConstraint => {
+  let frame = 0;
+  let detached = false;
+  let lastApplied: string | null = null;
+  let cleanups: Array<() => void> = [];
+
+  let apply = () => {
+    if (detached) return;
+    if (!element.isConnected) return;
+
+    let maxHeight = measureMenuMaxHeight(element);
+    if (maxHeight == null) return;
+
+    let value = `${maxHeight}px`;
+    if (lastApplied == value && element.style.maxHeight == value) return;
+
+    lastApplied = value;
+    element.style.maxHeight = value;
+  };
+
+  let schedule = () => {
+    if (detached || frame) return;
+
+    frame = requestAnimationFrame(() => {
+      frame = 0;
+      apply();
+    });
+  };
+
+  apply();
+
+  cleanups.push(addListener(window, 'resize', schedule));
+  cleanups.push(addListener(window, 'orientationchange', schedule));
+  cleanups.push(addListener(window, 'scroll', schedule, { capture: true, passive: true }));
+  cleanups.push(addListener(document, 'scroll', schedule, { capture: true, passive: true }));
+
+  try {
+    if (window.visualViewport) {
+      cleanups.push(addListener(window.visualViewport, 'resize', schedule));
+      cleanups.push(addListener(window.visualViewport, 'scroll', schedule));
+    }
+  } catch {
+    // visualViewport can be missing or unreadable.
+  }
+
+  if (typeof ResizeObserver != 'undefined') {
+    try {
+      let resizeObserver = new ResizeObserver(schedule);
+      resizeObserver.observe(element);
+      if (element.parentElement) resizeObserver.observe(element.parentElement);
+      if (document.documentElement) resizeObserver.observe(document.documentElement);
+      cleanups.push(() => resizeObserver.disconnect());
+    } catch {
+      // ResizeObserver can fail in detached documents.
+    }
+  }
+
+  if (typeof MutationObserver != 'undefined') {
+    try {
+      let mutationObserver = new MutationObserver(schedule);
+      mutationObserver.observe(element, {
+        attributes: true,
+        attributeFilter: ['style', 'data-side', 'data-align', 'data-state']
+      });
+
+      // Radix puts the transform on a wrapper around the content, so watch
+      // that node too — otherwise repositioning would not update max-height.
+      let wrapper = element.parentElement;
+      if (wrapper && wrapper != document.body && wrapper != document.documentElement) {
+        mutationObserver.observe(wrapper, {
+          attributes: true,
+          attributeFilter: ['style']
+        });
+      }
+
+      cleanups.push(() => mutationObserver.disconnect());
+    } catch {
+      // MutationObserver can fail in detached documents.
+    }
+  }
+
+  return {
+    apply,
+    detach: () => {
+      detached = true;
+      if (frame) cancelAnimationFrame(frame);
+      frame = 0;
+
+      for (let cleanup of cleanups) cleanup();
+      cleanups = [];
+
+      if (lastApplied != null && element.style.maxHeight == lastApplied) {
+        element.style.maxHeight = '';
+      }
+      lastApplied = null;
+    }
+  };
+};
+
+export let useConstrainedMenuHeight = () => {
+  let constraintRef = useRef<MenuHeightConstraint | null>(null);
+
+  let setRef = useCallback((node: HTMLDivElement | null) => {
+    constraintRef.current?.detach();
+    constraintRef.current = null;
+    if (node) constraintRef.current = attachMenuHeightConstraint(node);
+  }, []);
+
+  useLayoutEffect(() => {
+    // Child layout effects (Radix positioning) run first. Re-apply after that
+    // so the first paint already uses the correct max-height.
+    constraintRef.current?.apply();
+  });
+
+  useLayoutEffect(() => {
+    return () => {
+      constraintRef.current?.detach();
+      constraintRef.current = null;
+    };
+  }, []);
+
+  return setRef;
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped UI layout/overflow behavior in the shared menu component with no API or data-path changes; main risk is subtle positioning/scroll edge cases on mobile or nested submenus.
> 
> **Overview**
> Fixes **dropdown menus overflowing the viewport** by capping height and scrolling long item lists instead of clipping off-screen.
> 
> Menu content styles now use **vertical scroll** (`overflow-y: auto`), a Radix-based **CSS max-height** with viewport padding, and a narrower **`transition`** so height changes are not animated. Root and submenu portals render through **`ConstrainedContent` / `ConstrainedSubContent`**, which attach a new **`useConstrainedMenuHeight`** hook.
> 
> That hook **computes max-height from the menu’s position and visual viewport**, sets inline `maxHeight`, and **re-applies on resize, scroll, orientation, and Radix reposition** (ResizeObserver/MutationObserver on content and wrapper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c5b9246346d045698d0fa0206036bcfc64747a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->