### PR TITLE
Add slate adapters

### DIFF
--- a/src/slates/apps/hub/package.json
+++ b/src/slates/apps/hub/package.json
@@ -92,7 +92,7 @@
     "@remixicon/react": "^4.0.0",
     "@sentry/bun": "^10.36.0",
     "@sentry/cli": "^3.2.0",
-    "@slates/proto": "1.0.0-rc.13",
+    "@slates/proto": "1.0.0-rc.14",
     "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",

--- a/src/slates/apps/hub/prisma/schema/adapter.prisma
+++ b/src/slates/apps/hub/prisma/schema/adapter.prisma
@@ -1,0 +1,92 @@
+model Adapter {
+  oid BigInt @id
+  id  String @unique
+
+  name       String
+  identifier String @unique
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  slateAdapters        SlateAdapter[]
+  slateVersionAdapters SlateVersionAdapter[]
+  adapterCapabilities  AdapterCapability[]
+}
+
+model AdapterCapability {
+  oid BigInt @id
+  id  String @unique
+
+  adapterOid BigInt
+  adapter    Adapter @relation(fields: [adapterOid], references: [oid])
+
+  identifier String
+
+  createdAt DateTime @default(now())
+
+  slateVersionAdapterCapabilities SlateVersionAdapterCapability[]
+
+  @@unique([adapterOid, identifier])
+}
+
+model SlateAdapter {
+  oid BigInt @id
+  id  String @unique
+
+  identifier String @unique
+
+  slateOid BigInt
+  slate    Slate  @relation(fields: [slateOid], references: [oid])
+
+  adapterOid BigInt
+  adapter    Adapter @relation(fields: [adapterOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  slateVersionAdapters SlateVersionAdapter[]
+  slateActions         SlateAction[]
+
+  @@unique([slateOid, adapterOid])
+}
+
+model SlateVersionAdapter {
+  oid BigInt @id
+  id  String @unique
+
+  slateVersionOid BigInt
+  slateVersion    SlateVersion @relation(fields: [slateVersionOid], references: [oid])
+
+  adapterOid BigInt
+  adapter    Adapter @relation(fields: [adapterOid], references: [oid])
+
+  slateAdapterOid BigInt
+  slateAdapter    SlateAdapter @relation(fields: [slateAdapterOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  slateVersionAdapterCapabilities SlateVersionAdapterCapability[]
+
+  @@unique([slateVersionOid, adapterOid])
+  @@unique([slateVersionOid, slateAdapterOid])
+}
+
+model SlateVersionAdapterCapability {
+  oid BigInt @id
+  id  String @unique
+
+  slateVersionAdapterOid BigInt
+  slateVersionAdapter    SlateVersionAdapter @relation(fields: [slateVersionAdapterOid], references: [oid])
+
+  adapterCapabilityOid BigInt
+  adapterCapability    AdapterCapability @relation(fields: [adapterCapabilityOid], references: [oid])
+
+  /// [SlateAdapterCapabilityValue]
+  value Json
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([slateVersionAdapterOid, adapterCapabilityOid])
+}

--- a/src/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/slates/apps/hub/prisma/schema/slate.prisma
@@ -46,6 +46,7 @@ model Slate {
   slateTriggerEventInputs   SlateTriggerEventInput[]
   changeNotifications       ChangeNotification[]
   slateErrors               SlateError[]
+  slateAdapters             SlateAdapter[]
 
   @@unique([registryOid, slateIdOnRegistry])
   @@unique([registryOid, slateFullIdentifierOnRegistry])
@@ -109,6 +110,7 @@ model SlateVersion {
   slateSessionToolCalls      SlateSessionToolCall[]
   changeNotifications        ChangeNotification[]
   slateErrors                SlateError[]
+  slateVersionAdapters       SlateVersionAdapter[]
 
   @@unique([slateOid, version])
 }
@@ -222,6 +224,9 @@ model SlateAction {
 
   slateOid BigInt
   slate    Slate  @relation(fields: [slateOid], references: [oid])
+
+  slateAdapterOid BigInt?
+  slateAdapter    SlateAdapter? @relation(fields: [slateAdapterOid], references: [oid])
 
   mostRecentSpecificationOid BigInt
   mostRecentSpecification    SlateSpecification @relation(fields: [mostRecentSpecificationOid], references: [oid])

--- a/src/slates/apps/hub/src/apis/internal/tests/slateSpecification.e2e.test.ts
+++ b/src/slates/apps/hub/src/apis/internal/tests/slateSpecification.e2e.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SlateStatus } from '../../../../prisma/generated/client';
+import { getId } from '../../../id';
 import { slatesHubClient } from '../../../test/client';
 import { fixtures } from '../../../test/fixtures';
 import { cleanDatabase, testDb } from '../../../test/setup';
@@ -77,6 +78,51 @@ describe('slateSpecification:get E2E', () => {
       id: slate.currentVersion.specification.id,
       protocolVersion: '1.0'
     });
+  });
+
+  it('includes the adapter for adapter actions', async () => {
+    const slate = await f.slate.complete({ slateStatus: SlateStatus.active });
+    const adapter = await testDb.adapter.create({
+      data: {
+        ...getId('adapter'),
+        identifier: 'github',
+        name: 'GitHub'
+      }
+    });
+    const slateAdapter = await testDb.slateAdapter.create({
+      data: {
+        ...getId('slateAdapter'),
+        identifier: `slate::${slate.id}::adapter::github`,
+        slateOid: slate.oid,
+        adapterOid: adapter.oid
+      }
+    });
+    const action = await f.slateSpecification.createAction({
+      slateOid: slate.oid,
+      specificationOid: slate.currentVersion.specification.oid,
+      overrides: { slateAdapterOid: slateAdapter.oid }
+    });
+    await f.slateSpecification.linkAction({
+      specificationOid: slate.currentVersion.specification.oid,
+      actionOid: action.oid
+    });
+
+    const result = await slatesHubClient.slateSpecification.get({
+      slateSpecificationId: slate.currentVersion.specification.id
+    });
+
+    expect(result.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          adapter: expect.objectContaining({
+            id: adapter.id,
+            identifier: adapter.identifier,
+            slateIdentifier: slateAdapter.identifier,
+            name: 'GitHub'
+          })
+        })
+      ])
+    );
   });
 });
 

