### PR TITLE
Add completions to skill editor

### DIFF
--- a/src/metorial-frontend/packages/code-editor-monaco/src/monacoEditor.tsx
+++ b/src/metorial-frontend/packages/code-editor-monaco/src/monacoEditor.tsx
@@ -1,6 +1,10 @@
 /// <reference path="./worker.d.ts" />
 
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
+import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker.js?worker';
+import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker.js?worker';
+import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker.js?worker';
+import TypeScriptWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker';
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js?worker';
 import 'monaco-editor/esm/vs/basic-languages/css/css.contribution.js';
 import 'monaco-editor/esm/vs/basic-languages/html/html.contribution.js';
@@ -19,10 +23,81 @@ import {
 } from 'monaco-editor/esm/vs/basic-languages/typescript/typescript.js';
 import 'monaco-editor/esm/vs/basic-languages/xml/xml.contribution.js';
 import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
+import 'monaco-editor/esm/vs/language/css/monaco.contribution.js';
+import 'monaco-editor/esm/vs/language/html/monaco.contribution.js';
+import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
+import 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
+import 'monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution.js';
+import 'monaco-editor/esm/vs/editor/contrib/parameterHints/browser/parameterHints.js';
+import 'monaco-editor/esm/vs/editor/contrib/suggest/browser/suggestController.js';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
 let themeName = 'metorial-light';
 let isConfigured = false;
