### PR TITLE
Add auto created portals

### DIFF
--- a/src/metorial/db/prisma/schema/consumer/portal.prisma
+++ b/src/metorial/db/prisma/schema/consumer/portal.prisma
@@ -17,6 +17,8 @@ model Portal {
   /// [PortalAllowedRedirectUrlFilters]
   allowedRedirectUrlFilters Json?
 
+  isDefaultPortal Boolean @default(false)
+
   organizationOid BigInt
   organization    Organization @relation(fields: [organizationOid], references: [oid], onDelete: Cascade)
 

--- a/src/metorial/packages/fabric/src/types.ts
+++ b/src/metorial/packages/fabric/src/types.ts
@@ -556,7 +556,7 @@ export interface FabricEvents {
   'machine_access.service_account_credential.created:before': { serviceAccount: ServiceAccount; oauthApplication: OAuthApplication; oauthInstallation: OAuthInstallation; oauthAuthorization: OAuthAuthorization; organization: Organization; appActor: OrganizationActor | null; auditScope?: AuditScope };
   'machine_access.service_account_credential.created:after': { serviceAccount: ServiceAccount; serviceAccountCredential: ServiceAccountCredential; oauthApplication: OAuthApplication; oauthInstallation: OAuthInstallation; oauthAuthorization: OAuthAuthorization; organization: Organization; appActor: OrganizationActor | null; auditScope?: AuditScope };
 
-  'portal.created:before': { organization: Organization; instance: Instance; context: Context; input: { name: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
+  'portal.created:before': { organization: Organization; instance: Instance; context: Context; isDefaultPortal: boolean; input: { name: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
   'portal.created:after': { organization: Organization; instance: Instance; portal: Portal; context: Context; input: { name: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
   'portal.updated:before': { portal: Portal; input: { name?: string; description?: string; sessionExpiryTimeInSeconds?: number; } };
   'portal.updated:after': { portal: Portal; input: { name?: string; description?: string; sessionExpiryTimeInSeconds?: number; } };

--- a/src/metorial/products/core/modules/organization/src/index.ts
+++ b/src/metorial/products/core/modules/organization/src/index.ts
@@ -4,6 +4,7 @@ import {
   createOrganizationNotificationProcessor
 } from './queues/createNotification';
 import { organizationNotificationDigestProcessors } from './queues/createNotificationDigest';
+import { instancePortalSetupQueueProcessor } from './queues/instancePortalSetup';
 import { reconcileAuthVersionProcessors } from './queues/reconcileAuthVersion';
 import { reconcileDefaultPoliciesProcessors } from './queues/reconcileDefaultPolicies';
 import { reconcileProjectInstancesProcessors } from './queues/reconcileProjectInstances';
@@ -36,5 +37,7 @@ export let organizationQueueProcessor = combineQueueProcessors([
   reconcileDefaultPoliciesProcessors,
   reconcileProjectInstancesProcessors,
 
-  syncSubspaceTenantProcessors
+  syncSubspaceTenantProcessors,
+
+  instancePortalSetupQueueProcessor
 ]);

--- a/src/metorial/products/core/modules/organization/src/queues/instancePortalSetup.ts
+++ b/src/metorial/products/core/modules/organization/src/queues/instancePortalSetup.ts
@@ -1,0 +1,29 @@
+import { Context } from '@metorial/context';
+import { db } from '@metorial/db';
+import { portalService } from '@metorial/module-portal';
+import { createQueue, QueueRetryError } from '@metorial/queue';
+
+export let instancePortalSetupQueue = createQueue<{ instance: string; context: Context }>({
+  name: 'org/instancePortalSetup'
+});
+
+export let instancePortalSetupQueueProcessor = instancePortalSetupQueue.process(async data => {
+  let instance = await db.instance.findUnique({
+    where: { id: data.instance },
+    include: { organization: true, project: true }
+  });
+  if (!instance) throw new QueueRetryError();
+
+  await portalService.createPortal({
+    organization: instance.organization,
+    instance: instance,
+    context: data.context,
+    isDefaultPortal: true,
+    input: {
+      name:
+        instance.type === 'development'
+          ? `${instance.project.name} - ${instance.name}`
+          : instance.project.name
+    }
+  });
+});

--- a/src/metorial/products/core/modules/organization/src/services/instance.ts
+++ b/src/metorial/products/core/modules/organization/src/services/instance.ts
@@ -8,8 +8,10 @@ import {
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { createSlugGenerator } from '@lowerdeck/slugify';
+import { metorialResourceService } from '@metorial-subspace/module-tenant';
 import type { AuditScope } from '@metorial/audit-scope';
 import {
+  addAfterTransactionHook,
   addAwaitedAfterTransactionHook,
   db,
   ID,
@@ -25,8 +27,8 @@ import {
 } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import { generateCode } from '@metorial/id';
-import { metorialResourceService } from '@metorial-subspace/module-tenant';
 import { differenceInMinutes } from 'date-fns';
+import { instancePortalSetupQueue } from '../queues/instancePortalSetup';
 
 let getInstanceSlug = createSlugGenerator(async slug => {
   let instance = await db.instance.findFirst({
@@ -341,6 +343,10 @@ class InstanceService {
         instance,
         auditScope: d.auditScope
       });
+
+      await addAfterTransactionHook(() =>
+        instancePortalSetupQueue.add({ instance: instance.id, context: d.auditScope.context })
+      );
 
       await Fabric.fire('organization.project.instance.created:after', {
         organization: d.organization,

--- a/src/metorial/products/workforce/modules/portal/src/services/portal.ts
+++ b/src/metorial/products/workforce/modules/portal/src/services/portal.ts
@@ -225,6 +225,7 @@ class PortalServiceImpl {
       allowConsumerSkillAuthoring?: boolean;
       allowConsumerSkillPublishing?: boolean;
     };
+    isDefaultPortal?: boolean;
   }) {
     let portalId = await ID.generateId('portal');
     let slug = await getPortalSlug({
@@ -260,7 +261,8 @@ class PortalServiceImpl {
           ),
           organizationOid: d.organization.oid,
           surfaceOid: surface.oid,
-          instanceOid: d.instance.oid
+          instanceOid: d.instance.oid,
+          isDefaultPortal: !!d.isDefaultPortal
         },
         include
       });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Every new instance triggers async portal provisioning (retries if the instance is missing), and the Fabric `portal.created:before` event shape changes for any subscribers.
> 
> **Overview**
> New instances get a **default consumer portal** without a manual setup step. After `createInstance` commits, an **`org/instancePortalSetup`** queue job calls `portalService.createPortal` with **`isDefaultPortal: true`** and a name derived from the project (and instance name for development instances).
> 
> Portals gain an **`isDefaultPortal`** column (default `false`). **`createPortal`** accepts optional **`isDefaultPortal`**, persists it, and **`portal.created:before`** now includes **`isDefaultPortal`** in its Fabric payload so listeners can tell auto-provisioned portals from user-created ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7a3ee7b1008f790ebc860ec87ade208eb279cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->