--- a/src/slates/apps/hub/src/apis/internal/tests/slateVersion.e2e.test.ts
+++ b/src/slates/apps/hub/src/apis/internal/tests/slateVersion.e2e.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SlateStatus } from '../../../../prisma/generated/client';
+import { getId } from '../../../id';
 import { slatesHubClient } from '../../../test/client';
 import { fixtures } from '../../../test/fixtures';
 import { cleanDatabase, testDb } from '../../../test/setup';
@@ -68,6 +69,63 @@ describe('slateVersion:get E2E', () => {
       version: '1.0.0',
       slateId: slate.id
     });
+  });
+
+  it('includes discovered adapters', async () => {
+    const slate = await f.slate.complete({ slateStatus: SlateStatus.active });
+    const adapter = await testDb.adapter.create({
+      data: {
+        ...getId('adapter'),
+        identifier: 'github',
+        name: 'GitHub'
+      }
+    });
+    const slateAdapter = await testDb.slateAdapter.create({
+      data: {
+        ...getId('slateAdapter'),
+        identifier: `slate::${slate.id}::adapter::github`,
+        slateOid: slate.oid,
+        adapterOid: adapter.oid
+      }
+    });
+    const slateVersionAdapter = await testDb.slateVersionAdapter.create({
+      data: {
+        ...getId('slateVersionAdapter'),
+        slateVersionOid: slate.currentVersion.oid,
+        adapterOid: adapter.oid,
+        slateAdapterOid: slateAdapter.oid
+      }
+    });
+    const capability = await testDb.adapterCapability.create({
+      data: {
+        ...getId('adapterCapability'),
+        adapterOid: adapter.oid,
+        identifier: 'repo.read'
+      }
+    });
+    await testDb.slateVersionAdapterCapability.create({
+      data: {
+        ...getId('slateVersionAdapterCapability'),
+        slateVersionAdapterOid: slateVersionAdapter.oid,
+        adapterCapabilityOid: capability.oid,
+        value: true
+      }
+    });
+
+    const result = await slatesHubClient.slateVersion.get({
+      slateId: slate.id,
+      slateVersionId: slate.currentVersion.id
+    });
+
+    expect(result.adapters).toMatchObject([
+      {
+        id: adapter.id,
+        identifier: adapter.identifier,
+        slateIdentifier: slateAdapter.identifier,
+        name: 'GitHub',
+        capabilities: [{ id: 'repo.read', value: true }]
+      }
+    ]);
   });
 });
 

