### PR TITLE
Improve skill marketplace copy

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/(list)/marketplaces.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/(list)/marketplaces.tsx
@@ -40,7 +40,7 @@ export let SkillMarketplacesPage = () => {
     <ContentLayout>
       <PageHeader
         title="Skill Marketplaces"
-        description="Marketplaces let you publish selected plugins and skills to your users."
+        description="Marketplaces let you publish selected plugins and skills for your team."
         actions={
           <Button
             size="2"

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceGrid.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceGrid.tsx
@@ -88,7 +88,7 @@ export let SkillMarketplacesGrid = (
           <EmptyState
             extra="Skill Marketplaces"
             title="Create your first marketplace"
-            description="Marketplaces let you publish selected plugins and skills to your users."
+            description="Marketplaces let you publish selected plugins and skills for your team."
             action={{
               label: 'Create Marketplace',
               onClick: showCreateModal

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
@@ -1279,7 +1279,7 @@ export let SkillMarketplacePluginsScene = (p: {
     ({ marketplace, marketplacePlugins }) => (
       <PageHeaderSection
         title="Plugins and Skills"
-        description="Add and manage plugins and skills for this marketplace. Use plugins to group related skills together, or add individual skills directly to the marketplace."
+        description="Manage plugins and skills for this marketplace. Use plugins to group related skills or add individual skills to the marketplace directly."
       >
         <DndContext
           sensors={sensors}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy-only changes to UI descriptions with no logic, API, or data handling impact.
> 
> **Overview**
> Refines **skill marketplace** messaging in the dashboard so it speaks to internal teams instead of end users.
> 
> On the marketplaces list page header and empty state, the description now says marketplaces publish selected plugins and skills **for your team** (replacing **to your users**).
> 
> On the marketplace **Plugins and Skills** section, the `PageHeaderSection` description is shortened to emphasize managing plugins/skills, grouping related skills, and adding individual skills directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1fa7e59d17973ec2e85d91b61ce4c466088aae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->