### PR TITLE
Add internal tool calls

### DIFF
--- a/src/metorial/subspace/db/prisma/schema/session/connection.prisma
+++ b/src/metorial/subspace/db/prisma/schema/session/connection.prisma
@@ -33,6 +33,8 @@ model SessionConnection {
 
   token String @unique
 
+  systemIdentifier String? @unique
+
   isEphemeral Boolean
   isInternal  Boolean @default(false)
 

--- a/src/metorial/subspace/modules/connection/src/sender/manager.ts
+++ b/src/metorial/subspace/modules/connection/src/sender/manager.ts
@@ -127,6 +127,7 @@ export interface InitProps {
   mcpProtocolVersion?: string;
   mcpTransport: SessionConnectionMcpConnectionTransport;
   agentInstance?: AgentInstance | null;
+  systemIdentifier?: string;
 }
 
 export interface CallToolProps {
@@ -256,6 +257,7 @@ export class SenderManager {
                       data: {
                         ...getId('sessionConnection'),
                         token: oldToken,
+                        systemIdentifier: lockedConnection.systemIdentifier,
                         isEphemeral: lockedCurrentSession.isEphemeral,
                         isInternal: lockedCurrentSession.isInternal,
                         adapterGlobalOid: lockedCurrentSession.adapterGlobalOid,
@@ -1773,7 +1775,8 @@ export class SenderManager {
       lastActiveAt: new Date(),
       disconnectedAt: null,
 
-      transport: this.transport
+      transport: this.transport,
+      ...(d.systemIdentifier === undefined ? {} : { systemIdentifier: d.systemIdentifier })
     };
 
     let connection: SessionConnection;

--- a/src/metorial/subspace/modules/connection/src/sender/manager.ts
+++ b/src/metorial/subspace/modules/connection/src/sender/manager.ts
@@ -79,9 +79,9 @@ import {
   buildConnectionStatusTool,
   CONNECTION_STATUS_TOOL_KEY
 } from '../lib/connectionStatusTool';
+import { getProviderActionAdapterWhere } from '../lib/internalSession';
 import { broadcastNats } from '../lib/nats';
 import { isSyntheticTool } from '../lib/syntheticTool';
-import { getProviderActionAdapterWhere } from '../lib/internalSession';
 import {
   CONNECTION_DIAGNOSTICS_TIMEOUT_MS,
   CONNECTION_TOOL_DISCOVERY_TIMEOUT_MS
@@ -128,6 +128,7 @@ export interface InitProps {
   mcpTransport: SessionConnectionMcpConnectionTransport;
   agentInstance?: AgentInstance | null;
   systemIdentifier?: string;
+  allowReservedClientIdentifier?: boolean;
 }
 
 export interface CallToolProps {
@@ -1718,7 +1719,7 @@ export class SenderManager {
     // Ignore if already initialized
     if (this.connection?.initState === 'completed') return this.connection;
 
-    if (d.client.identifier.startsWith('metorial#') && !d.isManualConnection) {
+    if (d.client.identifier.startsWith('metorial#') && !d.allowReservedClientIdentifier) {
       throw new ServiceError(
         badRequestError({
           message: 'Client identifier cannot start with reserved prefix metorial#'

--- a/src/metorial/subspace/modules/session/src/services/index.ts
+++ b/src/metorial/subspace/modules/session/src/services/index.ts
@@ -1,6 +1,7 @@
 export * from './adminProviderTelemetry';
 export * from './adminProviderTelemetryErrorGroup';
 export * from './ephemeralManagedSession';
+export * from './internalToolCall';
 export * from './providerInvocation';
 export * from './providerRun';
 export * from './providerRunLogs';

--- a/src/metorial/subspace/modules/session/src/services/internalToolCall.test.ts
+++ b/src/metorial/subspace/modules/session/src/services/internalToolCall.test.ts
@@ -56,6 +56,7 @@ describe('internalToolCallService', () => {
     manager.create.mockResolvedValue(manager);
     manager.initialize.mockResolvedValue({ id: 'scn_1' });
     manager.callTool.mockResolvedValue({
+      status: 'succeeded',
       output: { type: 'tool.result', data: { result: 'ok' } },
       message: {
         id: 'smg_1',
@@ -75,7 +76,10 @@ describe('internalToolCallService', () => {
 
   it('uses a system-participant direct connection and returns basic telemetry', async () => {
     await expect(internalToolCallService.call(input as any)).resolves.toEqual({
-      output: { result: 'ok' },
+      result: {
+        status: 'success',
+        output: { result: 'ok' }
+      },
       message: {
         id: 'smg_1',
         oid: 5n,
@@ -83,8 +87,7 @@ describe('internalToolCallService', () => {
         createdAt: new Date('2026-01-01'),
         completedAt: new Date('2026-01-01')
       },
-      connection: { id: 'scn_1' },
-      toolCall: { id: 'tcl_1', toolKey: 'provider_search' }
+      connection: { id: 'scn_1' }
     });
 
     expect(assertSessionInternalAdapter).toHaveBeenCalledWith({
@@ -93,15 +96,14 @@ describe('internalToolCallService', () => {
     });
     expect(manager.initialize).toHaveBeenCalledWith({
       client: {
-        identifier: 'metorial#internal-tool-call:worker',
+        identifier: 'metorial#worker',
         name: 'Worker',
         privateMetadata: { source: 'test' }
       },
       mcpTransport: 'none',
       isManualConnection: true,
-      systemIdentifier: expect.stringMatching(
-        /^internal-tool-call:ses_1:worker:\d{4}-\d{2}-\d{2}$/
-      )
+      allowReservedClientIdentifier: true,
+      systemIdentifier: expect.stringMatching(/^int-tc:ses_1:worker:\d{4}-\d{2}-\d{2}$/)
     });
     expect(manager.callTool).toHaveBeenCalledWith({
       toolId: 'provider_search',
@@ -111,9 +113,7 @@ describe('internalToolCallService', () => {
     });
     expect(db.sessionConnection.findFirst).toHaveBeenCalledWith({
       where: {
-        systemIdentifier: expect.stringMatching(
-          /^internal-tool-call:ses_1:worker:\d{4}-\d{2}-\d{2}$/
-        ),
+        systemIdentifier: expect.stringMatching(/^int-tc:ses_1:worker:\d{4}-\d{2}-\d{2}$/),
         state: 'connected',
         status: 'active'
       },

--- a/src/metorial/subspace/modules/session/src/services/internalToolCall.test.ts
+++ b/src/metorial/subspace/modules/session/src/services/internalToolCall.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { createLock, manager, db, messageOutputToToolCall, assertSessionInternalAdapter } =
+  vi.hoisted(() => ({
+    createLock: vi.fn(() => ({
+      usingLock: async (_key: string, fn: () => Promise<any>) => fn()
+    })),
+    manager: {
+      create: vi.fn(),
+      setConnection: vi.fn(),
+      initialize: vi.fn(),
+      callTool: vi.fn()
+    },
+    db: {
+      sessionConnection: { findFirst: vi.fn() },
+      toolCall: { findFirstOrThrow: vi.fn() }
+    },
+    messageOutputToToolCall: vi.fn(),
+    assertSessionInternalAdapter: vi.fn()
+  }));
+
+vi.mock('@lowerdeck/lock', () => ({ createLock }));
+vi.mock('@metorial-subspace/db', () => ({ db, messageOutputToToolCall }));
+vi.mock('@metorial-subspace/module-connection', () => ({ SenderManager: manager }));
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  checkTenant: vi.fn(),
+  getMetorialSolution: vi.fn(async () => ({ id: 'sol_1', oid: 1 }))
+}));
+vi.mock('../env', () => ({ env: { service: { REDIS_URL: 'redis://test' } } }));
+vi.mock('./_shared/internalAdapter', () => ({ assertSessionInternalAdapter }));
+
+import { internalToolCallService } from './internalToolCall';
+
+let session = {
+  id: 'ses_1',
+  oid: 1n,
+  tenantOid: 2n,
+  environmentOid: 3n,
+  adapterGlobalOid: 4n,
+  isInternal: true
+};
+
+let input = {
+  tenant: { id: 'ten_1', oid: 2n },
+  environment: { id: 'env_1', oid: 3n },
+  session,
+  adapter: { identifier: 'adapter' },
+  client: { identifier: 'worker', name: 'Worker', privateMetadata: { source: 'test' } },
+  key: 'provider_search',
+  input: { query: 'hello' }
+};
+
+describe('internalToolCallService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager.create.mockResolvedValue(manager);
+    manager.initialize.mockResolvedValue({ id: 'scn_1' });
+    manager.callTool.mockResolvedValue({
+      output: { type: 'tool.result', data: { result: 'ok' } },
+      message: {
+        id: 'smg_1',
+        oid: 5n,
+        status: 'succeeded',
+        createdAt: new Date('2026-01-01'),
+        completedAt: new Date('2026-01-01')
+      }
+    });
+    db.sessionConnection.findFirst.mockResolvedValue(null);
+    db.toolCall.findFirstOrThrow.mockResolvedValue({
+      id: 'tcl_1',
+      toolKey: 'provider_search'
+    });
+    messageOutputToToolCall.mockResolvedValue({ result: 'ok' });
+  });
+
+  it('uses a system-participant direct connection and returns basic telemetry', async () => {
+    await expect(internalToolCallService.call(input as any)).resolves.toEqual({
+      output: { result: 'ok' },
+      message: {
+        id: 'smg_1',
+        oid: 5n,
+        status: 'succeeded',
+        createdAt: new Date('2026-01-01'),
+        completedAt: new Date('2026-01-01')
+      },
+      connection: { id: 'scn_1' },
+      toolCall: { id: 'tcl_1', toolKey: 'provider_search' }
+    });
+
+    expect(assertSessionInternalAdapter).toHaveBeenCalledWith({
+      session,
+      adapter: input.adapter
+    });
+    expect(manager.initialize).toHaveBeenCalledWith({
+      client: {
+        identifier: 'metorial#internal-tool-call:worker',
+        name: 'Worker',
+        privateMetadata: { source: 'test' }
+      },
+      mcpTransport: 'none',
+      isManualConnection: true,
+      systemIdentifier: expect.stringMatching(
+        /^internal-tool-call:ses_1:worker:\d{4}-\d{2}-\d{2}$/
+      )
+    });
+    expect(manager.callTool).toHaveBeenCalledWith({
+      toolId: 'provider_search',
+      input: { type: 'tool.call', data: { query: 'hello' } },
+      waitForResponse: true,
+      transport: 'tool_call'
+    });
+    expect(db.sessionConnection.findFirst).toHaveBeenCalledWith({
+      where: {
+        systemIdentifier: expect.stringMatching(
+          /^internal-tool-call:ses_1:worker:\d{4}-\d{2}-\d{2}$/
+        ),
+        state: 'connected',
+        status: 'active'
+      },
+      include: { participant: true }
+    });
+  });
+
+  it('reuses the connection belonging to the same caller', async () => {
+    db.sessionConnection.findFirst.mockResolvedValue({ id: 'scn_existing' });
+
+    await internalToolCallService.call(input as any);
+
+    expect(manager.initialize).not.toHaveBeenCalled();
+    expect(manager.setConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'scn_existing' })
+    );
+  });
+
+  it('does not initialize a connection when the internal adapter is rejected', async () => {
+    assertSessionInternalAdapter.mockRejectedValueOnce(new Error('adapter mismatch'));
+
+    await expect(internalToolCallService.call(input as any)).rejects.toThrow(
+      'adapter mismatch'
+    );
+
+    expect(manager.create).not.toHaveBeenCalled();
+    expect(manager.initialize).not.toHaveBeenCalled();
+  });
+});

--- a/src/metorial/subspace/modules/session/src/services/internalToolCall.ts
+++ b/src/metorial/subspace/modules/session/src/services/internalToolCall.ts
@@ -103,7 +103,8 @@ class internalToolCallServiceImpl {
           },
           systemIdentifier: getSystemIdentifier(d),
           mcpTransport: 'none',
-          isManualConnection: true
+          isManualConnection: true,
+          allowReservedClientIdentifier: true
         });
       }
     );

--- a/src/metorial/subspace/modules/session/src/services/internalToolCall.ts
+++ b/src/metorial/subspace/modules/session/src/services/internalToolCall.ts
@@ -1,0 +1,127 @@
+import { createLock } from '@lowerdeck/lock';
+import { Service } from '@lowerdeck/service';
+import {
+  db,
+  messageOutputToToolCall,
+  type Environment,
+  type Session,
+  type Tenant
+} from '@metorial-subspace/db';
+import { SenderManager } from '@metorial-subspace/module-connection';
+import { checkTenant, getMetorialSolution } from '@metorial-subspace/module-tenant';
+import { env } from '../env';
+import {
+  assertSessionInternalAdapter,
+  type InternalAdapterInput
+} from './_shared/internalAdapter';
+
+let connectionInitLock = createLock({
+  name: 'sub/ses/internalToolCall/connection/init',
+  redisUrl: env.service.REDIS_URL
+});
+
+export type InternalToolCallClient = {
+  identifier: string;
+  name: string;
+  privateMetadata?: Record<string, any>;
+};
+
+export type CallInternalToolParams = {
+  tenant: Tenant;
+  environment: Environment;
+  session: Session;
+  adapter: InternalAdapterInput;
+  client: InternalToolCallClient;
+  key: string;
+  input: Record<string, any>;
+};
+
+let getConnectionIdentifier = (client: InternalToolCallClient) =>
+  `metorial#${client.identifier}`;
+
+let getSystemIdentifier = (d: Pick<CallInternalToolParams, 'session' | 'client'>) =>
+  `int-tc:${d.session.id}:${d.client.identifier}:${new Date().toISOString().slice(0, 10)}`;
+
+class internalToolCallServiceImpl {
+  async call(d: CallInternalToolParams) {
+    let solution = await getMetorialSolution();
+    checkTenant({ ...d, solution }, d.session);
+    await assertSessionInternalAdapter({ session: d.session, adapter: d.adapter });
+
+    let manager = await SenderManager.create({
+      sessionId: d.session.id,
+      solutionId: solution.id,
+      tenantId: d.tenant.id,
+      transport: 'tool_call',
+      adapter: d.adapter,
+      connectionPrivateMetadata: {
+        source: 'internal-tool-call',
+        client: {
+          identifier: d.client.identifier,
+          privateMetadata: d.client.privateMetadata
+        }
+      }
+    });
+
+    let connection = await this.getOrCreateConnection({ manager, ...d });
+    await manager.setConnection(connection);
+
+    let result = await manager.callTool({
+      toolId: d.key,
+      input: { type: 'tool.call', data: d.input },
+      waitForResponse: true,
+      transport: 'tool_call'
+    });
+
+    return {
+      result: {
+        status: result.status === 'succeeded' ? 'success' : 'failure',
+        output: result.output
+          ? await messageOutputToToolCall(result.output, result.message)
+          : null
+      },
+      message: result.message,
+      connection
+    };
+  }
+
+  private async getOrCreateConnection(d: CallInternalToolParams & { manager: SenderManager }) {
+    let existing = await this.findConnection(d);
+    if (existing) return existing;
+
+    return await connectionInitLock.usingLock(
+      `${d.session.id}:${d.client.identifier}`,
+      async () => {
+        let current = await this.findConnection(d);
+        if (current) return current;
+
+        return await d.manager.initialize({
+          client: {
+            identifier: getConnectionIdentifier(d.client),
+            name: d.client.name,
+            privateMetadata: d.client.privateMetadata
+          },
+          systemIdentifier: getSystemIdentifier(d),
+          mcpTransport: 'none',
+          isManualConnection: true
+        });
+      }
+    );
+  }
+
+  private async findConnection(d: CallInternalToolParams) {
+    return await db.sessionConnection.findFirst({
+      where: {
+        systemIdentifier: getSystemIdentifier(d),
+        state: 'connected',
+        status: 'active'
+      },
+      include: { participant: true }
+    });
+  }
+}
+
+export let internalToolCallService = Service.create(
+  'internalToolCallService',
+  () => new internalToolCallServiceImpl()
+).build();

--- a/src/metorial/subspace/modules/session/src/services/toolCall.ts
+++ b/src/metorial/subspace/modules/session/src/services/toolCall.ts
@@ -453,6 +453,7 @@ class toolCallServiceImpl {
           },
           mcpTransport: 'none',
           isManualConnection: true,
+          allowReservedClientIdentifier: true,
           agentInstance
         });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes internal-session tool execution and connection identity rules (reserved client IDs, new unique DB column); mistakes could affect connection reuse or who can call internal tools.
> 
> **Overview**
> Adds **`internalToolCallService`**, so platform code can invoke tools on **internal sessions** with tenant/adapter checks, a dedicated `tool_call` connection, and normalized tool-call output plus message/connection telemetry.
> 
> Connections are **deduped per session + caller per day** via a new optional unique **`systemIdentifier`** on `SessionConnection` (pattern `int-tc:{sessionId}:{client}:{date}`), with Redis locking on first connect. Initialization uses a **`metorial#…` system client** and **`allowReservedClientIdentifier`** so reserved IDs are allowed for trusted internal/manual paths; existing manual **`toolCall`** setup passes the same flag.
> 
> **`SenderManager.initialize`** now accepts **`systemIdentifier`** and **`allowReservedClientIdentifier`**, persists the identifier on create/update, and keeps it when ephemeral backing sessions roll connections forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d15962104d0d053aaf858fc399006d7a31b4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->