+let unresolvedSymbolDiagnosticCodes = [2304, 2307, 2503, 2580, 2591, 2688, 2867, 2868, 7016];
+
+// This intentionally remains a compact, static set of declarations. It enables
+// useful browser and Node completions without syncing customer files or loading
+// project dependencies into the editor worker.
+let commonJavascriptGlobals = `
+interface Console {
+  log(...data: unknown[]): void;
+  error(...data: unknown[]): void;
+  warn(...data: unknown[]): void;
+  info(...data: unknown[]): void;
+}
+
+interface Location {
+  href: string;
+  origin: string;
+  pathname: string;
+  assign(url: string): void;
+  replace(url: string): void;
+  reload(): void;
+}
+
+interface Document {
+  querySelector<E extends Element = Element>(selectors: string): E | null;
+  querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
+  getElementById(elementId: string): HTMLElement | null;
+  createElement<K extends keyof HTMLElementTagNameMap>(tagName: K): HTMLElementTagNameMap[K];
+}
+
+interface Window {
+  readonly document: Document;
+  readonly location: Location;
+  alert(message?: unknown): void;
+  confirm(message?: string): boolean;
+  setTimeout(handler: (...args: unknown[]) => void, timeout?: number, ...args: unknown[]): number;
+  clearTimeout(id?: number): void;
+  fetch(input: string, init?: { method?: string; headers?: Record<string, string>; body?: string }): Promise<Response>;
+}
+
+interface Response {
+  readonly ok: boolean;
+  readonly status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+interface NodeProcess {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  platform: string;
+  version: string;
+  cwd(): string;
+  exit(code?: number): never;
+}
+
+declare const window: Window & typeof globalThis;
+declare const document: Document;
+declare const console: Console;
+declare const process: NodeProcess;
+declare const Buffer: {
+  from(input: string | ArrayBuffer | ArrayLike<number>, encoding?: string): Uint8Array;
+  isBuffer(value: unknown): boolean;
+};
+`;
 
 let declarationKeywords = [
   'abstract',
@@ -93,6 +168,76 @@ let typeKeywords = [
 ];
 let constantKeywords = ['false', 'null', 'super', 'this', 'true', 'undefined'];
 
+let localCompletionItems: Record<string, Array<{ label: string; insertText: string }>> = {
+  python: [
+    { label: 'def', insertText: 'def ${1:name}(${2:args}):\n    ${0:pass}' },
+    { label: 'class', insertText: 'class ${1:Name}:\n    ${0:pass}' },
+    { label: 'if', insertText: 'if ${1:condition}:\n    ${0:pass}' },
+    { label: 'for', insertText: 'for ${1:item} in ${2:items}:\n    ${0:pass}' },
+    {
+      label: 'try',
+      insertText: 'try:\n    ${1:pass}\nexcept ${2:Exception} as ${3:error}:\n    ${0:pass}'
+    },
+    { label: 'with', insertText: 'with ${1:expression} as ${2:value}:\n    ${0:pass}' },
+    { label: 'print', insertText: 'print(${0:value})' },
+    { label: 'range', insertText: 'range(${0:stop})' },
+    { label: 'len', insertText: 'len(${0:value})' },
+    { label: 'async', insertText: 'async def ${1:name}(${2:args}):\n    ${0:pass}' }
+  ],
+  sql: [
+    { label: 'SELECT', insertText: 'SELECT ${1:columns}\nFROM ${2:table};' },
+    {
+      label: 'INSERT',
+      insertText: 'INSERT INTO ${1:table} (${2:columns})\nVALUES (${0:values});'
+    },
+    { label: 'UPDATE', insertText: 'UPDATE ${1:table}\nSET ${2:column} = ${0:value};' },
+    { label: 'DELETE', insertText: 'DELETE FROM ${1:table}\nWHERE ${0:condition};' },
+    {
+      label: 'CREATE TABLE',
+      insertText: 'CREATE TABLE ${1:name} (\n  ${0:column} ${2:TEXT}\n);'
+    },
+    { label: 'JOIN', insertText: 'JOIN ${1:table} ON ${0:condition}' },
+    { label: 'WHERE', insertText: 'WHERE ${0:condition}' },
+    { label: 'ORDER BY', insertText: 'ORDER BY ${0:column}' }
+  ],
+  shell: [
+    { label: 'if', insertText: 'if ${1:condition}; then\n  ${0::}\nfi' },
+    { label: 'for', insertText: 'for ${1:item} in ${2:items}; do\n  ${0::}\ndone' },
+    { label: 'function', insertText: '${1:name}() {\n  ${0::}\n}' },
+    { label: 'echo', insertText: 'echo "${0:value}"' },
+    { label: 'printf', insertText: 'printf \'%s\\n\' "${0:value}"' },
+    { label: 'export', insertText: 'export ${1:NAME}=${0:value}' },
+    { label: 'grep', insertText: 'grep "${1:pattern}" ${0:file}' },
+    { label: 'curl', insertText: 'curl ${0:https://example.com}' }
+  ],
+  yaml: [
+    { label: 'key', insertText: '${1:key}: ${0:value}' },
+    { label: 'list', insertText: '${1:key}:\n  - ${0:item}' },
+    { label: 'true', insertText: 'true' },
+    { label: 'false', insertText: 'false' },
+    { label: 'null', insertText: 'null' }
+  ],
+  markdown: [
+    { label: 'heading', insertText: '## ${0:Heading}' },
+    { label: 'link', insertText: '[${1:text}](${0:url})' },
+    { label: 'image', insertText: '![${1:alt text}](${0:url})' },
+    { label: 'code block', insertText: '``` ${1:language}\n${0}\n```' },
+    { label: 'task', insertText: '- [ ] ${0:Task}' }
+  ],
+  xml: [
+    { label: 'element', insertText: '<${1:element}>${0}</${1:element}>' },
+    { label: 'comment', insertText: '<!-- ${0:comment} -->' },
+    { label: 'CDATA', insertText: '<![CDATA[${0}]]>' }
+  ],
+  rust: [
+    { label: 'fn', insertText: 'fn ${1:name}(${2:args}) {\n    ${0}\n}' },
+    { label: 'struct', insertText: 'struct ${1:Name} {\n    ${0}\n}' },
+    { label: 'impl', insertText: 'impl ${1:Type} {\n    ${0}\n}' },
+    { label: 'match', insertText: 'match ${1:value} {\n    ${0:_ => {}}\n}' },
+    { label: 'println', insertText: 'println!("${0}");' }
+  ]
+};
+
 let createRichJavascriptLanguage = (base: any) => ({
   ...base,
   declarationKeywords,
@@ -149,15 +294,96 @@ let createRichJavascriptLanguage = (base: any) => ({
   }
 });
 
+let registerLocalCompletionProvider = (
+  language: string,
+  items: Array<{ label: string; insertText: string }>
+) => {
+  monaco.languages.registerCompletionItemProvider(language, {
+    triggerCharacters: ['.', ':', ' '],
+    provideCompletionItems: (model, position) => {
+      let word = model.getWordUntilPosition(position);
+      let range = new monaco.Range(
+        position.lineNumber,
+        word.startColumn,
+        position.lineNumber,
+        word.endColumn
+      );
+
+      return {
+        suggestions: items.map((item, index) => ({
+          label: item.label,
+          kind: monaco.languages.CompletionItemKind.Keyword,
+          insertText: item.insertText,
+          insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          range,
+          sortText: `${index}`
+        }))
+      };
+    }
+  });
+};
+
+let getOpaqueModelUri = (language: string, fileName?: string) => {
+  let extension =
+    fileName
+      ?.split('.')
+      .pop()
+      ?.replace(/[^a-z0-9]/gi, '') || language;
+  let scope = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+  return monaco.Uri.parse(`inmemory://skill-editor/${scope}/file.${extension}`);
+};
+
 let configureMonaco = () => {
   if (isConfigured) return;
   isConfigured = true;
 
   (globalThis as any).MonacoEnvironment = {
-    getWorker() {
+    getWorker(_: string, label: string) {
+      if (label == 'json') return new JsonWorker();
+      if (label == 'css' || label == 'scss' || label == 'less') return new CssWorker();
+      if (label == 'html' || label == 'handlebars' || label == 'razor')
+        return new HtmlWorker();
+      if (label == 'typescript' || label == 'javascript') return new TypeScriptWorker();
       return new EditorWorker();
     }
   };
+
+  monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
+    allowJs: true,
+    allowNonTsExtensions: true,
+    checkJs: true,
+    noResolve: true,
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+    target: monaco.languages.typescript.ScriptTarget.ES2020
+  });
+  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    allowNonTsExtensions: true,
+    noResolve: true,
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+    target: monaco.languages.typescript.ScriptTarget.ES2020
+  });
+  monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
+    noSemanticValidation: false,
+    noSyntaxValidation: false,
+    diagnosticCodesToIgnore: unresolvedSymbolDiagnosticCodes
+  });
+  monaco.languages.typescript.javascriptDefaults.setEagerModelSync(false);
+  monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+    noSemanticValidation: false,
+    noSyntaxValidation: false,
+    diagnosticCodesToIgnore: unresolvedSymbolDiagnosticCodes
+  });
+  monaco.languages.typescript.typescriptDefaults.setEagerModelSync(false);
+  monaco.languages.typescript.javascriptDefaults.addExtraLib(
+    commonJavascriptGlobals,
+    'inmemory://metorial-editor/common-globals.d.ts'
+  );
+  monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    commonJavascriptGlobals,
+    'inmemory://metorial-editor/common-globals.d.ts'
+  );
 
   monaco.languages.register({
     id: 'javascript',
@@ -203,6 +429,10 @@ let configureMonaco = () => {
       ]
     }
   });
