### PR TITLE
Truncate provider error messages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@metorial/oss",
@@ -5065,7 +5066,7 @@
         "@remixicon/react": "^4.0.0",
         "@sentry/bun": "^10.36.0",
         "@sentry/cli": "^3.2.0",
-        "@slates/proto": "1.0.0-rc.13",
+        "@slates/proto": "1.0.0-rc.14",
         "@types/semver": "^7.7.1",
         "@types/unzipper": "^0.10.11",
         "date-fns": "^4.1.0",
@@ -7172,7 +7173,7 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
-    "@slates/proto": ["@slates/proto@1.0.0-rc.13", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-LpXwx2UnG6X6JlzKINdGNLFfSFt8F737dIbVvO31Kmv+i2egpBxm6g2mbmclke+Qe2WCBDnv3pMt0B+43PErOQ=="],
+    "@slates/proto": ["@slates/proto@1.0.0-rc.14", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-wEayhNEw1ZHXpPQ5bxT9PCI6rviDJoO85r2/twEswcd1Ck7Zcbe1uH8/mPg6PpogCp/ned3RP78rQ5rGxIOqJA=="],
 
     "@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 minimumReleaseAge = 604800
-minimumReleaseAgeExcludes = ["@codemirror/view", "resend"]
+minimumReleaseAgeExcludes = ["@codemirror/view", "resend", "@slates/proto"]
 linker = "hoisted"

--- a/src/metorial-frontend/apps/dashboard/src/product/pages/(logs)/provider-auth-error/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/(logs)/provider-auth-error/_layout.tsx
@@ -63,6 +63,11 @@ let humanizeCode = (code: string) =>
 
 let getErrorLabel = (code: string) => ERROR_LABELS[code] ?? humanizeCode(code);
 
+let truncate = (str: string, maxLength: number) => {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength) + '...';
+};
+
 export let ProviderAuthErrorLayout = () => {
   let instance = useCurrentInstance();
   let project = useCurrentProject();
@@ -97,7 +102,10 @@ export let ProviderAuthErrorLayout = () => {
       }
     >
       <ContentPanelLayout
-        title={group.data?.message ?? `Auth error ${providerAuthErrorId?.slice(0, 8)}...`}
+        title={truncate(
+          group.data?.message ?? `Auth error ${providerAuthErrorId?.slice(0, 8)}...`,
+          80
+        )}
         breadcrumbs={[
           {
             label: 'Auth Errors',

--- a/src/metorial-frontend/apps/dashboard/src/product/pages/(logs)/provider-error/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/(logs)/provider-error/_layout.tsx
@@ -45,6 +45,11 @@ let ExtraLabel = styled.span`
   color: ${theme.colors.gray600};
 `;
 
+let truncate = (str: string, maxLength: number) => {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength) + '...';
+};
+
 export let ProviderErrorLayout = () => {
   let instance = useCurrentInstance();
   let project = useCurrentProject();
@@ -75,7 +80,7 @@ export let ProviderErrorLayout = () => {
       }
     >
       <ContentPanelLayout
-        title={error.data?.message ?? `Error ${providerErrorId?.slice(0, 8)}...`}
+        title={truncate(error.data?.message ?? `Error ${providerErrorId?.slice(0, 8)}...`, 80)}
         breadcrumbs={[
           {
             label: 'Errors',

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthErrors/groupsTable.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthErrors/groupsTable.tsx
@@ -1,14 +1,14 @@
 import { DashboardInstanceProviderAuthConfigErrorsGroupsListOutput } from '@metorial/dashboard-sdk';
 import { Paths } from '@metorial/frontend-config';
 import { useCurrentInstance, useProviderAuthConfigErrorGroups } from '@metorial/state';
-import { Badge, RenderDate, Text } from '@metorial/ui';
-import { ID } from '@metorial/ui-product';
-import { Table as DashboardTable } from '@metorial/table';
 import {
+  Table as DashboardTable,
   TableStateProvider,
   TableStateProviderResult,
   getStringFilterValue
 } from '@metorial/table';
+import { Badge, RenderDate, Text } from '@metorial/ui';
+import { ID } from '@metorial/ui-product';
 import { getErrorLabel } from '../errorGroupLabel';
 
 type ErrorGroup = DashboardInstanceProviderAuthConfigErrorsGroupsListOutput['items'][number];
@@ -43,6 +43,11 @@ let errorGroupsTableState: TableStateProvider<
   };
 };
 
+let truncate = (str: string, maxLength: number) => {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength) + '...';
+};
+
 let providerAuthErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps, ErrorGroup>(
   'provider-auth-error-groups'
 )
@@ -63,7 +68,7 @@ let providerAuthErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps
       id: 'message',
       isDefault: true,
       header: 'Details',
-      render: group => <Text size="2">{group.message}</Text>
+      render: group => <Text size="2">{truncate(group.message, 100)}</Text>
     },
     {
       id: 'occurrenceCount',

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/providerErrors/groupsTable.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/providerErrors/groupsTable.tsx
@@ -4,16 +4,16 @@ import {
 } from '@metorial/dashboard-sdk';
 import { Paths } from '@metorial/frontend-config';
 import { useCurrentInstance, useSessionErrorGroups } from '@metorial/state';
-import { Badge, RenderDate, Text } from '@metorial/ui';
-import { ID } from '@metorial/ui-product';
-import { Table as DashboardTable } from '@metorial/table';
 import {
+  Table as DashboardTable,
   FilterPayload,
   TableStateProvider,
   TableStateProviderResult,
   getEnumListFilterValue,
   getStringFilterValue
 } from '@metorial/table';
+import { Badge, RenderDate, Text } from '@metorial/ui';
+import { ID } from '@metorial/ui-product';
 import { getErrorLabel } from '../errorGroupLabel';
 
 type ErrorGroup = DashboardInstanceSessionsErrorGroupsListOutput['items'][number];
@@ -57,6 +57,11 @@ let errorGroupsTableState: TableStateProvider<
   };
 };
 
+let truncate = (str: string, maxLength: number) => {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength) + '...';
+};
+
 let providerErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps, ErrorGroup>(
   'provider-error-groups'
 )
@@ -77,7 +82,7 @@ let providerErrorGroupsTable = new DashboardTable<ErrorGroupsTableStateProps, Er
       id: 'message',
       isDefault: true,
       header: 'Details',
-      render: error => <Text size="2">{error.message}</Text>
+      render: error => <Text size="2">{truncate(error.message, 100)}</Text>
     },
     {
       id: 'occurrenceCount',

--- a/src/metorial/subspace/db/prisma/schema/provider/adapter.prisma
+++ b/src/metorial/subspace/db/prisma/schema/provider/adapter.prisma
@@ -1,0 +1,93 @@
+model ProviderAdapterGlobal {
+  oid BigInt @id
+  id  String @unique
+
+  identifier String @unique
+  name       String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  providerAdapters ProviderAdapter[]
+}
+
+model ProviderAdapter {
+  oid BigInt @id
+  id  String @unique
+
+  identifier String
+
+  globalOid BigInt
+  global    ProviderAdapterGlobal @relation(fields: [globalOid], references: [oid])
+
+  providerOid BigInt
+  provider    Provider @relation(fields: [providerOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  capabilities    ProviderAdapterCapability[]
+  providerVersions ProviderVersionAdapter[]
+  tools           ProviderTool[]
+  triggers        ProviderTrigger[]
+
+  @@unique([providerOid, identifier])
+  @@unique([providerOid, globalOid])
+  @@index([identifier])
+}
+
+model ProviderAdapterCapability {
+  oid BigInt @id
+  id  String @unique
+
+  identifier String
+
+  adapterOid BigInt
+  adapter    ProviderAdapter @relation(fields: [adapterOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  providerVersionAdapterCapabilities ProviderVersionAdapterCapability[]
+
+  @@unique([adapterOid, identifier])
+}
+
+model ProviderVersionAdapter {
+  oid BigInt @id
+  id  String @unique
+
+  /// [ProviderAdapterCapabilities]
+  capabilities Json @default("[]")
+
+  providerVersionOid BigInt
+  providerVersion    ProviderVersion @relation(fields: [providerVersionOid], references: [oid])
+
+  adapterOid BigInt
+  adapter    ProviderAdapter @relation(fields: [adapterOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  capabilityValues ProviderVersionAdapterCapability[]
+
+  @@unique([providerVersionOid, adapterOid])
+}
+
+model ProviderVersionAdapterCapability {
+  oid BigInt @id
+  id  String @unique
+
+  providerVersionAdapterOid BigInt
+  providerVersionAdapter    ProviderVersionAdapter @relation(fields: [providerVersionAdapterOid], references: [oid], onDelete: Cascade)
+
+  adapterCapabilityOid BigInt
+  adapterCapability    ProviderAdapterCapability @relation(fields: [adapterCapabilityOid], references: [oid])
+
+  value Json
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([providerVersionAdapterOid, adapterCapabilityOid])
+}

--- a/src/metorial/subspace/db/prisma/schema/provider/provider.prisma
+++ b/src/metorial/subspace/db/prisma/schema/provider/provider.prisma
@@ -84,6 +84,7 @@ model Provider {
   providerOAuthSetups            ProviderOAuthSetup[]
   providerAuthConfigs            ProviderAuthConfig[]
   providerTriggers               ProviderTrigger[]
+  providerAdapters               ProviderAdapter[]
   providerToolGlobals            ProviderToolGlobal[]
   providerAuthMethodGlobals      ProviderAuthMethodGlobal[]
   providerTriggerGlobals         ProviderTriggerGlobal[]

--- a/src/metorial/subspace/db/prisma/schema/provider/spec.prisma
+++ b/src/metorial/subspace/db/prisma/schema/provider/spec.prisma
@@ -44,6 +44,9 @@ model ProviderTool {
   globalOid BigInt
   global    ProviderToolGlobal @relation(fields: [globalOid], references: [oid])
 
+  adapterOid BigInt?
+  adapter    ProviderAdapter? @relation(fields: [adapterOid], references: [oid])
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -53,6 +56,7 @@ model ProviderTool {
 
   @@unique([providerOid, specificationOid, hash])
   @@unique([specificationOid, key])
+  @@index([specificationOid, adapterOid])
 }
 
 model ProviderAuthMethodGlobal {
@@ -222,6 +226,9 @@ model ProviderTrigger {
   globalOid BigInt
   global    ProviderTriggerGlobal @relation(fields: [globalOid], references: [oid])
 
+  adapterOid BigInt?
+  adapter    ProviderAdapter? @relation(fields: [adapterOid], references: [oid])
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -230,4 +237,5 @@ model ProviderTrigger {
 
   @@unique([providerOid, specificationOid, hash])
   @@unique([specificationOid, key])
+  @@index([specificationOid, adapterOid])
 }

--- a/src/metorial/subspace/db/prisma/schema/provider/version.prisma
+++ b/src/metorial/subspace/db/prisma/schema/provider/version.prisma
@@ -69,6 +69,7 @@ model ProviderVersion {
   providerDeploymentVersions                   ProviderDeploymentVersion[]
   providerDeploymentConfigPairDiscoveries      ProviderDeploymentConfigPairDiscovery[]
   sessionConnectionProviderSpecifications      SessionConnectionProviderSpecification[]
+  providerAdapters                             ProviderVersionAdapter[]
 
   @@index([createdAt])
   @@index([updatedAt])

--- a/src/metorial/subspace/db/src/db.ts
+++ b/src/metorial/subspace/db/src/db.ts
@@ -90,6 +90,11 @@ declare global {
 
     type ProviderTriggerValue = SpecificationTrigger;
 
+    type ProviderAdapterCapabilities = {
+      id: string;
+      value: any;
+    }[];
+
     type ActionScopes = {
       AND: {
         OR: string[];

--- a/src/metorial/subspace/db/src/id.ts
+++ b/src/metorial/subspace/db/src/id.ts
@@ -71,6 +71,11 @@ export let ID = createIdGenerator({
   providerAuthMethodGlobal: idType.sorted('pamg'),
   providerTrigger: idType.sorted('ptr'),
   providerTriggerGlobal: idType.sorted('ptrg'),
+  providerAdapterGlobal: idType.sorted('padg'),
+  providerAdapter: idType.sorted('pad'),
+  providerAdapterCapability: idType.sorted('padc'),
+  providerVersionAdapter: idType.sorted('pva'),
+  providerVersionAdapterCapability: idType.sorted('pvac'),
 
   providerAuthCredentials: idType.sorted('par'),
   managedProviderAuthCredentials: idType.sorted('pmac'),

--- a/src/metorial/subspace/modules/auth/src/services/providerSetupSessionUi.ts
+++ b/src/metorial/subspace/modules/auth/src/services/providerSetupSessionUi.ts
@@ -702,7 +702,8 @@ class providerSetupSessionUiServiceImpl {
 
     let tools = await db.providerTool.findMany({
       where: {
-        specificationOid
+        specificationOid,
+        adapterOid: null
       },
       orderBy: {
         name: 'asc'

--- a/src/metorial/subspace/modules/callback/src/reconciler/lib/sync.ts
+++ b/src/metorial/subspace/modules/callback/src/reconciler/lib/sync.ts
@@ -237,13 +237,15 @@ export let syncCallbackInstance = async (d: {
   if (!callbackInstance) return;
 
   let callback = callbackInstance.callback;
-  let providerTriggerInputs = callback.callbackProviderTriggers.map(trigger => ({
-    triggerId: trigger.providerTrigger.specId,
-    ...(callback.pollIntervalSecondsOverride !== null &&
-    callback.pollIntervalSecondsOverride !== undefined
-      ? { pollIntervalSeconds: callback.pollIntervalSecondsOverride }
-      : {})
-  }));
+  let providerTriggerInputs = callback.callbackProviderTriggers
+    .filter(trigger => !trigger.providerTrigger.adapterOid)
+    .map(trigger => ({
+      triggerId: trigger.providerTrigger.specId,
+      ...(callback.pollIntervalSecondsOverride !== null &&
+      callback.pollIntervalSecondsOverride !== undefined
+        ? { pollIntervalSeconds: callback.pollIntervalSecondsOverride }
+        : {})
+    }));
   let eventTypes = [
     ...new Set(callback.callbackProviderTriggers.flatMap(trigger => trigger.eventTypes))
   ];

--- a/src/metorial/subspace/modules/callback/src/services/callback.test.ts
+++ b/src/metorial/subspace/modules/callback/src/services/callback.test.ts
@@ -137,6 +137,10 @@ describe('Callback creation double-writes the mirrored scoping columns', () => {
   it('writes projectOid and instanceOid next to the legacy oids', async () => {
     await callbackService.createCallbackInternal(createParams(linkedScope));
 
+    expect(mocks.providerTriggerFindMany).toHaveBeenCalledWith({
+      where: { specificationOid: 40n, adapterOid: null }
+    });
+
     expect(mocks.callbackCreate).toHaveBeenCalledTimes(1);
     expect(mocks.callbackCreate.mock.calls[0]![0].data).toMatchObject({
       tenantOid: 10n,

--- a/src/metorial/subspace/modules/callback/src/services/callback.ts
+++ b/src/metorial/subspace/modules/callback/src/services/callback.ts
@@ -283,7 +283,7 @@ class callbackServiceImpl {
     }
 
     let providerTriggers = await db.providerTrigger.findMany({
-      where: { specificationOid: version.specificationOid }
+      where: { specificationOid: version.specificationOid, adapterOid: null }
     });
 
     let byMatcher = new Map<string, (typeof providerTriggers)[number]>();

--- a/src/metorial/subspace/modules/catalog/src/services/providerSpecification.ts
+++ b/src/metorial/subspace/modules/catalog/src/services/providerSpecification.ts
@@ -107,9 +107,9 @@ class providerSpecificationServiceImpl {
 
             include: {
               provider: true,
-              providerTools: true,
+              providerTools: { where: { adapterOid: null } },
               providerAuthMethods: true,
-              providerTriggers: true
+              providerTriggers: { where: { adapterOid: null } }
             }
           })
       )

--- a/src/metorial/subspace/modules/catalog/src/services/providerTool.ts
+++ b/src/metorial/subspace/modules/catalog/src/services/providerTool.ts
@@ -47,8 +47,12 @@ let buildToolsWhere = (ctx: ListToolsContext) => ({
   ],
   providerOid: ctx.providerVersion.providerOid,
   ...(ctx.version?.specificationOid
-    ? { providerTools: { some: { specificationOid: ctx.version.specificationOid } } }
-    : { currentInstance: { isNot: null } })
+    ? {
+        providerTools: {
+          some: { specificationOid: ctx.version.specificationOid, adapterOid: null }
+        }
+      }
+    : { currentInstance: { is: { adapterOid: null } } })
 });
 
 let buildToolsInclude = (ctx: ListToolsContext) => ({
@@ -58,16 +62,13 @@ let buildToolsInclude = (ctx: ListToolsContext) => ({
     : { include: { specification: { omit: { value: true } } } },
   providerTools: ctx.version?.specificationOid
     ? {
-        where: { specificationOid: ctx.version.specificationOid },
+        where: { specificationOid: ctx.version.specificationOid, adapterOid: null },
         include: { specification: { omit: { value: true } } }
       }
     : false
 });
 
-let patchGlobalCursor = async (
-  ctx: ListToolsContext,
-  cursor?: { id: string }
-) => {
+let patchGlobalCursor = async (ctx: ListToolsContext, cursor?: { id: string }) => {
   if (!cursor?.id) return cursor;
 
   let tool = await db.providerTool.findFirst({
@@ -209,7 +210,9 @@ let mapAuthMethodToolFilter = (
 
   return {
     authMethods,
-    scopeSets: authMethods.map(authMethod => authMethod.value.scopes?.map(scope => scope.id) ?? [])
+    scopeSets: authMethods.map(
+      authMethod => authMethod.value.scopes?.map(scope => scope.id) ?? []
+    )
   };
 };
 
@@ -266,7 +269,9 @@ let resolveProviderAuthMethodsForToolFilter = async (
 type ListProviderToolsParams = {
   providerVersion: ProviderVersion;
 
-  providerAuthConfig?: (ProviderAuthConfig & { authMethod?: ProviderAuthMethod | null }) | null;
+  providerAuthConfig?:
+    | (ProviderAuthConfig & { authMethod?: ProviderAuthMethod | null })
+    | null;
   providerAuthCredentials?: ProviderAuthCredentials | null;
   providerAuthMethodIds?: string[];
 };
@@ -336,10 +341,7 @@ class providerToolServiceImpl {
     return Paginator.create(() => async input => {
       let allTools = await queryTools(ctx);
       let filtered = allTools.filter(tool => {
-        if (
-          d.providerAuthConfig &&
-          !checkToolAuthMethodSatisfied(tool, authMethod).allowed
-        ) {
+        if (d.providerAuthConfig && !checkToolAuthMethodSatisfied(tool, authMethod).allowed) {
           return false;
         }
 

--- a/src/metorial/subspace/modules/catalog/src/services/providerTrigger.ts
+++ b/src/metorial/subspace/modules/catalog/src/services/providerTrigger.ts
@@ -97,11 +97,11 @@ class providerTriggerServiceImpl {
             ...(version?.specificationOid
               ? {
                   providerTriggers: {
-                    some: { specificationOid: version.specificationOid }
+                    some: { specificationOid: version.specificationOid, adapterOid: null }
                   }
                 }
               : {
-                  currentInstance: { isNot: null }
+                  currentInstance: { is: { adapterOid: null } }
                 })
           },
 
@@ -112,7 +112,7 @@ class providerTriggerServiceImpl {
               : { include: { specification: { omit: { value: true } } } },
             providerTriggers: version?.specificationOid
               ? {
-                  where: { specificationOid: version.specificationOid },
+                  where: { specificationOid: version.specificationOid, adapterOid: null },
                   include: { specification: { omit: { value: true } } }
                 }
               : false

--- a/src/metorial/subspace/modules/connection/src/controller/receiver.ts
+++ b/src/metorial/subspace/modules/connection/src/controller/receiver.ts
@@ -320,7 +320,9 @@ export let startReceiver = () => {
       ) => {
         let [backend, tool] = await Promise.all([
           connectBackend(),
-          db.providerTool.findFirstOrThrow({ where: { id: data.toolId } })
+          db.providerTool.findFirstOrThrow({
+            where: { id: data.toolId, adapterOid: null }
+          })
         ]);
 
         return await backend.sendToolInvocation({

--- a/src/metorial/subspace/modules/connection/src/lib/connectionStatusTool.ts
+++ b/src/metorial/subspace/modules/connection/src/lib/connectionStatusTool.ts
@@ -230,7 +230,7 @@ let getProviderStatus = async (d: {
   let tools = describeTools({
     provider,
     tools: specificationOid
-      ? await db.providerTool.findMany({ where: { specificationOid } })
+      ? await db.providerTool.findMany({ where: { specificationOid, adapterOid: null } })
       : []
   });
 

--- a/src/metorial/subspace/modules/connection/src/lib/syntheticTool.ts
+++ b/src/metorial/subspace/modules/connection/src/lib/syntheticTool.ts
@@ -78,6 +78,7 @@ export let buildSyntheticTool = <P extends SessionProvider>(
     providerOid: 0n,
     specificationOid: 0n,
     globalOid: 0n,
+    adapterOid: null,
     createdAt: now,
     updatedAt: now,
     sessionProvider: input.sessionProvider,

--- a/src/metorial/subspace/modules/connection/src/sender/manager.ts
+++ b/src/metorial/subspace/modules/connection/src/sender/manager.ts
@@ -858,7 +858,7 @@ export class SenderManager {
 
     let tools = specificationOid
       ? await db.providerTool.findMany({
-          where: { specificationOid }
+          where: { specificationOid, adapterOid: null }
         })
       : [];
 
@@ -1065,7 +1065,8 @@ export class SenderManager {
     let tool = await db.providerTool.findFirst({
       where: {
         key: d.originalToolName,
-        specificationOid
+        specificationOid,
+        adapterOid: null
       }
     });
     if (!tool) return null;

--- a/src/metorial/subspace/modules/provider-internal/src/services/providerSpecification.ts
+++ b/src/metorial/subspace/modules/provider-internal/src/services/providerSpecification.ts
@@ -86,6 +86,34 @@ class providerSpecificationInternalServiceImpl {
       providerVersionId: d.providerVersion.id
     });
 
+    let adapterIdentifiers = [
+      ...new Set(
+        [...tools, ...triggers].flatMap(action =>
+          action.adapterIdentifier ? [action.adapterIdentifier] : []
+        )
+      )
+    ];
+    let providerAdapters = adapterIdentifiers.length
+      ? await db.providerAdapter.findMany({
+          where: {
+            providerOid: d.provider.oid,
+            identifier: { in: adapterIdentifiers }
+          },
+          select: { oid: true, identifier: true }
+        })
+      : [];
+    let adapterByIdentifier = new Map(
+      providerAdapters.map(adapter => [adapter.identifier, adapter])
+    );
+    let missingAdapterIdentifier = adapterIdentifiers.find(
+      identifier => !adapterByIdentifier.has(identifier)
+    );
+    if (missingAdapterIdentifier) {
+      throw new Error(
+        `Provider adapter not found for specification action: ${missingAdapterIdentifier}`
+      );
+    }
+
     let specHash = await Hash.sha256(
       canonicalize({
         type: d.type,
@@ -226,6 +254,9 @@ class providerSpecificationInternalServiceImpl {
 
                     providerOid: d.provider.oid,
                     globalOid: globalToolsMap.get(t.key)!.oid,
+                    adapterOid: t.adapterIdentifier
+                      ? adapterByIdentifier.get(t.adapterIdentifier)!.oid
+                      : null,
                     hash: await Hash.sha256(canonicalize([d.provider.id, t]))
                   }))
                 )
@@ -247,6 +278,9 @@ class providerSpecificationInternalServiceImpl {
 
                     providerOid: d.provider.oid,
                     globalOid: globalTriggersMap.get(t.key)!.oid,
+                    adapterOid: t.adapterIdentifier
+                      ? adapterByIdentifier.get(t.adapterIdentifier)!.oid
+                      : null,
                     hash: await Hash.sha256(canonicalize([d.provider.id, t]))
                   }))
                 )

--- a/src/metorial/subspace/provider-backends/provider-slates/src/adapterCapabilities.test.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/adapterCapabilities.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalizeAdapterCapabilities } from './adapterCapabilities';
+
+describe('canonicalizeAdapterCapabilities', () => {
+  it('deduplicates by identifier and sorts the version snapshot', () => {
+    expect(
+      canonicalizeAdapterCapabilities([
+        { id: 'messages.write', value: false },
+        { id: 'channels.read', value: true },
+        { id: 'messages.write', value: { mode: 'threaded' } }
+      ])
+    ).toEqual([
+      { id: 'channels.read', value: true },
+      { id: 'messages.write', value: { mode: 'threaded' } }
+    ]);
+  });
+});

--- a/src/metorial/subspace/provider-backends/provider-slates/src/adapterCapabilities.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/adapterCapabilities.ts
@@ -1,0 +1,8 @@
+export type ProviderAdapterCapabilityValue = { id: string; value: any };
+
+export let canonicalizeAdapterCapabilities = (
+  capabilities: ProviderAdapterCapabilityValue[]
+) =>
+  [...new Map(capabilities.map(capability => [capability.id, capability])).values()].sort(
+    (a, b) => a.id.localeCompare(b.id)
+  );

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
@@ -120,7 +120,8 @@ export class ProviderCapabilities extends IProviderCapabilities {
                       autoUnregistration: invocation.autoUnregistration
                     },
               capabilities: t.capabilities ?? {},
-              metadata: t.metadata ?? {}
+              metadata: t.metadata ?? {},
+              adapterIdentifier: t.adapter?.slateIdentifier ?? null
             };
           })
           .filter((t): t is NonNullable<typeof t> => t !== null),
@@ -142,6 +143,7 @@ export class ProviderCapabilities extends IProviderCapabilities {
             outputJsonSchema: t.outputSchema,
             capabilities: t.capabilities ?? {},
             metadata: t.metadata ?? {},
+            adapterIdentifier: t.adapter?.slateIdentifier ?? null,
             scopes: t.scopes ?? null,
             invocation:
               invocation.type === 'polling'
@@ -191,7 +193,8 @@ export class ProviderCapabilities extends IProviderCapabilities {
           scopes: t.scopes ?? null,
           authMethods: tool.authMethods ?? null,
           tags: t.tags,
-          metadata: {}
+          metadata: {},
+          adapterIdentifier: t.adapter?.slateIdentifier ?? null
         };
       })
     };

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
@@ -144,6 +144,10 @@ export class ProviderRunConnection extends IProviderRunConnection {
   override async handleToolInvocation(
     data: ToolInvocationCreateParam
   ): Promise<ToolInvocationCreateRes> {
+    if (data.tool.adapterOid) {
+      throw new Error('Adapter-linked tools cannot be invoked through provider connections');
+    }
+
     if (this.providerAuthConfigVersion && !this.providerAuthConfigVersion.slateAuthConfigOid) {
       throw new Error('Provider auth config is missing slate auth config association');
     }

--- a/src/metorial/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
@@ -4,7 +4,7 @@ import { Hash } from '@lowerdeck/hash';
 import { generateCode } from '@lowerdeck/id';
 import { createQueue } from '@lowerdeck/queue';
 import { slugify } from '@lowerdeck/slugify';
-import { db, snowflake } from '@metorial-subspace/db';
+import { db, getId, snowflake } from '@metorial-subspace/db';
 import {
   providerInternalService,
   providerVersionInternalService,
@@ -12,6 +12,7 @@ import {
 } from '@metorial-subspace/module-provider-internal';
 import { normalizeJsonSchema } from '@metorial-subspace/provider-utils';
 import { backend } from '../../backend';
+import { canonicalizeAdapterCapabilities } from '../../adapterCapabilities';
 import { slates } from '../../client';
 import { env } from '../../env';
 
@@ -94,6 +95,7 @@ let buildProviderListingDocs = (spec: any): PrismaJson.ProviderListingDocs | und
     }))
     .filter((authMethod: any) => authMethod.docs.length > 0);
   let actions = [...(spec.tools ?? []), ...(spec.triggers ?? [])]
+    .filter((action: any) => !action.adapter)
     .map((action: any) => ({
       key: action.key,
       name: action.name,
@@ -116,6 +118,140 @@ let buildProviderListingDocs = (spec: any): PrismaJson.ProviderListingDocs | und
     actions
   };
 };
+
+type SlatesAdapter = {
+  identifier: string;
+  slateIdentifier: string;
+  name: string;
+  capabilities: { id: string; value: any }[];
+};
+
+let syncProviderAdapters = async (d: { providerOid: bigint; adapters: SlatesAdapter[] }) =>
+  await db.$transaction(async tx => {
+    let adapterBySlateIdentifier = new Map<string, { oid: bigint }>();
+
+    for (let adapter of d.adapters) {
+      let global = await tx.providerAdapterGlobal.upsert({
+        where: { identifier: adapter.identifier },
+        create: {
+          ...getId('providerAdapterGlobal'),
+          identifier: adapter.identifier,
+          name: adapter.name
+        },
+        update: { name: adapter.name }
+      });
+
+      let providerAdapter = await tx.providerAdapter.upsert({
+        where: {
+          providerOid_globalOid: {
+            providerOid: d.providerOid,
+            globalOid: global.oid
+          }
+        },
+        create: {
+          ...getId('providerAdapter'),
+          identifier: adapter.slateIdentifier,
+          providerOid: d.providerOid,
+          globalOid: global.oid
+        },
+        update: { identifier: adapter.slateIdentifier }
+      });
+
+      for (let capability of canonicalizeAdapterCapabilities(adapter.capabilities)) {
+        await tx.providerAdapterCapability.upsert({
+          where: {
+            adapterOid_identifier: {
+              adapterOid: providerAdapter.oid,
+              identifier: capability.id
+            }
+          },
+          create: {
+            ...getId('providerAdapterCapability'),
+            adapterOid: providerAdapter.oid,
+            identifier: capability.id
+          },
+          update: {}
+        });
+      }
+
+      adapterBySlateIdentifier.set(adapter.slateIdentifier, providerAdapter);
+    }
+
+    return adapterBySlateIdentifier;
+  });
+
+let syncProviderVersionAdapters = async (d: {
+  providerVersionOid: bigint;
+  adapters: SlatesAdapter[];
+  adapterBySlateIdentifier: Map<string, { oid: bigint }>;
+}) =>
+  await db.$transaction(async tx => {
+    let desiredAdapterOids = d.adapters.flatMap(adapter => {
+      let record = d.adapterBySlateIdentifier.get(adapter.slateIdentifier);
+      return record ? [record.oid] : [];
+    });
+
+    await tx.providerVersionAdapter.deleteMany({
+      where: {
+        providerVersionOid: d.providerVersionOid,
+        adapterOid: { notIn: desiredAdapterOids }
+      }
+    });
+
+    for (let adapter of d.adapters) {
+      let providerAdapter = d.adapterBySlateIdentifier.get(adapter.slateIdentifier);
+      if (!providerAdapter) {
+        throw new Error(`Provider adapter not found: ${adapter.slateIdentifier}`);
+      }
+
+      let capabilities = canonicalizeAdapterCapabilities(adapter.capabilities);
+      let versionAdapter = await tx.providerVersionAdapter.upsert({
+        where: {
+          providerVersionOid_adapterOid: {
+            providerVersionOid: d.providerVersionOid,
+            adapterOid: providerAdapter.oid
+          }
+        },
+        create: {
+          ...getId('providerVersionAdapter'),
+          providerVersionOid: d.providerVersionOid,
+          adapterOid: providerAdapter.oid,
+          capabilities
+        },
+        update: { capabilities }
+      });
+
+      let capabilityRecords = await tx.providerAdapterCapability.findMany({
+        where: { adapterOid: providerAdapter.oid },
+        select: { oid: true, identifier: true }
+      });
+      let capabilityByIdentifier = new Map(
+        capabilityRecords.map(capability => [capability.identifier, capability])
+      );
+
+      await tx.providerVersionAdapterCapability.deleteMany({
+        where: { providerVersionAdapterOid: versionAdapter.oid }
+      });
+      if (capabilities.length > 0) {
+        await tx.providerVersionAdapterCapability.createMany({
+          data: capabilities.map(capability => {
+            let definition = capabilityByIdentifier.get(capability.id);
+            if (!definition) {
+              throw new Error(
+                `Provider adapter capability not found: ${adapter.slateIdentifier}/${capability.id}`
+              );
+            }
+            return {
+              ...getId('providerVersionAdapterCapability'),
+              providerVersionAdapterOid: versionAdapter.oid,
+              adapterCapabilityOid: definition.oid,
+              value: capability.value
+            };
+          })
+        });
+      }
+    }
+  });
 
 export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async data => {
   let version = await slates.slateVersion.get({
@@ -198,7 +334,7 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
   let hasConfig = !!(spec ? normalizeJsonSchema(spec.configSchema) : null);
   let hasAuthConfig = !!(spec && spec.authMethods.length > 0);
   let hasOAuth = spec?.authMethods.some(am => am.type === 'oauth');
-  let hasTriggers = !!(spec ? spec.triggers.length > 0 : false);
+  let hasTriggers = !!(spec ? spec.triggers.some(trigger => !trigger.adapter) : false);
   let docs = buildProviderListingDocs(spec);
 
   let type = {
@@ -278,7 +414,13 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
   // Abort if the version already existed
   // if (slateVersionRecord.oid !== newVersionOid) return;
 
-  await providerVersionInternalService.upsertVersion({
+  let adapters = (version.adapters ?? []) as SlatesAdapter[];
+  let adapterBySlateIdentifier = await syncProviderAdapters({
+    providerOid: provider.oid,
+    adapters
+  });
+
+  let providerVersion = await providerVersionInternalService.upsertVersion({
     variant: provider.defaultVariant,
     isCurrent: version.isCurrent,
     source: {
@@ -291,5 +433,11 @@ export let syncSlateVersionQueueProcessor = syncSlateVersionQueue.process(async 
       name: `v${version.version}`
     },
     type
+  });
+
+  await syncProviderVersionAdapters({
+    providerVersionOid: providerVersion.oid,
+    adapters,
+    adapterBySlateIdentifier
   });
 });

--- a/src/metorial/subspace/provider-backends/provider-utils/src/types/specification.ts
+++ b/src/metorial/subspace/provider-backends/provider-utils/src/types/specification.ts
@@ -87,6 +87,8 @@ export interface SpecificationTool {
   authMethods?: string[] | null;
 
   metadata: Record<string, any>;
+
+  adapterIdentifier?: string | null;
 }
 
 export interface SpecificationAuthMethod {
@@ -148,6 +150,8 @@ export interface SpecificationTrigger {
   scopes?: SpecificationActionScopes | null;
 
   metadata: Record<string, any>;
+
+  adapterIdentifier?: string | null;
 }
 
 export interface Specification {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Prisma schema and many tool/trigger/callback query paths; mis-filtering could hide tools or break callbacks until migrations and Slates sync are aligned.
> 
> **Overview**
> Adds **provider adapter** persistence and Slates sync so tools/triggers can be tied to an adapter via optional `adapterOid` / `adapterIdentifier`, with per-version capability snapshots. Slate version sync upserts adapter globals, capabilities, and `ProviderVersionAdapter` rows; specification ingestion resolves adapters and stores links on tool/trigger rows. Slates capability mapping now passes `adapterIdentifier` from proto `adapter` fields, bumps **`@slates/proto`** to `1.0.0-rc.14`, and excludes that package from Bun’s minimum release age.
> 
> **Connection and catalog behavior** now treats only non-adapter tools/triggers as connection-callable: list/get paths, setup-session tool listing, callback trigger resolution/reconcile, and Slates `handleToolInvocation` reject adapter-linked tools. Adapter-backed triggers are omitted from callback registration; `hasTriggers` and listing docs ignore adapter-only actions.
> 
> **Dashboard** truncates long provider/session auth error messages in detail layouts (80 chars) and error group tables (100 chars).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 885e1c255f3a7cb57a2471eb306d7a93e830a154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->