### PR TITLE
Add back consumer boot

### DIFF
--- a/src/metorial/apis/core/src/controllers/dashboard/boot.ts
+++ b/src/metorial/apis/core/src/controllers/dashboard/boot.ts
@@ -2,8 +2,7 @@ import { v } from '@lowerdeck/validation';
 import { consumerProfileService } from '@metorial/module-consumer-core';
 import { organizationService } from '@metorial/module-organization';
 import { Controller, Path } from '@metorial/rest';
-import { isDashboardGroup } from '../../middleware/isDashboard';
-import { userGroup } from '../../middleware/userGroup';
+import { userOrConsumerGroup } from '../../middleware/userGroup';
 import { bootPresenter } from '@metorial/presenters';
 
 export let dashboardBootController = Controller.create(
@@ -12,8 +11,7 @@ export let dashboardBootController = Controller.create(
     description: 'Boot user'
   },
   {
-    boot: userGroup
-      .use(isDashboardGroup())
+    boot: userOrConsumerGroup
       .post(Path('/dashboard/boot', 'dashboard.boot'), {
         name: 'Create organization',
         description: 'Create a new organization'
@@ -21,6 +19,23 @@ export let dashboardBootController = Controller.create(
       .body('default', v.object({}))
       .output(bootPresenter)
       .do(async ctx => {
+        if (ctx.consumerProfile) {
+          let res = await organizationService.bootConsumer({
+            consumerProfile: ctx.consumerProfile,
+            user: ctx.user
+          });
+
+          let consumers = await consumerProfileService.getConsumersForUser({
+            user: ctx.user,
+            consumerSurface: ctx.consumerSurface
+          });
+
+          return bootPresenter.present({
+            ...res,
+            consumers
+          });
+        }
+
         let res = await organizationService.bootUser({
           user: ctx.user
         });

--- a/src/metorial/apis/core/src/middleware/userGroup.ts
+++ b/src/metorial/apis/core/src/middleware/userGroup.ts
@@ -15,30 +15,41 @@ export let userGroup = apiGroup.use(async ctx => {
   };
 });
 
-// export let userOrConsumerGroup = apiGroup.use(async ctx => {
-//   if (
-//     ctx.auth.type === 'machine' &&
-//     ctx.auth.restrictions.type === 'instance' &&
-//     ctx.auth.restrictions.consumer
-//   ) {
-//     return {
-//       user: undefined,
-//       consumerProfile: ctx.auth.restrictions.consumer.consumerProfile,
-//       consumerSurface: ctx.auth.restrictions.consumer.consumerSurface
-//     };
-//   }
+export let userOrConsumerGroup = apiGroup.use(async ctx => {
+  if (
+    ctx.auth.type === 'machine' &&
+    ctx.auth.restrictions.type === 'instance' &&
+    ctx.auth.restrictions.consumer
+  ) {
+    let user = ctx.auth.restrictions.consumer.consumerProfile.consumer.user;
+    if (!user) {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'This endpoint is only available for user authentication'
+        })
+      );
+    }
 
-//   if (ctx.auth.type != 'user') {
-//     throw new ServiceError(
-//       forbiddenError({
-//         message: 'This endpoint is only available for user authentication'
-//       })
-//     );
-//   }
+    return {
+      user,
+      consumerProfile: ctx.auth.restrictions.consumer.consumerProfile,
+      consumerSurface: ctx.auth.restrictions.consumer.consumerSurface,
+      organization: ctx.auth.restrictions.organization
+    };
+  }
 
-//   return {
-//     user: ctx.auth.user,
-//     consumerProfile: undefined,
-//     consumerSurface: undefined
-//   };
-// });
+  if (ctx.auth.type != 'user') {
+    throw new ServiceError(
+      forbiddenError({
+        message: 'This endpoint is only available for user authentication'
+      })
+    );
+  }
+
+  return {
+    user: ctx.auth.user,
+    consumerProfile: undefined,
+    consumerSurface: undefined,
+    organization: undefined
+  };
+});

--- a/src/metorial/products/core/modules/access/src/services/authentication.ts
+++ b/src/metorial/products/core/modules/access/src/services/authentication.ts
@@ -51,7 +51,7 @@ export type AuthenticatedConsumerContext = {
   consumerSurface: ConsumerSurface;
   consumerSession: ConsumerSession;
   consumerProfile: ConsumerProfile & {
-    consumer: Consumer;
+    consumer: Consumer & { user: User | null };
     resourceActors: ResourceActor[];
   };
   consumerGroups: Awaited<

--- a/src/metorial/products/core/modules/organization/src/services/organization.ts
+++ b/src/metorial/products/core/modules/organization/src/services/organization.ts
@@ -486,7 +486,7 @@ class OrganizationService {
     };
   }
 
-  async bootConsumer(d: { consumerProfile: ConsumerProfile }) {
+  async bootConsumer(d: { consumerProfile: ConsumerProfile; user: User }) {
     let instance = await db.instance.findUniqueOrThrow({
       where: { oid: d.consumerProfile.instanceOid },
       include: {
@@ -499,9 +499,36 @@ class OrganizationService {
     });
 
     let org = instance.project.organization;
+
+    let member = await db.organizationMember.findFirst({
+      where: {
+        organizationOid: org.oid,
+        userOid: d.user.oid,
+        status: 'active'
+      },
+      include: {
+        actor: {
+          include: {
+            teams: {
+              include: {
+                team: true
+              }
+            }
+          }
+        }
+      }
+    });
+
+    let namespacesByOrganizationOid =
+      await namespaceService.getNamespacePropertiesByOrganizationOid({
+        organizations: [org]
+      });
+
     let orgsWithProjectAndInstances = [
       {
         ...org,
+        member: member ?? undefined,
+        namespaces: namespacesByOrganizationOid.get(org.oid) ?? [],
         projects: [
           {
             ...instance.project,
@@ -513,22 +540,8 @@ class OrganizationService {
       }
     ];
 
-    let [firstName, ...rest] = d.consumerProfile.name.split(' ');
-    let lastName = rest.join(' ');
-
     return {
-      user: {
-        id: d.consumerProfile.id,
-        status: 'active' as const,
-        type: 'consumer' as const,
-        email: d.consumerProfile.email,
-        name: d.consumerProfile.name,
-        firstName: firstName,
-        lastName: lastName,
-        image: { type: 'default' as const },
-        createdAt: d.consumerProfile.createdAt,
-        updatedAt: d.consumerProfile.updatedAt
-      },
+      user: d.user,
       organizations: orgsWithProjectAndInstances,
       projects: orgsWithProjectAndInstances.flatMap(org =>
         org.projects.map(project => ({ ...project, organization: org }))

--- a/src/metorial/products/workforce/modules/consumer-core/src/services/consumerProfile.ts
+++ b/src/metorial/products/workforce/modules/consumer-core/src/services/consumerProfile.ts
@@ -1329,7 +1329,7 @@ class ConsumerProfileServiceImpl {
     });
   }
 
-  async getConsumersForUser(d: { user: User }) {
+  async getConsumersForUser(d: { user: User; consumerSurface?: ConsumerSurface }) {
     let consumers = await this.getConsumersForUserInternal(d);
 
     let namespacesByPortalOid = await namespaceService.getNamespacePropertiesByPortalOid({

--- a/src/metorial/products/workforce/modules/consumer-entities/src/services/consumerProviderSetupSession.ts
+++ b/src/metorial/products/workforce/modules/consumer-entities/src/services/consumerProviderSetupSession.ts
@@ -190,7 +190,7 @@ class ConsumerProviderSetupSessionServiceImpl {
         }),
         configuration: {
           ui: {
-            layout: 'box'
+            layout: 'light'
           }
         }
       },

--- a/src/metorial/products/workforce/packages/consumer-auth/src/index.ts
+++ b/src/metorial/products/workforce/packages/consumer-auth/src/index.ts
@@ -19,7 +19,11 @@ let consumerTokens = new Tokens({
 export let consumerSessionInclude = {
   consumerProfile: {
     include: {
-      consumer: true,
+      consumer: {
+        include: {
+          user: true
+        }
+      },
       resourceActors: true,
       surface: {
         include: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authentication middleware and boot/auth payload for consumer machine sessions; incorrect user linking or boot data could affect dashboard access for workforce consumers.
> 
> **Overview**
> **Restores consumer boot** on `POST /dashboard/boot` by switching from user-only + dashboard middleware to **`userOrConsumerGroup`**, so instance machine auth with a consumer session can hit the same boot path as normal users.
> 
> For **consumer sessions**, the handler calls `organizationService.bootConsumer` with the linked **`User`** (not a synthetic consumer-shaped user), scopes **`getConsumersForUser`** with **`consumerSurface`**, and returns the same boot presenter shape. **`bootConsumer`** now loads org **member**, **namespaces**, and the instance’s org/project tree for that profile.
> 
> **`userOrConsumerGroup`** is enabled for machine/instance/consumer auth: it resolves `consumerProfile.consumer.user`, rejects consumers without a linked user, and passes **`organization`** on the consumer path.
> 
> **Auth/session loading** types and includes now **eager-load `consumer.user`** (`AuthenticatedConsumerContext`, `consumerSessionInclude`) so middleware can require a real user.
> 
> Unrelated: provider setup integration UI layout **`box` → `light`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5180093687b8ab950f457196759ee4d6dc9a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->