### PR TITLE
Add internal sessions

### DIFF
--- a/src/metorial/apis/core/src/controllers/instance/sessions/toolCall.ts
+++ b/src/metorial/apis/core/src/controllers/instance/sessions/toolCall.ts
@@ -2,12 +2,12 @@ import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { sessionService, toolCallService } from '@metorial-subspace/module-session';
+import { toolCallPresenter } from '@metorial/presenters';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../../lib/dateFilter';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
 import { checkAccess } from '../../../middleware/checkAccess';
 import { instanceGroup, instancePath } from '../../../middleware/instanceGroup';
-import { toolCallPresenter } from '@metorial/presenters';
 import { resolveActorIdsForLogFilters } from './_logFilterActors';
 
 let toolCallGroup = instanceGroup.use(async ctx => {
@@ -46,6 +46,9 @@ export let toolCallController = Controller.create(
         'default',
         Paginator.validate(
           v.object({
+            session_id: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description: 'Filter by session ID(s)'
+            }),
             session_template_id: v.optional(v.union([v.string(), v.array(v.string())]), {
               description: 'Filter by session template ID(s)'
             }),
@@ -99,6 +102,7 @@ export let toolCallController = Controller.create(
           instance: ctx.instance,
           allowDeleted: false,
           actorIds,
+          sessionIds: normalizeArrayParam(ctx.query.session_id),
           agentIds: normalizeArrayParam(ctx.query.agent_id),
           agentInstanceIds: normalizeArrayParam(ctx.query.agent_instance_id),
           sessionTemplateIds: normalizeArrayParam(ctx.query.session_template_id),

--- a/src/metorial/subspace/db/prisma/schema/callback/callback.prisma
+++ b/src/metorial/subspace/db/prisma/schema/callback/callback.prisma
@@ -74,6 +74,10 @@ model Callback {
   status        CallbackStatus
   mode          CallbackMode
   isCallbacksV2 Boolean        @default(false)
+  isInternal    Boolean        @default(false)
+
+  adapterGlobalOid BigInt?
+  adapterGlobal    ProviderAdapterGlobal? @relation(fields: [adapterGlobalOid], references: [oid])
 
   name                        String
   description                 String?
@@ -91,6 +95,8 @@ model Callback {
 
   @@index([tenantOid, environmentOid, solutionOid, status])
   @@index([providerDeploymentOid, status])
+  @@index([adapterGlobalOid])
+  @@index([tenantOid, environmentOid, isInternal, createdAt])
   @@index([projectOid])
   @@index([instanceOid])
 }

--- a/src/metorial/subspace/db/prisma/schema/provider/adapter.prisma
+++ b/src/metorial/subspace/db/prisma/schema/provider/adapter.prisma
@@ -8,7 +8,11 @@ model ProviderAdapterGlobal {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  providerAdapters ProviderAdapter[]
+  providerAdapters          ProviderAdapter[]
+  sessions                  Session[]
+  sessionConnections        SessionConnection[]
+  ephemeralManagedSessions  EphemeralManagedSession[]
+  callbacks                 Callback[]
 }
 
 model ProviderAdapter {

--- a/src/metorial/subspace/db/prisma/schema/session/connection.prisma
+++ b/src/metorial/subspace/db/prisma/schema/session/connection.prisma
@@ -34,6 +34,10 @@ model SessionConnection {
   token String @unique
 
   isEphemeral Boolean
+  isInternal  Boolean @default(false)
+
+  adapterGlobalOid BigInt?
+  adapterGlobal    ProviderAdapterGlobal? @relation(fields: [adapterGlobalOid], references: [oid])
 
   status    SessionConnectionStatus
   transport SessionConnectionTransport
@@ -104,6 +108,9 @@ model SessionConnection {
   @@index([lastActiveAt])
   @@index([state])
   @@index([status])
+  @@index([isInternal])
+  @@index([adapterGlobalOid])
+  @@index([tenantOid, environmentOid, isInternal, createdAt])
   @@index([projectOid])
   @@index([instanceOid])
 }

--- a/src/metorial/subspace/db/prisma/schema/session/ephemeralManaged.prisma
+++ b/src/metorial/subspace/db/prisma/schema/session/ephemeralManaged.prisma
@@ -15,6 +15,10 @@ model EphemeralManagedSession {
   templateHash                String?
   willRotateAt                DateTime?
   isReconciling               Boolean   @default(false)
+  markSessionsAsInternal      Boolean   @default(false)
+
+  adapterGlobalOid BigInt?
+  adapterGlobal    ProviderAdapterGlobal? @relation(fields: [adapterGlobalOid], references: [oid])
 
   tenantOid BigInt
   tenant    Tenant @relation(fields: [tenantOid], references: [oid])
@@ -57,6 +61,7 @@ model EphemeralManagedSession {
   @@index([status, archivedAt])
   @@index([sessionTemplateOid])
   @@index([identityOid])
+  @@index([adapterGlobalOid])
   @@index([currentSessionOid, status])
   @@index([projectOid])
   @@index([instanceOid])

--- a/src/metorial/subspace/db/prisma/schema/session/session.prisma
+++ b/src/metorial/subspace/db/prisma/schema/session/session.prisma
@@ -12,6 +12,10 @@ model Session {
   archivedAt DateTime?
 
   isEphemeral Boolean
+  isInternal  Boolean @default(false)
+
+  adapterGlobalOid BigInt?
+  adapterGlobal    ProviderAdapterGlobal? @relation(fields: [adapterGlobalOid], references: [oid])
 
   connectionState SessionConnectionState @default(disconnected)
   isStarted       Boolean                @default(false)
@@ -84,6 +88,9 @@ model Session {
   @@index([identityActorOid])
   @@index([identityOid])
   @@index([isEphemeral])
+  @@index([isInternal])
+  @@index([adapterGlobalOid])
+  @@index([tenantOid, environmentOid, isInternal, createdAt])
   @@index([ephemeralManagedSessionOid])
   @@index([projectOid])
   @@index([instanceOid])

--- a/src/metorial/subspace/modules/callback/src/reconciler/lib/state.ts
+++ b/src/metorial/subspace/modules/callback/src/reconciler/lib/state.ts
@@ -23,7 +23,9 @@ export let callbackInclude = {
   },
   callbackProviderTriggers: {
     include: {
-      providerTrigger: true
+      providerTrigger: {
+        include: { adapter: true }
+      }
     }
   }
 };
@@ -106,4 +108,5 @@ export let isCallbackSupported = (
 ) =>
   callback.status === 'active' &&
   callback.providerDeployment.provider.type.attributes.backend === 'slates' &&
-  callback.providerDeployment.provider.type.attributes.triggers.status === 'enabled';
+  (callback.isInternal ||
+    callback.providerDeployment.provider.type.attributes.triggers.status === 'enabled');

--- a/src/metorial/subspace/modules/callback/src/reconciler/lib/sync.ts
+++ b/src/metorial/subspace/modules/callback/src/reconciler/lib/sync.ts
@@ -6,9 +6,9 @@ import {
   getTenantForSlatesCached,
   isCallbackSupported,
   loadCallback,
+  loadCallbackInstance,
   loadFreshCallback,
   loadFreshCallbackInstance,
-  loadCallbackInstance,
   TRIGGER_PAGE_SIZE
 } from './state';
 
@@ -238,7 +238,11 @@ export let syncCallbackInstance = async (d: {
 
   let callback = callbackInstance.callback;
   let providerTriggerInputs = callback.callbackProviderTriggers
-    .filter(trigger => !trigger.providerTrigger.adapterOid)
+    .filter(trigger =>
+      callback.isInternal
+        ? trigger.providerTrigger.adapter?.globalOid === callback.adapterGlobalOid
+        : !trigger.providerTrigger.adapterOid
+    )
     .map(trigger => ({
       triggerId: trigger.providerTrigger.specId,
       ...(callback.pollIntervalSecondsOverride !== null &&

--- a/src/metorial/subspace/modules/callback/src/services/callback.test.ts
+++ b/src/metorial/subspace/modules/callback/src/services/callback.test.ts
@@ -7,6 +7,8 @@ let mocks = vi.hoisted(() => ({
   providerDeploymentFindFirst: vi.fn(),
   providerDeploymentFindFirstOrThrow: vi.fn(),
   providerTriggerFindMany: vi.fn(),
+  providerAdapterGlobalFindUnique: vi.fn(),
+  providerVersionAdapterFindFirst: vi.fn(),
   getCurrentVersion: vi.fn(),
   syncCallback: vi.fn()
 }));
@@ -46,6 +48,12 @@ vi.mock('@metorial-subspace/db', () => ({
     },
     providerTrigger: {
       findMany: mocks.providerTriggerFindMany
+    },
+    providerAdapterGlobal: {
+      findUnique: mocks.providerAdapterGlobalFindUnique
+    },
+    providerVersionAdapter: {
+      findFirst: mocks.providerVersionAdapterFindFirst
     },
     $transaction: vi.fn()
   },
@@ -119,7 +127,8 @@ describe('Callback creation double-writes the mirrored scoping columns', () => {
     vi.clearAllMocks();
     mocks.providerDeploymentFindFirst.mockResolvedValue(deployment);
     mocks.providerDeploymentFindFirstOrThrow.mockResolvedValue(deployment);
-    mocks.getCurrentVersion.mockResolvedValue({ specificationOid: 40n });
+    mocks.getCurrentVersion.mockResolvedValue({ oid: 41n, specificationOid: 40n });
+    mocks.providerVersionAdapterFindFirst.mockResolvedValue({ oid: 42n });
     mocks.providerTriggerFindMany.mockResolvedValue([
       {
         oid: 50n,
@@ -140,7 +149,6 @@ describe('Callback creation double-writes the mirrored scoping columns', () => {
     expect(mocks.providerTriggerFindMany).toHaveBeenCalledWith({
       where: { specificationOid: 40n, adapterOid: null }
     });
-
     expect(mocks.callbackCreate).toHaveBeenCalledTimes(1);
     expect(mocks.callbackCreate.mock.calls[0]![0].data).toMatchObject({
       tenantOid: 10n,
@@ -172,5 +180,37 @@ describe('Callback creation double-writes the mirrored scoping columns', () => {
     expect(where).toMatchObject({ tenantOid: 10n, environmentOid: 11n });
     expect(where).not.toHaveProperty('projectOid');
     expect(where).not.toHaveProperty('instanceOid');
+  });
+
+  it('binds internal callbacks to one global adapter and resolves only its triggers', async () => {
+    mocks.providerAdapterGlobalFindUnique.mockResolvedValue({
+      oid: 70n,
+      id: 'padg_1',
+      identifier: 'chat',
+      name: 'Chat'
+    });
+
+    await callbackService.createCallbackInternal({
+      ...createParams(linkedScope),
+      adapter: { identifier: 'chat' }
+    });
+
+    expect(mocks.providerTriggerFindMany).toHaveBeenCalledWith({
+      where: {
+        specificationOid: 40n,
+        adapter: { globalOid: 70n }
+      }
+    });
+    expect(mocks.providerVersionAdapterFindFirst).toHaveBeenCalledWith({
+      where: {
+        providerVersionOid: 41n,
+        adapter: { globalOid: 70n }
+      },
+      select: { oid: true }
+    });
+    expect(mocks.callbackCreate.mock.calls[0]![0].data).toMatchObject({
+      isInternal: true,
+      adapterGlobalOid: 70n
+    });
   });
 });

--- a/src/metorial/subspace/modules/callback/src/services/callback.ts
+++ b/src/metorial/subspace/modules/callback/src/services/callback.ts
@@ -21,13 +21,13 @@ import {
   normalizeStatusForList,
   resolveProviderDeployments
 } from '@metorial-subspace/list-utils';
+import { providerDeploymentInternalService } from '@metorial-subspace/module-provider-internal';
 import {
   getMetorialSolution,
   type MetorialFacing,
   resolveMetorialFacing,
   toProviderEventBase
 } from '@metorial-subspace/module-tenant';
-import { providerDeploymentInternalService } from '@metorial-subspace/module-provider-internal';
 import { Fabric } from '@metorial/fabric';
 import { callbackRegistrationService } from './callbackRegistration';
 
@@ -35,6 +35,7 @@ let MAX_DESTINATIONS_PER_CALLBACK = 100;
 let MAX_TRIGGERS_PER_CALLBACK = 100;
 
 let callbackInclude = {
+  adapterGlobal: true,
   providerDeployment: {
     include: {
       provider: {
@@ -60,6 +61,7 @@ let callbackInclude = {
 export type ListCallbacksParams = {
   status?: ('active' | 'archived' | 'deleted')[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
   ids?: string[];
   providerDeploymentIds?: string[];
   createdAt?: DateFilter;
@@ -85,6 +87,10 @@ export type CreateCallbackParams = {
   };
 };
 
+export type CreateInternalCallbackParams = CreateCallbackParams & {
+  adapter?: { identifier: string };
+};
+
 export type UpdateCallbackParams = {
   callback: Callback & {
     providerDeployment: ProviderDeployment & {
@@ -102,10 +108,12 @@ export type UpdateCallbackParams = {
     triggers?: { triggerId: string; eventTypes?: string[] }[];
     destinationIds?: string[];
   };
+  _allowInternalUpdate?: boolean;
 };
 
 export type ArchiveCallbackParams = {
   callback: Callback;
+  _allowInternalDelete?: boolean;
 };
 
 class callbackServiceImpl {
@@ -134,7 +142,9 @@ class callbackServiceImpl {
     });
   }
 
-  async listCallbacksInternal(d: { tenant: Tenant; environment: Environment } & ListCallbacksParams) {
+  async listCallbacksInternal(
+    d: { tenant: Tenant; environment: Environment } & ListCallbacksParams
+  ) {
     let solution = await getMetorialSolution();
     let ts = { tenant: d.tenant, environment: d.environment, solution };
     let deployments = await resolveProviderDeployments(ts, d.providerDeploymentIds);
@@ -148,6 +158,7 @@ class callbackServiceImpl {
             solutionOid: solution.oid,
             environmentOid: d.environment.oid,
             ...normalizeStatusForList(d).noParent,
+            ...(d.includeInternal ? {} : { isInternal: false }),
             AND: [
               d.ids ? { id: { in: d.ids } } : undefined!,
               deployments ? { providerDeploymentOid: deployments.in } : undefined!,
@@ -200,6 +211,7 @@ class callbackServiceImpl {
     providerDeployment: {
       id: string;
     };
+    allowAdapterTriggers?: boolean;
   }) {
     let solution = await getMetorialSolution();
 
@@ -230,7 +242,8 @@ class callbackServiceImpl {
 
     if (
       providerDeployment.provider.type.attributes.backend !== 'slates' ||
-      providerDeployment.provider.type.attributes.triggers.status !== 'enabled'
+      (!d.allowAdapterTriggers &&
+        providerDeployment.provider.type.attributes.triggers.status !== 'enabled')
     ) {
       throw new ServiceError(
         badRequestError({
@@ -247,6 +260,7 @@ class callbackServiceImpl {
     environment: Environment;
     deployment: ProviderDeployment;
     inputTriggers: { triggerId: string; eventTypes?: string[] }[];
+    adapterGlobalOid?: bigint | null;
   }) {
     let deployment = await db.providerDeployment.findFirstOrThrow({
       where: { oid: d.deployment.oid },
@@ -283,8 +297,31 @@ class callbackServiceImpl {
     }
 
     let providerTriggers = await db.providerTrigger.findMany({
-      where: { specificationOid: version.specificationOid, adapterOid: null }
+      where: {
+        specificationOid: version.specificationOid,
+        ...(d.adapterGlobalOid
+          ? { adapter: { globalOid: d.adapterGlobalOid } }
+          : { adapterOid: null })
+      }
     });
+
+    if (d.adapterGlobalOid) {
+      let versionAdapter = await db.providerVersionAdapter.findFirst({
+        where: {
+          providerVersionOid: version.oid,
+          adapter: { globalOid: d.adapterGlobalOid }
+        },
+        select: { oid: true }
+      });
+      if (!versionAdapter) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'internal_adapter_not_supported',
+            message: 'The callback provider version does not support the requested adapter.'
+          })
+        );
+      }
+    }
 
     let byMatcher = new Map<string, (typeof providerTriggers)[number]>();
     for (let trigger of providerTriggers) {
@@ -333,14 +370,24 @@ class callbackServiceImpl {
   }
 
   async createCallbackInternal(
-    d: { tenant: Tenant; environment: Environment } & CreateCallbackParams
+    d: { tenant: Tenant; environment: Environment } & CreateInternalCallbackParams
   ) {
     let solution = await getMetorialSolution();
+
+    let adapter = d.adapter
+      ? await db.providerAdapterGlobal.findUnique({
+          where: { identifier: d.adapter.identifier }
+        })
+      : null;
+    if (d.adapter && !adapter) {
+      throw new ServiceError(notFoundError('provider.adapter', d.adapter.identifier));
+    }
 
     let providerDeployment = await this.getDeploymentAndValidate({
       tenant: d.tenant,
       environment: d.environment,
-      providerDeployment: d.providerDeployment
+      providerDeployment: d.providerDeployment,
+      allowAdapterTriggers: !!adapter
     });
 
     if (d.input.triggers.length > MAX_TRIGGERS_PER_CALLBACK) {
@@ -355,7 +402,8 @@ class callbackServiceImpl {
     let providerTriggers = await this.resolveTriggerDefs({
       environment: d.environment,
       deployment: providerDeployment,
-      inputTriggers: d.input.triggers
+      inputTriggers: d.input.triggers,
+      adapterGlobalOid: adapter?.oid ?? null
     });
     let destinationIds = [...new Set(d.input.destinationIds)];
     if (destinationIds.length > MAX_DESTINATIONS_PER_CALLBACK) {
@@ -395,6 +443,8 @@ class callbackServiceImpl {
         providerDeploymentOid: providerDeployment.oid,
         status: 'active',
         mode: 'manual',
+        isInternal: !!adapter,
+        adapterGlobalOid: adapter?.oid ?? null,
         name: d.input.name,
         description: d.input.description,
         metadata: d.input.metadata,
@@ -439,6 +489,15 @@ class callbackServiceImpl {
     d: { tenant: Tenant; environment: Environment } & UpdateCallbackParams
   ) {
     let solution = await getMetorialSolution();
+
+    if (d.callback.isInternal && !d._allowInternalUpdate) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'internal_callback_readonly',
+          message: 'Internal callbacks cannot be updated by customers.'
+        })
+      );
+    }
 
     let pollIntervalSecondsOverride =
       d.input.pollIntervalSecondsOverride !== undefined
@@ -486,7 +545,8 @@ class callbackServiceImpl {
         ? await this.resolveTriggerDefs({
             environment: d.environment,
             deployment: d.callback.providerDeployment,
-            inputTriggers: d.input.triggers
+            inputTriggers: d.input.triggers,
+            adapterGlobalOid: d.callback.adapterGlobalOid
           })
         : undefined;
 
@@ -565,6 +625,14 @@ class callbackServiceImpl {
   async archiveCallbackInternal(
     d: { tenant: Tenant; environment: Environment } & ArchiveCallbackParams
   ) {
+    if (d.callback.isInternal && !d._allowInternalDelete) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'internal_callback_readonly',
+          message: 'Internal callbacks cannot be archived by customers.'
+        })
+      );
+    }
     let archivedAt = new Date();
 
     let archived = await withTransaction(async db => {

--- a/src/metorial/subspace/modules/callback/src/services/callbackInstance.ts
+++ b/src/metorial/subspace/modules/callback/src/services/callbackInstance.ts
@@ -1,4 +1,9 @@
-import { internalServerError, notFoundError, ServiceError } from '@lowerdeck/error';
+import {
+  badRequestError,
+  internalServerError,
+  notFoundError,
+  ServiceError
+} from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
@@ -28,12 +33,12 @@ import {
 } from '@metorial-subspace/module-provider-internal';
 import {
   getMetorialSolution,
-  type MetorialFacing,
   resolveMetorialFacing,
-  toProviderEventBase
+  toProviderEventBase,
+  type MetorialFacing
 } from '@metorial-subspace/module-tenant';
-import { Fabric } from '@metorial/fabric';
 import { getTenantForSlates, slates } from '@metorial-subspace/provider-slates/src/client';
+import { Fabric } from '@metorial/fabric';
 import { callbackService } from './callback';
 import { callbackRegistrationService } from './callbackRegistration';
 
@@ -74,6 +79,7 @@ export type ListCallbackInstancesParams = {
   ids?: string[];
   status?: ('attached' | 'detached')[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
   providerConfigIds?: string[];
   providerAuthConfigIds?: string[];
   createdAt?: DateFilter;
@@ -89,10 +95,12 @@ export type AttachCallbackInstanceParams = {
   };
   config: ProviderConfig;
   authConfig?: ProviderAuthConfig;
+  _allowInternalAttach?: boolean;
 };
 
 export type DetachCallbackInstanceParams = {
   callbackInstance: CallbackInstance;
+  _allowInternalDetach?: boolean;
 };
 
 class callbackInstanceServiceImpl {
@@ -107,7 +115,9 @@ class callbackInstanceServiceImpl {
     });
   }
 
-  async getInternal(d: { tenant: Tenant; environment: Environment } & GetCallbackInstanceParams) {
+  async getInternal(
+    d: { tenant: Tenant; environment: Environment } & GetCallbackInstanceParams
+  ) {
     let callback = await callbackService.getCallbackByIdInternal({
       tenant: d.tenant,
       environment: d.environment,
@@ -164,6 +174,9 @@ class callbackInstanceServiceImpl {
             ...normalizeStatusForList(d).onlyParent,
 
             AND: [
+              !d.includeInternal && !d.callbackIds?.length
+                ? { callback: { isInternal: false } }
+                : undefined!,
               callbacks ? { callbackOid: callbacks.in } : undefined!,
               d.ids ? { id: { in: d.ids } } : undefined!,
               d.status?.length ? { status: { in: d.status } } : undefined!,
@@ -219,6 +232,15 @@ class callbackInstanceServiceImpl {
   async attachInternal(
     d: { tenant: Tenant; environment: Environment } & AttachCallbackInstanceParams
   ) {
+    if (d.callback.isInternal && !d._allowInternalAttach) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'internal_callback_readonly',
+          message: 'Internal callback instances cannot be attached by customers.'
+        })
+      );
+    }
+
     if (d.callback.providerDeployment.status !== 'active') {
       throw new ServiceError(
         notFoundError('provider.deployment', d.callback.providerDeployment.id)
@@ -237,11 +259,13 @@ class callbackInstanceServiceImpl {
       ]
     });
 
-    let pairRes = await providerDeploymentConfigPairInternalService.upsertDeploymentConfigPair({
-      deployment: d.callback.providerDeployment,
-      config: combination.config,
-      authConfig: combination.authConfig
-    });
+    let pairRes = await providerDeploymentConfigPairInternalService.upsertDeploymentConfigPair(
+      {
+        deployment: d.callback.providerDeployment,
+        config: combination.config,
+        authConfig: combination.authConfig
+      }
+    );
 
     let callbackInstance = await db.callbackInstance.findFirst({
       where: {
@@ -311,6 +335,18 @@ class callbackInstanceServiceImpl {
   async detachInternal(
     d: { tenant: Tenant; environment: Environment } & DetachCallbackInstanceParams
   ) {
+    let callback = await db.callback.findUniqueOrThrow({
+      where: { oid: d.callbackInstance.callbackOid }
+    });
+    if (callback.isInternal && !d._allowInternalDetach) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'internal_callback_readonly',
+          message: 'Internal callback instances cannot be detached by customers.'
+        })
+      );
+    }
+
     if (d.callbackInstance.slateTriggerReceiverId) {
       let slatesTenant = await getTenantForSlates(d.tenant);
       try {

--- a/src/metorial/subspace/modules/connection/src/controller/receiver.ts
+++ b/src/metorial/subspace/modules/connection/src/controller/receiver.ts
@@ -28,6 +28,7 @@ import { conduit } from '../lib/conduit';
 import { broadcastNats } from '../lib/nats';
 import { CONDUIT_CONNECTION_MAX_PROCESSING_MS } from '../lib/timeouts';
 import { topics } from '../lib/topic';
+import { getProviderActionAdapterWhere } from '../lib/internalSession';
 import { completeMessage } from '../shared/completeMessage';
 import { setConnectionProviderSpecification } from '../shared/connectionSpecification';
 import { createMessage } from '../shared/createMessage';
@@ -321,7 +322,10 @@ export let startReceiver = () => {
         let [backend, tool] = await Promise.all([
           connectBackend(),
           db.providerTool.findFirstOrThrow({
-            where: { id: data.toolId, adapterOid: null }
+            where: {
+              id: data.toolId,
+              ...getProviderActionAdapterWhere(state.session)
+            }
           })
         ]);
 

--- a/src/metorial/subspace/modules/connection/src/controller/state/backend.ts
+++ b/src/metorial/subspace/modules/connection/src/controller/state/backend.ts
@@ -1,3 +1,4 @@
+import { db } from '@metorial-subspace/db';
 import { getBackend } from '@metorial-subspace/provider';
 import type {
   HandleMcpNotificationOrRequestParam,
@@ -8,6 +9,14 @@ import type { ConnectionState } from '.';
 
 export let getConnectionBackendConnection = async (state: ConnectionState) => {
   let backend = await getBackend({ entity: state.version });
+
+  let adapter = state.session.adapterGlobalOid
+    ? await db.providerAdapterGlobal.findUniqueOrThrow({
+        where: { oid: state.session.adapterGlobalOid },
+        select: { id: true, identifier: true, name: true }
+      })
+    : null;
+
   let run = await backend.providerRun.createProviderRun({
     tenant: state.instance.sessionProvider.tenant,
     providerConfigVersion: state.instance.sessionProvider.config.currentVersion!,
@@ -18,6 +27,7 @@ export let getConnectionBackendConnection = async (state: ConnectionState) => {
     session: state.session,
     connection: state.connection,
     participant: state.participant,
+    adapter,
 
     providerVersion: state.version,
     provider: state.version.provider,

--- a/src/metorial/subspace/modules/connection/src/lib/internalSession.test.ts
+++ b/src/metorial/subspace/modules/connection/src/lib/internalSession.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getProviderActionAdapterWhere } from './internalSession';
+
+describe('internal session adapter scope', () => {
+  it('selects only ordinary actions for ordinary sessions', () => {
+    expect(
+      getProviderActionAdapterWhere({ isInternal: false, adapterGlobalOid: null })
+    ).toEqual({ adapterOid: null });
+  });
+
+  it('selects only actions from the bound global adapter', () => {
+    expect(getProviderActionAdapterWhere({ isInternal: true, adapterGlobalOid: 42n })).toEqual(
+      { adapter: { globalOid: 42n } }
+    );
+  });
+
+  it('fails closed for an invalid internal session', () => {
+    expect(() =>
+      getProviderActionAdapterWhere({ isInternal: true, adapterGlobalOid: null })
+    ).toThrow('missing its adapter binding');
+  });
+});

--- a/src/metorial/subspace/modules/connection/src/lib/internalSession.ts
+++ b/src/metorial/subspace/modules/connection/src/lib/internalSession.ts
@@ -1,0 +1,13 @@
+export type SessionAdapterScope = {
+  isInternal: boolean;
+  adapterGlobalOid: bigint | null;
+};
+
+export let getProviderActionAdapterWhere = (session: SessionAdapterScope) => {
+  if (!session.isInternal) return { adapterOid: null } as const;
+  if (!session.adapterGlobalOid) {
+    throw new Error('Internal session is missing its adapter binding');
+  }
+
+  return { adapter: { globalOid: session.adapterGlobalOid } } as const;
+};

--- a/src/metorial/subspace/modules/connection/src/mcp/sender.ts
+++ b/src/metorial/subspace/modules/connection/src/mcp/sender.ts
@@ -321,6 +321,23 @@ export class McpSender {
       return;
     }
 
+    if (
+      this.session.isInternal &&
+      (method.startsWith('prompts/') || method.startsWith('resources/'))
+    ) {
+      return {
+        store: false,
+        mcp: {
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: -32601,
+            message: 'Method not found'
+          }
+        } satisfies JSONRPCErrorResponse
+      };
+    }
+
     switch (method) {
       case 'initialize': {
         let initMessage = mcpValidate(id, InitializeRequestSchema, msg);

--- a/src/metorial/subspace/modules/connection/src/sender/manager.ts
+++ b/src/metorial/subspace/modules/connection/src/sender/manager.ts
@@ -81,6 +81,7 @@ import {
 } from '../lib/connectionStatusTool';
 import { broadcastNats } from '../lib/nats';
 import { isSyntheticTool } from '../lib/syntheticTool';
+import { getProviderActionAdapterWhere } from '../lib/internalSession';
 import {
   CONNECTION_DIAGNOSTICS_TIMEOUT_MS,
   CONNECTION_TOOL_DISCOVERY_TIMEOUT_MS
@@ -165,6 +166,7 @@ export interface SenderMangerProps {
         foreignId: string;
       };
   connectionPrivateMetadata?: Record<string, any>;
+  adapter?: { identifier: string };
   ingressPolicyCheck?: {
     sourceIp: string;
     hostname?: string;
@@ -255,6 +257,8 @@ export class SenderManager {
                         ...getId('sessionConnection'),
                         token: oldToken,
                         isEphemeral: lockedCurrentSession.isEphemeral,
+                        isInternal: lockedCurrentSession.isInternal,
+                        adapterGlobalOid: lockedCurrentSession.adapterGlobalOid,
                         status: lockedConnection.status,
                         transport: lockedConnection.transport,
                         isParentDeleted: lockedConnection.isParentDeleted,
@@ -373,6 +377,29 @@ export class SenderManager {
       throw new ServiceError(goneError({ message: 'Session has been archived or deleted' }));
     }
 
+    let requestedAdapter = d.adapter
+      ? await db.providerAdapterGlobal.findUnique({
+          where: { identifier: d.adapter.identifier }
+        })
+      : null;
+    if (session.isInternal) {
+      if (!requestedAdapter || requestedAdapter.oid !== session.adapterGlobalOid) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'internal_session_adapter_mismatch',
+            message: 'The adapter supplied for this internal session is missing or incorrect.'
+          })
+        );
+      }
+    } else if (d.adapter) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'adapter_not_allowed_for_ordinary_session',
+          message: 'Adapters may only be used with internal sessions.'
+        })
+      );
+    }
+
     let connection = session.connection;
     if (d.connectionToken && !connection) {
       throw new ServiceError(notFoundError('connection'));
@@ -380,6 +407,18 @@ export class SenderManager {
     if (isRecordDeleted(connection)) {
       throw new ServiceError(
         goneError({ message: 'Connection has been archived or deleted' })
+      );
+    }
+    if (
+      connection &&
+      (connection.isInternal !== session.isInternal ||
+        (connection.adapterGlobalOid ?? null) !== (session.adapterGlobalOid ?? null))
+    ) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'connection_adapter_scope_mismatch',
+          message: 'The connection does not match the internal scope of its session.'
+        })
       );
     }
 
@@ -858,7 +897,10 @@ export class SenderManager {
 
     let tools = specificationOid
       ? await db.providerTool.findMany({
-          where: { specificationOid, adapterOid: null }
+          where: {
+            specificationOid,
+            ...getProviderActionAdapterWhere(this.session)
+          }
         })
       : [];
 
@@ -920,9 +962,11 @@ export class SenderManager {
 
     let tools = discoveryRes.flatMap(r => (r.status == 'ok' ? r.tools : []));
 
-    tools.push(buildConnectionStatusTool(this.session) as unknown as (typeof tools)[number]);
+    if (!this.session.isInternal) {
+      tools.push(buildConnectionStatusTool(this.session) as unknown as (typeof tools)[number]);
+    }
 
-    if (failedRes.length > 0) {
+    if (!this.session.isInternal && failedRes.length > 0) {
       // A failed provider never fails the whole listing: the session keeps
       // working and each failed provider gets a synthetic
       // `{provider}_connection_failed` tool that explains the failure.
@@ -1066,7 +1110,7 @@ export class SenderManager {
       where: {
         key: d.originalToolName,
         specificationOid,
-        adapterOid: null
+        ...getProviderActionAdapterWhere(this.session)
       }
     });
     if (!tool) return null;
@@ -1127,6 +1171,9 @@ export class SenderManager {
 
   async getToolById(d: { toolId: string }) {
     if (d.toolId === CONNECTION_STATUS_TOOL_KEY) {
+      if (this.session.isInternal) {
+        throw new ServiceError(notFoundError('tool', d.toolId));
+      }
       return {
         provider: null,
         instance: null,
@@ -1165,6 +1212,7 @@ export class SenderManager {
 
     for (let match of matches) {
       if (match!.originalToolName === CONNECTION_FAILED_TOOL_KEY) {
+        if (this.session.isInternal) continue;
         let synthetic = await this.resolveConnectionFailedTool(match!.provider);
         if (synthetic) return synthetic;
       }
@@ -1182,6 +1230,9 @@ export class SenderManager {
     provider: Awaited<ReturnType<SenderManager['listProviders']>>[number];
     type: string;
   }) {
+    if (this.session.isInternal) {
+      throw new ServiceError(notFoundError('tool', d.type));
+    }
     let toolsRes = await this.listToolsForProvider(d.provider);
     if (toolsRes.status === 'discovery_failed') {
       throw new ServiceError(
@@ -1559,6 +1610,8 @@ export class SenderManager {
           token: await ID.generateId('sessionConnection_token'),
 
           isEphemeral: this.session.isEphemeral,
+          isInternal: this.session.isInternal,
+          adapterGlobalOid: this.session.adapterGlobalOid,
 
           status: 'active',
           state: 'connected',
@@ -1604,12 +1657,32 @@ export class SenderManager {
   }
 
   async setConnection(connection: SessionConnection) {
+    if (
+      connection.sessionOid !== this.session.oid ||
+      connection.isInternal !== this.session.isInternal ||
+      (connection.adapterGlobalOid ?? null) !== (this.session.adapterGlobalOid ?? null)
+    ) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'connection_adapter_scope_mismatch',
+          message: 'The connection does not match the internal scope of its session.'
+        })
+      );
+    }
     this.connection = Object.assign(this.connection ?? {}, connection);
   }
 
   async disableConnection() {
     if (!this.connection) {
       throw new ServiceError(badRequestError({ message: 'No connection to disable' }));
+    }
+    if (this.session.isInternal) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'internal_session_readonly',
+          message: 'Internal session connections cannot be disabled by customers.'
+        })
+      );
     }
 
     this.connection = await db.sessionConnection.update({
@@ -1718,6 +1791,8 @@ export class SenderManager {
           isForManualToolCalls: !!d.isManualConnection,
           isReplaced: false,
           isEphemeral: this.session.isEphemeral,
+          isInternal: this.session.isInternal,
+          adapterGlobalOid: this.session.adapterGlobalOid,
           status: 'active',
           tenantOid: this.tenant.oid,
           projectOid: this.tenant.projectOid,

--- a/src/metorial/subspace/modules/monitor/src/services/alert.test.ts
+++ b/src/metorial/subspace/modules/monitor/src/services/alert.test.ts
@@ -81,6 +81,37 @@ describe('alertService', () => {
         })
       })
     );
+
+    let and = monitorAlertFindMany.mock.calls[0]![0].where.AND;
+    expect(and).toContainEqual({
+      OR: [
+        { protoGuardAlertOid: null },
+        { protoGuardAlert: { session: { isInternal: false } } }
+      ]
+    });
+  });
+
+  it('allows internal alerts only through an explicit session filter', async () => {
+    let shared = await import('./_shared');
+    vi.mocked(shared.resolveSessionOids).mockResolvedValue([44n] as any);
+    let { alertService } = await import('./alert');
+
+    let paginator = await alertService.listAlertsInternal({
+      tenant: { oid: 1n },
+      environment: { oid: 2n },
+      sessionIds: ['session_internal']
+    } as any);
+
+    await paginator.run({});
+
+    let and = monitorAlertFindMany.mock.calls[0]![0].where.AND;
+    expect(and).not.toContainEqual({
+      OR: [
+        { protoGuardAlertOid: null },
+        { protoGuardAlert: { session: { isInternal: false } } }
+      ]
+    });
+    expect(and).toContainEqual({ protoGuardAlert: { sessionOid: { in: [44n] } } });
   });
 
   it('passes the resolved actor through every Metorial-facing alert action', async () => {

--- a/src/metorial/subspace/modules/monitor/src/services/alert.ts
+++ b/src/metorial/subspace/modules/monitor/src/services/alert.ts
@@ -190,6 +190,7 @@ let getAlertById = async (d: Scope & { alertId: string; actor?: TenantActor | nu
 };
 
 export type ListAlertsParams = Scope & {
+  includeInternal?: boolean;
   ids?: string[];
   monitorIds?: string[];
   statuses?: MonitorAlertStatus[];
@@ -257,6 +258,14 @@ class alertServiceImpl {
             environmentOid: d.environment.oid,
             solutionOid: solution.oid,
             AND: [
+              !d.includeInternal && !d.sessionIds?.length
+                ? {
+                    OR: [
+                      { protoGuardAlertOid: null },
+                      { protoGuardAlert: { session: { isInternal: false } } }
+                    ]
+                  }
+                : undefined!,
               d.ids ? { id: { in: d.ids } } : undefined!,
               monitorOids ? { monitorOid: { in: monitorOids } } : undefined!,
               d.statuses ? { status: { in: d.statuses } } : undefined!,

--- a/src/metorial/subspace/modules/monitor/src/services/protoGuardAlert.ts
+++ b/src/metorial/subspace/modules/monitor/src/services/protoGuardAlert.ts
@@ -48,6 +48,7 @@ let getProtoGuardAlertById = async (d: Scope & { alertId: string }) => {
 };
 
 export type ListProtoGuardAlertsParams = Scope & {
+  includeInternal?: boolean;
   ids?: string[];
   runIds?: string[];
   filterIds?: string[];
@@ -95,6 +96,9 @@ class protoGuardAlertServiceImpl {
             environmentOid: d.environment.oid,
             solutionOid: solution.oid,
             AND: [
+              !d.includeInternal && !d.sessionIds?.length
+                ? { session: { isInternal: false } }
+                : undefined!,
               d.ids ? { id: { in: d.ids } } : undefined!,
               runOids ? { runOid: { in: runOids } } : undefined!,
               filterOids

--- a/src/metorial/subspace/modules/session/src/services/_shared/createSession.test.ts
+++ b/src/metorial/subspace/modules/session/src/services/_shared/createSession.test.ts
@@ -110,6 +110,24 @@ describe('createSessionRecord double writes', () => {
     expect(data.sessionEvents.create.instanceOid).toBeNull();
   });
 
+  it('stores an explicit internal adapter binding without consulting the template', async () => {
+    await createSessionRecord({
+      tenant: linkedTenant as any,
+      environment: linkedEnvironment as any,
+      isEphemeral: true,
+      isInternal: true,
+      adapterGlobalOid: 55n,
+      input: { providers: [{ deploymentId: 'pd_1' }] }
+    });
+
+    expect(createdData()).toMatchObject({
+      isEphemeral: true,
+      isInternal: true,
+      adapterGlobalOid: 55n
+    });
+    expect(mocks.sessionTemplateFindFirst).not.toHaveBeenCalled();
+  });
+
   it('does not add the mirrored references to any read filter', async () => {
     mocks.sessionTemplateFindFirst.mockResolvedValue(null);
 

--- a/src/metorial/subspace/modules/session/src/services/_shared/createSession.ts
+++ b/src/metorial/subspace/modules/session/src/services/_shared/createSession.ts
@@ -16,6 +16,7 @@ import {
 export let sessionInclude = {
   identityActor: true,
   identity: true,
+  adapterGlobal: true,
   providers: {
     include: sessionProviderInclude,
     where: { status: 'active' as const }
@@ -35,6 +36,8 @@ export let createSessionRecord = async (d: {
     providers: SessionProviderInput[];
   };
   isEphemeral: boolean;
+  isInternal?: boolean;
+  adapterGlobalOid?: bigint | null;
   ephemeralManagedSessionOid?: bigint | null;
 }) => {
   let solution = await getMetorialSolution();
@@ -66,6 +69,8 @@ export let createSessionRecord = async (d: {
         status: 'active',
 
         isEphemeral: d.isEphemeral,
+        isInternal: d.isInternal ?? false,
+        adapterGlobalOid: d.adapterGlobalOid ?? null,
 
         name: d.input.name?.trim() || undefined,
         description: d.input.description?.trim() || undefined,

--- a/src/metorial/subspace/modules/session/src/services/_shared/internalAdapter.ts
+++ b/src/metorial/subspace/modules/session/src/services/_shared/internalAdapter.ts
@@ -1,0 +1,118 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { db, type Environment, type Session, type Tenant } from '@metorial-subspace/db';
+
+export type InternalAdapterInput = { identifier: string };
+
+export let resolveInternalAdapter = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapter: InternalAdapterInput;
+}) => {
+  let adapter = await db.providerAdapterGlobal.findUnique({
+    where: { identifier: d.adapter.identifier }
+  });
+  if (!adapter) {
+    throw new ServiceError(notFoundError('provider.adapter', d.adapter.identifier));
+  }
+
+  return adapter;
+};
+
+export let assertInternalAdapterSupportedBySession = async (d: {
+  session: Pick<Session, 'oid'>;
+  adapterGlobalOid: bigint;
+}) => {
+  let sessionProviders = await db.sessionProvider.findMany({
+    where: { sessionOid: d.session.oid, status: 'active' },
+    include: {
+      deployment: {
+        include: {
+          currentVersion: true,
+          providerVariant: true
+        }
+      }
+    }
+  });
+
+  let versionOids = sessionProviders
+    .map(
+      provider =>
+        provider.deployment.currentVersion?.lockedVersionOid ??
+        provider.deployment.providerVariant.currentVersionOid
+    )
+    .filter((oid): oid is bigint => oid != null);
+
+  let supported = versionOids.length
+    ? await db.providerVersionAdapter.findFirst({
+        where: {
+          providerVersionOid: { in: versionOids },
+          adapter: { globalOid: d.adapterGlobalOid }
+        },
+        select: { oid: true }
+      })
+    : null;
+
+  if (!supported) {
+    throw new ServiceError(
+      badRequestError({
+        code: 'internal_adapter_not_supported',
+        message: 'None of the session provider versions support the requested adapter.'
+      })
+    );
+  }
+};
+
+export let assertSessionInternalAdapter = async (d: {
+  session: Pick<Session, 'isInternal' | 'adapterGlobalOid'>;
+  adapter?: InternalAdapterInput;
+}) => {
+  if (!d.session.isInternal) {
+    if (d.adapter) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'adapter_not_allowed_for_ordinary_session',
+          message: 'An adapter may only be supplied when accessing an internal session.'
+        })
+      );
+    }
+    return null;
+  }
+
+  if (!d.adapter || !d.session.adapterGlobalOid) {
+    throw new ServiceError(
+      badRequestError({
+        code: 'internal_session_adapter_required',
+        message: 'The adapter bound to this internal session must be supplied.'
+      })
+    );
+  }
+
+  let adapter = await db.providerAdapterGlobal.findUnique({
+    where: { identifier: d.adapter.identifier }
+  });
+  if (!adapter || adapter.oid !== d.session.adapterGlobalOid) {
+    throw new ServiceError(
+      badRequestError({
+        code: 'internal_session_adapter_mismatch',
+        message: 'The supplied adapter does not match the adapter bound to this session.'
+      })
+    );
+  }
+
+  return adapter;
+};
+
+export let assertInternalSessionMutable = (
+  session: Pick<Session, 'isInternal'>,
+  action: string,
+  allow = false
+) => {
+  if (!session.isInternal || allow) return;
+
+  throw new ServiceError(
+    badRequestError({
+      code: 'internal_session_readonly',
+      message: `Cannot ${action} an internal session.`
+    })
+  );
+};

--- a/src/metorial/subspace/modules/session/src/services/ephemeralManagedSession.ts
+++ b/src/metorial/subspace/modules/session/src/services/ephemeralManagedSession.ts
@@ -1,4 +1,4 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { createLock } from '@lowerdeck/lock';
 import { Service } from '@lowerdeck/service';
 import {
@@ -22,6 +22,11 @@ import {
 import { env } from '../env';
 import { sessionArchivedQueue } from '../queues/lifecycle/session';
 import { createSessionRecord } from './_shared/createSession';
+import {
+  assertInternalAdapterSupportedBySession,
+  type InternalAdapterInput,
+  resolveInternalAdapter
+} from './_shared/internalAdapter';
 import { type SessionProviderTemplateInput } from './sessionProviderInput';
 
 let ephemeralManagedSessionResolveLock = createLock({
@@ -89,6 +94,14 @@ let shouldRotateBackingSession = (ephemeralManagedSession: EphemeralManagedSessi
   if (currentSession.status !== 'active') return true;
   if (!currentSession.isEphemeral) return true;
   if (currentSession.ephemeralManagedSessionOid !== ephemeralManagedSession.oid) return true;
+  if (currentSession.isInternal !== ephemeralManagedSession.markSessionsAsInternal)
+    return true;
+  if (
+    (currentSession.adapterGlobalOid ?? null) !==
+    (ephemeralManagedSession.adapterGlobalOid ?? null)
+  ) {
+    return true;
+  }
   if (
     (ephemeralManagedSession.templateHash ?? null) !==
     (ephemeralManagedSession.sessionTemplate.hash ?? null)
@@ -141,6 +154,8 @@ export type CreateEphemeralManagedSessionParams = {
   sessionTemplate: SessionProviderTemplateInput;
   input: {
     maxSessionDurationInMinutes: number;
+    markSessionsAsInternal?: boolean;
+    adapter?: InternalAdapterInput;
   };
 };
 
@@ -151,6 +166,8 @@ export type UpsertPlaceholderEphemeralManagedSessionParams = {
     maxSessionDurationInMinutes: number;
     actorOid?: bigint | null;
     isReconciling?: boolean;
+    markSessionsAsInternal?: boolean;
+    adapter?: InternalAdapterInput;
   };
 };
 
@@ -159,7 +176,9 @@ export type ArchiveEphemeralManagedSessionParams = {
 };
 
 class ephemeralManagedSessionServiceImpl {
-  async getEphemeralManagedSessionById(d: MetorialFacing<GetEphemeralManagedSessionByIdParams>) {
+  async getEphemeralManagedSessionById(
+    d: MetorialFacing<GetEphemeralManagedSessionByIdParams>
+  ) {
     let { instance, organizationActor, ...rest } = d;
     let scope = await resolveMetorialFacing(d);
 
@@ -210,6 +229,22 @@ class ephemeralManagedSessionServiceImpl {
     let solution = await getMetorialSolution();
 
     return withTransaction(async db => {
+      let markSessionsAsInternal = d.input.markSessionsAsInternal ?? false;
+      if (markSessionsAsInternal !== !!d.input.adapter) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'invalid_internal_ephemeral_session_adapter',
+            message: 'Internal ephemeral managed sessions require exactly one adapter.'
+          })
+        );
+      }
+      let adapter = d.input.adapter
+        ? await resolveInternalAdapter({
+            tenant: d.tenant,
+            environment: d.environment,
+            adapter: d.input.adapter
+          })
+        : null;
       let ephemeralManagedSession = await db.ephemeralManagedSession.create({
         data: {
           ...getId('ephemeralManagedSession'),
@@ -223,7 +258,9 @@ class ephemeralManagedSessionServiceImpl {
           actorOid: d.sessionTemplate.identityActorOid ?? null,
           identityOid: d.sessionTemplate.identityOid ?? null,
           maxSessionDurationInMinutes: d.input.maxSessionDurationInMinutes,
-          templateHash: d.sessionTemplate.hash ?? null
+          templateHash: d.sessionTemplate.hash ?? null,
+          markSessionsAsInternal,
+          adapterGlobalOid: adapter?.oid ?? null
         },
         include
       });
@@ -232,6 +269,8 @@ class ephemeralManagedSessionServiceImpl {
         tenant: d.tenant,
         environment: d.environment,
         isEphemeral: true,
+        isInternal: markSessionsAsInternal,
+        adapterGlobalOid: adapter?.oid ?? null,
         ephemeralManagedSessionOid: ephemeralManagedSession.oid,
         identityActorOid: d.sessionTemplate.identityActorOid ?? null,
         identityOid: d.sessionTemplate.identityOid ?? null,
@@ -249,6 +288,13 @@ class ephemeralManagedSessionServiceImpl {
           ]
         }
       });
+
+      if (adapter) {
+        await assertInternalAdapterSupportedBySession({
+          session,
+          adapterGlobalOid: adapter.oid
+        });
+      }
 
       return await db.ephemeralManagedSession.update({
         where: { oid: ephemeralManagedSession.oid },
@@ -287,6 +333,22 @@ class ephemeralManagedSessionServiceImpl {
     let solution = await getMetorialSolution();
 
     return withTransaction(async db => {
+      let markSessionsAsInternal = d.input.markSessionsAsInternal ?? false;
+      if (markSessionsAsInternal !== !!d.input.adapter) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'invalid_internal_ephemeral_session_adapter',
+            message: 'Internal ephemeral managed sessions require exactly one adapter.'
+          })
+        );
+      }
+      let adapter = d.input.adapter
+        ? await resolveInternalAdapter({
+            tenant: d.tenant,
+            environment: d.environment,
+            adapter: d.input.adapter
+          })
+        : null;
       let data = {
         status: 'active' as const,
         archivedAt: null,
@@ -294,7 +356,9 @@ class ephemeralManagedSessionServiceImpl {
         sessionTemplateOid: d.sessionTemplate.oid,
         actorOid: d.input.actorOid ?? d.sessionTemplate.identityActorOid ?? null,
         identityOid: d.sessionTemplate.identityOid ?? null,
-        isReconciling: d.input.isReconciling ?? false
+        isReconciling: d.input.isReconciling ?? false,
+        markSessionsAsInternal,
+        adapterGlobalOid: adapter?.oid ?? null
       };
 
       if (d.ephemeralManagedSession) {
@@ -325,7 +389,9 @@ class ephemeralManagedSessionServiceImpl {
     });
   }
 
-  async archiveEphemeralManagedSession(d: MetorialFacing<ArchiveEphemeralManagedSessionParams>) {
+  async archiveEphemeralManagedSession(
+    d: MetorialFacing<ArchiveEphemeralManagedSessionParams>
+  ) {
     let { instance, organizationActor, ...rest } = d;
     let scope = await resolveMetorialFacing(d);
 
@@ -457,6 +523,8 @@ class ephemeralManagedSessionServiceImpl {
           tenant: ephemeralManagedSession.tenant,
           environment: ephemeralManagedSession.environment,
           isEphemeral: true,
+          isInternal: ephemeralManagedSession.markSessionsAsInternal,
+          adapterGlobalOid: ephemeralManagedSession.adapterGlobalOid,
           ephemeralManagedSessionOid: ephemeralManagedSession.oid,
           identityActorOid: ephemeralManagedSession.sessionTemplate.identityActorOid ?? null,
           identityOid: ephemeralManagedSession.sessionTemplate.identityOid ?? null,
@@ -476,6 +544,13 @@ class ephemeralManagedSessionServiceImpl {
             ]
           }
         });
+
+        if (ephemeralManagedSession.adapterGlobalOid) {
+          await assertInternalAdapterSupportedBySession({
+            session,
+            adapterGlobalOid: ephemeralManagedSession.adapterGlobalOid
+          });
+        }
 
         await db.ephemeralManagedSession.update({
           where: { oid: ephemeralManagedSession.oid },

--- a/src/metorial/subspace/modules/session/src/services/providerRun.ts
+++ b/src/metorial/subspace/modules/session/src/services/providerRun.ts
@@ -1,7 +1,12 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { db, type Environment, type ProviderRunStatus, type Tenant } from '@metorial-subspace/db';
+import {
+  db,
+  type Environment,
+  type ProviderRunStatus,
+  type Tenant
+} from '@metorial-subspace/db';
 import {
   type DateFilter,
   mergeRetentionWithDateFilter,
@@ -31,6 +36,7 @@ export let providerRunInclude = include;
 export type ListProviderRunsParams = {
   status?: ProviderRunStatus[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
   sessionIds?: string[];
@@ -84,6 +90,9 @@ class providerRunServiceImpl {
               ...normalizeStatusForList(d).onlyParent,
 
               AND: [
+                !d.includeInternal && !d.sessionIds?.length
+                  ? { session: { isInternal: false } }
+                  : undefined!,
                 d.ids ? { id: { in: d.ids } } : undefined!,
 
                 sessions ? { sessionOid: sessions.in } : undefined!,

--- a/src/metorial/subspace/modules/session/src/services/session.ts
+++ b/src/metorial/subspace/modules/session/src/services/session.ts
@@ -43,6 +43,12 @@ import {
 } from '../lib/sessionEnrichment';
 import { sessionArchivedQueue, sessionUpdatedQueue } from '../queues/lifecycle/session';
 import { createSessionRecord, sessionInclude as include } from './_shared/createSession';
+import {
+  assertInternalAdapterSupportedBySession,
+  assertInternalSessionMutable,
+  type InternalAdapterInput,
+  resolveInternalAdapter
+} from './_shared/internalAdapter';
 import { type SessionProviderInput } from './sessionProviderInput';
 
 export { finalizeSessionCreate };
@@ -66,6 +72,7 @@ let assertCanWriteSession = (
 export type ListSessionsParams = {
   status?: SessionStatus[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
   accessTagSessionIds?: string[];
@@ -102,6 +109,10 @@ export type CreateSessionParams = {
   };
 };
 
+export type CreateInternalSessionParams = CreateSessionParams & {
+  adapter?: InternalAdapterInput;
+};
+
 export type UpdateSessionParams = {
   session: Session;
   input: {
@@ -111,11 +122,13 @@ export type UpdateSessionParams = {
     privateMetadata?: Record<string, any>;
   };
   _allowMagicMcpUpdate?: boolean;
+  _allowInternalUpdate?: boolean;
 };
 
 export type ArchiveSessionParams = {
   session: Session;
   _allowMagicMcpDelete?: boolean;
+  _allowInternalDelete?: boolean;
 };
 
 class sessionServiceImpl {
@@ -144,7 +157,10 @@ class sessionServiceImpl {
   }
 
   async listSessionsInternal(
-    d: { tenant: Tenant; environment: Environment } & Omit<ListSessionsParams, 'accessTagSessionIds'>
+    d: { tenant: Tenant; environment: Environment } & Omit<
+      ListSessionsParams,
+      'accessTagSessionIds'
+    >
   ) {
     let solution = await getMetorialSolution();
 
@@ -172,6 +188,7 @@ class sessionServiceImpl {
               // isEphemeral: false,
 
               ...normalizeStatusForList(d).noParent,
+              ...(d.includeInternal ? {} : { isInternal: false }),
 
               AND: [
                 d.ids ? { id: { in: d.ids } } : undefined!,
@@ -249,7 +266,9 @@ class sessionServiceImpl {
     });
   }
 
-  async getSessionByIdInternal(d: { tenant: Tenant; environment: Environment } & GetSessionByIdParams) {
+  async getSessionByIdInternal(
+    d: { tenant: Tenant; environment: Environment } & GetSessionByIdParams
+  ) {
     let solution = await getMetorialSolution();
 
     let session = await db.session.findFirst({
@@ -326,15 +345,35 @@ class sessionServiceImpl {
     return enriched;
   }
 
-  async createSessionInternal(d: { tenant: Tenant; environment: Environment } & CreateSessionParams) {
-    return withTransaction(async db =>
-      createSessionRecord({
+  async createSessionInternal(
+    d: { tenant: Tenant; environment: Environment } & CreateInternalSessionParams
+  ) {
+    return withTransaction(async db => {
+      let adapter = d.adapter
+        ? await resolveInternalAdapter({
+            tenant: d.tenant,
+            environment: d.environment,
+            adapter: d.adapter
+          })
+        : null;
+      let session = await createSessionRecord({
         tenant: d.tenant,
         environment: d.environment,
         input: d.input,
-        isEphemeral: false
-      })
-    );
+        isEphemeral: false,
+        isInternal: !!adapter,
+        adapterGlobalOid: adapter?.oid ?? null
+      });
+
+      if (adapter) {
+        await assertInternalAdapterSupportedBySession({
+          session,
+          adapterGlobalOid: adapter.oid
+        });
+      }
+
+      return session;
+    });
   }
 
   async updateSession(d: MetorialFacing<UpdateSessionParams>) {
@@ -366,13 +405,17 @@ class sessionServiceImpl {
   }
 
   async updateSessionInternal(
-    d: { tenant: Tenant; environment: Environment } & Omit<UpdateSessionParams, '_allowMagicMcpUpdate'>
+    d: { tenant: Tenant; environment: Environment } & Omit<
+      UpdateSessionParams,
+      '_allowMagicMcpUpdate'
+    >
   ) {
     let solution = await getMetorialSolution();
 
     checkTenant(d, d.session);
     checkDeletedEdit(d.session, 'update');
     assertCanWriteSession(d.session, 'update');
+    assertInternalSessionMutable(d.session, 'update', d._allowInternalUpdate);
 
     return withTransaction(async db => {
       let session = await db.session.update({
@@ -428,13 +471,17 @@ class sessionServiceImpl {
   }
 
   async archiveSessionInternal(
-    d: { tenant: Tenant; environment: Environment } & Omit<ArchiveSessionParams, '_allowMagicMcpDelete'>
+    d: { tenant: Tenant; environment: Environment } & Omit<
+      ArchiveSessionParams,
+      '_allowMagicMcpDelete'
+    >
   ) {
     let solution = await getMetorialSolution();
 
     checkTenant(d, d.session);
     checkDeletedEdit(d.session, 'archive');
     assertCanWriteSession(d.session, 'archive');
+    assertInternalSessionMutable(d.session, 'archive', d._allowInternalDelete);
 
     return withTransaction(async db => {
       let archivedAt = new Date();
@@ -472,7 +519,10 @@ class sessionServiceImpl {
   }
 
   async deleteSessionInternal(
-    d: { tenant: Tenant; environment: Environment } & Omit<ArchiveSessionParams, '_allowMagicMcpDelete'>
+    d: { tenant: Tenant; environment: Environment } & Omit<
+      ArchiveSessionParams,
+      '_allowMagicMcpDelete'
+    >
   ) {
     return this.archiveSessionInternal(d);
   }

--- a/src/metorial/subspace/modules/session/src/services/sessionConnection.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionConnection.ts
@@ -31,6 +31,7 @@ import { sessionParticipantInclude } from './sessionParticipant';
 
 let include = {
   session: true,
+  adapterGlobal: true,
   participant: { include: sessionParticipantInclude }
 };
 export let sessionConnectionInclude = include;
@@ -39,6 +40,7 @@ export type ListSessionConnectionsParams = {
   status?: SessionConnectionStatus[];
   connectionState?: SessionConnectionState[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
   agentIds?: string[];
@@ -128,6 +130,9 @@ class sessionConnectionServiceImpl {
               state: d.connectionState ? { in: d.connectionState } : undefined,
 
               AND: [
+                !d.includeInternal && !d.sessionIds?.length
+                  ? { isInternal: false }
+                  : undefined!,
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 d.agentInstanceIds
                   ? { participant: { agentInstance: { id: { in: d.agentInstanceIds } } } }

--- a/src/metorial/subspace/modules/session/src/services/sessionError.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionError.ts
@@ -39,6 +39,7 @@ export let sessionErrorInclude = include;
 export type ListSessionErrorsParams = {
   types?: SessionErrorType[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
   sessionIds?: string[];
@@ -106,6 +107,9 @@ class sessionErrorServiceImpl {
               ...normalizeStatusForList(d).onlyParent,
 
               AND: [
+                !d.includeInternal && !d.sessionIds?.length
+                  ? { session: { isInternal: false } }
+                  : undefined!,
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 d.types ? { type: { in: d.types } } : undefined!,
 

--- a/src/metorial/subspace/modules/session/src/services/sessionErrorGroup.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionErrorGroup.ts
@@ -1,7 +1,12 @@
 import { notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { db, type Environment, type SessionErrorType, type Tenant } from '@metorial-subspace/db';
+import {
+  db,
+  type Environment,
+  type SessionErrorType,
+  type Tenant
+} from '@metorial-subspace/db';
 import {
   type DateFilter,
   mergeRetentionWithDateFilter,
@@ -22,6 +27,7 @@ let include = {
 
 export type ListSessionErrorGroupsParams = {
   types?: SessionErrorType[];
+  includeInternal?: boolean;
 
   ids?: string[];
   sessionIds?: string[];
@@ -66,6 +72,9 @@ class sessionErrorGroupServiceImpl {
               environmentOid: d.environment.oid,
 
               AND: [
+                !d.includeInternal && !d.sessionIds?.length
+                  ? { instances: { some: { session: { isInternal: false } } } }
+                  : undefined!,
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 d.types ? { type: { in: d.types } } : undefined!,
 

--- a/src/metorial/subspace/modules/session/src/services/sessionEvent.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionEvent.ts
@@ -44,6 +44,7 @@ let include = {
 export type ListSessionEventsParams = {
   types?: SessionEventType[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
   sessionIds?: string[];
@@ -158,6 +159,9 @@ class sessionEventServiceImpl {
             ...normalizeStatusForList(d).onlyParent,
 
             AND: [
+              !d.includeInternal && !d.sessionIds?.length
+                ? { session: { isInternal: false } }
+                : undefined!,
               d.ids ? { id: { in: d.ids } } : undefined!,
               d.types ? { type: { in: d.types } } : undefined!,
 

--- a/src/metorial/subspace/modules/session/src/services/sessionMcpMessaging.test.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionMcpMessaging.test.ts
@@ -45,6 +45,7 @@ describe('sessionMcpMessagingService', () => {
         tenantId: 'tenant_1',
         sessionId: 'session_1',
         connectionToken: 'existing_token',
+        adapter: { identifier: 'chat' },
         message: {
           jsonrpc: '2.0',
           id: 1,
@@ -66,6 +67,7 @@ describe('sessionMcpMessagingService', () => {
         tenantId: 'tenant_1',
         sessionId: 'session_1',
         connectionToken: 'existing_token',
+        adapter: { identifier: 'chat' },
         mcpTransport: 'streamable_http',
         waitForResponse: true
       })

--- a/src/metorial/subspace/modules/session/src/services/sessionMcpMessaging.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionMcpMessaging.ts
@@ -1,4 +1,5 @@
 import { Service } from '@lowerdeck/service';
+import { handleMcpRequest } from '@metorial-subspace/module-connection';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 
 export type SessionMcpAgentClient =
@@ -24,11 +25,10 @@ class SessionMcpMessagingService {
     connectionToken?: string | null;
     agentClient?: SessionMcpAgentClient;
     connectionPrivateMetadata?: Record<string, any>;
+    adapter?: { identifier: string };
     message: JSONRPCMessage;
     onProgress?: (message: JSONRPCMessage) => Promise<void>;
   }) {
-    // This is intentionally lazy: connection already depends on session utilities.
-    let { handleMcpRequest } = await import('@metorial-subspace/module-connection');
     let { connection, response } = await handleMcpRequest({
       solutionId: d.solutionId,
       tenantId: d.tenantId,
@@ -36,6 +36,7 @@ class SessionMcpMessagingService {
       connectionToken: d.connectionToken ?? undefined,
       agentClient: d.agentClient,
       connectionPrivateMetadata: d.connectionPrivateMetadata,
+      adapter: d.adapter,
       mcpTransport: 'streamable_http',
       message: d.message,
       waitForResponse: true,

--- a/src/metorial/subspace/modules/session/src/services/sessionMessage.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionMessage.ts
@@ -46,6 +46,7 @@ export type ListSessionMessagesParams = {
   hierarchy?: ('parent' | 'child')[];
 
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
   sessionIds?: string[];
@@ -182,6 +183,9 @@ class sessionMessageServiceImpl {
             environmentOid: d.environment.oid,
 
             AND: [
+              !d.includeInternal && !d.sessionIds?.length
+                ? { session: { isInternal: false } }
+                : undefined!,
               normalizeStatusForList(d).onlyParent,
               { status: { not: 'waiting_for_response' as const } },
 

--- a/src/metorial/subspace/modules/session/src/services/sessionParticipant.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionParticipant.ts
@@ -47,6 +47,7 @@ export let sessionParticipantInclude = include;
 export type ListSessionParticipantsParams = {
   types?: SessionParticipantType[];
   connectionTypes?: SessionParticipantConnectionType[];
+  includeInternal?: boolean;
 
   ids?: string[];
   agentIds?: string[];
@@ -116,6 +117,27 @@ class sessionParticipantServiceImpl {
               environmentOid: d.environment.oid,
 
               AND: [
+                !d.includeInternal && !d.sessionIds?.length
+                  ? {
+                      OR: [
+                        {
+                          sessionConnections: {
+                            some: { session: { isInternal: false } }
+                          }
+                        },
+                        {
+                          sessionMessagesSender: {
+                            some: { session: { isInternal: false } }
+                          }
+                        },
+                        {
+                          sessionMessagesResponder: {
+                            some: { session: { isInternal: false } }
+                          }
+                        }
+                      ]
+                    }
+                  : undefined!,
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 d.types ? { type: { in: d.types } } : undefined!,
                 d.connectionTypes ? { connectionType: { in: d.connectionTypes } } : undefined!,

--- a/src/metorial/subspace/modules/session/src/services/sessionProvider.ts
+++ b/src/metorial/subspace/modules/session/src/services/sessionProvider.ts
@@ -38,6 +38,7 @@ import {
   type SessionProviderInputToolFilters
 } from './sessionProviderInput';
 import { sessionProviderNameTemplateService } from './sessionProviderNameTemplate';
+import { assertInternalSessionMutable } from './_shared/internalAdapter';
 
 let include = {
   provider: true,
@@ -53,6 +54,7 @@ export let sessionProviderInclude = include;
 export type ListSessionProvidersParams = {
   status?: SessionProviderStatus[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
   sessionIds?: string[];
@@ -74,6 +76,7 @@ export type GetSessionProviderByIdParams = {
 export type CreateSessionProviderParams = {
   session: Session;
   input: SessionProviderInput;
+  _allowInternalUpdate?: boolean;
 };
 
 export type UpdateSessionProviderParams = {
@@ -81,10 +84,12 @@ export type UpdateSessionProviderParams = {
   input: {
     toolFilters?: SessionProviderInputToolFilters;
   };
+  _allowInternalUpdate?: boolean;
 };
 
 export type ArchiveSessionProviderParams = {
   sessionProvider: SessionProvider;
+  _allowInternalDelete?: boolean;
 };
 
 class sessionProviderServiceImpl {
@@ -134,6 +139,9 @@ class sessionProviderServiceImpl {
               ...normalizeStatusForList(d).noParent,
 
               AND: [
+                !d.includeInternal && !d.sessionIds?.length
+                  ? { session: { isInternal: false } }
+                  : undefined!,
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 sessions ? { sessionOid: sessions.in } : undefined!,
                 sessionTemplates ? { fromTemplateOid: sessionTemplates.in } : undefined!,
@@ -212,6 +220,7 @@ class sessionProviderServiceImpl {
     d: { tenant: Tenant; environment: Environment } & CreateSessionProviderParams
   ) {
     checkDeletedRelation(d.session);
+    assertInternalSessionMutable(d.session, 'add providers to', d._allowInternalUpdate);
 
     let [res] = await sessionProviderInputService.createSessionProvidersForInput({
       tenant: d.tenant,
@@ -252,6 +261,10 @@ class sessionProviderServiceImpl {
 
     checkTenant(d, d.sessionProvider);
     checkDeletedEdit(d.sessionProvider, 'update');
+    let session = await db.session.findUniqueOrThrow({
+      where: { oid: d.sessionProvider.sessionOid }
+    });
+    assertInternalSessionMutable(session, 'update providers on', d._allowInternalUpdate);
 
     return await db.sessionProvider.update({
       where: {
@@ -293,6 +306,10 @@ class sessionProviderServiceImpl {
   ) {
     checkTenant(d, d.sessionProvider);
     checkDeletedEdit(d.sessionProvider, 'archive');
+    let session = await db.session.findUniqueOrThrow({
+      where: { oid: d.sessionProvider.sessionOid }
+    });
+    assertInternalSessionMutable(session, 'archive providers on', d._allowInternalDelete);
 
     return await db.sessionProvider.update({
       where: {

--- a/src/metorial/subspace/modules/session/src/services/toolCall.ts
+++ b/src/metorial/subspace/modules/session/src/services/toolCall.ts
@@ -26,6 +26,7 @@ import {
   resolveProviderDeployments,
   resolveProviders,
   resolveProviderTools,
+  resolveSessions,
   resolveSessionTemplates
 } from '@metorial-subspace/list-utils';
 import { agentInstanceService, agentService } from '@metorial-subspace/module-agent';
@@ -59,8 +60,10 @@ let connectionInitLock = createLock({
 export type ListToolCallsParams = {
   status?: SessionMessageStatus[];
   allowDeleted?: boolean;
+  includeInternal?: boolean;
 
   ids?: string[];
+  sessionIds?: string[];
   agentIds?: string[];
   actorIds?: string[];
   identityIds?: string[];
@@ -92,6 +95,10 @@ export type CreateToolCallParams = {
     rationale?: string;
     operation?: string;
   };
+};
+
+export type CreateInternalToolCallParams = CreateToolCallParams & {
+  adapter?: { identifier: string };
 };
 
 class toolCallServiceImpl {
@@ -149,7 +156,9 @@ class toolCallServiceImpl {
     });
   }
 
-  async listToolCallsInternal(d: { tenant: Tenant; environment: Environment } & ListToolCallsParams) {
+  async listToolCallsInternal(
+    d: { tenant: Tenant; environment: Environment } & ListToolCallsParams
+  ) {
     let solution = await getMetorialSolution();
     let ts = { tenant: d.tenant, environment: d.environment, solution };
 
@@ -163,6 +172,7 @@ class toolCallServiceImpl {
     let configs = await resolveProviderConfigs(ts, d.providerConfigIds);
     let authConfigs = await resolveProviderAuthConfigs(ts, d.providerAuthConfigIds);
     let tools = await resolveProviderTools(d.toolIds);
+    let sessions = await resolveSessions(ts, d.sessionIds);
 
     return Paginator.create(({ prisma }) =>
       prisma(async opts => {
@@ -176,7 +186,11 @@ class toolCallServiceImpl {
             message: normalizeStatusForList(d).onlyParent,
 
             AND: [
+              !d.includeInternal && !d.sessionIds?.length
+                ? { session: { isInternal: false } }
+                : undefined!,
               d.ids ? { id: { in: d.ids } } : undefined!,
+              sessions ? { sessionOid: sessions.in } : undefined!,
               d.agentInstanceIds
                 ? {
                     message: {
@@ -308,7 +322,9 @@ class toolCallServiceImpl {
         toolCall.message.responderParticipant
       ].filter((participant): participant is NonNullable<typeof participant> => !!participant)
     });
-    let participantMap = new Map(participants.map(participant => [participant.id, participant]));
+    let participantMap = new Map(
+      participants.map(participant => [participant.id, participant])
+    );
 
     return {
       ...toolCall,
@@ -364,7 +380,7 @@ class toolCallServiceImpl {
   }
 
   async createToolCallInternal(
-    d: { tenant: Tenant; environment: Environment } & CreateToolCallParams
+    d: { tenant: Tenant; environment: Environment } & CreateInternalToolCallParams
   ) {
     let solution = await getMetorialSolution();
 
@@ -401,7 +417,8 @@ class toolCallServiceImpl {
       sessionId: d.session.id,
       solutionId: solution.id,
       tenantId: d.tenant.id,
-      transport: 'tool_call'
+      transport: 'tool_call',
+      adapter: d.adapter
     });
 
     let connection = await db.sessionConnection.findFirst({

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
@@ -144,8 +144,27 @@ export class ProviderRunConnection extends IProviderRunConnection {
   override async handleToolInvocation(
     data: ToolInvocationCreateParam
   ): Promise<ToolInvocationCreateRes> {
-    if (data.tool.adapterOid) {
-      throw new Error('Adapter-linked tools cannot be invoked through provider connections');
+    if (this.params.session.isInternal) {
+      if (
+        !data.tool.adapterOid ||
+        !this.params.session.adapterGlobalOid ||
+        !this.params.adapter
+      ) {
+        throw new Error('Internal sessions may only invoke tools from their adapter');
+      }
+      let adapter = await db.providerAdapter.findFirst({
+        where: {
+          oid: data.tool.adapterOid,
+          globalOid: this.params.session.adapterGlobalOid,
+          global: { identifier: this.params.adapter.identifier }
+        },
+        select: { oid: true }
+      });
+      if (!adapter) {
+        throw new Error('Tool adapter does not match the internal session adapter');
+      }
+    } else if (data.tool.adapterOid || this.params.adapter) {
+      throw new Error('Adapter-linked tools require an internal session');
     }
 
     if (this.providerAuthConfigVersion && !this.providerAuthConfigVersion.slateAuthConfigOid) {

--- a/src/metorial/subspace/provider-backends/provider-utils/src/interfaces/providerRun.ts
+++ b/src/metorial/subspace/provider-backends/provider-utils/src/interfaces/providerRun.ts
@@ -99,6 +99,11 @@ export interface ProviderRunCreateParam {
   session: Session;
   connection: SessionConnection;
   participant: SessionParticipant;
+  adapter: {
+    id: string;
+    identifier: string;
+    name: string;
+  } | null;
 
   mcp: {
     clientInfo: InitializeRequest['params']['clientInfo'];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core session/connection/MCP paths, provider tool invocation, and callback reconciliation across many services; incorrect adapter scoping could break tool calls or leak internal activity into customer views.
> 
> **Overview**
> Introduces **internal sessions** (and matching connections/callbacks) tied to a single **global provider adapter**, so platform flows can use adapter-scoped tools and triggers without exposing that surface in normal customer APIs.
> 
> Schema adds `isInternal`, `adapterGlobalOid`, and indexes on **Session**, **SessionConnection**, **EphemeralManagedSession**, and **Callback**. Sessions can be created with an optional adapter; ephemeral managed sessions can mark rotated sessions internal and re-rotate when adapter binding changes.
> 
> **Connection/MCP behavior** for internal sessions: tool discovery and invocation filter by the bound adapter via `getProviderActionAdapterWhere`; synthetic connection-status/failure tools are omitted; `prompts/*` and `resources/*` return method-not-found; callers must pass a matching `adapter` identifier; connections inherit internal scope and reject disable/mismatch. Provider runs receive adapter context; Slates backend only allows adapter-linked tool calls on internal sessions.
> 
> **Callbacks**: optional adapter on create sets `isInternal` and resolves adapter-specific triggers; reconciler syncs only those triggers for internal callbacks; customer update/archive/attach/detach blocked unless internal override flags. Lists default to hiding `isInternal` records (`includeInternal` opt-in).
> 
> **Observability**: session-related lists (sessions, connections, messages, tool calls, provider runs, errors, events, etc.) and monitor/protoGuard alerts exclude internal sessions by default; explicit `session_id` filters can include them. Instance **tool-calls** list gains `session_id` filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d0d28a583460555eea98be576ff0dabb4470a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->