### PR TITLE
Add skill file editing

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/product/pages/skill-item-document.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/skill-item-document.tsx
@@ -1,4 +1,6 @@
 import { DocumentEditorScene } from '@metorial/scene-docs';
+import { isSkillTextFile, SkillTextFileEditorScene } from '@metorial/scene-skills';
+import { renderWithLoader } from '@metorial/data-hooks';
 import {
   useCurrentInstance,
   useCurrentOrganization,
@@ -15,23 +17,39 @@ export let SkillItemDocumentPage = () => {
   let skill = useSkill(instance.data?.id, skillId);
   let item = useStoreItem(instance.data?.id, skill.data?.storeId, itemId);
 
-  return (
-    <DocumentEditorScene
-      instanceId={instance.data?.id}
-      documentId={item.data?.document?.id}
-      loadError={skill.error ?? item.error}
-      onBack={() => navigate(-1)}
-      setRestrictHeight={enabled => (window as any).metorial_setRestrictHeight?.(enabled)}
-      hideSharingControls
-      skillShareContext={
-        skillId
-          ? {
-              mode: 'dashboard',
-              organizationId: organization.data?.id,
-              skills: [{ id: skillId, name: skill.data?.name ?? null }]
-            }
-          : null
-      }
-    />
-  );
+  return renderWithLoader({ item, skill })(({ item, skill }) => {
+    if (
+      item.data.kind == 'file' &&
+      item.data.file &&
+      isSkillTextFile({ fileName: item.data.path, fileType: item.data.file.fileType })
+    ) {
+      return (
+        <SkillTextFileEditorScene
+          instanceId={instance.data?.id}
+          itemId={item.data.id}
+          setRestrictHeight={enabled => (window as any).metorial_setRestrictHeight?.(enabled)}
+          storeId={skill.data.storeId}
+        />
+      );
+    }
+
+    return (
+      <DocumentEditorScene
+        instanceId={instance.data?.id}
+        documentId={item.data.document?.id}
+        onBack={() => navigate(-1)}
+        setRestrictHeight={enabled => (window as any).metorial_setRestrictHeight?.(enabled)}
+        hideSharingControls
+        skillShareContext={
+          skillId
+            ? {
+                mode: 'dashboard',
+                organizationId: organization.data?.id,
+                skills: [{ id: skillId, name: skill.data.name }]
+              }
+            : null
+        }
+      />
+    );
+  });
 };

--- a/src/metorial-frontend/apps/dashboard/vite.config.ts
+++ b/src/metorial-frontend/apps/dashboard/vite.config.ts
@@ -1,15 +1,34 @@
 import react from '@vitejs/plugin-react';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
+
+let workspaceRoot = fileURLToPath(new URL('../../../../../', import.meta.url));
+
+let stripBrokenMonacoSourceMap = () => ({
+  name: 'strip-broken-monaco-source-map',
+  apply: 'serve' as const,
+  enforce: 'pre' as const,
+  async load(id: string) {
+    if (!id.includes('/monaco-editor/esm/vs/base/common/marked/marked.js')) return;
+
+    let code = await readFile(id.split('?')[0], 'utf8');
+    return code.replace(/\n\/\/# sourceMappingURL=marked\.umd\.js\.map\s*$/, '');
+  }
+});
 
 // https://vitejs.dev/config/
 export default defineConfig({
   server: {
     host: '0.0.0.0',
-    allowedHosts: ['localhost', 'wsx', 'chronos', 'vulcan']
+    allowedHosts: ['localhost', 'wsx', 'chronos', 'vulcan'],
+    fs: { allow: [workspaceRoot] }
   },
 
   plugins: [
+    stripBrokenMonacoSourceMap(),
     react({
+      exclude: /clients\/metorial-dashboard\/dist/,
       babel: {
         plugins: ['babel-plugin-styled-components', {}],
         babelrc: false,
@@ -17,6 +36,10 @@ export default defineConfig({
       }
     })
   ],
+
+  optimizeDeps: {
+    exclude: ['monaco-editor']
+  },
 
   build: {
     rollupOptions: {

--- a/src/metorial-frontend/packages/code-editor-monaco/package.json
+++ b/src/metorial-frontend/packages/code-editor-monaco/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@metorial/code-editor-monaco",
+  "version": "1.0.0",
+  "author": "Tobias Herber",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "lint": "prettier src/**/*.{ts,tsx} --check",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@metorial/dynamic-component": "workspace:*",
+    "monaco-editor": "0.52.2",
+    "react": "19.1.1"
+  },
+  "devDependencies": {
+    "@metorial/tsconfig": "^1.0.0",
+    "typescript": "5.8.2",
+    "vitest": "^3.1.2"
+  }
+}

--- a/src/metorial-frontend/packages/code-editor-monaco/src/index.ts
+++ b/src/metorial-frontend/packages/code-editor-monaco/src/index.ts
@@ -1,0 +1,8 @@
+import { dynamicComponent } from '@metorial/dynamic-component';
+import type { MonacoCodeEditor as _MonacoCodeEditor } from './monacoEditor';
+
+export type { MonacoCodeEditorHandle, MonacoCodeEditorProps } from './monacoEditor';
+
+export let MonacoCodeEditor = dynamicComponent<Parameters<typeof _MonacoCodeEditor>>(() =>
+  import('./monacoEditor').then(module => module.MonacoCodeEditor)
+);

--- a/src/metorial-frontend/packages/code-editor-monaco/src/monacoEditor.tsx
+++ b/src/metorial-frontend/packages/code-editor-monaco/src/monacoEditor.tsx
@@ -1,0 +1,409 @@
+/// <reference path="./worker.d.ts" />
+
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js?worker';
+import 'monaco-editor/esm/vs/basic-languages/css/css.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/html/html.contribution.js';
+import {
+  conf as javascriptConfiguration,
+  language as javascriptLanguage
+} from 'monaco-editor/esm/vs/basic-languages/javascript/javascript.js';
+import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/python/python.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/rust/rust.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/shell/shell.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js';
+import {
+  conf as typescriptConfiguration,
+  language as typescriptLanguage
+} from 'monaco-editor/esm/vs/basic-languages/typescript/typescript.js';
+import 'monaco-editor/esm/vs/basic-languages/xml/xml.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+
+let themeName = 'metorial-light';
+let isConfigured = false;
+
+let declarationKeywords = [
+  'abstract',
+  'class',
+  'const',
+  'declare',
+  'enum',
+  'export',
+  'extends',
+  'from',
+  'function',
+  'get',
+  'implements',
+  'import',
+  'interface',
+  'let',
+  'module',
+  'namespace',
+  'new',
+  'override',
+  'private',
+  'protected',
+  'public',
+  'readonly',
+  'set',
+  'static',
+  'type',
+  'var'
+];
+let controlKeywords = [
+  'async',
+  'await',
+  'break',
+  'case',
+  'catch',
+  'continue',
+  'default',
+  'do',
+  'else',
+  'finally',
+  'for',
+  'if',
+  'return',
+  'switch',
+  'throw',
+  'try',
+  'while',
+  'yield'
+];
+let typeKeywords = [
+  'any',
+  'bigint',
+  'boolean',
+  'infer',
+  'is',
+  'keyof',
+  'never',
+  'number',
+  'object',
+  'out',
+  'satisfies',
+  'string',
+  'symbol',
+  'typeof',
+  'unique',
+  'unknown',
+  'void'
+];
+let constantKeywords = ['false', 'null', 'super', 'this', 'true', 'undefined'];
+
+let createRichJavascriptLanguage = (base: any) => ({
+  ...base,
+  declarationKeywords,
+  controlKeywords,
+  typeKeywords,
+  constantKeywords,
+  tokenizer: {
+    ...base.tokenizer,
+    common: [
+      [
+        /(function)([ \t]+)([A-Za-z_$][\w$]*)/,
+        ['keyword.declaration', '', 'function.declaration']
+      ],
+      [
+        /(class|interface|type|enum|namespace)([ \t]+)([A-Za-z_$][\w$]*)/,
+        ['keyword.declaration', '', 'type.identifier']
+      ],
+      [
+        /(const|let|var)([ \t]+)([A-Za-z_$][\w$]*)/,
+        ['keyword.declaration', '', 'variable.declaration']
+      ],
+      [/(\.)([A-Z][\w$]*)/, ['delimiter', 'constant']],
+      [/(\.)([a-z_$][\w$]*)(?=[ \t]*\()/, ['delimiter', 'function.method']],
+      [/(\.)([a-z_$][\w$]*)/, ['delimiter', 'property']],
+      [/[A-Za-z_$][\w$]*(?=[ \t]*:)/, 'property'],
+      [
+        /#?[a-z_$][\w$]*(?=[ \t]*\()/,
+        {
+          cases: {
+            '@controlKeywords': 'keyword.control',
+            '@declarationKeywords': 'keyword.declaration',
+            '@typeKeywords': 'keyword.type',
+            '@constantKeywords': 'constant.language',
+            '@keywords': 'keyword',
+            '@default': 'function'
+          }
+        }
+      ],
+      [
+        /#?[a-z_$][\w$]*/,
+        {
+          cases: {
+            '@controlKeywords': 'keyword.control',
+            '@declarationKeywords': 'keyword.declaration',
+            '@typeKeywords': 'keyword.type',
+            '@constantKeywords': 'constant.language',
+            '@keywords': 'keyword',
+            '@default': 'variable'
+          }
+        }
+      ],
+      ...base.tokenizer.common.slice(1)
+    ]
+  }
+});
+
+let configureMonaco = () => {
+  if (isConfigured) return;
+  isConfigured = true;
+
+  (globalThis as any).MonacoEnvironment = {
+    getWorker() {
+      return new EditorWorker();
+    }
+  };
+
+  monaco.languages.register({
+    id: 'javascript',
+    extensions: ['.js', '.es6', '.jsx', '.mjs', '.cjs'],
+    firstLine: '^#!.*\\bnode',
+    filenames: ['jakefile'],
+    aliases: ['JavaScript', 'javascript', 'js'],
+    mimetypes: ['text/javascript']
+  });
+  monaco.languages.setLanguageConfiguration('javascript', javascriptConfiguration);
+  monaco.languages.setMonarchTokensProvider(
+    'javascript',
+    createRichJavascriptLanguage(javascriptLanguage)
+  );
+
+  monaco.languages.register({
+    id: 'typescript',
+    extensions: ['.ts', '.tsx', '.cts', '.mts'],
+    aliases: ['TypeScript', 'ts', 'typescript'],
+    mimetypes: ['text/typescript']
+  });
+  monaco.languages.setLanguageConfiguration('typescript', typescriptConfiguration);
+  monaco.languages.setMonarchTokensProvider(
+    'typescript',
+    createRichJavascriptLanguage(typescriptLanguage)
+  );
+
+  monaco.languages.register({
+    id: 'json',
+    extensions: ['.json'],
+    aliases: ['JSON', 'json'],
+    mimetypes: ['application/json']
+  });
+  monaco.languages.setMonarchTokensProvider('json', {
+    tokenizer: {
+      root: [
+        [/"(?:[^"\\]|\\.)*"(?=\s*:)/, 'key'],
+        [/"(?:[^"\\]|\\.)*"/, 'string'],
+        [/-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/, 'number'],
+        [/\b(?:true|false|null)\b/, 'keyword'],
+        [/[{}\[\],:]/, 'delimiter'],
+        [/\s+/, 'white']
+      ]
+    }
+  });
+
+  monaco.editor.defineTheme(themeName, {
+    base: 'vs',
+    inherit: true,
+    rules: [
+      { token: 'comment', foreground: '71808B', fontStyle: 'italic' },
+      { token: 'comment.doc', foreground: '4F8872', fontStyle: 'italic' },
+      { token: 'keyword', foreground: '7C3ED1' },
+      { token: 'keyword.declaration', foreground: '7C3ED1' },
+      { token: 'keyword.control', foreground: 'C13C75' },
+      { token: 'keyword.type', foreground: '008C87' },
+      { token: 'keyword.operator', foreground: '2D6EB5' },
+      { token: 'number', foreground: 'D3620B' },
+      { token: 'number.hex', foreground: 'D3620B' },
+      { token: 'string', foreground: '008A62' },
+      { token: 'string.escape', foreground: 'C65710', fontStyle: 'bold' },
+      { token: 'regexp', foreground: 'D13F72' },
+      { token: 'type', foreground: '008C87' },
+      { token: 'type.identifier', foreground: '008C87' },
+      { token: 'function', foreground: '006FD6' },
+      { token: 'function.declaration', foreground: '006FD6' },
+      { token: 'function.method', foreground: '0095A8' },
+      { token: 'variable', foreground: '365D78' },
+      { token: 'variable.declaration', foreground: 'B85B12' },
+      { token: 'variable.predefined', foreground: 'A43DA8' },
+      { token: 'constant', foreground: 'D05B21' },
+      { token: 'constant.language', foreground: 'D05B21' },
+      { token: 'property', foreground: '007CBA' },
+      { token: 'key', foreground: '007CBA' },
+      { token: 'tag', foreground: '8052D0' },
+      { token: 'attribute.name', foreground: '008C87' },
+      { token: 'attribute.value', foreground: '008A62' },
+      { token: 'annotation', foreground: 'D05B21' },
+      { token: 'operator', foreground: '2D6EB5' },
+      { token: 'delimiter', foreground: '747E89' },
+      { token: 'delimiter.bracket', foreground: '3478C7' },
+      { token: 'identifier', foreground: '365D78' },
+      { token: 'invalid', foreground: 'C13E46', fontStyle: 'underline' }
+    ],
+    colors: {
+      'editor.background': '#FFFFFF',
+      'editor.foreground': '#39434B',
+      'editorCursor.foreground': '#006FD6',
+      'editor.selectionBackground': '#CADFFF',
+      'editor.inactiveSelectionBackground': '#E2ECFA',
+      'editor.selectionHighlightBackground': '#DDEBFA80',
+      'editor.wordHighlightBackground': '#DCEAE580',
+      'editor.wordHighlightStrongBackground': '#D7E3F580',
+      'editor.lineHighlightBackground': '#F6F8FA',
+      'editorLineNumber.foreground': '#929BA2',
+      'editorLineNumber.activeForeground': '#3478C7',
+      'editorGutter.background': '#FFFFFF',
+      'editorIndentGuide.background1': '#E5E5E5',
+      'editorIndentGuide.activeBackground1': '#AABAC5',
+      'editorWhitespace.foreground': '#D5D5D5',
+      'editorBracketHighlight.foreground1': '#3478C7',
+      'editorBracketHighlight.foreground2': '#8A4FD1',
+      'editorBracketHighlight.foreground3': '#06966B',
+      'editorBracketHighlight.foreground4': '#D66B13',
+      'editorBracketHighlight.foreground5': '#D34B78',
+      'editorBracketHighlight.foreground6': '#009994',
+      'editorBracketHighlight.unexpectedBracket.foreground': '#C13E46',
+      'editorWidget.background': '#FFFFFF',
+      'editorWidget.border': '#DDDDDD',
+      'editorSuggestWidget.background': '#FFFFFF',
+      'editorSuggestWidget.border': '#DDDDDD',
+      'editorSuggestWidget.selectedBackground': '#EEF3FA',
+      'scrollbar.shadow': '#00000012',
+      'scrollbarSlider.background': '#0000001F',
+      'scrollbarSlider.hoverBackground': '#00000033',
+      'scrollbarSlider.activeBackground': '#00000042'
+    }
+  });
+};
+
+export type MonacoCodeEditorHandle = {
+  focus: () => void;
+  insert: (text: string) => void;
+  isFocused: () => boolean;
+};
+
+export type MonacoCodeEditorProps = {
+  value: string;
+  language?: string;
+  onChange?: (value: string) => void;
+  onBlur?: () => void;
+  readOnly?: boolean;
+  ariaLabel?: string;
+};
+
+export let MonacoCodeEditor = forwardRef<MonacoCodeEditorHandle, MonacoCodeEditorProps>(
+  ({ value, language = 'plaintext', onChange, onBlur, readOnly, ariaLabel }, outerRef) => {
+    let containerRef = useRef<HTMLDivElement | null>(null);
+    let editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+    let modelRef = useRef<monaco.editor.ITextModel | null>(null);
+    let onChangeRef = useRef(onChange);
+    let onBlurRef = useRef(onBlur);
+    onChangeRef.current = onChange;
+    onBlurRef.current = onBlur;
+
+    useImperativeHandle(
+      outerRef,
+      () => ({
+        focus: () => editorRef.current?.focus(),
+        insert: text => {
+          let editor = editorRef.current;
+          let selection = editor?.getSelection();
+          if (!editor || !selection) return;
+          editor.executeEdits('metorial', [
+            { range: selection, text, forceMoveMarkers: true }
+          ]);
+        },
+        isFocused: () => editorRef.current?.hasTextFocus() ?? false
+      }),
+      []
+    );
+
+    useEffect(() => {
+      let container = containerRef.current;
+      if (!container) return;
+
+      configureMonaco();
+      let model = monaco.editor.createModel(value, language);
+      let editor = monaco.editor.create(container, {
+        model,
+        theme: themeName,
+        readOnly: !!readOnly,
+        ariaLabel: ariaLabel ?? 'Code editor',
+        automaticLayout: false,
+        fontFamily:
+          "'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace",
+        fontSize: 13,
+        lineHeight: 21,
+        lineNumbers: 'on',
+        lineNumbersMinChars: 3,
+        glyphMargin: false,
+        folding: false,
+        minimap: { enabled: false },
+        renderLineHighlight: 'line',
+        renderWhitespace: 'selection',
+        roundedSelection: false,
+        scrollBeyondLastLine: false,
+        smoothScrolling: true,
+        wordWrap: 'off',
+        padding: { top: 14, bottom: 14 },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          horizontalScrollbarSize: 10,
+          verticalScrollbarSize: 10
+        },
+        overviewRulerLanes: 0,
+        hideCursorInOverviewRuler: true,
+        stickyScroll: { enabled: false },
+        bracketPairColorization: { enabled: true },
+        guides: { bracketPairs: false, indentation: true }
+      });
+      let resizeObserver = new ResizeObserver(() => editor.layout());
+      resizeObserver.observe(container);
+      let contentSubscription = editor.onDidChangeModelContent(() => {
+        onChangeRef.current?.(model.getValue());
+      });
+      let blurSubscription = editor.onDidBlurEditorText(() => onBlurRef.current?.());
+
+      editorRef.current = editor;
+      modelRef.current = model;
+      editor.layout();
+
+      return () => {
+        resizeObserver.disconnect();
+        contentSubscription.dispose();
+        blurSubscription.dispose();
+        editor.dispose();
+        model.dispose();
+        editorRef.current = null;
+        modelRef.current = null;
+      };
+    }, []);
+
+    useEffect(() => {
+      let model = modelRef.current;
+      if (!model || model.getValue() == value) return;
+
+      model.setValue(value);
+    }, [value]);
+
+    useEffect(() => {
+      let model = modelRef.current;
+      if (model && model.getLanguageId() != language) {
+        monaco.editor.setModelLanguage(model, language);
+      }
+    }, [language]);
+
+    useEffect(() => {
+      editorRef.current?.updateOptions({ readOnly: !!readOnly });
+    }, [readOnly]);
+
+    return (
+      <div
+        ref={containerRef}
+        style={{ width: '100%', height: '100%', minWidth: 0, minHeight: 0 }}
+      />
+    );
+  }
+);

--- a/src/metorial-frontend/packages/code-editor-monaco/src/worker.d.ts
+++ b/src/metorial-frontend/packages/code-editor-monaco/src/worker.d.ts
@@ -1,0 +1,18 @@
+declare module 'monaco-editor/esm/vs/editor/editor.worker.js?worker' {
+  let WorkerConstructor: { new (): Worker };
+  export default WorkerConstructor;
+}
+
+declare module 'monaco-editor/esm/vs/basic-languages/javascript/javascript.js' {
+  import type { languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
+
+  export let conf: languages.LanguageConfiguration;
+  export let language: languages.IMonarchLanguage;
+}
+
+declare module 'monaco-editor/esm/vs/basic-languages/typescript/typescript.js' {
+  import type { languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
+
+  export let conf: languages.LanguageConfiguration;
+  export let language: languages.IMonarchLanguage;
+}

--- a/src/metorial-frontend/packages/code-editor-monaco/tsconfig.json
+++ b/src/metorial-frontend/packages/code-editor-monaco/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@metorial/tsconfig/base.json",
+  "exclude": ["dist"],
+  "include": ["src"],
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "lib": ["es2021", "DOM", "WebWorker"],
+    "target": "ESNext",
+    "module": "ESNext"
+  }
+}

--- a/src/metorial-frontend/scenes/docs/src/scenes/documentEditor.tsx
+++ b/src/metorial-frontend/scenes/docs/src/scenes/documentEditor.tsx
@@ -1396,7 +1396,6 @@ let DocumentEditorLoaded = (p: {
           <Shell>
             <Header>
               <HeaderLeft>
-                {p.onBack && <BackButton onClick={p.onBack} />}
                 <TitleButton
                   title={title}
                   readOnly={readOnly}

--- a/src/metorial-frontend/scenes/skills/package.json
+++ b/src/metorial-frontend/scenes/skills/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@metorial/code": "^1.0.0",
     "@metorial/code-editor": "workspace:*",
+    "@metorial/code-editor-monaco": "workspace:*",
     "@metorial/data-hooks": "^1.0.0",
     "@metorial/dynamic-component": "^1.0.0",
     "@metorial/frontend-config": "^1.0.0",

--- a/src/metorial-frontend/scenes/skills/src/components/filePreviewLightbox.tsx
+++ b/src/metorial-frontend/scenes/skills/src/components/filePreviewLightbox.tsx
@@ -6,6 +6,7 @@ import { RiCloseLine } from '@remixicon/react';
 import * as pdfjsLib from 'pdfjs-dist';
 import { ReactNode, Ref, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
+import { getSkillFileExtension, isSkillTextFile } from './textFile';
 
 type PreviewKind = 'image' | 'pdf' | 'video' | 'audio' | 'text' | 'fallback';
 
@@ -17,31 +18,6 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
 let imageExtensions = new Set(['avif', 'gif', 'jpeg', 'jpg', 'png', 'svg', 'webp']);
 let videoExtensions = new Set(['mp4', 'mov', 'm4v', 'webm', 'ogv']);
 let audioExtensions = new Set(['aac', 'flac', 'm4a', 'mp3', 'oga', 'ogg', 'wav', 'weba']);
-let textExtensions = new Set([
-  'csv',
-  'css',
-  'env',
-  'graphql',
-  'html',
-  'js',
-  'json',
-  'jsx',
-  'log',
-  'md',
-  'mdx',
-  'py',
-  'rs',
-  'sql',
-  'svg',
-  'toml',
-  'ts',
-  'tsx',
-  'txt',
-  'xml',
-  'yaml',
-  'yml'
-]);
-
 let fadeIn = keyframes`
   from { opacity: 0; }
   to { opacity: 1; }
@@ -363,10 +339,8 @@ let TriggerButton = styled.button`
   cursor: pointer;
 `;
 
-let getExtension = (fileName: string) => fileName.split('.').pop()?.toLowerCase() ?? '';
-
 let getCodeLanguage = (fileName: string) => {
-  let extension = getExtension(fileName);
+  let extension = getSkillFileExtension(fileName);
 
   if (extension == 'tsx') return 'tsx';
   if (extension == 'ts') return 'typescript';
@@ -389,19 +363,14 @@ let getCodeLanguage = (fileName: string) => {
 let getPreviewKind = (file: ManagedFile | null | undefined): PreviewKind => {
   if (!file) return 'fallback';
 
-  let extension = getExtension(file.fileName || file.title);
+  let extension = getSkillFileExtension(file.fileName || file.title);
   let fileType = file.fileType?.toLowerCase() ?? '';
 
   if (fileType.startsWith('image/') || imageExtensions.has(extension)) return 'image';
   if (fileType == 'application/pdf' || extension == 'pdf') return 'pdf';
   if (fileType.startsWith('video/') || videoExtensions.has(extension)) return 'video';
   if (fileType.startsWith('audio/') || audioExtensions.has(extension)) return 'audio';
-  if (
-    fileType.startsWith('text/') ||
-    fileType.includes('json') ||
-    fileType.includes('xml') ||
-    textExtensions.has(extension)
-  ) {
+  if (isSkillTextFile({ fileName: file.fileName || file.title, fileType })) {
     return 'text';
   }
 

--- a/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
+++ b/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
@@ -15,6 +15,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { SkillFilePreviewLightbox } from './filePreviewLightbox';
 import type { SkillSharePanelContext } from './skillSharePanel';
+import { isSkillTextFile } from './textFile';
 
 export type SkillFileTreeNode = {
   id: string;
@@ -597,9 +598,12 @@ let SkillFileTreeRow = (p: {
   let documentPath =
     p.node.kind == 'document' && p.node.documentId && p.node.itemId
       ? p.getDocumentPath(p.node.documentId, p.node.itemId)
-      : null;
-  let isActive =
-    p.node.kind == 'document' && documentPath?.split(/[?#]/)[0] == location.pathname;
+      : p.node.kind == 'file' &&
+          p.node.itemId &&
+          isSkillTextFile({ fileName: p.node.name, fileType: p.node.fileType })
+        ? p.getDocumentPath('', p.node.itemId)
+        : null;
+  let isActive = documentPath?.split(/[?#]/)[0] == location.pathname;
   let fileInputRef = useRef<HTMLInputElement | null>(null);
   let previewTriggerRef = useRef<HTMLButtonElement | null>(null);
   let [fileError, setFileError] = useState<string | null>(null);

--- a/src/metorial-frontend/scenes/skills/src/components/index.ts
+++ b/src/metorial-frontend/scenes/skills/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './filePreviewLightbox';
+export * from './textFile';
 export * from './fileTree';
 export * from './skillSharePanel';
 export * from './surfaceCard';

--- a/src/metorial-frontend/scenes/skills/src/components/textFile.ts
+++ b/src/metorial-frontend/scenes/skills/src/components/textFile.ts
@@ -1,0 +1,73 @@
+let textExtensions = new Set([
+  'c',
+  'cjs',
+  'cpp',
+  'cs',
+  'csv',
+  'css',
+  'env',
+  'go',
+  'graphql',
+  'h',
+  'html',
+  'java',
+  'js',
+  'json',
+  'jsx',
+  'log',
+  'md',
+  'mdx',
+  'mjs',
+  'php',
+  'py',
+  'rb',
+  'rs',
+  'sh',
+  'sql',
+  'swift',
+  'toml',
+  'ts',
+  'tsx',
+  'txt',
+  'xml',
+  'yaml',
+  'yml'
+]);
+
+export let getSkillFileExtension = (fileName: string) =>
+  fileName.split('.').pop()?.toLowerCase() ?? '';
+
+export let isSkillTextFile = (file: {
+  fileName?: string | null;
+  fileType?: string | null;
+}) => {
+  let extension = getSkillFileExtension(file.fileName ?? '');
+  let fileType = file.fileType?.toLowerCase() ?? '';
+
+  return (
+    fileType.startsWith('text/') ||
+    fileType.includes('json') ||
+    fileType.includes('xml') ||
+    textExtensions.has(extension)
+  );
+};
+
+export let getSkillCodeEditorLanguage = (fileName: string) => {
+  let extension = getSkillFileExtension(fileName);
+
+  if (extension == 'ts' || extension == 'tsx') return 'typescript';
+  if (extension == 'js' || extension == 'jsx' || extension == 'mjs' || extension == 'cjs') {
+    return 'javascript';
+  }
+  if (extension == 'json') return 'json';
+  if (extension == 'css') return 'css';
+  if (extension == 'html') return 'html';
+  if (extension == 'md' || extension == 'mdx') return 'markdown';
+  if (extension == 'py') return 'python';
+  if (extension == 'rs') return 'rust';
+  if (extension == 'sh') return 'shell';
+  if (extension == 'sql') return 'sql';
+  if (extension == 'xml') return 'xml';
+  if (extension == 'yaml' || extension == 'yml') return 'yaml';
+  return 'plaintext';
+};

--- a/src/metorial-frontend/scenes/skills/src/scenes/index.ts
+++ b/src/metorial-frontend/scenes/skills/src/scenes/index.ts
@@ -48,6 +48,7 @@ import type {
 } from './skillStoreFileViewer';
 import type { SkillVersionsScene as _SkillVersionsScene } from './skillVersions';
 import type { SkillWorkspaceLayout as _SkillWorkspaceLayout } from './skillWorkspaceLayout';
+import type { SkillTextFileEditorScene as _SkillTextFileEditorScene } from './skillTextFileEditor';
 
 export type { SkillWorkspaceLayoutProps, SkillWorkspaceRoutes } from './skillWorkspaceLayout';
 
@@ -134,3 +135,7 @@ export let StoreFileViewerScene = dynamicComponent<Parameters<typeof _StoreFileV
 export let SkillWorkspaceLayout = dynamicComponent<Parameters<typeof _SkillWorkspaceLayout>>(
   () => import('./skillWorkspaceLayout').then(m => m.SkillWorkspaceLayout)
 );
+
+export let SkillTextFileEditorScene = dynamicComponent<
+  Parameters<typeof _SkillTextFileEditorScene>
+>(() => import('./skillTextFileEditor').then(m => m.SkillTextFileEditorScene));

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillTextFileEditor.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillTextFileEditor.tsx
@@ -1,0 +1,341 @@
+import { MonacoCodeEditor } from '@metorial/code-editor-monaco';
+import { renderWithLoader } from '@metorial/data-hooks';
+import {
+  useFile,
+  useModifyStoreItems,
+  useStoreItem,
+  useStorePermissions,
+  useUploadFile
+} from '@metorial/state';
+import { Button, Input, Popover, Spinner, Text, theme, toast } from '@metorial/ui';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { getSkillCodeEditorLanguage } from '../components/textFile';
+import { forceFileTreeRefetch } from './skillStoreFileViewer';
+
+let Shell = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: ${theme.colors.background};
+`;
+
+let Header = styled.header`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 56px;
+  padding: 0 14px;
+  border-bottom: 1px solid ${theme.colors.gray300};
+  background: ${theme.colors.background};
+  flex-shrink: 0;
+`;
+
+let HeaderSide = styled.div`
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  min-width: 0;
+
+  &:last-child {
+    justify-content: flex-end;
+  }
+`;
+
+let NameTrigger = styled.button`
+  display: inline-flex;
+  align-items: center;
+  height: 30px;
+  max-width: 280px;
+  padding: 0 8px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: ${theme.colors.foreground};
+  font: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: ${theme.colors.gray300};
+  }
+
+  &:disabled {
+    color: ${theme.colors.gray600};
+    cursor: default;
+  }
+`;
+
+let NamePopover = styled.div`
+  width: 270px;
+`;
+
+let EditorWrap = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+let Center = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+`;
+
+let basename = (path: string) => path.split('/').filter(Boolean).pop() ?? path;
+let dirname = (path: string) => {
+  let parts = path.split('/').filter(Boolean);
+  parts.pop();
+  return parts.join('/');
+};
+let pathWithName = (path: string, name: string) => {
+  let parent = dirname(path);
+  return parent ? `${parent}/${name}` : name;
+};
+
+let SkillTextFileEditorInner = (p: {
+  instanceId: string;
+  storeId: string;
+  itemId: string;
+  item: NonNullable<ReturnType<typeof useStoreItem>['data']>;
+  readOnly: boolean;
+  onItemChange: () => void;
+  setRestrictHeight?: (enabled: boolean) => void;
+}) => {
+  let file = useFile(p.instanceId, p.item.file?.id);
+  let uploadFile = useUploadFile();
+  let modifyStoreItems = useModifyStoreItems();
+  let [content, setContent] = useState<string | null>(null);
+  let [savedContent, setSavedContent] = useState('');
+  let [path, setPath] = useState(p.item.path);
+  let [draftName, setDraftName] = useState(basename(p.item.path));
+  let [loadError, setLoadError] = useState<string | null>(null);
+  let [isRenaming, setIsRenaming] = useState(false);
+  let renameInFlight = useRef(false);
+  let savedFileIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    p.setRestrictHeight?.(true);
+    return () => p.setRestrictHeight?.(false);
+  }, [p.setRestrictHeight]);
+
+  useEffect(() => {
+    setPath(p.item.path);
+    setDraftName(basename(p.item.path));
+  }, [p.item.path]);
+
+  useEffect(() => {
+    let downloadUrl = file.data?.downloadUrl;
+    if (!downloadUrl) return;
+
+    if (file.data?.id == savedFileIdRef.current) {
+      savedFileIdRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+    setContent(null);
+    setLoadError(null);
+
+    fetch(downloadUrl)
+      .then(async response => {
+        if (!response.ok) throw new Error(`Failed to load file (${response.status})`);
+        return response.text();
+      })
+      .then(value => {
+        if (cancelled) return;
+        setContent(value);
+        setSavedContent(value);
+      })
+      .catch(error => {
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error.message : 'Failed to load file');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [file.data?.downloadUrl]);
+
+  let fileName = basename(path);
+  let language = useMemo(() => getSkillCodeEditorLanguage(fileName), [fileName]);
+  let isSaving = uploadFile.isLoading || modifyStoreItems.isLoading;
+
+  let rename = async () => {
+    let name = draftName.trim();
+    if (
+      p.readOnly ||
+      renameInFlight.current ||
+      !name ||
+      name.includes('/') ||
+      name == fileName
+    ) {
+      if (!name || name.includes('/')) setDraftName(fileName);
+      return;
+    }
+
+    let nextPath = pathWithName(path, name);
+    renameInFlight.current = true;
+    setIsRenaming(true);
+    try {
+      let [, error] = await modifyStoreItems.mutate({
+        instanceId: p.instanceId,
+        storeId: p.storeId,
+        operations: [{ type: 'modify', itemId: p.itemId, path: nextPath }]
+      });
+      if (error) throw error;
+      setPath(nextPath);
+      p.onItemChange();
+      forceFileTreeRefetch();
+    } catch (error) {
+      setDraftName(fileName);
+      toast.error(error instanceof Error ? error.message : 'Failed to rename file');
+    } finally {
+      renameInFlight.current = false;
+      setIsRenaming(false);
+    }
+  };
+
+  let save = async () => {
+    if (p.readOnly || content == null || content == savedContent || !p.item.file) return;
+
+    let [uploaded, uploadError] = await uploadFile.mutate({
+      instanceId: p.instanceId,
+      file: new File([content], fileName, {
+        type: p.item.file.fileType || 'text/plain'
+      }),
+      title: fileName,
+      purpose: p.item.file.purpose || 'generic'
+    });
+    if (uploadError) return;
+    if (!uploaded) {
+      toast.error('File upload completed without a result');
+      return;
+    }
+
+    let [, modifyError] = await modifyStoreItems.mutate({
+      instanceId: p.instanceId,
+      storeId: p.storeId,
+      operations: [{ type: 'modify', itemId: p.itemId, fileId: uploaded.id }]
+    });
+    if (modifyError) return;
+
+    savedFileIdRef.current = uploaded.id;
+    setSavedContent(content);
+    p.onItemChange();
+    forceFileTreeRefetch();
+  };
+
+  if (file.error || loadError) {
+    return (
+      <Center>
+        <Text color="red600" size="2">
+          {loadError ?? file.error?.message ?? 'Failed to load file'}
+        </Text>
+      </Center>
+    );
+  }
+
+  if (content == null) {
+    return (
+      <Center>
+        <Spinner size={20} />
+      </Center>
+    );
+  }
+
+  return (
+    <Shell>
+      <Header>
+        <HeaderSide>
+          <Popover
+            align="start"
+            operationKey={path}
+            side="bottom"
+            sideOffset={7}
+            trigger={
+              <NameTrigger disabled={p.readOnly} title={fileName} type="button">
+                {fileName}
+              </NameTrigger>
+            }
+          >
+            <Popover.Content>
+              <NamePopover>
+                <Input
+                  autoFocus
+                  disabled={isRenaming}
+                  label="Name"
+                  value={draftName}
+                  onBlur={() => void rename()}
+                  onInput={setDraftName}
+                  onKeyDown={event => {
+                    if (event.key == 'Enter') {
+                      event.preventDefault();
+                      void rename();
+                    }
+                  }}
+                />
+              </NamePopover>
+            </Popover.Content>
+          </Popover>
+        </HeaderSide>
+        <HeaderSide>
+          <Button
+            disabled={p.readOnly || content == savedContent}
+            loading={isSaving}
+            onClick={() => void save()}
+            size="2"
+          >
+            Save
+          </Button>
+        </HeaderSide>
+      </Header>
+      <EditorWrap>
+        <MonacoCodeEditor
+          ariaLabel={`${fileName} editor`}
+          language={language}
+          onChange={setContent}
+          readOnly={p.readOnly}
+          value={content}
+        />
+      </EditorWrap>
+      <uploadFile.RenderError />
+      <modifyStoreItems.RenderError />
+    </Shell>
+  );
+};
+
+export let SkillTextFileEditorScene = (p: {
+  instanceId: string | null | undefined;
+  storeId: string | null | undefined;
+  itemId: string | null | undefined;
+  setRestrictHeight?: (enabled: boolean) => void;
+}) => {
+  let item = useStoreItem(p.instanceId, p.storeId, p.itemId);
+  let permissions = useStorePermissions(p.instanceId, p.storeId);
+
+  return renderWithLoader({ item, permissions })(({ item, permissions }) => (
+    <SkillTextFileEditorInner
+      instanceId={p.instanceId!}
+      item={item.data}
+      itemId={p.itemId!}
+      onItemChange={() => item.refetch()}
+      readOnly={
+        !permissions.data.hasFullAccess &&
+        !permissions.data.permissions.includes('content_write')
+      }
+      setRestrictHeight={p.setRestrictHeight}
+      storeId={p.storeId!}
+    />
+  ));
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches store file upload and modify flows for user content; save is manual (no autosave), so data-loss risk if users navigate away without saving.
> 
> **Overview**
> Adds **in-browser editing for skill store text files** via a new Monaco-based editor scene, while documents still use the existing doc editor.
> 
> The skill item route now waits for data, then opens **text files** in `SkillTextFileEditorScene` (fetch content, Monaco edit, **Save** via re-upload + store item update, rename via path modify) and **documents** in `DocumentEditorScene` as before. The file tree treats editable text files like documents for navigation and active state, with shared `isSkillTextFile` / language helpers for previews and the editor.
> 
> Introduces **`@metorial/code-editor-monaco`** (lazy-loaded React wrapper, Metorial theme, language setup) and **dashboard Vite tweaks** so Monaco works in dev (workspace `fs.allow`, exclude from `optimizeDeps`, broken sourcemap strip). The document editor header no longer shows the back button in the loaded view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3004ed02e151e7f0aaf8a10684874e59c2771af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->