### PR TITLE
Add fast file updates

### DIFF
--- a/clients/metorial-dashboard/src/sdk.ts
+++ b/clients/metorial-dashboard/src/sdk.ts
@@ -485,6 +485,7 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
         id: string;
         path: string;
       };
+      storeReplace?: boolean;
     }) => {
       let body = new FormData();
       body.append('file', input.file);
@@ -495,6 +496,7 @@ export let createMetorialDashboardSDK = sdkBuilder.build(
         body.append('store_id', input.store.id);
         body.append('path', input.store.path);
       }
+      if (input.storeReplace) body.append('store_replace', 'true');
 
       console.log('Uploading file with body:', Object.fromEntries(body.entries()));
 

--- a/src/metorial-frontend/packages/state/src/files/loaders/files.ts
+++ b/src/metorial-frontend/packages/state/src/files/loaders/files.ts
@@ -27,6 +27,7 @@ export let useUploadFile = filesLoader.createExternalMutator(
       id: string;
       path: string;
     };
+    storeReplace?: boolean;
   }) => withAuth(sdk => sdk.files.upload(i))
 );
 

--- a/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
+++ b/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
@@ -838,7 +838,7 @@ let SkillFileTreeRow = (p: {
 
     if (!isOpen) p.onToggle(p.node.path);
 
-    if (itemId == 'file') {
+    if (itemId == 'upload') {
       setFileError(null);
       fileInputRef.current?.click();
       return;
@@ -849,8 +849,12 @@ let SkillFileTreeRow = (p: {
   let directoryContextMenuItems = p.canWrite
     ? [
         {
-          id: 'file',
+          id: 'upload',
           label: 'Upload File'
+        },
+        {
+          id: 'file',
+          label: 'Create File'
         },
         {
           id: 'document',
@@ -959,8 +963,12 @@ let SkillFileTreeRow = (p: {
             label={`Add item to ${getDisplayName(p.node)}`}
             items={[
               {
-                id: 'file',
+                id: 'upload',
                 label: 'Upload File'
+              },
+              {
+                id: 'file',
+                label: 'Create File'
               },
               {
                 id: 'document',

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillTextFileEditor.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillTextFileEditor.tsx
@@ -7,8 +7,9 @@ import {
   useStorePermissions,
   useUploadFile
 } from '@metorial/state';
-import { Button, Input, Popover, Spinner, Text, theme, toast } from '@metorial/ui';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Input, Popover, Spinner, Text, theme, toast } from '@metorial/ui';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useBlocker, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { getSkillCodeEditorLanguage } from '../components/textFile';
 import { forceFileTreeRefetch } from './skillStoreFileViewer';
@@ -102,6 +103,10 @@ let pathWithName = (path: string, name: string) => {
   return parent ? `${parent}/${name}` : name;
 };
 
+let AUTOSAVE_DELAY_MS = 7_000;
+let AUTOSAVE_MAX_DELAY_MS = 60_000;
+type SaveStatus = 'saved' | 'pending' | 'saving' | 'error';
+
 let SkillTextFileEditorInner = (p: {
   instanceId: string;
   storeId: string;
@@ -120,8 +125,29 @@ let SkillTextFileEditorInner = (p: {
   let [draftName, setDraftName] = useState(basename(p.item.path));
   let [loadError, setLoadError] = useState<string | null>(null);
   let [isRenaming, setIsRenaming] = useState(false);
+  let [saveStatus, setSaveStatus] = useState<SaveStatus>('saved');
   let renameInFlight = useRef(false);
-  let savedFileIdRef = useRef<string | null>(null);
+  let savedFileIdsRef = useRef(new Set<string>());
+  let contentRef = useRef<string | null>(null);
+  let savedContentRef = useRef('');
+  let pathRef = useRef(p.item.path);
+  let saveTimerRef = useRef<number | null>(null);
+  let maxSaveTimerRef = useRef<number | null>(null);
+  let saveInFlightRef = useRef<Promise<boolean> | null>(null);
+  let mountedRef = useRef(true);
+  let pendingNavigationRef = useRef(false);
+  let uploadFileRef = useRef(uploadFile);
+  let itemFileRef = useRef(p.item.file);
+  let onItemChangeRef = useRef(p.onItemChange);
+  let flushSaveRef = useRef<() => Promise<boolean>>(async () => true);
+  let navigate = useNavigate();
+
+  uploadFileRef.current = uploadFile;
+  itemFileRef.current = p.item.file;
+  onItemChangeRef.current = p.onItemChange;
+  contentRef.current = content;
+  savedContentRef.current = savedContent;
+  pathRef.current = path;
 
   useEffect(() => {
     p.setRestrictHeight?.(true);
@@ -130,6 +156,7 @@ let SkillTextFileEditorInner = (p: {
 
   useEffect(() => {
     setPath(p.item.path);
+    pathRef.current = p.item.path;
     setDraftName(basename(p.item.path));
   }, [p.item.path]);
 
@@ -137,8 +164,8 @@ let SkillTextFileEditorInner = (p: {
     let downloadUrl = file.data?.downloadUrl;
     if (!downloadUrl) return;
 
-    if (file.data?.id == savedFileIdRef.current) {
-      savedFileIdRef.current = null;
+    if (file.data?.id && savedFileIdsRef.current.has(file.data.id)) {
+      savedFileIdsRef.current.delete(file.data.id);
       return;
     }
 
@@ -154,7 +181,10 @@ let SkillTextFileEditorInner = (p: {
       .then(value => {
         if (cancelled) return;
         setContent(value);
+        contentRef.current = value;
         setSavedContent(value);
+        savedContentRef.current = value;
+        setSaveStatus('saved');
       })
       .catch(error => {
         if (!cancelled) {
@@ -169,7 +199,102 @@ let SkillTextFileEditorInner = (p: {
 
   let fileName = basename(path);
   let language = useMemo(() => getSkillCodeEditorLanguage(fileName), [fileName]);
-  let isSaving = uploadFile.isLoading || modifyStoreItems.isLoading;
+
+  let flushSave = useCallback(async () => {
+    if (saveTimerRef.current) {
+      window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    if (maxSaveTimerRef.current) {
+      window.clearTimeout(maxSaveTimerRef.current);
+      maxSaveTimerRef.current = null;
+    }
+
+    if (saveInFlightRef.current) {
+      let previousSucceeded = await saveInFlightRef.current;
+      if (!previousSucceeded) return false;
+    }
+
+    let nextContent = contentRef.current;
+    if (
+      p.readOnly ||
+      nextContent == null ||
+      nextContent == savedContentRef.current ||
+      !itemFileRef.current
+    ) {
+      if (mountedRef.current) setSaveStatus('saved');
+      return true;
+    }
+
+    let savePath = pathRef.current;
+    let saveFileName = basename(savePath);
+    if (mountedRef.current) setSaveStatus('saving');
+
+    let savePromise = (async () => {
+      let itemFile = itemFileRef.current!;
+      let [uploaded, uploadError] = await uploadFileRef.current.mutate({
+        instanceId: p.instanceId,
+        file: new File([nextContent], saveFileName, {
+          type: itemFile.fileType || 'text/plain'
+        }),
+        title: saveFileName,
+        purpose: itemFile.purpose || 'generic',
+        store: {
+          id: p.storeId,
+          path: savePath
+        },
+        storeReplace: true
+      });
+      if (uploadError || !uploaded) {
+        if (!uploaded && !uploadError) {
+          toast.error('File upload completed without a result');
+        }
+        if (mountedRef.current) setSaveStatus('error');
+        return false;
+      }
+
+      savedFileIdsRef.current.add(uploaded.id);
+      savedContentRef.current = nextContent;
+      if (mountedRef.current) {
+        setSavedContent(nextContent);
+        setSaveStatus(contentRef.current == nextContent ? 'saved' : 'pending');
+      }
+      onItemChangeRef.current();
+      forceFileTreeRefetch();
+      return true;
+    })();
+
+    saveInFlightRef.current = savePromise;
+    try {
+      return await savePromise;
+    } finally {
+      if (saveInFlightRef.current === savePromise) saveInFlightRef.current = null;
+    }
+  }, [p.instanceId, p.readOnly, p.storeId]);
+  flushSaveRef.current = flushSave;
+
+  let enqueueSave = useCallback(() => {
+    if (p.readOnly || contentRef.current == savedContentRef.current) {
+      setSaveStatus('saved');
+      return;
+    }
+
+    setSaveStatus('pending');
+    if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = window.setTimeout(() => {
+      void flushSave();
+    }, AUTOSAVE_DELAY_MS);
+    if (!maxSaveTimerRef.current) {
+      maxSaveTimerRef.current = window.setTimeout(() => {
+        void flushSave();
+      }, AUTOSAVE_MAX_DELAY_MS);
+    }
+  }, [flushSave, p.readOnly]);
+
+  useEffect(() => {
+    if (content == null || content == savedContentRef.current) return;
+    enqueueSave();
+  }, [content, enqueueSave]);
 
   let rename = async () => {
     let name = draftName.trim();
@@ -188,6 +313,10 @@ let SkillTextFileEditorInner = (p: {
     renameInFlight.current = true;
     setIsRenaming(true);
     try {
+      if (!(await flushSave())) {
+        setDraftName(fileName);
+        return;
+      }
       let [, error] = await modifyStoreItems.mutate({
         instanceId: p.instanceId,
         storeId: p.storeId,
@@ -195,6 +324,7 @@ let SkillTextFileEditorInner = (p: {
       });
       if (error) throw error;
       setPath(nextPath);
+      pathRef.current = nextPath;
       p.onItemChange();
       forceFileTreeRefetch();
     } catch (error) {
@@ -206,35 +336,97 @@ let SkillTextFileEditorInner = (p: {
     }
   };
 
-  let save = async () => {
-    if (p.readOnly || content == null || content == savedContent || !p.item.file) return;
+  let hasUnsavedChanges =
+    !p.readOnly &&
+    (content != savedContent || saveStatus == 'saving' || saveStatus == 'error');
 
-    let [uploaded, uploadError] = await uploadFile.mutate({
-      instanceId: p.instanceId,
-      file: new File([content], fileName, {
-        type: p.item.file.fileType || 'text/plain'
-      }),
-      title: fileName,
-      purpose: p.item.file.purpose || 'generic'
+  useBlocker(tx => {
+    if (!hasUnsavedChanges || pendingNavigationRef.current) return false;
+    pendingNavigationRef.current = true;
+
+    void flushSave().then(saved => {
+      if (!saved) {
+        pendingNavigationRef.current = false;
+        toast.error('Could not save file.');
+        return;
+      }
+
+      navigate(
+        {
+          pathname: tx.nextLocation.pathname,
+          search: tx.nextLocation.search,
+          hash: tx.nextLocation.hash
+        },
+        { state: tx.nextLocation.state }
+      );
     });
-    if (uploadError) return;
-    if (!uploaded) {
-      toast.error('File upload completed without a result');
-      return;
-    }
 
-    let [, modifyError] = await modifyStoreItems.mutate({
-      instanceId: p.instanceId,
-      storeId: p.storeId,
-      operations: [{ type: 'modify', itemId: p.itemId, fileId: uploaded.id }]
-    });
-    if (modifyError) return;
+    return true;
+  });
 
-    savedFileIdRef.current = uploaded.id;
-    setSavedContent(content);
-    p.onItemChange();
-    forceFileTreeRefetch();
-  };
+  useEffect(() => {
+    if (!hasUnsavedChanges) return;
+    let handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      void flushSave();
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [flushSave, hasUnsavedChanges]);
+
+  useEffect(() => {
+    let handleSaveShortcut = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() != 's') return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      toast('File saved automatically');
+    };
+
+    window.addEventListener('keydown', handleSaveShortcut, true);
+    return () => window.removeEventListener('keydown', handleSaveShortcut, true);
+  }, []);
+
+  useEffect(() => {
+    let handleVisibilityChange = () => {
+      if (
+        document.visibilityState == 'hidden' &&
+        contentRef.current != savedContentRef.current
+      ) {
+        void flushSave();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [flushSave]);
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return;
+    let handleReloadShortcut = (event: KeyboardEvent) => {
+      let isReloadShortcut =
+        event.key == 'F5' ||
+        ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() == 'r');
+      if (!isReloadShortcut) return;
+      event.preventDefault();
+      event.stopPropagation();
+      void flushSave().then(saved => {
+        if (saved) window.location.reload();
+      });
+    };
+    window.addEventListener('keydown', handleReloadShortcut, true);
+    return () => window.removeEventListener('keydown', handleReloadShortcut, true);
+  }, [flushSave, hasUnsavedChanges]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
+      if (maxSaveTimerRef.current) window.clearTimeout(maxSaveTimerRef.current);
+      void flushSaveRef.current();
+    };
+  }, []);
 
   if (file.error || loadError) {
     return (
@@ -290,14 +482,9 @@ let SkillTextFileEditorInner = (p: {
           </Popover>
         </HeaderSide>
         <HeaderSide>
-          <Button
-            disabled={p.readOnly || content == savedContent}
-            loading={isSaving}
-            onClick={() => void save()}
-            size="2"
-          >
-            Save
-          </Button>
+          <Text color="gray600" size="1">
+            File saved automatically
+          </Text>
         </HeaderSide>
       </Header>
       <EditorWrap>

--- a/src/metorial/apis/files/src/index.ts
+++ b/src/metorial/apis/files/src/index.ts
@@ -14,6 +14,7 @@ import { generatePlainId } from '@metorial/id';
 import { websocket } from 'hono/bun';
 import { resolveDocumentsLiveToken } from './documentsLiveAuth';
 import { resolveUploadTarget } from './uploadAccess';
+import { parseStoreReplace } from './uploadForm';
 
 type FileApiAuthResult = Awaited<ReturnType<typeof authenticate>>;
 
@@ -48,6 +49,7 @@ let createFileUploadHandler =
         let instanceId = body.get('instance_id');
         let attachedStoreId = body.get('store_id');
         let attachedStorePath = body.get('path');
+        let storeReplaceValue = body.get('store_replace');
         let title = (body.get('title') || undefined) as string | undefined;
 
         if (!file || !purpose) {
@@ -95,6 +97,11 @@ let createFileUploadHandler =
           );
         }
 
+        let storeReplace = parseStoreReplace(
+          storeReplaceValue,
+          !!attachedStoreId && !!attachedStorePath
+        );
+
         let target = await resolveUploadTarget({
           auth,
           instanceId: typeof instanceId == 'string' ? instanceId : null,
@@ -126,7 +133,8 @@ let createFileUploadHandler =
             typeof attachedStoreId == 'string' && typeof attachedStorePath == 'string'
               ? {
                   id: attachedStoreId,
-                  path: attachedStorePath
+                  path: attachedStorePath,
+                  replace: storeReplace
                 }
               : undefined
         });
@@ -197,7 +205,7 @@ let getFileContentHandler = async (c: Context) => {
           ? getDocumentContentType(metadata.contentType)
           : getServedContentType(metadata.contentType),
       'Cache-Control':
-        metadata.source === 'document' || link.expiresAt
+        metadata.source === 'document' || metadata.source === 'database' || link.expiresAt
           ? 'private, no-store'
           : 'public, max-age=31536000, immutable',
       'X-Content-Type-Options': 'nosniff',

--- a/src/metorial/apis/files/src/uploadForm.test.ts
+++ b/src/metorial/apis/files/src/uploadForm.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { parseStoreReplace } from './uploadForm';
+
+describe('store_replace upload field', () => {
+  it('defaults to false and accepts explicit booleans', () => {
+    expect(parseStoreReplace(null, false)).toBe(false);
+    expect(parseStoreReplace('false', true)).toBe(false);
+    expect(parseStoreReplace('true', true)).toBe(true);
+  });
+
+  it('requires a linked store for replace mode', () => {
+    expect(() => parseStoreReplace('true', false)).toThrow(/requires store_id and path/);
+  });
+
+  it('rejects invalid boolean values', () => {
+    expect(() => parseStoreReplace('1', true)).toThrow(/must be true or false/);
+  });
+});

--- a/src/metorial/apis/files/src/uploadForm.ts
+++ b/src/metorial/apis/files/src/uploadForm.ts
@@ -1,0 +1,22 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+
+export let parseStoreReplace = (value: FormDataEntryValue | null, hasStore: boolean) => {
+  if (value !== null && value !== 'true' && value !== 'false') {
+    throw new ServiceError(
+      badRequestError({
+        message: 'store_replace must be true or false'
+      })
+    );
+  }
+
+  let replace = value === 'true';
+  if (replace && !hasStore) {
+    throw new ServiceError(
+      badRequestError({
+        message: 'store_replace requires store_id and path'
+      })
+    );
+  }
+
+  return replace;
+};

--- a/src/metorial/db/prisma/schema/file/file.prisma
+++ b/src/metorial/db/prisma/schema/file/file.prisma
@@ -66,6 +66,7 @@ model File {
   expiresAt DateTime?
 
   links                         FileLink[]
+  pendingContent                FilePendingContent?
   document                      Document?
   storeItems                    StoreItem[]
   storeVersionItems             StoreVersionItem[]
@@ -78,6 +79,22 @@ model File {
 
   @@index([storeId, status])
   @@index([status, expiresAt, oid])
+}
+
+model FilePendingContent {
+  oid BigInt @id @default(autoincrement())
+
+  fileOid BigInt @unique
+  file    File   @relation(fields: [fileOid], references: [oid], onDelete: Cascade)
+
+  content    Bytes
+  revision   Int      @default(1)
+  flushAfter DateTime
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@index([flushAfter])
 }
 
 model FileLink {

--- a/src/metorial/products/storage/modules/file/src/lib/fileContent.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/fileContent.ts
@@ -1,7 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { documentService } from '@metorial/module-documents';
 import { fileDownloadService } from '../services/fileDownload';
-import { getCargoFilesBucketName, getStorage } from '../storage';
+import { getStoredFileContent } from './pendingFileContent';
 
 export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
   let { link, file } = await fileDownloadService.getFileByDownloadKey(d);
@@ -29,15 +29,15 @@ export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
     };
   }
 
-  let object = await getStorage().getObject(getCargoFilesBucketName(), file.storeId);
+  let stored = await getStoredFileContent({ file });
 
   return {
     file,
     link,
-    content: object.data,
+    content: stored.data,
     metadata: {
-      contentType: object.metadata.content_type ?? file.fileType,
-      source: 'object' as const
+      contentType: stored.contentType ?? file.fileType,
+      source: stored.source
     }
   };
 };

--- a/src/metorial/products/storage/modules/file/src/lib/fileContentPolicy.test.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/fileContentPolicy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isBufferableTextFile, maxBufferedFileSize } from './fileContentPolicy';
+
+describe('buffered file content policy', () => {
+  it('accepts common text extensions case-insensitively below one MiB', () => {
+    expect(isBufferableTextFile({ fileName: 'server.TS', size: 1 })).toBe(true);
+    expect(
+      isBufferableTextFile({ fileName: 'configuration.YAML', size: maxBufferedFileSize - 1 })
+    ).toBe(true);
+  });
+
+  it('rejects files at the size boundary and unknown extensions', () => {
+    expect(isBufferableTextFile({ fileName: 'server.ts', size: maxBufferedFileSize })).toBe(
+      false
+    );
+    expect(isBufferableTextFile({ fileName: 'archive.zip', size: 1 })).toBe(false);
+  });
+});

--- a/src/metorial/products/storage/modules/file/src/lib/fileContentPolicy.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/fileContentPolicy.ts
@@ -1,0 +1,48 @@
+export let maxBufferedFileSize = 1024 * 1024;
+
+export let textFileExtensions = new Set([
+  'c',
+  'cjs',
+  'cpp',
+  'cs',
+  'csv',
+  'css',
+  'scss',
+  'less',
+  'env',
+  'go',
+  'graphql',
+  'h',
+  'html',
+  'htm',
+  'java',
+  'js',
+  'json',
+  'jsx',
+  'log',
+  'md',
+  'mdx',
+  'mjs',
+  'php',
+  'py',
+  'rb',
+  'rs',
+  'sh',
+  'bash',
+  'zsh',
+  'sql',
+  'swift',
+  'toml',
+  'ts',
+  'tsx',
+  'txt',
+  'xml',
+  'yaml',
+  'yml'
+]);
+
+let getFileExtension = (fileName: string) =>
+  fileName.split('.').pop()?.trim().toLowerCase() ?? '';
+
+export let isBufferableTextFile = (d: { fileName: string; size: number }) =>
+  d.size < maxBufferedFileSize && textFileExtensions.has(getFileExtension(d.fileName));

--- a/src/metorial/products/storage/modules/file/src/lib/fileReplacement.test.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/fileReplacement.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { canDeleteDisplacedFile } from './fileReplacement';
+
+let unreferencedFile = {
+  isSameFile: false,
+  status: 'active',
+  isInternal: false,
+  isReadOnly: false,
+  isTemplateBacking: false,
+  hasDocument: false,
+  fileLinkCount: 0,
+  hasFileReferences: false,
+  referenceCounts: {
+    storeItems: 0,
+    storeVersionItems: 0,
+    skillExports: 0,
+    skillImports: 0,
+    mergeRequests: 0
+  }
+};
+
+describe('displaced file cleanup', () => {
+  it('deletes an active writable file without durable uses', () => {
+    expect(canDeleteDisplacedFile(unreferencedFile)).toBe(true);
+  });
+
+  it('does not treat a file link itself as a durable reference', () => {
+    expect(canDeleteDisplacedFile({ ...unreferencedFile, fileLinkCount: 3 })).toBe(true);
+  });
+
+  it('keeps a file with an actual file reference', () => {
+    expect(canDeleteDisplacedFile({ ...unreferencedFile, hasFileReferences: true })).toBe(
+      false
+    );
+  });
+
+  it('keeps a file for every kind of remaining durable use', () => {
+    for (let reference of Object.keys(unreferencedFile.referenceCounts)) {
+      expect(
+        canDeleteDisplacedFile({
+          ...unreferencedFile,
+          referenceCounts: {
+            ...unreferencedFile.referenceCounts,
+            [reference]: 1
+          }
+        })
+      ).toBe(false);
+    }
+    expect(canDeleteDisplacedFile({ ...unreferencedFile, hasDocument: true })).toBe(false);
+  });
+
+  it('keeps the replacement itself and protected files', () => {
+    expect(canDeleteDisplacedFile({ ...unreferencedFile, isSameFile: true })).toBe(false);
+    expect(canDeleteDisplacedFile({ ...unreferencedFile, isInternal: true })).toBe(false);
+    expect(canDeleteDisplacedFile({ ...unreferencedFile, isReadOnly: true })).toBe(false);
+    expect(canDeleteDisplacedFile({ ...unreferencedFile, isTemplateBacking: true })).toBe(
+      false
+    );
+  });
+});

--- a/src/metorial/products/storage/modules/file/src/lib/fileReplacement.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/fileReplacement.ts
@@ -1,0 +1,19 @@
+export let canDeleteDisplacedFile = (d: {
+  isSameFile: boolean;
+  status: string;
+  isInternal: boolean;
+  isReadOnly: boolean;
+  isTemplateBacking: boolean;
+  hasDocument: boolean;
+  fileLinkCount: number;
+  hasFileReferences: boolean;
+  referenceCounts: Record<string, number>;
+}) =>
+  !d.isSameFile &&
+  d.status === 'active' &&
+  !d.isInternal &&
+  !d.isReadOnly &&
+  !d.isTemplateBacking &&
+  !d.hasDocument &&
+  !d.hasFileReferences &&
+  Object.values(d.referenceCounts).every(count => count === 0);

--- a/src/metorial/products/storage/modules/file/src/lib/pendingFileContent.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/pendingFileContent.ts
@@ -1,0 +1,57 @@
+import { db, withTransaction } from '@metorial/db';
+import { getCargoFilesBucketName, getStorage } from '../storage';
+import {
+  isBufferableTextFile,
+  maxBufferedFileSize,
+  textFileExtensions
+} from './fileContentPolicy';
+
+let pendingContentDurationMs = 60 * 60 * 1000;
+
+export let shouldBufferFileContent = (d: { fileName: string; size: number }) =>
+  isBufferableTextFile(d);
+
+export let getPendingFileContentFlushAfter = () =>
+  new Date(Date.now() + pendingContentDurationMs);
+
+export let getStoredFileContent = async (d: { file: { oid: bigint; storeId: string } }) => {
+  let pending = await db.filePendingContent.findUnique({
+    where: {
+      fileOid: d.file.oid
+    },
+    select: {
+      content: true
+    }
+  });
+
+  if (pending) {
+    return {
+      data: Buffer.from(pending.content),
+      source: 'database' as const
+    };
+  }
+
+  let object = await getStorage().getObject(getCargoFilesBucketName(), d.file.storeId);
+  return {
+    data: object.data,
+    contentType: object.metadata.content_type,
+    source: 'object' as const
+  };
+};
+
+export let deletePendingFileContent = async (fileOid: bigint) =>
+  await withTransaction(
+    async db =>
+      await db.filePendingContent.deleteMany({
+        where: {
+          fileOid
+        }
+      }),
+    { ifExists: true }
+  );
+
+export let pendingFileContentConfig = {
+  maxBufferedFileSize,
+  pendingContentDurationMs,
+  textFileExtensions
+};

--- a/src/metorial/products/storage/modules/file/src/lib/uploadFile.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/uploadFile.ts
@@ -3,6 +3,10 @@ import type { StoreParticipantPermissions } from '@metorial/db';
 import type { CargoOwnerScope } from '../internal/ownerScope';
 import type { ResourceAuthorization } from '@metorial/module-access';
 import { fileService } from '../services/file';
+import {
+  getPendingFileContentFlushAfter,
+  shouldBufferFileContent
+} from './pendingFileContent';
 import { getCargoFilesBucketName, getStorage } from '../storage';
 
 export let uploadCargoFile = async (
@@ -20,19 +24,37 @@ export let uploadCargoFile = async (
     store?: {
       id: string;
       path: string;
+      replace?: boolean;
     };
   }
 ) => {
   let storeId = d.storeId ?? generatePlainId(20);
   let mimeType = d.mimeType || d.file.type || 'application/octet-stream';
 
-  await getStorage().putObject(getCargoFilesBucketName(), storeId, d.file, mimeType);
+  let bufferContent = shouldBufferFileContent({
+    fileName: d.fileName,
+    size: d.file.size
+  });
+  let contentPersistence: Parameters<typeof fileService.createFile>[0]['internal'] = {
+    contentPersistence: bufferContent
+      ? {
+          type: 'database',
+          content: new Uint8Array(await d.file.arrayBuffer()),
+          flushAfter: getPendingFileContentFlushAfter()
+        }
+      : { type: 'object' }
+  };
+
+  if (!bufferContent) {
+    await getStorage().putObject(getCargoFilesBucketName(), storeId, d.file, mimeType);
+  }
 
   let { file, ...scope } = d;
 
   return await fileService.createFile({
     ...scope,
     storeId,
+    internal: contentPersistence,
     input: {
       id: d.fileId,
       name: d.fileName,

--- a/src/metorial/products/storage/modules/file/src/queues/fileCleanup.ts
+++ b/src/metorial/products/storage/modules/file/src/queues/fileCleanup.ts
@@ -35,7 +35,7 @@ export let listDeletedFilesWithStorage = async (d: { cursor?: string; limit: num
     take: d.limit
   });
 
-export let cleanupDeletedFileStorage = async (d: { fileId: string }) => {
+export let cleanupDeletedFileStorage = async (d: { fileId: string; storeId?: string }) => {
   let file = await db.file.findUnique({
     where: {
       id: d.fileId
@@ -45,17 +45,18 @@ export let cleanupDeletedFileStorage = async (d: { fileId: string }) => {
       storeId: true
     }
   });
-  if (!file || file.status !== 'deleted' || file.storeId === '') return false;
+  let storeId = d.storeId ?? file?.storeId;
+  if (!file || file.status !== 'deleted' || !storeId) return false;
 
   let activeFileCount = await db.file.count({
     where: {
       status: 'active',
-      storeId: file.storeId
+      storeId
     }
   });
   if (activeFileCount > 0) return false;
 
-  await getStorage().deleteObject(getCargoFilesBucketName(), file.storeId);
+  await getStorage().deleteObject(getCargoFilesBucketName(), storeId);
 
   return true;
 };

--- a/src/metorial/products/storage/modules/file/src/queues/fileContentFlush.ts
+++ b/src/metorial/products/storage/modules/file/src/queues/fileContentFlush.ts
@@ -1,0 +1,164 @@
+import { createCron } from '@metorial/cron';
+import { db, withTransaction } from '@metorial/db';
+import { combineQueueProcessors, createQueue } from '@metorial/queue';
+import { getCargoFilesBucketName, getStorage } from '../storage';
+import { cleanupDeletedFileStorage } from './fileCleanup';
+
+let batchSize = 100;
+
+export let fileContentFlushManyQueue = createQueue<{
+  dueBefore: string;
+  cursor?: string;
+}>({
+  name: 'cargo/file/contentFlush/many',
+  workerOpts: {
+    concurrency: 1
+  }
+});
+
+export let fileContentFlushSingleQueue = createQueue<{ fileId: string }>({
+  name: 'cargo/file/contentFlush/single',
+  workerOpts: {
+    concurrency: 5
+  }
+});
+
+export let listPendingFileContentToFlush = async (d: {
+  dueBefore: Date;
+  cursor?: string;
+  limit: number;
+}) =>
+  await db.filePendingContent.findMany({
+    where: {
+      flushAfter: { lte: d.dueBefore },
+      file: {
+        id: d.cursor ? { gt: d.cursor } : undefined
+      }
+    },
+    orderBy: {
+      file: {
+        id: 'asc'
+      }
+    },
+    select: {
+      file: {
+        select: {
+          id: true,
+          oid: true
+        }
+      }
+    },
+    take: d.limit
+  });
+
+export let flushPendingFileContent = async (d: { fileId: string }) => {
+  let pending = await db.filePendingContent.findFirst({
+    where: {
+      file: {
+        id: d.fileId
+      }
+    },
+    include: {
+      file: true
+    }
+  });
+  if (!pending || pending.flushAfter > new Date()) return false;
+
+  if (pending.file.status !== 'active') {
+    await db.filePendingContent.deleteMany({
+      where: {
+        oid: pending.oid,
+        revision: pending.revision
+      }
+    });
+    return false;
+  }
+
+  await getStorage().putObject(
+    getCargoFilesBucketName(),
+    pending.file.storeId,
+    Buffer.from(pending.content),
+    pending.file.fileType
+  );
+
+  let result = await withTransaction(async db => {
+    let currentFile = await db.file.findUnique({
+      where: { id: pending.file.id },
+      select: { status: true }
+    });
+    if (!currentFile || currentFile.status !== 'active') {
+      await db.filePendingContent.deleteMany({
+        where: {
+          oid: pending.oid,
+          revision: pending.revision
+        }
+      });
+      return 'deleted' as const;
+    }
+
+    let deleted = await db.filePendingContent.deleteMany({
+      where: {
+        oid: pending.oid,
+        revision: pending.revision
+      }
+    });
+
+    return deleted.count > 0 ? ('flushed' as const) : ('stale' as const);
+  });
+
+  if (result === 'deleted') {
+    await cleanupDeletedFileStorage({
+      fileId: pending.file.id,
+      storeId: pending.file.storeId
+    });
+  }
+
+  return result === 'flushed';
+};
+
+export let fileContentFlushManyProcessor = fileContentFlushManyQueue.process(async data => {
+  let files = await listPendingFileContentToFlush({
+    dueBefore: new Date(data.dueBefore),
+    cursor: data.cursor,
+    limit: batchSize
+  });
+  if (files.length === 0) return;
+
+  await fileContentFlushSingleQueue.addManyWithOps(
+    files.map(({ file }) => ({
+      data: { fileId: file.id },
+      opts: { id: `file-content-flush:${file.oid.toString()}` }
+    }))
+  );
+
+  if (files.length === batchSize) {
+    await fileContentFlushManyQueue.add({
+      dueBefore: data.dueBefore,
+      cursor: files[files.length - 1]!.file.id
+    });
+  }
+});
+
+export let fileContentFlushSingleProcessor = fileContentFlushSingleQueue.process(
+  async data => {
+    await flushPendingFileContent({ fileId: data.fileId });
+  }
+);
+
+export let fileContentFlushCron = createCron(
+  {
+    name: 'cargo/file/contentFlush/cron',
+    cron: '*/15 * * * *'
+  },
+  async () => {
+    await fileContentFlushManyQueue.add({
+      dueBefore: new Date().toISOString()
+    });
+  }
+);
+
+export let fileContentFlushProcessors = combineQueueProcessors([
+  fileContentFlushManyProcessor,
+  fileContentFlushSingleProcessor,
+  fileContentFlushCron
+]);

--- a/src/metorial/products/storage/modules/file/src/queues/fileExpiration.ts
+++ b/src/metorial/products/storage/modules/file/src/queues/fileExpiration.ts
@@ -99,6 +99,10 @@ export let fileExpirationSingleProcessor = fileExpirationSingleQueue.process(asy
         }
       })
     ).map(item => item.storeOid);
+    let pendingContent = await db.filePendingContent.findUnique({
+      where: { fileOid: file.oid },
+      select: { oid: true }
+    });
 
     let updated = await db.file.updateMany({
       where: {
@@ -109,10 +113,17 @@ export let fileExpirationSingleProcessor = fileExpirationSingleQueue.process(asy
         }
       },
       data: {
-        status: 'deleted'
+        status: 'deleted',
+        storeId: pendingContent ? '' : undefined
       }
     });
     if (updated.count === 0) return null;
+
+    await db.filePendingContent.deleteMany({
+      where: {
+        fileOid: file.oid
+      }
+    });
 
     await db.fileReference.deleteMany({
       where: {

--- a/src/metorial/products/storage/modules/file/src/queues/index.ts
+++ b/src/metorial/products/storage/modules/file/src/queues/index.ts
@@ -1,11 +1,14 @@
 import { combineQueueProcessors } from '@metorial/queue';
 import { fileCleanupProcessors } from './fileCleanup';
+import { fileContentFlushProcessors } from './fileContentFlush';
 import { fileExpirationProcessors } from './fileExpiration';
 
 export * from './fileCleanup';
+export * from './fileContentFlush';
 export * from './fileExpiration';
 
 export let fileQueueProcessor = combineQueueProcessors([
   fileCleanupProcessors,
+  fileContentFlushProcessors,
   fileExpirationProcessors
 ]);

--- a/src/metorial/products/storage/modules/file/src/services/file.ts
+++ b/src/metorial/products/storage/modules/file/src/services/file.ts
@@ -40,6 +40,13 @@ import type { ResourceAuthorization } from '@metorial/module-access';
 import { resourceActorPresentationInclude } from '@metorial/module-resource-actor';
 import { cargoFileScope, type CargoOwnerScope } from '../internal/ownerScope';
 import { requireInstanceScope } from '../lib/instanceScope';
+import { canDeleteDisplacedFile } from '../lib/fileReplacement';
+import {
+  getPendingFileContentFlushAfter,
+  getStoredFileContent,
+  shouldBufferFileContent
+} from '../lib/pendingFileContent';
+import { fileCleanupSingleQueue } from '../queues/fileCleanup';
 import { getCargoFilesBucketName, getStorage } from '../storage';
 import { documentFilePurposeSlug, filePurposeService } from './filePurpose';
 import { fileReferenceService } from './fileReference';
@@ -66,6 +73,111 @@ type FileAccessInput = {
 };
 
 class FileServiceImpl {
+  private async persistFileContent(
+    fileOid: bigint,
+    persistence:
+      | { type: 'database'; content: Uint8Array<ArrayBuffer>; flushAfter: Date }
+      | { type: 'object' }
+      | undefined
+  ) {
+    if (!persistence) return;
+
+    await withTransaction(async db => {
+      if (persistence.type === 'object') {
+        await db.filePendingContent.deleteMany({ where: { fileOid } });
+        return;
+      }
+
+      await db.filePendingContent.upsert({
+        where: { fileOid },
+        create: {
+          fileOid,
+          content: persistence.content,
+          flushAfter: persistence.flushAfter
+        },
+        update: {
+          content: persistence.content,
+          flushAfter: persistence.flushAfter,
+          revision: { increment: 1 }
+        }
+      });
+    });
+  }
+
+  private async deleteFileIfUnreferenced(d: { fileId: string; replacementFileOid: bigint }) {
+    return await withTransaction(async db => {
+      let file = await db.file.findUnique({
+        where: { id: d.fileId },
+        select: {
+          oid: true,
+          id: true,
+          status: true,
+          isInternal: true,
+          isReadOnly: true,
+          isTemplateBacking: true,
+          document: { select: { id: true } },
+          links: {
+            select: {
+              _count: {
+                select: {
+                  references: true
+                }
+              }
+            }
+          },
+          pendingContent: { select: { oid: true } },
+          _count: {
+            select: {
+              storeItems: true,
+              storeVersionItems: true,
+              skillExports: true,
+              skillExportRefs: true,
+              skillImports: true,
+              mergeRequestItemsAsBaseFile: true,
+              mergeRequestItemsAsSourceFile: true,
+              mergeRequestItemsAsTargetFile: true
+            }
+          }
+        }
+      });
+
+      if (!file) return null;
+      if (
+        !canDeleteDisplacedFile({
+          isSameFile: file.oid === d.replacementFileOid,
+          status: file.status,
+          isInternal: file.isInternal,
+          isReadOnly: file.isReadOnly,
+          isTemplateBacking: file.isTemplateBacking,
+          hasDocument: !!file.document,
+          fileLinkCount: file.links.length,
+          hasFileReferences: file.links.some(link => link._count.references > 0),
+          referenceCounts: file._count
+        })
+      )
+        return null;
+
+      let hadPendingContent = !!file.pendingContent;
+      let deleted = await db.file.updateMany({
+        where: {
+          oid: file.oid,
+          status: 'active'
+        },
+        data: {
+          status: 'deleted',
+          storeId: hadPendingContent ? '' : undefined
+        }
+      });
+      if (deleted.count === 0) return null;
+
+      await db.filePendingContent.deleteMany({
+        where: { fileOid: file.oid }
+      });
+
+      return hadPendingContent ? null : file.id;
+    });
+  }
+
   private assertFileWritable(file: Pick<File, 'id' | 'isReadOnly'>) {
     if (file.isReadOnly) {
       throw new ServiceError(
@@ -126,6 +238,9 @@ class FileServiceImpl {
         isReadOnly?: boolean;
         isTemplateBacking?: boolean;
         allowReadOnlyStore?: boolean;
+        contentPersistence?:
+          | { type: 'database'; content: Uint8Array<ArrayBuffer>; flushAfter: Date }
+          | { type: 'object' };
       };
       input: {
         id?: string;
@@ -138,13 +253,15 @@ class FileServiceImpl {
         store?: {
           id: string;
           path: string;
+          replace?: boolean;
         };
         defaultPermissions?: StoreParticipantPermissions[];
         overridePermissions?: boolean;
       };
     }
   ): Promise<FileRecord> {
-    return await withTransaction(async db => {
+    let cleanupFileId: string | null = null;
+    let result = await withTransaction(async db => {
       let fileName = d.input.name?.trim();
       if (!fileName) {
         throw new ServiceError(
@@ -196,6 +313,7 @@ class FileServiceImpl {
           },
           include
         });
+        await this.persistFileContent(updatedFile.oid, d.internal?.contentPersistence);
 
         if (d.input.store) {
           let scope = requireInstanceScope(d, 'Attaching a file to a store');
@@ -214,7 +332,7 @@ class FileServiceImpl {
             requiredPermission: storeWritePermission
           });
 
-          await storeItemMutationService.attachTargetToStore({
+          let attached = await storeItemMutationService.attachTargetToStore({
             ...scope,
             store,
             path: d.input.store.path,
@@ -225,6 +343,12 @@ class FileServiceImpl {
             actor,
             allowReadOnly: d.internal?.allowReadOnlyStore
           });
+          if (d.input.store.replace && attached.previousFile) {
+            cleanupFileId = await this.deleteFileIfUnreferenced({
+              fileId: attached.previousFile.id,
+              replacementFileOid: updatedFile.oid
+            });
+          }
         }
 
         return await this.withEffectiveStoreId(updatedFile);
@@ -247,6 +371,7 @@ class FileServiceImpl {
         },
         include
       });
+      await this.persistFileContent(createdFile.oid, d.internal?.contentPersistence);
 
       if (d.input.store) {
         let scope = requireInstanceScope(d, 'Attaching a file to a store');
@@ -265,7 +390,7 @@ class FileServiceImpl {
           requiredPermission: storeWritePermission
         });
 
-        await storeItemMutationService.attachTargetToStore({
+        let attached = await storeItemMutationService.attachTargetToStore({
           ...scope,
           store,
           path: d.input.store.path,
@@ -276,10 +401,25 @@ class FileServiceImpl {
           actor,
           allowReadOnly: d.internal?.allowReadOnlyStore
         });
+        if (d.input.store.replace && attached.previousFile) {
+          cleanupFileId = await this.deleteFileIfUnreferenced({
+            fileId: attached.previousFile.id,
+            replacementFileOid: createdFile.oid
+          });
+        }
       }
 
       return await this.withEffectiveStoreId(createdFile);
     });
+
+    if (cleanupFileId) {
+      await fileCleanupSingleQueue.add(
+        { fileId: cleanupFileId },
+        { id: `file-cleanup:${cleanupFileId}` }
+      );
+    }
+
+    return result;
   }
 
   async getFileById(
@@ -313,14 +453,16 @@ class FileServiceImpl {
   }
 
   async downloadFileContent(d: {
-    file: Pick<File, 'status' | 'storeId'> & { effectiveStoreId?: string };
+    file: Pick<File, 'oid' | 'status' | 'storeId'> & { effectiveStoreId?: string };
   }) {
     await this.ensureFileActive(d.file);
 
-    let object = await getStorage().getObject(
-      getCargoFilesBucketName(),
-      d.file.effectiveStoreId ?? d.file.storeId
-    );
+    let object = await getStoredFileContent({
+      file: {
+        oid: d.file.oid,
+        storeId: d.file.effectiveStoreId ?? d.file.storeId
+      }
+    });
 
     return await this.objectDataToBuffer(object.data);
   }
@@ -341,8 +483,14 @@ class FileServiceImpl {
   ) {
     let mimeType = d.input.mimeType ?? d.file.type ?? 'application/octet-stream';
     let storeId = generatePlainId(20);
+    let bufferContent = shouldBufferFileContent({
+      fileName: d.input.name,
+      size: d.file.size
+    });
 
-    await getStorage().putObject(getCargoFilesBucketName(), storeId, d.file, mimeType);
+    if (!bufferContent) {
+      await getStorage().putObject(getCargoFilesBucketName(), storeId, d.file, mimeType);
+    }
 
     let { file, input, ...scope } = d;
 
@@ -350,7 +498,14 @@ class FileServiceImpl {
       ...scope,
       storeId,
       internal: {
-        isReadOnly: true
+        isReadOnly: true,
+        contentPersistence: bufferContent
+          ? {
+              type: 'database',
+              content: new Uint8Array(await d.file.arrayBuffer()),
+              flushAfter: getPendingFileContentFlushAfter()
+            }
+          : { type: 'object' }
       },
       input: {
         id: d.input.id,
@@ -388,12 +543,14 @@ class FileServiceImpl {
       size += chunk.byteLength;
     }
 
-    await getStorage().putObject(
-      getCargoFilesBucketName(),
-      storeId,
-      new Blob(chunks as any[]),
-      mimeType
-    );
+    let blob = new Blob(chunks as any[]);
+    let bufferContent = shouldBufferFileContent({
+      fileName: d.input.name,
+      size
+    });
+    if (!bufferContent) {
+      await getStorage().putObject(getCargoFilesBucketName(), storeId, blob, mimeType);
+    }
 
     let { content, input, ...scope } = d;
 
@@ -401,7 +558,14 @@ class FileServiceImpl {
       ...scope,
       storeId,
       internal: {
-        isReadOnly: true
+        isReadOnly: true,
+        contentPersistence: bufferContent
+          ? {
+              type: 'database',
+              content: new Uint8Array(await blob.arrayBuffer()),
+              flushAfter: getPendingFileContentFlushAfter()
+            }
+          : { type: 'object' }
       },
       input: {
         id: d.input.id,
@@ -521,15 +685,23 @@ class FileServiceImpl {
           id: true
         }
       });
+      let pendingContent = await db.filePendingContent.findUnique({
+        where: { fileOid: d.file.oid },
+        select: { oid: true }
+      });
 
       let deletedFile = await db.file.update({
         where: {
           id: d.file.id
         },
         data: {
-          status: 'deleted'
+          status: 'deleted',
+          storeId: pendingContent ? '' : undefined
         },
         include
+      });
+      await db.filePendingContent.deleteMany({
+        where: { fileOid: d.file.oid }
       });
 
       return {

--- a/src/metorial/products/storage/modules/store/src/services/storeItemMutation.ts
+++ b/src/metorial/products/storage/modules/store/src/services/storeItemMutation.ts
@@ -1029,7 +1029,8 @@ class StoreItemMutationServiceImpl {
             target: d.target,
             actor: d.actor
           }),
-          created: false
+          created: false,
+          previousItem: existingItem
         };
       }
 
@@ -1062,6 +1063,7 @@ class StoreItemMutationServiceImpl {
       if (createResult.count === 1) {
         return {
           created: true,
+          previousItem: null,
           item: (await client.storeItem.findUnique({
             where: {
               id: itemId
@@ -1104,7 +1106,8 @@ class StoreItemMutationServiceImpl {
           target: d.target,
           actor: d.actor
         }),
-        created: false
+        created: false,
+        previousItem: conflictingItem
       };
     });
   }
@@ -1414,11 +1417,14 @@ class StoreItemMutationServiceImpl {
 
       await this.syncSkillAgentForStoreItemTransition({
         skill,
-        previousItem: null,
+        previousItem: result.previousItem,
         nextItem: result.item
       });
 
-      return result.item;
+      return {
+        item: result.item,
+        previousFile: result.previousItem?.file ?? null
+      };
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core file upload, read, deletion, and store-attach behavior plus a new DB model and background flush jobs; incorrect replace or cleanup logic could lose files or leave stale content.
> 
> **Overview**
> Adds **fast in-place updates** for skill store text files by uploading with `store_id`, `path`, and optional **`store_replace`** so the store item is updated in one request instead of upload + separate store modify.
> 
> On the backend, eligible **small text files** (under 1 MiB, known extensions) are written to new **`FilePendingContent`** in the database first and skip immediate object storage; a **flush queue/cron** later moves them to blob storage. Downloads read pending DB bytes when present and use **`private, no-store`** caching for that path. With **`store_replace`**, the previous file at that path can be **soft-deleted** when it has no durable references.
> 
> The skill **text file editor** drops the manual Save button in favor of **debounced autosave** (7s / 60s max), flush on leave/hide/unmount, and navigation blocking until save. The file tree separates **Upload File** from **Create File** in directory menus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49d48f216115ac872eaa448b5b75c966686f82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->