### PR TITLE
Fix unnamed file creation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1337,6 +1337,20 @@
         "vitest": "^0.34.6",
       },
     },
+    "src/metorial-frontend/packages/code-editor-monaco": {
+      "name": "@metorial/code-editor-monaco",
+      "version": "1.0.0",
+      "dependencies": {
+        "@metorial/dynamic-component": "workspace:*",
+        "monaco-editor": "0.52.2",
+        "react": "19.1.1",
+      },
+      "devDependencies": {
+        "@metorial/tsconfig": "^1.0.0",
+        "typescript": "5.8.2",
+        "vitest": "^3.1.2",
+      },
+    },
     "src/metorial-frontend/packages/config": {
       "name": "@metorial/frontend-config",
       "version": "1.0.0",
@@ -1897,6 +1911,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@metorial/code": "^1.0.0",
         "@metorial/code-editor": "workspace:*",
+        "@metorial/code-editor-monaco": "workspace:*",
         "@metorial/data-hooks": "^1.0.0",
         "@metorial/dynamic-component": "^1.0.0",
         "@metorial/frontend-config": "^1.0.0",
@@ -6414,6 +6429,8 @@
 
     "@metorial/code-editor": ["@metorial/code-editor@workspace:src/metorial-frontend/packages/code-editor"],
 
+    "@metorial/code-editor-monaco": ["@metorial/code-editor-monaco@workspace:src/metorial-frontend/packages/code-editor-monaco"],
+
     "@metorial/code-workspace": ["@metorial/code-workspace@workspace:src/origin/apps/code-workspace"],
 
     "@metorial/config": ["@metorial/config@workspace:src/metorial/packages/config"],
@@ -9045,6 +9062,8 @@
     "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
+    "monaco-editor": ["monaco-editor@0.52.2", "", {}, "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="],
 
     "mongodb": ["mongodb@7.2.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.2.0", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw=="],
 

--- a/src/metorial/apis/files/src/index.ts
+++ b/src/metorial/apis/files/src/index.ts
@@ -58,6 +58,27 @@ let createFileUploadHandler =
           );
         }
 
+        let fileNameFromStorePath =
+          typeof attachedStorePath == 'string'
+            ? attachedStorePath.split('/').filter(Boolean).at(-1)?.trim()
+            : undefined;
+        let fileName =
+          typeof file.name == 'string' && file.name.trim()
+            ? file.name.trim()
+            : fileNameFromStorePath
+              ? fileNameFromStorePath
+              : typeof title == 'string' && title.trim()
+                ? title.trim()
+                : null;
+
+        if (!fileName) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'Missing file name'
+            })
+          );
+        }
+
         if (!purposeSlugs.includes(purpose as (typeof purposeSlugs)[number])) {
           throw new ServiceError(
             badRequestError({
@@ -97,7 +118,7 @@ let createFileUploadHandler =
           purpose,
           file,
           title,
-          fileName: file.name,
+          fileName,
           authorization: access.authorization,
           defaultPermissions: access.defaultPermissions,
           overridePermissions: access.overridePermissions,

--- a/src/metorial/products/storage/modules/file/src/services/file.ts
+++ b/src/metorial/products/storage/modules/file/src/services/file.ts
@@ -145,6 +145,15 @@ class FileServiceImpl {
     }
   ): Promise<FileRecord> {
     return await withTransaction(async db => {
+      let fileName = d.input.name?.trim();
+      if (!fileName) {
+        throw new ServiceError(
+          badRequestError({
+            message: 'File name is required'
+          })
+        );
+      }
+
       let purpose = await filePurposeService.getFilePurposeById({
         id: d.purpose
       });
@@ -174,7 +183,7 @@ class FileServiceImpl {
           },
           data: {
             storeId: d.storeId,
-            fileName: d.input.name,
+            fileName,
             fileSize: d.input.size,
             fileType: d.input.mimeType,
             title: d.input.title,
@@ -227,7 +236,7 @@ class FileServiceImpl {
           ...cargoFileScope(d),
           purposeOid: purpose.oid,
           storeId: d.storeId,
-          fileName: d.input.name,
+          fileName,
           fileSize: d.input.size,
           fileType: d.input.mimeType,
           title: d.input.title,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Targeted validation and naming fallbacks on the upload path; no auth or schema changes beyond rejecting bad inputs earlier.
> 
> **Overview**
> **File uploads** no longer rely on a possibly empty `file.name` from the multipart body. The files API **resolves** a display/storage name in order: trimmed `file.name`, else the last segment of `path`, else trimmed `title`, and returns **400** with `Missing file name` when none apply.
> 
> **File creation** in the storage module **trims** `input.name` and rejects creates/updates with **400** (`File name is required`) when the result is empty, so unnamed records cannot be persisted downstream.
> 
> The lockfile also registers **`@metorial/code-editor-monaco`** (Monaco 0.52.2) and adds it as a dependency of the skills scene.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a3080b2f2f7a6aae31b5f3fa37d2e5cb6d589f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->