--- a/src/slates/apps/hub/src/db.ts
+++ b/src/slates/apps/hub/src/db.ts
@@ -2,6 +2,7 @@ import { PrismaPg } from '@prisma/adapter-pg';
 import { readReplicas } from '@prisma/extension-read-replicas';
 import type {
   SlatesAction as ProtoSlatesAction,
+  SlateAdapter as ProtoSlateAdapter,
   SlateAuthenticationMethod,
   SlatesMessageProviderIdentifyResponse
 } from '@slates/proto';
@@ -81,9 +82,13 @@ declare global {
 
     type SlateAuthMethod = SlateAuthenticationMethod;
     type SlateAction = ProtoSlatesAction;
+    type SlateAdapter = ProtoSlateAdapter;
+    type SlateAdapterCapabilities = ProtoSlateAdapter['capabilities'];
+    type SlateAdapterCapabilityValue = ProtoSlateAdapter['capabilities'][number]['value'];
 
     type SlateAuthMethods = SlateAuthenticationMethod[];
     type SlateActions = ProtoSlatesAction[];
+    type SlateAdapters = ProtoSlateAdapter[];
 
     type AnyRecord = Record<string, any>;
 

--- a/src/slates/apps/hub/src/id.ts
+++ b/src/slates/apps/hub/src/id.ts
@@ -20,6 +20,11 @@ export let ID = createIdGenerator({
   slateSpecification: idType.sorted('shspe'),
   slateSpecificationChange: idType.sorted('shspc'),
   slateAction: idType.sorted('shac'),
+  adapter: idType.sorted('shad'),
+  adapterCapability: idType.sorted('shadc'),
+  slateAdapter: idType.sorted('shsad'),
+  slateVersionAdapter: idType.sorted('shsvad'),
+  slateVersionAdapterCapability: idType.sorted('shsvac'),
   slateConfigSchema: idType.sorted('shcs'),
   slateAuthMethod: idType.sorted('sham'),
 

--- a/src/slates/apps/hub/src/presenters/adapter.ts
+++ b/src/slates/apps/hub/src/presenters/adapter.ts
@@ -1,0 +1,37 @@
+import type {
+  Adapter,
+  AdapterCapability,
+  SlateAdapter,
+  SlateVersionAdapter,
+  SlateVersionAdapterCapability
+} from '../../prisma/generated/client';
+
+export let adapterPresenter = (adapter: Adapter, slateIdentifier: string) => ({
+  object: 'slate.adapter',
+
+  id: adapter.id,
+  identifier: adapter.identifier,
+  slateIdentifier,
+  name: adapter.name,
+
+  createdAt: adapter.createdAt,
+  updatedAt: adapter.updatedAt
+});
+
+export let slateVersionAdapterPresenter = (
+  slateVersionAdapter: SlateVersionAdapter & {
+    slateAdapter: SlateAdapter & { adapter: Adapter };
+    slateVersionAdapterCapabilities: (SlateVersionAdapterCapability & {
+      adapterCapability: AdapterCapability;
+    })[];
+  }
+) => ({
+  ...adapterPresenter(
+    slateVersionAdapter.slateAdapter.adapter,
+    slateVersionAdapter.slateAdapter.identifier
+  ),
+  capabilities: slateVersionAdapter.slateVersionAdapterCapabilities.map(capability => ({
+    id: capability.adapterCapability.identifier,
+    value: capability.value
+  }))
+});

--- a/src/slates/apps/hub/src/presenters/index.ts
+++ b/src/slates/apps/hub/src/presenters/index.ts
@@ -3,6 +3,7 @@ export * from './registry';
 export * from './secret';
 export * from './slate';
 export * from './slateAction';
+export * from './adapter';
 export * from './slateAttachment';
 export * from './slateAuthConfig';
 export * from './slateAuthConfigEvent';

--- a/src/slates/apps/hub/src/presenters/slate.ts
+++ b/src/slates/apps/hub/src/presenters/slate.ts
@@ -1,8 +1,13 @@
 import type {
   Registry,
+  Adapter,
+  SlateAdapter,
   Slate,
   SlateSpecification,
-  SlateVersion
+  SlateVersion,
+  SlateVersionAdapter,
+  SlateVersionAdapterCapability,
+  AdapterCapability
 } from '../../prisma/generated/client';
 import { slateVersionPresenter } from './slateVersion';
 
@@ -12,10 +17,22 @@ export let slatePresenter = (
     currentVersion:
       | (SlateVersion & {
           specification: SlateSpecification | null;
+          slateVersionAdapters?: (SlateVersionAdapter & {
+            slateAdapter: SlateAdapter & { adapter: Adapter };
+            slateVersionAdapterCapabilities: (SlateVersionAdapterCapability & {
+              adapterCapability: AdapterCapability;
+            })[];
+          })[];
         })
       | null;
     slateVersions?: (SlateVersion & {
       specification: SlateSpecification | null;
+      slateVersionAdapters?: (SlateVersionAdapter & {
+        slateAdapter: SlateAdapter & { adapter: Adapter };
+        slateVersionAdapterCapabilities: (SlateVersionAdapterCapability & {
+          adapterCapability: AdapterCapability;
+        })[];
+      })[];
     })[];
   }
 ) => ({

--- a/src/slates/apps/hub/src/presenters/slateAction.ts
+++ b/src/slates/apps/hub/src/presenters/slateAction.ts
@@ -1,8 +1,10 @@
-import type { Slate, SlateAction } from '../../prisma/generated/client';
+import type { Adapter, Slate, SlateAction, SlateAdapter } from '../../prisma/generated/client';
+import { adapterPresenter } from './adapter';
 
 export let slateActionPresenter = (
   method: SlateAction & {
     slate: Slate;
+    slateAdapter: (SlateAdapter & { adapter: Adapter }) | null;
   }
 ) => {
   let spec = method.spec as typeof method.spec & { authMethods?: string[] | null };
@@ -31,6 +33,9 @@ export let slateActionPresenter = (
     tags: method.spec.tags,
     scopes: method.spec.scopes,
     authMethods: spec.authMethods,
+    adapter: method.slateAdapter
+      ? adapterPresenter(method.slateAdapter.adapter, method.slateAdapter.identifier)
+      : null,
 
     createdAt: method.createdAt
   };

--- a/src/slates/apps/hub/src/presenters/slateSpecification.ts
+++ b/src/slates/apps/hub/src/presenters/slateSpecification.ts
@@ -1,5 +1,7 @@
 import type {
   Slate,
+  Adapter,
+  SlateAdapter,
   SlateAction,
   SlateAuthMethod,
   SlateSpecification,
@@ -14,7 +16,9 @@ export let slateSpecificationPresenter = (
     slate: Slate;
 
     slateAuthMethods: (SlateSpecificationAuthMethod & { authMethod: SlateAuthMethod })[];
-    slateActions: (SlateSpecificationAction & { action: SlateAction })[];
+    slateActions: (SlateSpecificationAction & {
+      action: SlateAction & { slateAdapter: (SlateAdapter & { adapter: Adapter }) | null };
+    })[];
   }
 ) => ({
   object: 'slate.specification',

--- a/src/slates/apps/hub/src/presenters/slateSpecificationChange.ts
+++ b/src/slates/apps/hub/src/presenters/slateSpecificationChange.ts
@@ -1,5 +1,7 @@
 import type {
   Slate,
+  Adapter,
+  SlateAdapter,
   SlateAction,
   SlateAuthMethod,
   SlateSpecification,
@@ -19,11 +21,15 @@ export let slateSpecificationChangePresenter = (
 
     fromSpecification: SlateSpecification & {
       slateAuthMethods: (SlateSpecificationAuthMethod & { authMethod: SlateAuthMethod })[];
-      slateActions: (SlateSpecificationAction & { action: SlateAction })[];
+      slateActions: (SlateSpecificationAction & {
+        action: SlateAction & { slateAdapter: (SlateAdapter & { adapter: Adapter }) | null };
+      })[];
     };
     toSpecification: SlateSpecification & {
       slateAuthMethods: (SlateSpecificationAuthMethod & { authMethod: SlateAuthMethod })[];
-      slateActions: (SlateSpecificationAction & { action: SlateAction })[];
+      slateActions: (SlateSpecificationAction & {
+        action: SlateAction & { slateAdapter: (SlateAdapter & { adapter: Adapter }) | null };
+      })[];
     };
   }
 ) => ({

--- a/src/slates/apps/hub/src/presenters/slateVersion.ts
+++ b/src/slates/apps/hub/src/presenters/slateVersion.ts
@@ -1,10 +1,26 @@
 import { shadowId } from '@lowerdeck/shadow-id';
-import type { Slate, SlateSpecification, SlateVersion } from '../../prisma/generated/client';
+import type {
+  Adapter,
+  SlateAdapter,
+  Slate,
+  SlateSpecification,
+  SlateVersion,
+  SlateVersionAdapter,
+  SlateVersionAdapterCapability,
+  AdapterCapability
+} from '../../prisma/generated/client';
+import { slateVersionAdapterPresenter } from './adapter';
 
 export let slateVersionPresenter = (
   slateVersion: SlateVersion & {
     slate: Slate;
     specification: SlateSpecification | null;
+    slateVersionAdapters?: (SlateVersionAdapter & {
+      slateAdapter: SlateAdapter & { adapter: Adapter };
+      slateVersionAdapterCapabilities: (SlateVersionAdapterCapability & {
+        adapterCapability: AdapterCapability;
+      })[];
+    })[];
   }
 ) => ({
   object: 'slate.version',
@@ -18,6 +34,8 @@ export let slateVersionPresenter = (
   slateId: slateVersion.slate.id,
 
   manifest: slateVersion.manifest,
+
+  adapters: slateVersion.slateVersionAdapters?.map(slateVersionAdapterPresenter) ?? [],
 
   specification: slateVersion.specification
     ? {

--- a/src/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/slates/apps/hub/src/queues/discovery/discover.ts
@@ -1,7 +1,7 @@
 import { createLock } from '@lowerdeck/lock';
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { getSentry } from '@lowerdeck/sentry';
-import type { SlateAuthenticationMethod, SlatesAction } from '@slates/proto';
+import type { SlateAdapter, SlateAuthenticationMethod, SlatesAction } from '@slates/proto';
 import { differenceInMinutes } from 'date-fns';
 import semver from 'semver';
 import { db } from '../../db';
@@ -112,21 +112,216 @@ let syncSpecificationConfigSchema = async (d: {
   });
 };
 
+let syncDiscoveredAdapters = async (d: {
+  adapters: SlateAdapter[];
+  slateOid: bigint;
+  slateId: string;
+  slateVersionOid: bigint;
+}) => {
+  let adaptersById = new Map(d.adapters.map(adapter => [adapter.id, adapter]));
+  let adapters = [...adaptersById.values()];
+
+  for (let adapter of adapters) {
+    await db.adapter.upsert({
+      where: { identifier: adapter.id },
+      create: {
+        ...getId('adapter'),
+        identifier: adapter.id,
+        name: adapter.name
+      },
+      update: { name: adapter.name }
+    });
+  }
+
+  let upsertedAdapters = adapters.length
+    ? await db.adapter.findMany({
+        where: { identifier: { in: adapters.map(adapter => adapter.id) } }
+      })
+    : [];
+  let adapterOidByIdentifier = new Map(
+    upsertedAdapters.map(adapter => [adapter.identifier, adapter.oid])
+  );
+  let adapterOidById = new Map(
+    adapters.flatMap(adapter => {
+      let adapterOid = adapterOidByIdentifier.get(adapter.id);
+      return adapterOid ? [[adapter.id, adapterOid] as const] : [];
+    })
+  );
+
+  for (let adapter of adapters) {
+    let adapterOid = adapterOidById.get(adapter.id);
+    if (!adapterOid) continue;
+
+    await db.slateAdapter.upsert({
+      where: { slateOid_adapterOid: { slateOid: d.slateOid, adapterOid } },
+      create: {
+        ...getId('slateAdapter'),
+        identifier: `slate::${d.slateId}::adapter::${adapter.id}`,
+        slateOid: d.slateOid,
+        adapterOid
+      },
+      update: { identifier: `slate::${d.slateId}::adapter::${adapter.id}` }
+    });
+  }
+
+  let slateAdapters = await db.slateAdapter.findMany({
+    where: { slateOid: d.slateOid, adapterOid: { in: [...adapterOidById.values()] } },
+    select: { oid: true, adapterOid: true }
+  });
+  let slateAdapterOidByAdapterOid = new Map(
+    slateAdapters.map(slateAdapter => [slateAdapter.adapterOid, slateAdapter.oid])
+  );
+  let slateAdapterOidById = new Map(
+    adapters.flatMap(adapter => {
+      let adapterOid = adapterOidById.get(adapter.id);
+      let slateAdapterOid = adapterOid
+        ? slateAdapterOidByAdapterOid.get(adapterOid)
+        : undefined;
+      return slateAdapterOid ? [[adapter.id, slateAdapterOid] as const] : [];
+    })
+  );
+
+  for (let adapter of adapters) {
+    let adapterOid = adapterOidById.get(adapter.id);
+    if (!adapterOid) continue;
+
+    let capabilitiesById = new Map(
+      adapter.capabilities.map(capability => [capability.id, capability])
+    );
+    for (let capability of capabilitiesById.values()) {
+      await db.adapterCapability.upsert({
+        where: {
+          adapterOid_identifier: {
+            adapterOid,
+            identifier: capability.id
+          }
+        },
+        create: {
+          ...getId('adapterCapability'),
+          adapterOid,
+          identifier: capability.id
+        },
+        update: {}
+      });
+    }
+  }
+
+  let desiredSlateAdapterOids = [...slateAdapterOidById.values()];
+  let staleVersionAdapters = await db.slateVersionAdapter.findMany({
+    where: {
+      slateVersionOid: d.slateVersionOid,
+      slateAdapterOid: { notIn: desiredSlateAdapterOids }
+    },
+    select: { oid: true }
+  });
+  if (staleVersionAdapters.length > 0) {
+    await db.slateVersionAdapterCapability.deleteMany({
+      where: { slateVersionAdapterOid: { in: staleVersionAdapters.map(a => a.oid) } }
+    });
+    await db.slateVersionAdapter.deleteMany({
+      where: { oid: { in: staleVersionAdapters.map(a => a.oid) } }
+    });
+  }
+
+  await db.slateVersionAdapter.createMany({
+    skipDuplicates: true,
+    data: adapters.flatMap(adapter => {
+      let adapterOid = adapterOidById.get(adapter.id);
+      let slateAdapterOid = slateAdapterOidById.get(adapter.id);
+      return adapterOid && slateAdapterOid
+        ? [
+            {
+              ...getId('slateVersionAdapter'),
+              slateVersionOid: d.slateVersionOid,
+              adapterOid,
+              slateAdapterOid
+            }
+          ]
+        : [];
+    })
+  });
+
+  let slateVersionAdapters = await db.slateVersionAdapter.findMany({
+    where: { slateVersionOid: d.slateVersionOid },
+    select: { oid: true, slateAdapterOid: true }
+  });
+  let slateVersionAdapterOidBySlateAdapterOid = new Map(
+    slateVersionAdapters.map(adapter => [adapter.slateAdapterOid, adapter.oid])
+  );
+
+  let adapterCapabilities = await db.adapterCapability.findMany({
+    where: { adapterOid: { in: upsertedAdapters.map(adapter => adapter.oid) } },
+    select: { oid: true, adapterOid: true, identifier: true }
+  });
+  let adapterCapabilityOidByKey = new Map(
+    adapterCapabilities.map(capability => [
+      `${capability.adapterOid}:${capability.identifier}`,
+      capability.oid
+    ])
+  );
+  let slateVersionAdapterOids = [...slateVersionAdapterOidBySlateAdapterOid.values()];
+
+  await db.slateVersionAdapterCapability.deleteMany({
+    where: { slateVersionAdapterOid: { in: slateVersionAdapterOids } }
+  });
+
+  let versionCapabilities = adapters.flatMap(adapter => {
+    let adapterOid = adapterOidById.get(adapter.id);
+    let slateAdapterOid = slateAdapterOidById.get(adapter.id);
+    if (!adapterOid || !slateAdapterOid) return [];
+    let slateVersionAdapterOid = slateVersionAdapterOidBySlateAdapterOid.get(slateAdapterOid);
+    if (!slateVersionAdapterOid) return [];
+
+    return [
+      ...new Map(adapter.capabilities.map(capability => [capability.id, capability])).values()
+    ].flatMap(capability => {
+      let adapterCapabilityOid = adapterCapabilityOidByKey.get(
+        `${adapterOid}:${capability.id}`
+      );
+      return adapterCapabilityOid
+        ? [
+            {
+              ...getId('slateVersionAdapterCapability'),
+              slateVersionAdapterOid,
+              adapterCapabilityOid,
+              value: capability.value
+            }
+          ]
+        : [];
+    });
+  });
+  if (versionCapabilities.length > 0) {
+    await db.slateVersionAdapterCapability.createMany({
+      data: versionCapabilities
+    });
+  }
+
+  return slateAdapterOidById;
+};
+
 let buildActionUpsertData = async (d: {
   actions: SlatesAction[];
   slateOid: bigint;
   specificationOid: bigint;
   identifierBase: string;
   actionHashes: string[];
+  slateAdapterOidById: Map<string, bigint>;
 }) =>
   d.actions.map((action, index) => {
     let hash = d.actionHashes[index]!;
     let identifier = `${d.identifierBase}::action::${action.id}::${hash}`;
+    let slateAdapterOid = action.adapter
+      ? d.slateAdapterOidById.get(action.adapter)
+      : undefined;
+    if (action.adapter && !slateAdapterOid) {
+      throw new Error(`Adapter not found for action ${action.id}: ${action.adapter}`);
+    }
 
     return {
       ...getId('slateAction'),
       slateOid: d.slateOid,
       mostRecentSpecificationOid: d.specificationOid,
+      slateAdapterOid,
 
       type: {
         'action.tool': 'tool' as const,
@@ -289,7 +484,8 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         slateInvocationService.getConfigSchema({ stack }),
         // slateInvocationService.getDefaultConfig({ stack }),
         slateInvocationService.listAuthMethods({ stack }),
-        slateInvocationService.listActions({ stack })
+        slateInvocationService.listActions({ stack }),
+        slateInvocationService.listAdapters({ stack })
       ]);
 
       let invocation = stackResult[0].invocation;
@@ -307,7 +503,7 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         return;
       }
 
-      let [providerInfo, configSchema, authMethods, actions] =
+      let [providerInfo, configSchema, authMethods, actions, adapters] =
         getStackResultsOrThrow(stackResult);
 
       let discoveredAuthMethods = dedupeDiscoveredItems(authMethods.authenticationMethods, {
@@ -375,7 +571,13 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         slateOid: slate.oid,
         specificationOid: specification.oid,
         identifierBase,
-        actionHashes: discoveryHashes.actionHashes
+        actionHashes: discoveryHashes.actionHashes,
+        slateAdapterOidById: await syncDiscoveredAdapters({
+          adapters: adapters.adapters,
+          slateOid: slate.oid,
+          slateId: slate.id,
+          slateVersionOid: version.oid
+        })
       });
       await db.slateAction.createManyAndReturn({
         skipDuplicates: true,

--- a/src/slates/apps/hub/src/services/slate.ts
+++ b/src/slates/apps/hub/src/services/slate.ts
@@ -10,14 +10,26 @@ let include = {
   registry: true,
   currentVersion: {
     include: {
-      specification: true
+      specification: true,
+      slateVersionAdapters: {
+        include: {
+          slateAdapter: { include: { adapter: true } },
+          slateVersionAdapterCapabilities: { include: { adapterCapability: true } }
+        }
+      }
     }
   },
   slateVersions: {
     orderBy: [{ createdAt: 'desc' as const }, { oid: 'desc' as const }],
     take: 1,
     include: {
-      specification: true
+      specification: true,
+      slateVersionAdapters: {
+        include: {
+          slateAdapter: { include: { adapter: true } },
+          slateVersionAdapterCapabilities: { include: { adapterCapability: true } }
+        }
+      }
     }
   }
 };

--- a/src/slates/apps/hub/src/services/slateInvocation.ts
+++ b/src/slates/apps/hub/src/services/slateInvocation.ts
@@ -208,8 +208,16 @@ class slateInvocationServiceImpl {
     });
   }
 
+  async listAdapters(d: { stack: SlateInvocationStack }) {
+    return await d.stack.invoke('slates/adapters.list', {});
+  }
+
+  async getAdapter(d: { stack: SlateInvocationStack; adapterId: string }) {
+    return await d.stack.invoke('slates/adapter.get', { adapterId: d.adapterId });
+  }
+
   async listActions(d: { stack: SlateInvocationStack }) {
-    return await d.stack.invoke('slates/actions.list', {});
+    return await d.stack.invoke('slates/actions.list', { includeAdapterActions: true });
   }
 
   async getAction(d: { stack: SlateInvocationStack; actionId: string }) {

--- a/src/slates/apps/hub/src/services/slateSpecification.ts
+++ b/src/slates/apps/hub/src/services/slateSpecification.ts
@@ -9,7 +9,7 @@ let include = {
     include: { authMethod: true }
   },
   slateActions: {
-    include: { action: true }
+    include: { action: { include: { slateAdapter: { include: { adapter: true } } } } }
   },
   slateConfigSchemas: {
     include: { configSchema: true }

--- a/src/slates/apps/hub/src/services/slateSpecificationChange.ts
+++ b/src/slates/apps/hub/src/services/slateSpecificationChange.ts
@@ -10,13 +10,13 @@ let include = {
   fromSpecification: {
     include: {
       slateAuthMethods: { include: { authMethod: true } },
-      slateActions: { include: { action: true } }
+      slateActions: { include: { action: { include: { slateAdapter: { include: { adapter: true } } } } } }
     }
   },
   toSpecification: {
     include: {
       slateAuthMethods: { include: { authMethod: true } },
-      slateActions: { include: { action: true } }
+      slateActions: { include: { action: { include: { slateAdapter: { include: { adapter: true } } } } } }
     }
   }
 };

--- a/src/slates/apps/hub/src/services/slateVersion.ts
+++ b/src/slates/apps/hub/src/services/slateVersion.ts
@@ -12,7 +12,13 @@ let include = {
       registry: true
     }
   },
-  specification: true
+  specification: true,
+  slateVersionAdapters: {
+    include: {
+      slateAdapter: { include: { adapter: true } },
+      slateVersionAdapterCapabilities: { include: { adapterCapability: true } }
+    }
+  }
 };
 
 class slateVersionServiceImpl {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches discovery persistence and versioned adapter sync (delete/recreate capabilities), which can affect specification/action consistency if discovery fails mid-sync; requires a Prisma schema migration in deployed environments.
> 
> **Overview**
> Adds **first-class slate adapters** to the hub: new Prisma models link global adapters, per-slate bindings, per-version snapshots, and capability values; `SlateAction` can optionally reference a `SlateAdapter`.
> 
> **Discovery** now calls `slates/adapters.list` alongside existing discovery, runs `syncDiscoveredAdapters` to upsert adapter graph data and prune stale version adapters, and maps each action’s proto `adapter` field to `slateAdapterOid` (fails discovery if the adapter is missing). Action listing uses `includeAdapterActions: true`; `@slates/proto` is bumped to `1.0.0-rc.14`.
> 
> **API responses** expose adapters on slate versions (`adapters` with capabilities) and on specification tools/triggers (`adapter` on each action). Services load the new relations; E2E tests cover both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0322aa7afc6e734e1eed579b88eba071b2b73a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->