+
+  for (let [language, items] of Object.entries(localCompletionItems)) {
+    registerLocalCompletionProvider(language, items);
+  }
 
   monaco.editor.defineTheme(themeName, {
     base: 'vs',
@@ -270,6 +500,14 @@ let configureMonaco = () => {
       'editorSuggestWidget.background': '#FFFFFF',
       'editorSuggestWidget.border': '#DDDDDD',
       'editorSuggestWidget.selectedBackground': '#EEF3FA',
+      'editorSuggestWidget.foreground': '#39434B',
+      'editorSuggestWidget.selectedForeground': '#263641',
+      'editorSuggestWidget.highlightForeground': '#006FD6',
+      'list.activeSelectionBackground': '#E4EEF9',
+      'list.activeSelectionForeground': '#263641',
+      'list.inactiveSelectionBackground': '#EEF3FA',
+      'list.inactiveSelectionForeground': '#39434B',
+      'list.focusAndSelectionOutline': '#B6D0EC',
       'scrollbar.shadow': '#00000012',
       'scrollbarSlider.background': '#0000001F',
       'scrollbarSlider.hoverBackground': '#00000033',
@@ -291,10 +529,14 @@ export type MonacoCodeEditorProps = {
   onBlur?: () => void;
   readOnly?: boolean;
   ariaLabel?: string;
+  fileName?: string;
 };
 
 export let MonacoCodeEditor = forwardRef<MonacoCodeEditorHandle, MonacoCodeEditorProps>(
-  ({ value, language = 'plaintext', onChange, onBlur, readOnly, ariaLabel }, outerRef) => {
+  (
+    { value, language = 'plaintext', onChange, onBlur, readOnly, ariaLabel, fileName },
+    outerRef
+  ) => {
     let containerRef = useRef<HTMLDivElement | null>(null);
     let editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
     let modelRef = useRef<monaco.editor.ITextModel | null>(null);
@@ -325,7 +567,11 @@ export let MonacoCodeEditor = forwardRef<MonacoCodeEditorHandle, MonacoCodeEdito
       if (!container) return;
 
       configureMonaco();
-      let model = monaco.editor.createModel(value, language);
+      let model = monaco.editor.createModel(
+        value,
+        language,
+        getOpaqueModelUri(language, fileName)
+      );
       let editor = monaco.editor.create(container, {
         model,
         theme: themeName,
@@ -341,6 +587,12 @@ export let MonacoCodeEditor = forwardRef<MonacoCodeEditorHandle, MonacoCodeEdito
         glyphMargin: false,
         folding: false,
         minimap: { enabled: false },
+        quickSuggestions: true,
+        suggestOnTriggerCharacters: true,
+        tabCompletion: 'on',
+        parameterHints: { enabled: true },
+        hover: { enabled: true },
+        wordBasedSuggestions: 'currentDocument',
         renderLineHighlight: 'line',
         renderWhitespace: 'selection',
         roundedSelection: false,

--- a/src/metorial-frontend/packages/code-editor-monaco/src/worker.d.ts
+++ b/src/metorial-frontend/packages/code-editor-monaco/src/worker.d.ts
@@ -3,6 +3,26 @@ declare module 'monaco-editor/esm/vs/editor/editor.worker.js?worker' {
   export default WorkerConstructor;
 }
 
+declare module 'monaco-editor/esm/vs/language/css/css.worker.js?worker' {
+  let WorkerConstructor: { new (): Worker };
+  export default WorkerConstructor;
+}
+
+declare module 'monaco-editor/esm/vs/language/html/html.worker.js?worker' {
+  let WorkerConstructor: { new (): Worker };
+  export default WorkerConstructor;
+}
+
+declare module 'monaco-editor/esm/vs/language/json/json.worker.js?worker' {
+  let WorkerConstructor: { new (): Worker };
+  export default WorkerConstructor;
+}
+
+declare module 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker' {
+  let WorkerConstructor: { new (): Worker };
+  export default WorkerConstructor;
+}
+
 declare module 'monaco-editor/esm/vs/basic-languages/javascript/javascript.js' {
   import type { languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
 

--- a/src/metorial-frontend/scenes/skills/src/components/textFile.ts
+++ b/src/metorial-frontend/scenes/skills/src/components/textFile.ts
@@ -5,11 +5,14 @@ let textExtensions = new Set([
   'cs',
   'csv',
   'css',
+  'scss',
+  'less',
   'env',
   'go',
   'graphql',
   'h',
   'html',
+  'htm',
   'java',
   'js',
   'json',
@@ -23,6 +26,8 @@ let textExtensions = new Set([
   'rb',
   'rs',
   'sh',
+  'bash',
+  'zsh',
   'sql',
   'swift',
   'toml',
@@ -60,12 +65,12 @@ export let getSkillCodeEditorLanguage = (fileName: string) => {
     return 'javascript';
   }
   if (extension == 'json') return 'json';
-  if (extension == 'css') return 'css';
-  if (extension == 'html') return 'html';
+  if (extension == 'css' || extension == 'scss' || extension == 'less') return 'css';
+  if (extension == 'html' || extension == 'htm') return 'html';
   if (extension == 'md' || extension == 'mdx') return 'markdown';
   if (extension == 'py') return 'python';
   if (extension == 'rs') return 'rust';
-  if (extension == 'sh') return 'shell';
+  if (extension == 'sh' || extension == 'bash' || extension == 'zsh') return 'shell';
   if (extension == 'sql') return 'sql';
   if (extension == 'xml') return 'xml';
   if (extension == 'yaml' || extension == 'yml') return 'yaml';

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillTextFileEditor.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillTextFileEditor.tsx
@@ -303,6 +303,7 @@ let SkillTextFileEditorInner = (p: {
       <EditorWrap>
         <MonacoCodeEditor
           ariaLabel={`${fileName} editor`}
+          fileName={fileName}
           language={language}
           onChange={setContent}
           readOnly={p.readOnly}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only editor UX changes in the skills text editor path; no auth, APIs, or persisted data behavior changes.
> 
> **Overview**
> The skill text file editor gets **autocomplete and richer language support** in the shared `MonacoCodeEditor` package.
> 
> Monaco now loads **language-specific web workers** (JSON, CSS/SCSS/Less, HTML, TypeScript/JavaScript) instead of only the generic editor worker, and pulls in hover, parameter hints, and suggest contributions. **JS/TS** models use in-memory URIs from `fileName`, compiler options with `noResolve`, ignored “missing module” diagnostic codes, and a static `commonJavascriptGlobals` extra lib for browser/Node completions without project deps. **Python, SQL, shell, YAML, markdown, XML, and Rust** get registered **snippet completion providers**; suggest UI theme colors are tuned.
> 
> Editor options turn on quick suggestions, tab completion, parameter hints, and hover. The skills scene passes **`fileName`** into the editor and maps more extensions (`scss`/`less`, `htm`, `bash`/`zsh`) to Monaco languages in `textFile.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5018f3ef3a241a2f5b4b9fb3ea15ab59a7f45d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->