### PR TITLE
Add namespaced portal connect urls

### DIFF
--- a/src/metorial/apis/connection/src/oauth/skeleton.ts
+++ b/src/metorial/apis/connection/src/oauth/skeleton.ts
@@ -35,7 +35,7 @@ export let buildOAuthClientConfig = (base: string) => ({
 });
 
 type OAuthRouteHandlers<TInput, TRoute> = {
-  resolveRoute: (route: TInput) => Promise<TRoute>;
+  resolveRoute: (route: TInput, c: Context) => Promise<TRoute>;
   resolveConnectRoute?: (route: TInput, c: Context) => Promise<TRoute>;
   metadata: (d: { route: TRoute }, c: Context) => Promise<Response>;
   portal: (d: { route: TRoute }, c: Context) => Promise<Response>;
@@ -114,14 +114,15 @@ let createOAuthRouteServers = <TInput, TRoute>(d: {
   parseRouteInput: (c: Context) => TInput;
   handlers: OAuthRouteHandlers<TInput, TRoute>;
 }) => {
-  let resolveRoute = async (c: Context) => await d.handlers.resolveRoute(d.parseRouteInput(c));
+  let resolveRoute = async (c: Context) =>
+    await d.handlers.resolveRoute(d.parseRouteInput(c), c);
   let resolveConnectRoute = async (c: Context) => {
     let input = d.parseRouteInput(c);
     if (d.handlers.resolveConnectRoute) {
       return await d.handlers.resolveConnectRoute(input, c);
     }
 
-    return await d.handlers.resolveRoute(input);
+    return await d.handlers.resolveRoute(input, c);
   };
 
   let withResolvedRoute =

--- a/src/metorial/apis/connection/src/portal.ts
+++ b/src/metorial/apis/connection/src/portal.ts
@@ -1,4 +1,5 @@
 import { Context, useRequestContext, useValidatedBody } from '@lowerdeck/hono';
+import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { v } from '@lowerdeck/validation';
 import { getConfig } from '@metorial/config';
 import { AuthInfo } from '@metorial/module-access';
@@ -22,6 +23,21 @@ import {
 import { getClientCredentials, getString, parseOAuthBody } from './oauth/utils';
 
 export { createPluginOAuthServers, createPortalOAuthServers } from './oauth/skeleton';
+
+let getNamespaceHost = (c: Context) => {
+  let host = c.req.header('Metorial-Namespace-Host')?.trim().toLowerCase();
+  if (!host) return undefined;
+
+  if (
+    host.length > 253 ||
+    !host.includes('.') ||
+    host.split('.').some(label => !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label))
+  ) {
+    throw new ServiceError(notFoundError('namespace'));
+  }
+
+  return host;
+};
 
 let buildOAuthClientRegistration = (d: {
   registration: {
@@ -100,16 +116,18 @@ export let createPortalHandler = (d: {
   connectPortalServer: ReturnType<typeof createPortalOAuthServers>['connectPortalServer'];
 } => {
   return createPortalOAuthServers({
-    resolveRoute: async ({ portalId, magicMcpTargetId }) => {
+    resolveRoute: async ({ portalId, magicMcpTargetId }, c) => {
       return await consumerOAuthRoutingService.resolvePortalRoute({
         portalId,
-        magicMcpTargetId
+        magicMcpTargetId,
+        namespaceHost: getNamespaceHost(c)
       });
     },
-    resolveConnectRoute: async ({ portalId, magicMcpTargetId }) => {
+    resolveConnectRoute: async ({ portalId, magicMcpTargetId }, c) => {
       return await consumerOAuthRoutingService.resolvePortalMcpRoute({
         portalId,
-        magicMcpTargetId
+        magicMcpTargetId,
+        namespaceHost: getNamespaceHost(c)
       });
     },
 

--- a/src/metorial/presenters/src/implementation/provider/magicMcp/magicMcpEndpoint.ts
+++ b/src/metorial/presenters/src/implementation/provider/magicMcp/magicMcpEndpoint.ts
@@ -3,6 +3,7 @@ import { getConfig } from '@metorial/config';
 import { Presenter } from '@metorial/presenter';
 import { magicMcpEndpointType } from '../../../types';
 import { v1ConsumerIntegrationEndpointPresenter } from './consumerOwnership';
+import { getCachedPortalConnectUrl } from './portalConnectUrl';
 import { v1MagicMcpServerPreview } from './magicMcpServerPreview';
 
 let endpointToolFilterSchema = v.union([
@@ -44,24 +45,28 @@ let endpointServerSchema = v.intersection([
 ]);
 
 export let v1MagicMcpEndpointPresenter = Presenter.create(magicMcpEndpointType)
-  .presenter(async ({ magicMcpEndpoint, portal }) => ({
-    object: 'magic_mcp.endpoint' as const,
-    id: magicMcpEndpoint.id,
-    status: magicMcpEndpoint.status,
-    slug: magicMcpEndpoint.slug,
-    url: portal?.id
-      ? `${getConfig().urls.apiUrl}/connect/portal/${portal.slug}/${magicMcpEndpoint.slug}`
-      : `${getConfig().urls.apiUrl}/connect/magic/${magicMcpEndpoint.slug}`,
-    servers: magicMcpEndpoint.servers.map(server => ({
-      ...v1MagicMcpServerPreview(server.magicMcpServer),
-      tool_filters: server.toolFilters ?? null
-    })),
-    name: magicMcpEndpoint.name,
-    description: magicMcpEndpoint.description,
-    metadata: magicMcpEndpoint.metadata,
-    created_at: magicMcpEndpoint.createdAt,
-    updated_at: magicMcpEndpoint.updatedAt
-  }))
+  .presenter(async ({ magicMcpEndpoint, portal }) => {
+    let portalConnectUrl = portal ? await getCachedPortalConnectUrl(portal) : null;
+
+    return {
+      object: 'magic_mcp.endpoint' as const,
+      id: magicMcpEndpoint.id,
+      status: magicMcpEndpoint.status,
+      slug: magicMcpEndpoint.slug,
+      url: portalConnectUrl
+        ? `${portalConnectUrl}/${magicMcpEndpoint.slug}`
+        : `${getConfig().urls.apiUrl}/connect/magic/${magicMcpEndpoint.slug}`,
+      servers: magicMcpEndpoint.servers.map(server => ({
+        ...v1MagicMcpServerPreview(server.magicMcpServer),
+        tool_filters: server.toolFilters ?? null
+      })),
+      name: magicMcpEndpoint.name,
+      description: magicMcpEndpoint.description,
+      metadata: magicMcpEndpoint.metadata,
+      created_at: magicMcpEndpoint.createdAt,
+      updated_at: magicMcpEndpoint.updatedAt
+    };
+  })
   .schema(
     v.object({
       object: v.literal('magic_mcp.endpoint'),

--- a/src/metorial/presenters/src/implementation/provider/magicMcp/magicMcpServer.ts
+++ b/src/metorial/presenters/src/implementation/provider/magicMcp/magicMcpServer.ts
@@ -8,6 +8,7 @@ import {
   dashboardMagicMcpServerProviderPresenter,
   v1MagicMcpServerProviderPresenter
 } from './magicMcpServerProvider';
+import { getCachedPortalConnectUrl } from './portalConnectUrl';
 
 let magicMcpServerSchema = v.object({
   object: v.literal('magic_mcp.server'),
@@ -124,6 +125,7 @@ export let v1MagicMcpServerPresenter = Presenter.create(magicMcpServerType)
           : magicMcpServer.ownerType === 'integration'
             ? ('inherited_from_integration' as const)
             : ('manual' as const);
+      let portalConnectUrl = portal ? await getCachedPortalConnectUrl(portal) : null;
 
       return {
         object: 'magic_mcp.server' as const,
@@ -136,8 +138,8 @@ export let v1MagicMcpServerPresenter = Presenter.create(magicMcpServerType)
         endpoints: magicMcpServer.aliases.map(a => ({
           id: shadowId('mgsea_', [magicMcpServer.id], [a.slug]),
           alias: a.slug,
-          url: portal?.id
-            ? `${getConfig().urls.apiUrl}/connect/portal/${portal.slug}/${a.slug}`
+          url: portalConnectUrl
+            ? `${portalConnectUrl}/${a.slug}`
             : `${getConfig().urls.apiUrl}/connect/magic/${a.slug}`
         })),
 

--- a/src/metorial/presenters/src/implementation/provider/magicMcp/portalConnectUrl.ts
+++ b/src/metorial/presenters/src/implementation/provider/magicMcp/portalConnectUrl.ts
@@ -1,0 +1,14 @@
+import { Portal } from '@metorial/db';
+import { portalService } from '@metorial/module-portal';
+
+let cache = new WeakMap<Portal, Promise<string>>();
+
+export let getCachedPortalConnectUrl = (portal: Portal) => {
+  let cached = cache.get(portal);
+  if (cached) return cached;
+
+  let url = portalService.getPrimaryPortalConnectUrl({ portal });
+  cache.set(portal, url);
+
+  return url;
+};

--- a/src/metorial/products/workforce/modules/consumer-oauth/src/services/routing.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/src/services/routing.ts
@@ -7,13 +7,33 @@ import { portalService } from '@metorial/module-portal';
 import { DashboardConsumerSurface } from './_types';
 
 class ConsumerOAuthRoutingService {
-  private portalBase(d: { portalId: string; magicMcpTargetId?: string }) {
-    return `${getConfig().urls.apiUrl}/connect/portal/${d.portalId}${
+  private portalBase(d: {
+    portalId: string;
+    magicMcpTargetId?: string;
+    namespaceHost?: string;
+  }) {
+    let origin = d.namespaceHost ? `https://${d.namespaceHost}` : getConfig().urls.apiUrl;
+
+    return `${origin}/connect/portal/${d.portalId}${
       d.magicMcpTargetId ? `/${d.magicMcpTargetId}` : ''
     }`;
   }
 
-  async resolvePortalRoute(d: { portalId: string; magicMcpTargetId?: string }) {
+  private parseNamespaceHost(namespaceHost?: string) {
+    if (!namespaceHost) return undefined;
+
+    let [value, ...compartmentParts] = namespaceHost.split('.');
+    let compartmentValue = compartmentParts.join('.');
+    if (!value || !compartmentValue) return undefined;
+
+    return { value, compartmentValue };
+  }
+
+  async resolvePortalRoute(d: {
+    portalId: string;
+    magicMcpTargetId?: string;
+    namespaceHost?: string;
+  }) {
     let portal: Awaited<ReturnType<typeof portalService.getPortalPublic>> | null = null;
     let consumerSurface:
       | (DashboardConsumerSurface & {
@@ -23,8 +43,15 @@ class ConsumerOAuthRoutingService {
       | null = null;
 
     try {
-      portal = await portalService.getPortalPublic({ portalId: d.portalId });
+      portal = await portalService.getPortalPublic({
+        portalId: d.portalId,
+        namespace: this.parseNamespaceHost(d.namespaceHost)
+      });
     } catch {
+      if (d.namespaceHost) {
+        throw new ServiceError(notFoundError('portal'));
+      }
+
       let surface = await db.consumerSurface.findFirst({
         where: {
           id: d.portalId,
@@ -68,14 +95,33 @@ class ConsumerOAuthRoutingService {
     };
   }
 
-  async resolvePortalMcpRoute(d: { portalId: string; magicMcpTargetId?: string }) {
+  async resolvePortalMcpRoute(d: {
+    portalId: string;
+    magicMcpTargetId?: string;
+    namespaceHost?: string;
+  }) {
+    let namespace = this.parseNamespaceHost(d.namespaceHost);
     let portal = await db.portal.findFirst({
       where: {
         status: 'active',
         surface: {
           status: 'active'
         },
-        OR: [{ id: d.portalId }, { slug: d.portalId }]
+        ...(namespace
+          ? {
+              slug: d.portalId,
+              namespaceProperties: {
+                some: {
+                  type: 'portal' as const,
+                  namespace: {
+                    value: namespace.value,
+                    purposes: { has: 'metorial_portal' as const },
+                    compartment: { value: namespace.compartmentValue }
+                  }
+                }
+              }
+            }
+          : { OR: [{ id: d.portalId }, { slug: d.portalId }] })
       },
       include: {
         instance: {
@@ -87,22 +133,23 @@ class ConsumerOAuthRoutingService {
       }
     });
 
-    let consumerSurface = portal
-      ? null
-      : await db.consumerSurface.findFirst({
-          where: {
-            id: d.portalId,
-            status: 'active'
-          },
-          include: {
-            instance: {
-              include: {
-                project: true,
-                organization: true
+    let consumerSurface =
+      portal || d.namespaceHost
+        ? null
+        : await db.consumerSurface.findFirst({
+            where: {
+              id: d.portalId,
+              status: 'active'
+            },
+            include: {
+              instance: {
+                include: {
+                  project: true,
+                  organization: true
+                }
               }
             }
-          }
-        });
+          });
 
     if (!portal && !consumerSurface) {
       throw new ServiceError(notFoundError('portal'));

--- a/src/metorial/products/workforce/modules/consumer-oauth/test/consumerOAuthRouting.test.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/test/consumerOAuthRouting.test.ts
@@ -82,4 +82,60 @@ describe('consumerOAuthRoutingService', () => {
     expect(route.instance.id).toBe('ins_1');
     expect(route.magicMcpTarget?.target.oid).toBe(20n);
   });
+
+  it('constrains namespace MCP routes to portals assigned to the namespace', async () => {
+    (db.portal.findFirst as any).mockResolvedValue({
+      instance: {
+        oid: 10n,
+        id: 'ins_1'
+      }
+    });
+
+    let route = await consumerOAuthRoutingService.resolvePortalMcpRoute({
+      portalId: 'portal-slug',
+      namespaceHost: 'test.metorial.com'
+    });
+
+    expect(db.portal.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          slug: 'portal-slug',
+          namespaceProperties: {
+            some: {
+              type: 'portal',
+              namespace: {
+                value: 'test',
+                purposes: { has: 'metorial_portal' },
+                compartment: { value: 'metorial.com' }
+              }
+            }
+          }
+        })
+      })
+    );
+    expect(route.base).toBe('https://test.metorial.com/connect/portal/portal-slug');
+  });
+
+  it('uses the namespace when resolving OAuth metadata routes', async () => {
+    vi.mocked(portalService.getPortalPublic).mockResolvedValue({
+      instance: {
+        oid: 10n,
+        id: 'ins_1'
+      }
+    } as any);
+
+    let route = await consumerOAuthRoutingService.resolvePortalRoute({
+      portalId: 'portal-slug',
+      namespaceHost: 'tenant.example.co.uk'
+    });
+
+    expect(portalService.getPortalPublic).toHaveBeenCalledWith({
+      portalId: 'portal-slug',
+      namespace: {
+        value: 'tenant',
+        compartmentValue: 'example.co.uk'
+      }
+    });
+    expect(route.base).toBe('https://tenant.example.co.uk/connect/portal/portal-slug');
+  });
 });

--- a/src/metorial/products/workforce/modules/portal/src/services/portal.ts
+++ b/src/metorial/products/workforce/modules/portal/src/services/portal.ts
@@ -24,6 +24,7 @@ import {
   parsePortalIdFromHost as resolvePortalIdFromHost,
   getPortalUrlForOrigin as resolvePortalUrlForOrigin,
   getPortalUrls as resolvePortalUrls,
+  getPrimaryPortalConnectUrl as resolvePrimaryPortalConnectUrl,
   getPrimaryPortalUrl as resolvePrimaryPortalUrl,
   getPrimaryPortalUrls as resolvePrimaryPortalUrls
 } from '@metorial/portal-url';
@@ -151,14 +152,31 @@ class PortalServiceImpl {
     });
   }
 
-  async getPortalPublic(d: { portalId: string }) {
+  async getPortalPublic(d: {
+    portalId: string;
+    namespace?: { value: string; compartmentValue: string };
+  }) {
     let portal = await db.portal.findFirst({
       where: {
         status: 'active',
         surface: {
           status: 'active'
         },
-        OR: [{ id: d.portalId }, { slug: d.portalId }]
+        ...(d.namespace
+          ? {
+              slug: d.portalId,
+              namespaceProperties: {
+                some: {
+                  type: 'portal' as const,
+                  namespace: {
+                    value: d.namespace.value,
+                    purposes: { has: 'metorial_portal' as const },
+                    compartment: { value: d.namespace.compartmentValue }
+                  }
+                }
+              }
+            }
+          : { OR: [{ id: d.portalId }, { slug: d.portalId }] })
       },
       include
     });
@@ -423,6 +441,10 @@ class PortalServiceImpl {
 
   async getPrimaryPortalUrl(d: { portal: Pick<Portal, 'oid' | 'slug'> }) {
     return await resolvePrimaryPortalUrl(d);
+  }
+
+  async getPrimaryPortalConnectUrl(d: { portal: Pick<Portal, 'oid' | 'slug'> }) {
+    return await resolvePrimaryPortalConnectUrl(d);
   }
 
   async getPortalUrlForOrigin(d: {

--- a/src/metorial/products/workforce/modules/portal/test/portalNamespaceUrls.test.ts
+++ b/src/metorial/products/workforce/modules/portal/test/portalNamespaceUrls.test.ts
@@ -18,7 +18,10 @@ vi.mock('@lowerdeck/slugify', () => ({
 
 let config = {
   env: 'production' as 'production' | 'development',
-  urls: { portalsUrl: 'http://localhost:4300' }
+  urls: {
+    apiUrl: 'https://api.metorial.test',
+    portalsUrl: 'http://localhost:4300'
+  }
 };
 
 vi.hoisted(() => {
@@ -168,6 +171,28 @@ describe('portalService.getPrimaryPortalUrls', () => {
     let urls = await portalService.getPrimaryPortalUrls({ portals: [portal] });
 
     expect(urls.get(portal.oid)).toBe('https://portals.metorial.test/acme');
+  });
+
+  it('builds the connect URL from the primary namespace origin', async () => {
+    mockNamespaces([
+      namespaceProperty({
+        value: 'acme',
+        compartment: 'portals.metorial.com',
+        purposes: ['metorial_portal']
+      })
+    ]);
+
+    expect(await portalService.getPrimaryPortalConnectUrl({ portal })).toBe(
+      'https://acme.portals.metorial.com/connect/portal/acme'
+    );
+  });
+
+  it('uses the API connect URL when the portal has no namespace', async () => {
+    mockNamespaces([]);
+
+    expect(await portalService.getPrimaryPortalConnectUrl({ portal })).toBe(
+      'https://api.metorial.test/connect/portal/acme'
+    );
   });
 
   it('resolves every portal in one namespace lookup', async () => {

--- a/src/metorial/products/workforce/packages/portal-url/src/urls.ts
+++ b/src/metorial/products/workforce/packages/portal-url/src/urls.ts
@@ -91,6 +91,30 @@ export let getPrimaryPortalUrl = async (d: { portal: Pick<Portal, 'oid' | 'slug'
   return urls.get(d.portal.oid) ?? getPortalHost({ portal: d.portal }).host;
 };
 
+export let getPortalConnectUrl = (d: {
+  portal: Pick<Portal, 'slug'>;
+  namespaces: NamespacePropertyWithNamespace[];
+}) => {
+  let origin = d.namespaces.length
+    ? new URL(getPortalUrls(d)[0]!.url).origin
+    : getConfig().urls.apiUrl.replace(/\/+$/, '');
+
+  return `${origin}/connect/portal/${d.portal.slug}`;
+};
+
+export let getPrimaryPortalConnectUrl = async (d: {
+  portal: Pick<Portal, 'oid' | 'slug'>;
+}) => {
+  let namespacesByPortalOid = await namespaceService.getNamespacePropertiesByPortalOid({
+    portals: [d.portal]
+  });
+
+  return getPortalConnectUrl({
+    portal: d.portal,
+    namespaces: namespacesByPortalOid.get(d.portal.oid) ?? []
+  });
+};
+
 export let getPortalUrlForOrigin = async (d: {
   portal: Pick<Portal, 'oid' | 'slug'>;
   origin?: string | null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth routing, portal public resolution, and externally visible MCP/connect URLs; incorrect namespace binding could mis-route or leak wrong portal context, but behavior is constrained by namespace DB filters and tests.
> 
> **Overview**
> Portal **connect** and **OAuth** flows now honor custom portal hostnames instead of always using the API origin.
> 
> The connection API reads **`Metorial-Namespace-Host`**, validates it as a DNS hostname, and passes it into portal OAuth route resolution. **OAuth `base` URLs** (issuer, metadata, protected resource) use `https://{namespaceHost}` when present. Portal lookup is **scoped to the namespace** (slug + `metorial_portal` namespace property); namespace requests no longer fall back to consumer-surface resolution.
> 
> **`getPrimaryPortalConnectUrl`** / **`getPortalConnectUrl`** build connect URLs from the portal’s primary namespace origin when configured, otherwise `{apiUrl}/connect/portal/{slug}`. Magic MCP **endpoint** and **server** presenters use a cached helper so returned URLs match that scheme.
> 
> Tests cover namespace MCP/OAuth routing and connect URL construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e867d766a15bfb48a3ce52e8b396f9d340cf8186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->