### PR TITLE
Add marktplace managers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/metorial/packages/*'
 
       - name: Test Metorial Modules
-        run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/metorial/products/*'
+        run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/metorial/products/**'
 
       - name: Test Lowerdeck Packages
         run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/lowerdeck/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/metorial/packages/*'
 
       - name: Test Metorial Modules
-        run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/metorial/modules/*'
+        run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/metorial/products/*'
 
       - name: Test Lowerdeck Packages
         run: bunx turbo run --concurrency=1 --ui=stream test --filter='./src/lowerdeck/**'

--- a/src/metorial-frontend/apps/dashboard/package.json
+++ b/src/metorial-frontend/apps/dashboard/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "vite --port 3300 --host",
-    "frontend:build": "tsc -b && vite build",
+    "_frontend:build": "tsc -b && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -49,7 +49,6 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^8.54.0",
-    "@tanstack/react-virtual": "^3.13.12",
     "@tiptap/extension-color": "3.6.1",
     "@tiptap/extension-highlight": "3.6.1",
     "@tiptap/extension-horizontal-rule": "3.6.1",
@@ -82,6 +81,7 @@
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.7",
+    "p-queue": "^8.1.0",
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "react-helmet": "^6.1.0",

--- a/src/metorial-frontend/apps/dashboard/src/index.ts
+++ b/src/metorial-frontend/apps/dashboard/src/index.ts
@@ -51,6 +51,12 @@ export {
   useSkillTemplateFilters
 } from './product/scenes/skills/filters';
 export { SkillPluginsGrid } from './product/scenes/skills/pluginGrid';
+export { SkillMarketplacesGrid } from './product/scenes/skills/marketplaceGrid';
+export {
+  GroupMarketplaceManagersList,
+  MarketplaceManagersList,
+  showMarketplaceManagerPanel
+} from './product/scenes/skills/marketplaceManagers';
 export { showSkillPluginFormModal } from './product/scenes/skills/pluginModal';
 export { showSkillFormModal } from './product/scenes/skills/modal';
 export { showSkillTemplateFormModal } from './product/scenes/skills/templateModal';

--- a/src/metorial-frontend/apps/dashboard/src/product/index.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/index.tsx
@@ -140,6 +140,9 @@ let SkillMarketplaceSettingsPage = dynamicPage(() =>
     c => c.SkillMarketplaceSettingsPage
   )
 );
+let SkillMarketplaceAccessPage = dynamicPage(() =>
+  import('./pages/(skills)/skill-marketplace/access').then(c => c.SkillMarketplaceAccessPage)
+);
 let IntegrationLayout = dynamicPage(() =>
   import('./pages/(integrations)/integration/_layout').then(c => c.IntegrationLayout)
 );
@@ -695,6 +698,10 @@ export let productSkillsSlice = createSlice([
               {
                 path: 'settings',
                 element: <SkillMarketplaceSettingsPage />
+              },
+              {
+                path: 'access',
+                element: <SkillMarketplaceAccessPage />
               }
             ]
           }

--- a/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/(list)/skills.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/(list)/skills.tsx
@@ -322,6 +322,10 @@ export let SkillsPage = () => {
                 onClick: skillImport.uploadSkill
               },
               {
+                label: 'Upload Folder',
+                onClick: skillImport.uploadSkillDirectory
+              },
+              {
                 label: 'Create Template',
                 onClick: () =>
                   showSkillTemplateFormModal({

--- a/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/skill-marketplace/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/skill-marketplace/_layout.tsx
@@ -121,6 +121,10 @@ export let SkillMarketplaceLayout = () => {
                   to: Paths.instance.skillMarketplace(...marketplacePathParams)
                 },
                 {
+                  label: 'Managers & Access',
+                  to: Paths.instance.skillMarketplace(...marketplacePathParams, 'access')
+                },
+                {
                   label: 'Settings',
                   to: Paths.instance.skillMarketplace(...marketplacePathParams, 'settings')
                 }

--- a/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/skill-marketplace/access.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/(skills)/skill-marketplace/access.tsx
@@ -1,0 +1,20 @@
+import { useCurrentInstance } from '@metorial/state';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { MarketplaceManagersList } from '../../../scenes/skills/marketplaceManagers';
+
+export let SkillMarketplaceAccessPage = () => {
+  let instance = useCurrentInstance();
+  let { skillMarketplaceId } = useParams();
+  let [searchParams] = useSearchParams();
+  let portalId = searchParams.get('portalId') ?? undefined;
+
+  if (!instance.data?.id || !skillMarketplaceId) return null;
+
+  return (
+    <MarketplaceManagersList
+      instanceId={instance.data.id}
+      skillMarketplaceId={skillMarketplaceId}
+      portalId={portalId}
+    />
+  );
+};

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceGrid.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceGrid.tsx
@@ -34,12 +34,16 @@ let Description = styled.span`
 `;
 
 export let SkillMarketplacesGrid = (
-  p: { instanceId: string } & Omit<
+  p: {
+    instanceId: string;
+    getHref?: (marketplaceId: string) => string;
+    hideCreate?: boolean;
+  } & Omit<
     DashboardInstanceSkillsMarketplacesListQuery,
     'after' | 'before' | 'cursor' | 'limit'
   >
 ) => {
-  let { instanceId, ...query } = p;
+  let { instanceId, getHref, hideCreate, ...query } = p;
   let organization = useCurrentOrganization();
   let project = useCurrentProject();
   let instance = useCurrentInstance();
@@ -57,20 +61,22 @@ export let SkillMarketplacesGrid = (
     (Array.isArray(query.status) ? query.status.length > 0 : query.status)
   );
 
+  let marketplaceHref = (marketplaceId: string) =>
+    getHref?.(marketplaceId) ??
+    Paths.instance.skillMarketplace(
+      organization.data,
+      project.data,
+      instance.data,
+      marketplaceId
+    );
+
   let showCreateModal = () => {
-    if (!instance.data) return;
+    if (!instance.data || hideCreate) return;
 
     showSkillMarketplaceFormModal({
       instanceId: instance.data.id,
       onCreate: marketplace => {
-        navigate(
-          Paths.instance.skillMarketplace(
-            organization.data,
-            project.data,
-            instance.data,
-            marketplace.id
-          )
-        );
+        navigate(marketplaceHref(marketplace.id));
       }
     });
   };
@@ -84,7 +90,7 @@ export let SkillMarketplacesGrid = (
           </Text>
         )}
 
-        {!hasActiveFilters && (
+        {!hasActiveFilters && !hideCreate && (
           <EmptyState
             extra="Skill Marketplaces"
             title="Create your first marketplace"
@@ -94,6 +100,12 @@ export let SkillMarketplacesGrid = (
               onClick: showCreateModal
             }}
           />
+        )}
+
+        {!hasActiveFilters && hideCreate && (
+          <Text size="2" color="gray600">
+            No skill marketplaces yet.
+          </Text>
         )}
 
         {!query.search && hasActiveFilters && (
@@ -116,12 +128,7 @@ export let SkillMarketplacesGrid = (
             return (
               <ItemGrid.Item
                 key={marketplace.id}
-                href={Paths.instance.skillMarketplace(
-                  organization.data,
-                  project.data,
-                  instance.data,
-                  marketplace.id
-                )}
+                href={marketplaceHref(marketplace.id)}
                 entity={{ id: marketplace.id, hasUsage: true }}
                 title={marketplace.name}
                 description={<Description>{marketplace.description}</Description>}

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/groupList.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/groupList.tsx
@@ -1,0 +1,106 @@
+import { PageHeaderSection } from '@metorial/layout';
+import { useAllPortalConsumerAccess, useSkillMarketplaces } from '@metorial/state';
+import { Button } from '@metorial/ui';
+import { Box } from '@metorial/ui-product';
+import { useMemo } from 'react';
+import { groupManagersByMarketplace, pluginsFromMarketplace } from './groupManagers';
+import { GroupMarketplaceManagersTable } from './managersTable';
+import { showMarketplaceManagerPanel } from './panel';
+import { MARKETPLACE_MANAGER_COPY } from './types';
+
+export let GroupMarketplaceManagersList = (props: {
+  instanceId: string;
+  portalId: string;
+  consumerGroupId: string;
+  asBox?: boolean;
+}) => {
+  let marketplaces = useSkillMarketplaces(props.instanceId, {
+    order: 'desc',
+    status: ['active'],
+    limit: 100
+  });
+  let accesses = useAllPortalConsumerAccess(props.instanceId, props.portalId, {
+    consumerGroupId: props.consumerGroupId,
+    type: ['skill_marketplace', 'skill_plugin'],
+    limit: 100
+  });
+
+  let marketplaceOptions = useMemo(
+    () =>
+      (marketplaces.data?.items ?? []).map(marketplace => ({
+        id: marketplace.id,
+        name: marketplace.name,
+        description: marketplace.description,
+        plugins: pluginsFromMarketplace(marketplace)
+      })),
+    [marketplaces.data?.items]
+  );
+
+  let rows = useMemo(
+    () =>
+      groupManagersByMarketplace({
+        portalId: props.portalId,
+        consumerGroupId: props.consumerGroupId,
+        kind: 'group',
+        groupDescription: null,
+        accesses: accesses.data,
+        marketplaces: marketplaceOptions
+      }),
+    [accesses.data, marketplaceOptions, props.consumerGroupId, props.portalId]
+  );
+
+  let refetch = () => {
+    accesses.refetch();
+    marketplaces.refetch();
+  };
+
+  let inner = (
+    <GroupMarketplaceManagersTable
+      instanceId={props.instanceId}
+      rows={rows}
+      isLoading={marketplaces.isLoading || accesses.isLoading}
+      error={marketplaces.error || accesses.error}
+      refetch={refetch}
+      emptyState="No marketplace management access yet."
+    />
+  );
+
+  let actions = (
+    <Button
+      size="2"
+      onClick={() =>
+        showMarketplaceManagerPanel({
+          instanceId: props.instanceId,
+          portalId: props.portalId,
+          consumerGroupId: props.consumerGroupId,
+          subjectMode: 'group',
+          onSuccess: refetch
+        })
+      }
+    >
+      Add Marketplace Manager
+    </Button>
+  );
+
+  if (props.asBox) {
+    return (
+      <Box
+        title="Marketplace Managers"
+        description={MARKETPLACE_MANAGER_COPY}
+        rightActions={actions}
+      >
+        {inner}
+      </Box>
+    );
+  }
+
+  return (
+    <PageHeaderSection
+      title="Marketplace Managers"
+      description={MARKETPLACE_MANAGER_COPY}
+      actions={actions}
+    >
+      {inner}
+    </PageHeaderSection>
+  );
+};

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/groupManagers.ts
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/groupManagers.ts
@@ -1,0 +1,211 @@
+import type {
+  MarketplaceManagerAccess,
+  MarketplaceManagerRow,
+  MarketplacePluginOption
+} from './types';
+
+export let pluginsFromMarketplace = (
+  marketplace: {
+    plugins?: {
+      status: string;
+      identifier: string;
+      skillPlugin?: { id: string; name?: string | null } | null;
+    }[];
+  },
+  opts?: { includeArchived?: boolean }
+): MarketplacePluginOption[] =>
+  (marketplace.plugins ?? [])
+    .filter(
+      plugin =>
+        plugin.skillPlugin &&
+        (opts?.includeArchived
+          ? plugin.status == 'active' || plugin.status == 'archived'
+          : plugin.status == 'active')
+    )
+    .map(plugin => ({
+      id: plugin.skillPlugin!.id,
+      name: plugin.skillPlugin!.name || plugin.identifier
+    }));
+
+export let groupMarketplaceManagers = (d: {
+  portalId: string;
+  skillMarketplaceId: string;
+  marketplaceAccesses: MarketplaceManagerAccess[] | null | undefined;
+  pluginAccesses: MarketplaceManagerAccess[] | null | undefined;
+  plugins: MarketplacePluginOption[];
+  defaultGroupIds: Set<string>;
+  profiles: {
+    id: string;
+    name: string;
+    email: string;
+    personalGroupId?: string;
+  }[];
+}): MarketplaceManagerRow[] => {
+  let pluginById = new Map(d.plugins.map(plugin => [plugin.id, plugin]));
+  let profileByPersonalGroupId = new Map(
+    d.profiles
+      .filter(profile => profile.personalGroupId)
+      .map(profile => [profile.personalGroupId!, profile])
+  );
+  let byGroup = new Map<
+    string,
+    {
+      consumerGroupId: string;
+      name: string;
+      description: string | null;
+      marketplaceAccessId?: string;
+      pluginAccesses: { pluginId: string; accessId: string }[];
+    }
+  >();
+
+  let ensureGroup = (access: MarketplaceManagerAccess) => {
+    let current = byGroup.get(access.consumerGroup.id);
+    if (current) return current;
+
+    current = {
+      consumerGroupId: access.consumerGroup.id,
+      name: access.consumerGroup.name,
+      description: access.consumerGroup.description,
+      pluginAccesses: []
+    };
+    byGroup.set(access.consumerGroup.id, current);
+    return current;
+  };
+
+  for (let access of d.marketplaceAccesses ?? []) {
+    if (access.access.type != 'skill_marketplace') continue;
+    if (access.accessLevel != 'manage') continue;
+    ensureGroup(access).marketplaceAccessId = access.id;
+  }
+
+  for (let access of d.pluginAccesses ?? []) {
+    if (access.access.type != 'skill_plugin') continue;
+    let pluginId = access.access.skillPlugin.id;
+    if (!pluginById.has(pluginId)) continue;
+    ensureGroup(access).pluginAccesses.push({ pluginId, accessId: access.id });
+  }
+
+  return [...byGroup.values()]
+    .map(group => {
+      let profile = profileByPersonalGroupId.get(group.consumerGroupId);
+      let kind: MarketplaceManagerRow['kind'] = d.defaultGroupIds.has(group.consumerGroupId)
+        ? 'group'
+        : 'account';
+
+      return {
+        id: `${d.portalId}:${d.skillMarketplaceId}:${group.consumerGroupId}`,
+        portalId: d.portalId,
+        consumerGroupId: group.consumerGroupId,
+        skillMarketplaceId: d.skillMarketplaceId,
+        name: profile?.name || group.name,
+        description: profile?.email || group.description,
+        kind,
+        accountId: profile?.id,
+        scope: group.marketplaceAccessId
+          ? { type: 'entire' as const }
+          : {
+              type: 'plugins' as const,
+              plugins: group.pluginAccesses
+                .map(pluginAccess => pluginById.get(pluginAccess.pluginId))
+                .filter(Boolean) as MarketplacePluginOption[]
+            },
+        marketplaceAccessId: group.marketplaceAccessId,
+        pluginAccesses: group.pluginAccesses
+      };
+    })
+    .filter(row => row.scope.type == 'entire' || row.scope.plugins.length > 0)
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+export let groupManagersByMarketplace = (d: {
+  portalId: string;
+  consumerGroupId: string;
+  kind: MarketplaceManagerRow['kind'];
+  accountId?: string;
+  groupDescription: string | null;
+  accesses: MarketplaceManagerAccess[] | null | undefined;
+  marketplaces: {
+    id: string;
+    name: string;
+    description?: string | null;
+    plugins: MarketplacePluginOption[];
+  }[];
+}): MarketplaceManagerRow[] => {
+  let marketplaceByPluginId = new Map<string, string[]>();
+  let marketplaceById = new Map(d.marketplaces.map(marketplace => [marketplace.id, marketplace]));
+
+  for (let marketplace of d.marketplaces) {
+    for (let plugin of marketplace.plugins) {
+      let current = marketplaceByPluginId.get(plugin.id) ?? [];
+      current.push(marketplace.id);
+      marketplaceByPluginId.set(plugin.id, current);
+    }
+  }
+
+  let byMarketplace = new Map<
+    string,
+    {
+      skillMarketplaceId: string;
+      marketplaceAccessId?: string;
+      pluginAccesses: { pluginId: string; accessId: string }[];
+    }
+  >();
+
+  let ensureMarketplace = (skillMarketplaceId: string) => {
+    let current = byMarketplace.get(skillMarketplaceId);
+    if (current) return current;
+    current = { skillMarketplaceId, pluginAccesses: [] };
+    byMarketplace.set(skillMarketplaceId, current);
+    return current;
+  };
+
+  for (let access of d.accesses ?? []) {
+    if (access.consumerGroup.id != d.consumerGroupId) continue;
+
+    if (access.access.type == 'skill_marketplace') {
+      if (access.accessLevel != 'manage') continue;
+      ensureMarketplace(access.access.skillMarketplace.id).marketplaceAccessId = access.id;
+      continue;
+    }
+
+    if (access.access.type != 'skill_plugin') continue;
+    let pluginId = access.access.skillPlugin.id;
+    for (let skillMarketplaceId of marketplaceByPluginId.get(pluginId) ?? []) {
+      ensureMarketplace(skillMarketplaceId).pluginAccesses.push({
+        pluginId,
+        accessId: access.id
+      });
+    }
+  }
+
+  return [...byMarketplace.values()]
+    .map(group => {
+      let marketplace = marketplaceById.get(group.skillMarketplaceId);
+      let pluginById = new Map(
+        (marketplace?.plugins ?? []).map(plugin => [plugin.id, plugin])
+      );
+
+      return {
+        id: `${d.portalId}:${group.skillMarketplaceId}:${d.consumerGroupId}`,
+        portalId: d.portalId,
+        consumerGroupId: d.consumerGroupId,
+        skillMarketplaceId: group.skillMarketplaceId,
+        name: marketplace?.name || group.skillMarketplaceId,
+        description: marketplace?.description ?? d.groupDescription,
+        kind: d.kind,
+        accountId: d.accountId,
+        scope: group.marketplaceAccessId
+          ? { type: 'entire' as const }
+          : {
+              type: 'plugins' as const,
+              plugins: group.pluginAccesses
+                .map(pluginAccess => pluginById.get(pluginAccess.pluginId))
+                .filter(Boolean) as MarketplacePluginOption[]
+            },
+        marketplaceAccessId: group.marketplaceAccessId,
+        pluginAccesses: group.pluginAccesses
+      };
+    })
+    .filter(row => row.scope.type == 'entire' || row.scope.plugins.length > 0)
+    .sort((a, b) => a.name.localeCompare(b.name));
+};

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/index.ts
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/index.ts
@@ -1,0 +1,3 @@
+export { showMarketplaceManagerPanel } from './panel';
+export { GroupMarketplaceManagersList } from './groupList';
+export { MarketplaceManagersList } from './list';

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/list.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/list.tsx
@@ -1,0 +1,205 @@
+import { renderWithLoader } from '@metorial/data-hooks';
+import { PageHeaderSection } from '@metorial/layout';
+import {
+  useAllPortalConsumerAccess,
+  useAllSkillMarketplacePlugins,
+  usePortalConsumerGroups,
+  usePortalConsumerProfiles,
+  usePortals,
+  useSkillMarketplace
+} from '@metorial/state';
+import { Button, Menu, Spacer, Text } from '@metorial/ui';
+import { useMemo, useState } from 'react';
+import { groupMarketplaceManagers, pluginsFromMarketplace } from './groupManagers';
+import { MarketplaceManagersTable } from './managersTable';
+import { showMarketplaceManagerPanel } from './panel';
+import { MARKETPLACE_MANAGER_COPY } from './types';
+
+export { MarketplaceManagerScopeBadges, removeMarketplaceManager } from './shared';
+
+let MarketplaceManagersForPortal = (props: {
+  instanceId: string;
+  portalId: string;
+  skillMarketplaceId: string;
+}) => {
+  let marketplace = useSkillMarketplace(props.instanceId, props.skillMarketplaceId);
+  let marketplacePlugins = useAllSkillMarketplacePlugins(
+    props.instanceId,
+    props.skillMarketplaceId,
+    {
+      order: 'asc',
+      status: ['active', 'archived']
+    }
+  );
+  let plugins = useMemo(() => {
+    if (marketplacePlugins.data?.length) {
+      return marketplacePlugins.data
+        .filter(plugin => plugin.skillPlugin)
+        .map(plugin => ({
+          id: plugin.skillPlugin!.id,
+          name: plugin.skillPlugin!.name || plugin.identifier
+        }));
+    }
+
+    return marketplace.data ? pluginsFromMarketplace(marketplace.data, { includeArchived: true }) : [];
+  }, [marketplace.data, marketplacePlugins.data]);
+  let marketplaceAccess = useAllPortalConsumerAccess(props.instanceId, props.portalId, {
+    type: 'skill_marketplace',
+    skillMarketplaceId: props.skillMarketplaceId,
+    limit: 100
+  });
+  let pluginAccess = useAllPortalConsumerAccess(props.instanceId, props.portalId, {
+    type: 'skill_plugin',
+    limit: 100
+  });
+  let groups = usePortalConsumerGroups(props.instanceId, props.portalId, {
+    status: ['active'],
+    limit: 100
+  });
+  let profiles = usePortalConsumerProfiles(props.instanceId, props.portalId, {
+    limit: 100
+  });
+
+  let rows = useMemo(
+    () =>
+      groupMarketplaceManagers({
+        portalId: props.portalId,
+        skillMarketplaceId: props.skillMarketplaceId,
+        marketplaceAccesses: marketplaceAccess.data,
+        pluginAccesses: pluginAccess.data,
+        plugins,
+        defaultGroupIds: new Set((groups.data?.items ?? []).map(group => group.id)),
+        profiles: (profiles.data?.items ?? []).map(profile => ({
+          id: profile.id,
+          name: profile.name,
+          email: profile.email,
+          personalGroupId: (profile.groups ?? []).find(
+            assignment => assignment.assignedVia == 'user'
+          )?.group.id
+        }))
+      }),
+    [
+      groups.data?.items,
+      marketplaceAccess.data,
+      pluginAccess.data,
+      plugins,
+      profiles.data?.items,
+      props.portalId,
+      props.skillMarketplaceId
+    ]
+  );
+
+  let refetch = () => {
+    marketplace.refetch();
+    marketplacePlugins.refetch();
+    marketplaceAccess.refetch();
+    pluginAccess.refetch();
+    groups.refetch();
+    profiles.refetch();
+  };
+
+  let isLoading =
+    marketplace.isLoading ||
+    marketplacePlugins.isLoading ||
+    marketplaceAccess.isLoading ||
+    pluginAccess.isLoading ||
+    groups.isLoading ||
+    profiles.isLoading;
+  let error =
+    marketplace.error ||
+    marketplacePlugins.error ||
+    marketplaceAccess.error ||
+    pluginAccess.error ||
+    groups.error ||
+    profiles.error;
+
+  return (
+    <MarketplaceManagersTable
+      instanceId={props.instanceId}
+      rows={rows}
+      isLoading={isLoading}
+      error={error}
+      refetch={refetch}
+      emptyState="No Marketplace Managers yet."
+    />
+  );
+};
+
+export let MarketplaceManagersList = (props: {
+  instanceId: string;
+  skillMarketplaceId: string;
+  portalId?: string;
+}) => {
+  let portals = usePortals(props.instanceId, { limit: 50 });
+  let [revision, setRevision] = useState(0);
+  let portalItems = portals.data?.items ?? [];
+  let activePortals = props.portalId
+    ? portalItems.filter(portal => portal.id == props.portalId)
+    : portalItems;
+
+  return (
+    <PageHeaderSection
+      title="Marketplace Managers"
+      description={MARKETPLACE_MANAGER_COPY}
+      actions={
+        <Menu
+          items={[
+            {
+              id: 'group',
+              label: 'Group',
+              description: 'Grant management access to a group.'
+            },
+            {
+              id: 'account',
+              label: 'Account',
+              description: 'Grant a single person access.'
+            }
+          ]}
+          onItemClick={id => {
+            if (id != 'group' && id != 'account') return;
+            showMarketplaceManagerPanel({
+              instanceId: props.instanceId,
+              skillMarketplaceId: props.skillMarketplaceId,
+              portalId:
+                props.portalId ?? (portalItems.length == 1 ? portalItems[0]?.id : undefined),
+              subjectMode: id,
+              onSuccess: () => setRevision(value => value + 1)
+            });
+          }}
+        >
+          <Button size="2">Add Marketplace Manager</Button>
+        </Menu>
+      }
+    >
+      {renderWithLoader({ portals })(() =>
+        activePortals.length ? (
+          <>
+            {activePortals.map(portal => (
+              <div key={portal.id}>
+                {activePortals.length > 1 ? (
+                  <>
+                    <Text size="2" weight="strong">
+                      {portal.name}
+                    </Text>
+                    <Spacer size={10} />
+                  </>
+                ) : null}
+                <MarketplaceManagersForPortal
+                  key={`${portal.id}:${revision}`}
+                  instanceId={props.instanceId}
+                  portalId={portal.id}
+                  skillMarketplaceId={props.skillMarketplaceId}
+                />
+                {activePortals.length > 1 ? <Spacer size={20} /> : null}
+              </div>
+            ))}
+          </>
+        ) : (
+          <Text size="2" color="gray600">
+            Create a portal before assigning Marketplace Managers.
+          </Text>
+        )
+      )}
+    </PageHeaderSection>
+  );
+};

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/managersTable.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/managersTable.tsx
@@ -1,0 +1,270 @@
+import {
+  useDeletePortalConsumerAccess
+} from '@metorial/state';
+import { Table } from '@metorial/table';
+import {
+  getEnumListFilterValue,
+  type TableStateProvider,
+  type TableStateProviderResult
+} from '@metorial/table';
+import { Badge, Flex, Text, confirm } from '@metorial/ui';
+import { RiDeleteBinLine, RiEditLine } from '@remixicon/react';
+import { useMemo } from 'react';
+import { showMarketplaceManagerPanel } from './panel';
+import { MarketplaceManagerScopeBadges, removeMarketplaceManager } from './shared';
+import type { MarketplaceManagerRow } from './types';
+
+export type MarketplaceManagersTableVariant = 'people' | 'marketplaces';
+
+export type MarketplaceManagersTableProps = {
+  instanceId: string;
+  variant: MarketplaceManagersTableVariant;
+  rows: MarketplaceManagerRow[];
+  isLoading: boolean;
+  error?: unknown;
+  refetch: () => void;
+  emptyState: string;
+};
+
+type MarketplaceManagersTableState = TableStateProviderResult<MarketplaceManagerRow> & {
+  refetch: () => void;
+};
+
+let matchesSearch = (row: MarketplaceManagerRow, search?: string) => {
+  if (!search) return true;
+
+  let pluginNames =
+    row.scope.type == 'plugins' ? row.scope.plugins.map(plugin => plugin.name).join(' ') : '';
+  let hay = [
+    row.name,
+    row.description ?? '',
+    row.kind,
+    row.scope.type == 'entire' ? 'entire marketplace' : pluginNames
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return hay.includes(search.trim().toLowerCase());
+};
+
+let useMarketplaceManagersTableState: TableStateProvider<
+  MarketplaceManagersTableProps,
+  MarketplaceManagerRow,
+  MarketplaceManagersTableState
+> = (props, opts) => {
+  let items = useMemo(() => {
+    let kinds = getEnumListFilterValue(opts.filter.kind, ['group', 'account']);
+
+    return props.rows.filter(row => {
+      if (kinds?.length && !kinds.includes(row.kind)) return false;
+      return matchesSearch(row, opts.search);
+    });
+  }, [opts.filter.kind, opts.search, props.rows]);
+
+  return {
+    isLoading: props.isLoading,
+    error: (props.error as MarketplaceManagersTableState['error']) ?? null,
+    items,
+    hasMoreAfter: false,
+    hasMoreBefore: false,
+    loadNext: () => {},
+    loadPrevious: () => {},
+    refetch: props.refetch
+  };
+};
+
+let useMarketplaceManagersTableHookState = (
+  state: MarketplaceManagersTableState,
+  props: MarketplaceManagersTableProps
+) => {
+  let deleteAccess = useDeletePortalConsumerAccess();
+
+  return {
+    instanceId: props.instanceId,
+    variant: props.variant,
+    refetch: state.refetch,
+    deleteAccess
+  };
+};
+
+type MarketplaceManagersHookState = ReturnType<typeof useMarketplaceManagersTableHookState>;
+
+let marketplaceManagerActions = {
+  edit: async (rows: MarketplaceManagerRow[], hookState: MarketplaceManagersHookState) => {
+    let row = rows[0];
+    if (!row) return;
+
+    showMarketplaceManagerPanel({
+      instanceId: hookState.instanceId,
+      skillMarketplaceId: row.skillMarketplaceId,
+      portalId: row.portalId,
+      consumerGroupId: row.consumerGroupId,
+      edit: row,
+      onSuccess: hookState.refetch
+    });
+  },
+  remove: async (rows: MarketplaceManagerRow[], hookState: MarketplaceManagersHookState) => {
+    let row = rows[0];
+    if (!row) return;
+
+    confirm({
+      title: 'Remove Marketplace Manager',
+      description:
+        hookState.variant == 'marketplaces'
+          ? `Remove this group as a Marketplace Manager of ${row.name}?`
+          : `Remove ${row.name} as a Marketplace Manager? They will no longer be able to manage this marketplace.`,
+      confirmText: 'Remove',
+      onConfirm: async () => {
+        let removed = await removeMarketplaceManager({
+          instanceId: hookState.instanceId,
+          portalId: row.portalId,
+          row,
+          deleteAccess: hookState.deleteAccess
+        });
+        if (removed) hookState.refetch();
+      }
+    });
+  }
+};
+
+let marketplaceManagerRowActions = [
+  {
+    id: 'edit',
+    label: 'Edit',
+    icon: <RiEditLine />,
+    action: 'edit' as const
+  },
+  {
+    id: 'remove',
+    label: 'Remove',
+    icon: <RiDeleteBinLine />,
+    action: 'remove' as const
+  }
+];
+
+let marketplaceManagersPeopleTable = new Table<
+  MarketplaceManagersTableProps,
+  MarketplaceManagerRow
+>('marketplace-managers', { hasPagination: false })
+  .state(useMarketplaceManagersTableState)
+  .hookState(useMarketplaceManagersTableHookState)
+  .columns([
+    {
+      id: 'name',
+      isDefault: true,
+      header: 'Name',
+      render: row => (
+        <Flex gap={2} direction="column">
+          <Text size="2" weight="strong">
+            {row.name}
+          </Text>
+          <Text size="1" color="gray600">
+            {row.description || (row.kind == 'account' ? 'Account' : 'Group')}
+          </Text>
+        </Flex>
+      )
+    },
+    {
+      id: 'kind',
+      isDefault: true,
+      header: 'Kind',
+      render: row => (
+        <Badge color="gray" size="1">{row.kind == 'account' ? 'Account' : 'Group'}</Badge>
+      )
+    },
+    {
+      id: 'access',
+      isDefault: true,
+      header: 'Access',
+      render: row => <MarketplaceManagerScopeBadges row={row} />
+    }
+  ])
+  .filters([
+    {
+      id: 'kind',
+      fields: ['kind'],
+      label: 'Kind',
+      description: 'Filter by kind',
+      type: 'select',
+      options: [
+        { id: 'group', label: 'Group' },
+        { id: 'account', label: 'Account' }
+      ]
+    }
+  ])
+  .search('Search managers…')
+  .actions(marketplaceManagerActions)
+  .rowActions(marketplaceManagerRowActions)
+  .clickable((row, props) => {
+    showMarketplaceManagerPanel({
+      instanceId: props.instanceId,
+      skillMarketplaceId: row.skillMarketplaceId,
+      portalId: row.portalId,
+      consumerGroupId: row.consumerGroupId,
+      edit: row,
+      onSuccess: props.refetch
+    });
+  })
+  .build();
+
+let groupMarketplaceManagersTable = new Table<
+  MarketplaceManagersTableProps,
+  MarketplaceManagerRow
+>('group-marketplace-managers', { hasPagination: false })
+  .state(useMarketplaceManagersTableState)
+  .hookState(useMarketplaceManagersTableHookState)
+  .columns([
+    {
+      id: 'marketplace',
+      isDefault: true,
+      header: 'Marketplace',
+      render: row => (
+        <Flex gap={2} direction="column">
+          <Text size="2" weight="strong">
+            {row.name}
+          </Text>
+          {row.description ? (
+            <Text size="1" color="gray600">
+              {row.description}
+            </Text>
+          ) : null}
+        </Flex>
+      )
+    },
+    {
+      id: 'access',
+      isDefault: true,
+      header: 'Access',
+      render: row => <MarketplaceManagerScopeBadges row={row} />
+    }
+  ])
+  .search('Search marketplaces…')
+  .actions(marketplaceManagerActions)
+  .rowActions(marketplaceManagerRowActions)
+  .clickable((row, props) => {
+    showMarketplaceManagerPanel({
+      instanceId: props.instanceId,
+      skillMarketplaceId: row.skillMarketplaceId,
+      portalId: row.portalId,
+      consumerGroupId: row.consumerGroupId,
+      edit: row,
+      onSuccess: props.refetch
+    });
+  })
+  .build();
+
+export let MarketplaceManagersTable = (
+  props: Omit<MarketplaceManagersTableProps, 'variant'>
+) =>
+  marketplaceManagersPeopleTable({
+    ...props,
+    variant: 'people'
+  });
+
+export let GroupMarketplaceManagersTable = (
+  props: Omit<MarketplaceManagersTableProps, 'variant'>
+) =>
+  groupMarketplaceManagersTable({
+    ...props,
+    variant: 'marketplaces'
+  });

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/panel.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/panel.tsx
@@ -1,0 +1,651 @@
+import { renderWithLoader, renderWithPagination } from '@metorial/data-hooks';
+import {
+  useCreatePortalConsumerAccessQuiet,
+  useDeletePortalConsumerAccess,
+  usePortalConsumerGroups,
+  usePortalConsumerProfiles,
+  usePortals,
+  useSkillMarketplace,
+  useSkillMarketplaces
+} from '@metorial/state';
+import {
+  Button,
+  CenteredSpinner,
+  Checkbox,
+  Dialog,
+  Entity,
+  Flex,
+  Input,
+  Select,
+  Spacer,
+  Text,
+  toast
+} from '@metorial/ui';
+import { Table } from '@metorial/ui-product';
+import { useSearchFilter } from '@metorial/use-search-filter';
+import { useEffect, useMemo, useState } from 'react';
+import PQueue from 'p-queue';
+import { AuthMethodPicker } from '../../providerAuthConfigs/authMethodPicker';
+import {
+  ProviderCreationPanelShell,
+  showProviderCreationPanel
+} from '../../providerCreationPanel';
+import { pluginsFromMarketplace } from './groupManagers';
+import { MarketplaceManagerPanelScroll } from './panelShell';
+import {
+  MARKETPLACE_MANAGER_COPY,
+  type MarketplaceManagerRow,
+  type MarketplaceManagerSubjectMode
+} from './types';
+
+let paginationOpts = { hidePaginationWhenUnavailable: true };
+
+let runAccessJobs = async (jobs: (() => Promise<boolean>)[]) => {
+  if (!jobs.length) return true;
+  let queue = new PQueue({ concurrency: 10 });
+  let results = await queue.addAll(jobs);
+  return results.every(Boolean);
+};
+
+let MarketplaceManagerPortalSelect = (p: {
+  instanceId: string;
+  value?: string;
+  onChange: (portalId: string) => void;
+}) => {
+  let portals = usePortals(p.instanceId, { limit: 50 });
+
+  return renderWithLoader({ portals })(({ portals }) => (
+    <Select
+      label="Portal"
+      value={p.value}
+      items={portals.data.items.map(portal => ({
+        id: portal.id,
+        label: portal.name
+      }))}
+      onChange={p.onChange}
+    />
+  ));
+};
+
+let MarketplacePicker = (p: {
+  instanceId: string;
+  selectedMarketplaceId: string;
+  onSelect: (marketplaceId: string) => void;
+}) => {
+  let { search, setSearch, searchQuery } = useSearchFilter(500, {
+    updateSearchParams: false
+  });
+  let marketplaces = useSkillMarketplaces(p.instanceId, {
+    order: 'desc',
+    status: ['active'],
+    search: searchQuery
+  });
+
+  return (
+    <>
+      <Input
+        label="Search marketplaces"
+        hideLabel
+        placeholder="Search marketplaces..."
+        value={search}
+        onInput={setSearch}
+      />
+      {renderWithPagination(
+        marketplaces,
+        paginationOpts
+      )(marketplaces => (
+        <MarketplaceManagerPanelScroll>
+          {marketplaces.data.items.map(item => (
+            <div key={item.id} onClick={() => p.onSelect(item.id)}>
+              <Entity.Wrapper>
+                <Entity.Content>
+                  <Entity.Field
+                    prefix={
+                      <Checkbox
+                        checked={p.selectedMarketplaceId == item.id}
+                        onCheckedChange={() => p.onSelect(item.id)}
+                        label="Select Marketplace"
+                        hideLabel
+                      />
+                    }
+                    title={item.name}
+                    value={item.description ?? undefined}
+                  />
+                </Entity.Content>
+              </Entity.Wrapper>
+              <Spacer size={10} />
+            </div>
+          ))}
+          {marketplaces.data.items.length == 0 && (
+            <Text size="2" color="gray600">
+              No skill marketplaces found.
+            </Text>
+          )}
+        </MarketplaceManagerPanelScroll>
+      ))}
+    </>
+  );
+};
+
+let GroupPicker = (p: {
+  instanceId: string;
+  portalId: string;
+  selectedGroupId: string;
+  onSelect: (groupId: string) => void;
+}) => {
+  let { search, setSearch, searchQuery } = useSearchFilter(500, {
+    updateSearchParams: false
+  });
+  let groups = usePortalConsumerGroups(p.instanceId, p.portalId, {
+    order: 'desc',
+    status: ['active'],
+    search: searchQuery,
+    limit: 30
+  });
+
+  return (
+    <>
+      <Input
+        label="Search groups"
+        hideLabel
+        placeholder="Search groups..."
+        value={search}
+        onInput={setSearch}
+      />
+      {renderWithPagination(
+        groups,
+        paginationOpts
+      )(groups => (
+        <MarketplaceManagerPanelScroll>
+          {groups.data.items.map(group => (
+            <div key={group.id} onClick={() => p.onSelect(group.id)}>
+              <Entity.Wrapper>
+                <Entity.Content>
+                  <Entity.Field
+                    prefix={
+                      <Checkbox
+                        checked={p.selectedGroupId == group.id}
+                        onCheckedChange={() => p.onSelect(group.id)}
+                        label="Select Group"
+                        hideLabel
+                      />
+                    }
+                    title={group.name}
+                    value={group.description?.trim() || undefined}
+                  />
+                </Entity.Content>
+              </Entity.Wrapper>
+              <Spacer size={10} />
+            </div>
+          ))}
+          {groups.data.items.length == 0 && (
+            <Text size="2" color="gray600">
+              No groups found.
+            </Text>
+          )}
+        </MarketplaceManagerPanelScroll>
+      ))}
+    </>
+  );
+};
+
+let AccountPicker = (p: {
+  instanceId: string;
+  portalId: string;
+  selectedGroupId: string;
+  onSelect: (groupId: string) => void;
+}) => {
+  let { search, setSearch, searchQuery } = useSearchFilter(500, {
+    updateSearchParams: false
+  });
+  let profiles = usePortalConsumerProfiles(p.instanceId, p.portalId, {
+    order: 'desc',
+    search: searchQuery,
+    limit: 30
+  });
+
+  return (
+    <>
+      <Input
+        label="Search accounts"
+        hideLabel
+        placeholder="Search accounts by name or email..."
+        value={search}
+        onInput={setSearch}
+      />
+      {renderWithPagination(
+        profiles,
+        paginationOpts
+      )(profiles => (
+        <MarketplaceManagerPanelScroll>
+          {profiles.data.items.map(profile => {
+            let personalGroupId = (profile.groups ?? []).find(
+              assignment => assignment.assignedVia == 'user'
+            )?.group.id;
+
+            return (
+              <div
+                key={profile.id}
+                onClick={() => personalGroupId && p.onSelect(personalGroupId)}
+              >
+                <Entity.Wrapper>
+                  <Entity.Content>
+                    <Entity.Field
+                      prefix={
+                        <Checkbox
+                          checked={p.selectedGroupId == personalGroupId}
+                          disabled={!personalGroupId}
+                          onCheckedChange={() =>
+                            personalGroupId && p.onSelect(personalGroupId)
+                          }
+                          label="Select Account"
+                          hideLabel
+                        />
+                      }
+                      title={profile.name || profile.email || profile.id}
+                      value={profile.name ? profile.email : undefined}
+                    />
+                  </Entity.Content>
+                </Entity.Wrapper>
+                <Spacer size={10} />
+              </div>
+            );
+          })}
+          {profiles.data.items.length == 0 && (
+            <Text size="2" color="gray600">
+              No accounts found.
+            </Text>
+          )}
+        </MarketplaceManagerPanelScroll>
+      ))}
+    </>
+  );
+};
+
+let MarketplaceManagerSelectStep = (p: {
+  instanceId: string;
+  subjectMode: MarketplaceManagerSubjectMode;
+  showPortalSelect: boolean;
+  needsWho: boolean;
+  needsMarketplace: boolean;
+  resolvedPortalId?: string;
+  selectedGroupId: string;
+  selectedMarketplaceId: string;
+  onPortalChange: (portalId: string) => void;
+  onSelectGroup: (groupId: string) => void;
+  onSelectMarketplace: (marketplaceId: string) => void;
+}) => (
+  <Flex direction="column" gap={16}>
+    {p.showPortalSelect ? (
+      <MarketplaceManagerPortalSelect
+        instanceId={p.instanceId}
+        value={p.resolvedPortalId}
+        onChange={p.onPortalChange}
+      />
+    ) : null}
+
+    {p.needsMarketplace ? (
+      <MarketplacePicker
+        instanceId={p.instanceId}
+        selectedMarketplaceId={p.selectedMarketplaceId}
+        onSelect={p.onSelectMarketplace}
+      />
+    ) : null}
+
+    {p.needsWho && p.resolvedPortalId && p.subjectMode == 'group' ? (
+      <GroupPicker
+        instanceId={p.instanceId}
+        portalId={p.resolvedPortalId}
+        selectedGroupId={p.selectedGroupId}
+        onSelect={p.onSelectGroup}
+      />
+    ) : null}
+
+    {p.needsWho && p.resolvedPortalId && p.subjectMode == 'account' ? (
+      <AccountPicker
+        instanceId={p.instanceId}
+        portalId={p.resolvedPortalId}
+        selectedGroupId={p.selectedGroupId}
+        onSelect={p.onSelectGroup}
+      />
+    ) : null}
+  </Flex>
+);
+
+let MarketplaceManagerAccessStep = (p: {
+  isEdit: boolean;
+  hasSelectStep: boolean;
+  scope: 'entire' | 'plugins';
+  onScopeChange: (scope: 'entire' | 'plugins') => void;
+  plugins: { id: string; name: string }[];
+  pluginsLoading: boolean;
+  selectedPluginIds: string[];
+  onTogglePlugin: (pluginId: string) => void;
+  canSubmit: boolean;
+  saving: boolean;
+  onBack: () => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) => (
+  <Flex direction="column" gap={16}>
+    <AuthMethodPicker
+      label="Access"
+      value={p.scope}
+      onChange={value => {
+        if (value == 'entire' || value == 'plugins') p.onScopeChange(value);
+      }}
+      items={[
+        {
+          id: 'entire',
+          name: 'Entire marketplace',
+          description:
+            'Full Marketplace Manager. Create plugins, update every plugin, and add or remove skills.'
+        },
+        {
+          id: 'plugins',
+          name: 'Specific plugins',
+          description:
+            'Plugin Manager. Can view the whole marketplace, but can only update the selected plugins and their skills. Cannot create or delete plugins.'
+        }
+      ]}
+    />
+
+    {p.scope == 'plugins' ? (
+      p.pluginsLoading ? (
+        <CenteredSpinner />
+      ) : p.plugins.length ? (
+        <Table
+          headers={['Plugin']}
+          data={p.plugins.map(plugin => ({
+            data: [
+              <Flex gap={8}>
+                <div style={{ width: 24 }} onClick={event => event.stopPropagation()}>
+                  <Checkbox
+                    checked={p.selectedPluginIds.includes(plugin.id)}
+                    onCheckedChange={() => p.onTogglePlugin(plugin.id)}
+                    label={plugin.name}
+                    hideLabel
+                  />
+                </div>
+                <Text size="2">{plugin.name}</Text>
+              </Flex>
+            ],
+            onClick: () => p.onTogglePlugin(plugin.id)
+          }))}
+        />
+      ) : (
+        <Text size="2" color="gray600">
+          This marketplace has no plugins yet.
+        </Text>
+      )
+    ) : null}
+
+    <Dialog.Actions>
+      {p.hasSelectStep ? (
+        <Button type="button" variant="outline" onClick={p.onBack}>
+          Back
+        </Button>
+      ) : (
+        <Button type="button" variant="outline" onClick={p.onCancel}>
+          Cancel
+        </Button>
+      )}
+      <Button disabled={!p.canSubmit} loading={p.saving} onClick={p.onSubmit}>
+        {p.isEdit ? 'Save Marketplace Manager' : 'Add as Marketplace Manager'}
+      </Button>
+    </Dialog.Actions>
+  </Flex>
+);
+
+let MarketplaceManagerPanel = (props: {
+  instanceId: string;
+  skillMarketplaceId?: string;
+  portalId?: string;
+  consumerGroupId?: string;
+  subjectMode?: MarketplaceManagerSubjectMode;
+  edit?: MarketplaceManagerRow;
+  close: () => void;
+  setPanelWidth: (width: number) => void;
+  onSuccess?: () => void;
+}) => {
+  let portals = usePortals(props.instanceId, { limit: 50 });
+  let [step, setStep] = useState(0);
+  let [portalId, setPortalId] = useState(props.edit?.portalId ?? props.portalId ?? '');
+  let [selectedGroupId, setSelectedGroupId] = useState(
+    props.edit?.consumerGroupId ?? props.consumerGroupId ?? ''
+  );
+  let [selectedMarketplaceId, setSelectedMarketplaceId] = useState(
+    props.edit?.skillMarketplaceId ?? props.skillMarketplaceId ?? ''
+  );
+  let [scope, setScope] = useState<'entire' | 'plugins'>(
+    props.edit?.scope.type == 'plugins' ? 'plugins' : 'entire'
+  );
+  let [selectedPluginIds, setSelectedPluginIds] = useState<string[]>(
+    props.edit?.scope.type == 'plugins'
+      ? props.edit.scope.plugins.map(plugin => plugin.id)
+      : []
+  );
+  let [saving, setSaving] = useState(false);
+
+  let subjectMode = props.subjectMode ?? (props.edit?.kind == 'account' ? 'account' : 'group');
+  let resolvedPortalId = portalId || portals.data?.items[0]?.id;
+  let marketplace = useSkillMarketplace(
+    props.instanceId,
+    selectedMarketplaceId || props.skillMarketplaceId
+  );
+  let createAccess = useCreatePortalConsumerAccessQuiet();
+  let deleteAccess = useDeletePortalConsumerAccess();
+
+  let plugins = useMemo(
+    () => (marketplace.data ? pluginsFromMarketplace(marketplace.data) : []),
+    [marketplace.data]
+  );
+
+  let portalItems = portals.data?.items ?? [];
+  let showPortalSelect = !props.portalId && !props.edit && portalItems.length > 1;
+  let needsWho = !props.consumerGroupId && !props.edit;
+  let needsMarketplace = !props.skillMarketplaceId && !props.edit;
+  let hasSelectStep = needsWho || needsMarketplace;
+
+  useEffect(() => {
+    props.setPanelWidth(hasSelectStep && step == 0 ? 720 : 660);
+  }, [hasSelectStep, props.setPanelWidth, step]);
+
+  let marketplaceId = selectedMarketplaceId || props.skillMarketplaceId;
+  let canGoToAccess = !!resolvedPortalId && !!selectedGroupId && !!marketplaceId;
+  let canSubmit = canGoToAccess && (scope == 'entire' || selectedPluginIds.length > 0);
+
+  let goToAccessIfReady = (next: { groupId?: string; marketplaceId?: string }) => {
+    let groupId = next.groupId ?? selectedGroupId;
+    let nextMarketplaceId = next.marketplaceId ?? marketplaceId;
+    if (resolvedPortalId && groupId && nextMarketplaceId) setStep(1);
+  };
+
+  let selectMarketplace = (nextMarketplaceId: string) => {
+    setSelectedMarketplaceId(nextMarketplaceId);
+    if (!props.edit) setSelectedPluginIds([]);
+    goToAccessIfReady({ marketplaceId: nextMarketplaceId });
+  };
+
+  let selectGroup = (groupId: string) => {
+    setSelectedGroupId(groupId);
+    goToAccessIfReady({ groupId });
+  };
+
+  let togglePlugin = (pluginId: string) =>
+    setSelectedPluginIds(current =>
+      current.includes(pluginId)
+        ? current.filter(id => id != pluginId)
+        : [...current, pluginId]
+    );
+
+  let submit = async () => {
+    if (!resolvedPortalId || !selectedGroupId || !marketplaceId) return;
+
+    let createJob =
+      (access: Parameters<typeof createAccess.mutate>[0]['access']) => async () => {
+        let [, error] = await createAccess.mutate({
+          instanceId: props.instanceId,
+          portalId: resolvedPortalId,
+          consumerGroupId: selectedGroupId,
+          access
+        });
+        return !error;
+      };
+
+    let deleteJob = (consumerAccessId: string) => async () => {
+      let [, error] = await deleteAccess.mutate({
+        instanceId: props.instanceId,
+        portalId: resolvedPortalId,
+        consumerAccessId
+      });
+      return !error;
+    };
+
+    setSaving(true);
+    try {
+      if (scope == 'entire') {
+        let created = await createJob({
+          type: 'skill_marketplace',
+          skillMarketplaceId: marketplaceId,
+          permission: 'manage'
+        })();
+        if (!created) return;
+
+        let removed = await runAccessJobs(
+          (props.edit?.pluginAccesses ?? []).map(pluginAccess =>
+            deleteJob(pluginAccess.accessId)
+          )
+        );
+        if (!removed) return;
+      } else {
+        if (props.edit?.marketplaceAccessId) {
+          let deletedMarketplace = await deleteJob(props.edit.marketplaceAccessId)();
+          if (!deletedMarketplace) return;
+        }
+
+        let remainingPluginIds = new Set(
+          props.edit?.marketplaceAccessId
+            ? []
+            : (props.edit?.pluginAccesses.map(item => item.pluginId) ?? [])
+        );
+        let desiredPluginIds = new Set(selectedPluginIds);
+
+        let assigned = await runAccessJobs([
+          ...selectedPluginIds
+            .filter(pluginId => !remainingPluginIds.has(pluginId))
+            .map(pluginId =>
+              createJob({
+                type: 'skill_plugin',
+                skillMarketplaceId: marketplaceId,
+                skillPluginId: pluginId
+              })
+            ),
+          ...(props.edit?.marketplaceAccessId ? [] : (props.edit?.pluginAccesses ?? []))
+            .filter(pluginAccess => !desiredPluginIds.has(pluginAccess.pluginId))
+            .map(pluginAccess => deleteJob(pluginAccess.accessId))
+        ]);
+        if (!assigned) return;
+      }
+
+      toast.success(props.edit ? 'Marketplace Manager updated' : 'Marketplace Manager added');
+      props.onSuccess?.();
+      props.close();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  let selectStepTitle = needsMarketplace
+    ? 'Select Marketplace'
+    : subjectMode == 'account'
+      ? 'Select Account'
+      : 'Select Group';
+
+  let steps = [
+    {
+      title: selectStepTitle,
+      render: () => (
+        <MarketplaceManagerSelectStep
+          instanceId={props.instanceId}
+          subjectMode={subjectMode}
+          showPortalSelect={showPortalSelect}
+          needsWho={needsWho}
+          needsMarketplace={needsMarketplace}
+          resolvedPortalId={resolvedPortalId}
+          selectedGroupId={selectedGroupId}
+          selectedMarketplaceId={selectedMarketplaceId}
+          onPortalChange={value => {
+            setPortalId(value);
+            if (!props.consumerGroupId) setSelectedGroupId('');
+          }}
+          onSelectGroup={selectGroup}
+          onSelectMarketplace={selectMarketplace}
+        />
+      )
+    },
+    {
+      title: 'Access',
+      render: () => (
+        <MarketplaceManagerAccessStep
+          isEdit={!!props.edit}
+          hasSelectStep={hasSelectStep}
+          scope={scope}
+          onScopeChange={setScope}
+          plugins={plugins}
+          pluginsLoading={marketplace.isLoading}
+          selectedPluginIds={selectedPluginIds}
+          onTogglePlugin={togglePlugin}
+          canSubmit={canSubmit}
+          saving={saving}
+          onBack={() => setStep(0)}
+          onCancel={props.close}
+          onSubmit={submit}
+        />
+      )
+    }
+  ];
+
+  return (
+    <ProviderCreationPanelShell
+      title={props.edit ? 'Edit Marketplace Manager' : 'Add Marketplace Manager'}
+      description={MARKETPLACE_MANAGER_COPY}
+      steps={hasSelectStep ? steps : [steps[1]!]}
+      currentStep={hasSelectStep ? step : 0}
+      setCurrentStep={nextStep => {
+        if (!hasSelectStep) return;
+        if (nextStep == 0 || canGoToAccess) setStep(nextStep);
+      }}
+      isStepDisabled={nextStep => nextStep == 1 && !canGoToAccess}
+      hideStepper={!hasSelectStep}
+    />
+  );
+};
+
+export let showMarketplaceManagerPanel = (props: {
+  instanceId: string;
+  skillMarketplaceId?: string;
+  portalId?: string;
+  consumerGroupId?: string;
+  subjectMode?: MarketplaceManagerSubjectMode;
+  edit?: MarketplaceManagerRow;
+  onSuccess?: () => void;
+}) =>
+  showProviderCreationPanel(
+    ({ close, setWidth }) => (
+      <MarketplaceManagerPanel
+        instanceId={props.instanceId}
+        skillMarketplaceId={props.skillMarketplaceId}
+        portalId={props.portalId}
+        consumerGroupId={props.consumerGroupId}
+        subjectMode={props.subjectMode}
+        edit={props.edit}
+        close={close}
+        setPanelWidth={setWidth}
+        onSuccess={props.onSuccess}
+      />
+    ),
+    {
+      width: props.edit || (props.consumerGroupId && props.skillMarketplaceId) ? 660 : 720
+    }
+  );

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/panelShell.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/panelShell.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+let PanelScrollArea = styled.div`
+  max-height: calc(100vh - 320px);
+  overflow: auto;
+  padding-right: 4px;
+`;
+
+export let MarketplaceManagerPanelScroll = PanelScrollArea;

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/shared.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/shared.tsx
@@ -1,0 +1,55 @@
+import { useDeletePortalConsumerAccess } from '@metorial/state';
+import { Badge, Flex, toast } from '@metorial/ui';
+import type { MarketplaceManagerRow } from './types';
+
+export let MarketplaceManagerScopeBadges = (props: { row: MarketplaceManagerRow }) => {
+  if (props.row.scope.type == 'entire') {
+    return (
+      <Badge color="orange" size="1">
+        Entire marketplace
+      </Badge>
+    );
+  }
+
+  let plugins = props.row.scope.plugins;
+  let visible = plugins.slice(0, 3);
+  let extra = plugins.length - visible.length;
+
+  return (
+    <Flex gap={6} wrap="wrap">
+      {visible.map(plugin => (
+        <Badge key={plugin.id} color="blue" size="1">
+          {plugin.name}
+        </Badge>
+      ))}
+      {extra > 0 ? (
+        <Badge color="blue" size="1">
+          +{extra}
+        </Badge>
+      ) : null}
+    </Flex>
+  );
+};
+
+export let removeMarketplaceManager = async (d: {
+  instanceId: string;
+  portalId: string;
+  row: MarketplaceManagerRow;
+  deleteAccess: ReturnType<typeof useDeletePortalConsumerAccess>;
+}) => {
+  let accessIds = d.row.marketplaceAccessId
+    ? [d.row.marketplaceAccessId]
+    : d.row.pluginAccesses.map(item => item.accessId);
+
+  for (let consumerAccessId of accessIds) {
+    let [, error] = await d.deleteAccess.mutate({
+      instanceId: d.instanceId,
+      portalId: d.portalId,
+      consumerAccessId
+    });
+    if (error) return false;
+  }
+
+  toast.success('Marketplace Manager removed');
+  return true;
+};

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/types.ts
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/skills/marketplaceManagers/types.ts
@@ -1,0 +1,34 @@
+import type { DashboardInstancePortalsAccessListOutput } from '@metorial/dashboard-sdk';
+
+export type MarketplaceManagerAccess =
+  DashboardInstancePortalsAccessListOutput['items'][number];
+
+export type MarketplacePluginOption = {
+  id: string;
+  name: string;
+};
+
+export type MarketplaceManagerScope =
+  | { type: 'entire' }
+  | { type: 'plugins'; plugins: MarketplacePluginOption[] };
+
+export type MarketplaceManagerKind = 'group' | 'account';
+
+export type MarketplaceManagerRow = {
+  id: string;
+  portalId: string;
+  consumerGroupId: string;
+  skillMarketplaceId: string;
+  name: string;
+  description: string | null;
+  kind: MarketplaceManagerKind;
+  accountId?: string;
+  scope: MarketplaceManagerScope;
+  marketplaceAccessId?: string;
+  pluginAccesses: { pluginId: string; accessId: string }[];
+};
+
+export let MARKETPLACE_MANAGER_COPY =
+  'Marketplace managers can update skills and plugins in the marketplace. You can assign managers to manage the entire marketplace or specific plugins.';
+
+export type MarketplaceManagerSubjectMode = 'group' | 'account';

--- a/src/metorial-frontend/packages/state/src/consumer/loaders/portalConsumers.ts
+++ b/src/metorial-frontend/packages/state/src/consumer/loaders/portalConsumers.ts
@@ -5,7 +5,7 @@ import type {
   DashboardInstancePortalsConsumerProfilesListQuery,
   DashboardInstancePortalsAccessUpdateBody
 } from '@metorial/dashboard-sdk';
-import { createLoader } from '@metorial/data-hooks';
+import { createLoader, useMutation } from '@metorial/data-hooks';
 import { autoPaginate } from '../../lib/autoPaginate';
 import { usePaginator } from '../../lib/usePaginator';
 import { withAuth } from '../../user';
@@ -161,3 +161,35 @@ export let usePortalConsumerAccess = (
     deleteMutator: access.useMutator('delete')
   };
 };
+
+let refetchPortalConsumerAccess = () => {
+  allPortalConsumerAccessLoader.refetchAll();
+  portalConsumerAccessLoader.refetchAll();
+};
+
+export let useCreatePortalConsumerAccessQuiet = () =>
+  useMutation(
+    (
+      i: DashboardInstancePortalsAccessCreateBody & {
+        instanceId: string;
+        portalId: string;
+      }
+    ) => withAuth(sdk => sdk.portals.consumerAccess.create(i.instanceId, i.portalId, i)),
+    {
+      onSuccess: refetchPortalConsumerAccess,
+      disableToast: true
+    }
+  );
+
+export let useDeletePortalConsumerAccess = () =>
+  useMutation(
+    (i: { instanceId: string; portalId: string; consumerAccessId: string }) =>
+      withAuth(sdk =>
+        sdk.portals.consumerAccess.delete(i.instanceId, i.portalId, i.consumerAccessId)
+      ),
+    {
+      onSuccess: refetchPortalConsumerAccess,
+      disableToast: true
+    }
+  );
+

--- a/src/metorial-frontend/packages/state/src/lib/useAccumulatedPaginatedLoader.ts
+++ b/src/metorial-frontend/packages/state/src/lib/useAccumulatedPaginatedLoader.ts
@@ -58,9 +58,17 @@ export let useAccumulatedPaginatedLoader = <
     if (!firstItems.length && !cursorItems.length) return;
 
     setItemsMap(current => {
-      let next = new Map(current);
-      for (let item of firstItems) next.set(item.id, item);
-      for (let item of cursorItems) next.set(item.id, item);
+      let next = current;
+
+      for (let item of [...firstItems, ...cursorItems]) {
+        let existing = current.get(item.id);
+        if (existing === item) continue;
+        if (existing && JSON.stringify(existing) === JSON.stringify(item)) continue;
+
+        if (next === current) next = new Map(current);
+        next.set(item.id, item);
+      }
+
       return next;
     });
   }, [firstPage.data?.items, cursorPage.data?.items]);

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.test.ts
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.test.ts
@@ -231,7 +231,7 @@ describe('sortMarketplacePluginHierarchy', () => {
     ]);
   });
 
-  it('puts matching single-skill plugins first and sorts them by skill name', () => {
+  it('sorts all items alphabetically by displayed name', () => {
     let multiSkill = makeItem({
       pluginName: 'Able Plugin',
       skills: [
@@ -260,10 +260,10 @@ describe('sortMarketplacePluginHierarchy', () => {
     ]);
 
     expect(result.map(item => item.skillPlugin!.name)).toEqual([
-      'Alpha Skill',
-      'Zulu Skill',
       'Aardvark Wrapper',
-      'Able Plugin'
+      'Able Plugin',
+      'Alpha Skill',
+      'Zulu Skill'
     ]);
   });
 });

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
@@ -44,6 +44,7 @@ import {
   theme
 } from '@metorial/ui';
 import { Table } from '@metorial/ui-product';
+import { useSearchFilter } from '@metorial/use-search-filter';
 import {
   RiAddLine,
   RiDraggable,
@@ -51,7 +52,8 @@ import {
   RiPuzzle2Line
 } from '@remixicon/react';
 import PQueue from 'p-queue';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import styled from 'styled-components';
 
 type EmbeddedPluginSkill = SkillPlugin['skills'][number];
@@ -77,7 +79,7 @@ let Tree = styled.div`
   flex-direction: column;
 `;
 
-let TreeRow = styled.div<{ $dropTarget?: boolean; $dragging?: boolean }>`
+let TreeRow = styled.div<{ $dropTarget?: boolean; $dragging?: boolean; $muted?: boolean }>`
   min-height: 38px;
   padding: 3px 6px;
   display: flex;
@@ -88,7 +90,8 @@ let TreeRow = styled.div<{ $dropTarget?: boolean; $dragging?: boolean }>`
   border: 1px solid
     ${({ $dropTarget }) => ($dropTarget ? theme.colors.blue600 : 'transparent')};
   border-radius: 8px;
-  opacity: ${({ $dragging }) => ($dragging ? 0.45 : 1)};
+  opacity: ${({ $dragging, $muted }) => ($dragging ? 0.45 : $muted ? 0.5 : 1)};
+  color: ${({ $muted }) => ($muted ? theme.colors.gray600 : 'inherit')};
   transition: 120ms ease;
 `;
 
@@ -250,16 +253,18 @@ let FormStack = styled.div`
 
 let normalizeName = (value: string | null | undefined) => value?.trim().toLowerCase();
 
-let useDebouncedSearch = (value: string, delay = 500) => {
-  let [debouncedValue, setDebouncedValue] = useState(value);
+let paginationOpts = { hidePaginationWhenUnavailable: true };
 
-  useEffect(() => {
-    let timeout = window.setTimeout(() => setDebouncedValue(value), delay);
-    return () => window.clearTimeout(timeout);
-  }, [value, delay]);
+let marketplaceCanCreatePlugins = (marketplace: {
+  status: string;
+  canCreatePlugins?: boolean;
+}) => marketplace.canCreatePlugins ?? marketplace.status == 'active';
 
-  return debouncedValue.trim() || undefined;
-};
+let pluginCanUpdate = (plugin: { status: string; canUpdate?: boolean }) =>
+  plugin.canUpdate ?? plugin.status == 'active';
+
+let pluginCanDelete = (plugin: { status: string; canDelete?: boolean }) =>
+  plugin.canDelete === true;
 
 export let isCollapsedMarketplacePlugin = (item: SkillMarketplacePlugin) => {
   let plugin = item.skillPlugin;
@@ -294,14 +299,18 @@ export let moveSkillOptimistically = (
   items: SkillMarketplacePlugin[],
   sourcePluginId: string,
   destinationPluginId: string,
-  skill: EmbeddedPluginSkill
+  skill: EmbeddedPluginSkill,
+  removeEmptySource = true
 ) =>
   items.flatMap(item => {
     let plugin = item.skillPlugin;
     if (!plugin) return [item];
 
     if (plugin.id === sourcePluginId) {
-      if (plugin.skills.length === 1) return [];
+      if (plugin.skills.length === 1) {
+        if (removeEmptySource) return [];
+        return [{ ...item, skillPlugin: { ...plugin, skills: [] } }];
+      }
       return [
         {
           ...item,
@@ -329,12 +338,16 @@ export let moveSkillToStandaloneOptimistically = (
   items: SkillMarketplacePlugin[],
   sourcePluginId: string,
   skill: EmbeddedPluginSkill,
-  standalonePlugin: SkillMarketplacePlugin
+  standalonePlugin: SkillMarketplacePlugin,
+  removeEmptySource = true
 ) => [
   ...items.flatMap(item => {
     let plugin = item.skillPlugin;
     if (!plugin || plugin.id !== sourcePluginId) return [item];
-    if (plugin.skills.length === 1) return [];
+    if (plugin.skills.length === 1) {
+      if (removeEmptySource) return [];
+      return [{ ...item, skillPlugin: { ...plugin, skills: [] } }];
+    }
 
     return [
       {
@@ -348,6 +361,43 @@ export let moveSkillToStandaloneOptimistically = (
   }),
   standalonePlugin
 ];
+
+let asStandaloneMarketplacePlugin = (d: {
+  plugin: SkillPlugin;
+  skill: EmbeddedPluginSkill;
+  skillMarketplaceId: string;
+}): SkillMarketplacePlugin => ({
+  object: 'skill.marketplace_plugin',
+  id: `optimistic:${d.plugin.id}`,
+  status: 'active',
+  identifier: d.plugin.slug,
+  skillConfigurationId: d.plugin.skillConfigurationId,
+  skillMarketplaceId: d.skillMarketplaceId,
+  skillPlugin: {
+    ...d.plugin,
+    skills: [d.skill]
+  },
+  createdAt: d.plugin.createdAt,
+  updatedAt: d.plugin.updatedAt
+});
+
+let asOptimisticStandaloneMarketplacePlugin = (d: {
+  sourcePlugin: SkillPlugin;
+  skill: EmbeddedPluginSkill;
+  skillMarketplaceId: string;
+}) =>
+  asStandaloneMarketplacePlugin({
+    plugin: {
+      ...d.sourcePlugin,
+      id: `optimistic-plugin:${d.skill.id}`,
+      name: d.skill.skill.name,
+      slug: d.skill.skill.slug,
+      description: d.skill.skill.description,
+      skills: [d.skill]
+    },
+    skill: d.skill,
+    skillMarketplaceId: d.skillMarketplaceId
+  });
 
 let compareNames = (
   aName: string | null | undefined,
@@ -376,14 +426,10 @@ export let sortMarketplacePluginHierarchy = (items: SkillMarketplacePlugin[]) =>
         : null
     }))
     .sort((a, b) => {
-      let aIsStandalone = isCollapsedMarketplacePlugin(a);
-      let bIsStandalone = isCollapsedMarketplacePlugin(b);
-      if (aIsStandalone !== bIsStandalone) return aIsStandalone ? -1 : 1;
-
-      let aName = aIsStandalone
+      let aName = isCollapsedMarketplacePlugin(a)
         ? a.skillPlugin!.skills[0].skill.name
         : (a.skillPlugin?.name ?? a.identifier);
-      let bName = bIsStandalone
+      let bName = isCollapsedMarketplacePlugin(b)
         ? b.skillPlugin!.skills[0].skill.name
         : (b.skillPlugin?.name ?? b.identifier);
       return compareNames(aName, bName, a.id, b.id);
@@ -404,14 +450,64 @@ let addSelectedItems = async <T,>(items: T[], onSelect: (item: T) => Promise<boo
   return results.every(Boolean);
 };
 
+let PluginPickerResults = (p: {
+  plugins: ReturnType<typeof useSkillPlugins>;
+  excluded: Set<string>;
+  selectedIds: Set<string>;
+  search: string;
+  isAdding: boolean;
+  onToggle: (plugin: SkillPlugin, checked: boolean) => void;
+}) =>
+  renderWithPagination(
+    p.plugins,
+    paginationOpts
+  )(plugins => {
+    let items = plugins.data.items.filter(plugin => !p.excluded.has(plugin.id));
+
+    if (!items.length)
+      return (
+        <Text size="2" color="gray600">
+          {p.search.trim()
+            ? 'No available plugins match your search.'
+            : 'No additional plugins to add to this marketplace.'}
+        </Text>
+      );
+
+    return (
+      <Table
+        headers={['Name', 'Identifier']}
+        data={items.map(plugin => ({
+          data: [
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <PickerCheckbox key={plugin.id} onClick={event => event.stopPropagation()}>
+                <Checkbox
+                  label={`Select ${plugin.name}`}
+                  hideLabel
+                  checked={p.selectedIds.has(plugin.id)}
+                  disabled={p.isAdding}
+                  onCheckedChange={checked => p.onToggle(plugin, checked)}
+                />
+              </PickerCheckbox>
+
+              <span>{plugin.name}</span>
+            </div>,
+            plugin.slug
+          ],
+          onClick: () => !p.isAdding && p.onToggle(plugin, !p.selectedIds.has(plugin.id))
+        }))}
+      />
+    );
+  });
+
 let PluginPickerPanel = (p: {
   instanceId: string;
   excludePluginIds: string[];
   close: () => void;
   onSelect: (plugin: SkillPlugin) => Promise<boolean>;
 }) => {
-  let [search, setSearch] = useState('');
-  let searchQuery = useDebouncedSearch(search);
+  let { search, setSearch, searchQuery } = useSearchFilter(500, {
+    updateSearchParams: false
+  });
   let [selectedPlugins, setSelectedPlugins] = useState<SkillPlugin[]>([]);
   let [isAdding, setIsAdding] = useState(false);
   let plugins = useSkillPlugins(p.instanceId, {
@@ -421,6 +517,10 @@ let PluginPickerPanel = (p: {
     ...(searchQuery ? { search: searchQuery } : {})
   });
   let excluded = useMemo(() => new Set(p.excludePluginIds), [p.excludePluginIds]);
+  let selectedIds = useMemo(
+    () => new Set(selectedPlugins.map(plugin => plugin.id)),
+    [selectedPlugins]
+  );
 
   let toggleSelected = (plugin: SkillPlugin, checked: boolean) =>
     setSelectedPlugins(current =>
@@ -448,47 +548,14 @@ let PluginPickerPanel = (p: {
             value={search}
             onInput={setSearch}
           />
-          {renderWithPagination(plugins, { hidePaginationWhenUnavailable: true })(plugins => {
-            let items = plugins.data.items.filter(plugin => !excluded.has(plugin.id));
-            let selected = new Set(selectedPlugins.map(plugin => plugin.id));
-
-            if (!items.length)
-              return (
-                <Text size="2" color="gray600">
-                  {search.trim()
-                    ? 'No available plugins match your search.'
-                    : 'No additional plugins to add to this marketplace.'}
-                </Text>
-              );
-
-            return (
-              <Table
-                headers={['Name', 'Identifier']}
-                data={items.map(plugin => ({
-                  data: [
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <PickerCheckbox
-                        key={plugin.id}
-                        onClick={event => event.stopPropagation()}
-                      >
-                        <Checkbox
-                          label={`Select ${plugin.name}`}
-                          hideLabel
-                          checked={selected.has(plugin.id)}
-                          disabled={isAdding}
-                          onCheckedChange={checked => toggleSelected(plugin, checked)}
-                        />
-                      </PickerCheckbox>
-
-                      <span>{plugin.name}</span>
-                    </div>,
-                    plugin.slug
-                  ],
-                  onClick: () => !isAdding && toggleSelected(plugin, !selected.has(plugin.id))
-                }))}
-              />
-            );
-          })}
+          <PluginPickerResults
+            plugins={plugins}
+            excluded={excluded}
+            selectedIds={selectedIds}
+            search={search}
+            isAdding={isAdding}
+            onToggle={toggleSelected}
+          />
           <PickerActions>
             <Button
               loading={isAdding}
@@ -511,14 +578,65 @@ let PluginPickerPanel = (p: {
   );
 };
 
+let SkillPickerResults = (p: {
+  skills: ReturnType<typeof useSkills>;
+  linked: Set<string>;
+  selectedIds: Set<string>;
+  search: string;
+  isAdding: boolean;
+  onToggle: (skill: Skill, checked: boolean) => void;
+}) =>
+  renderWithPagination(
+    p.skills,
+    paginationOpts
+  )(skills => {
+    let items = skills.data.items.filter(skill => !p.linked.has(skill.id));
+
+    if (!items.length)
+      return (
+        <Text size="2" color="gray600">
+          {p.search.trim()
+            ? 'No available skills match your search.'
+            : 'All skills on this page are already in this marketplace.'}
+        </Text>
+      );
+
+    return (
+      <Table
+        headers={['Name', 'Identifier']}
+        data={items.map(skill => ({
+          data: [
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <PickerCheckbox key={skill.id} onClick={event => event.stopPropagation()}>
+                <Checkbox
+                  label={`Select ${skill.name}`}
+                  hideLabel
+                  checked={p.selectedIds.has(skill.id)}
+                  disabled={p.isAdding}
+                  onCheckedChange={checked => p.onToggle(skill, checked)}
+                />
+              </PickerCheckbox>
+
+              <span>{skill.name}</span>
+            </div>,
+
+            skill.slug
+          ],
+          onClick: () => !p.isAdding && p.onToggle(skill, !p.selectedIds.has(skill.id))
+        }))}
+      />
+    );
+  });
+
 let SkillPickerPanel = (p: {
   instanceId: string;
   linkedSkillIds: string[];
   close: () => void;
   onSelect: (skill: Skill) => Promise<boolean>;
 }) => {
-  let [search, setSearch] = useState('');
-  let searchQuery = useDebouncedSearch(search);
+  let { search, setSearch, searchQuery } = useSearchFilter(500, {
+    updateSearchParams: false
+  });
   let [selectedSkills, setSelectedSkills] = useState<Skill[]>([]);
   let [isAdding, setIsAdding] = useState(false);
   let skills = useSkills(p.instanceId, {
@@ -528,6 +646,10 @@ let SkillPickerPanel = (p: {
     ...(searchQuery ? { search: searchQuery } : {})
   });
   let linked = useMemo(() => new Set(p.linkedSkillIds), [p.linkedSkillIds]);
+  let selectedIds = useMemo(
+    () => new Set(selectedSkills.map(skill => skill.id)),
+    [selectedSkills]
+  );
 
   let toggleSelected = (skill: Skill, checked: boolean) =>
     setSelectedSkills(current =>
@@ -553,48 +675,14 @@ let SkillPickerPanel = (p: {
             value={search}
             onInput={setSearch}
           />
-          {renderWithPagination(skills, { hidePaginationWhenUnavailable: true })(skills => {
-            let items = skills.data.items.filter(skill => !linked.has(skill.id));
-            let selected = new Set(selectedSkills.map(skill => skill.id));
-
-            if (!items.length)
-              return (
-                <Text size="2" color="gray600">
-                  {search.trim()
-                    ? 'No available skills match your search.'
-                    : 'All skills on this page are already in this marketplace.'}
-                </Text>
-              );
-
-            return (
-              <Table
-                headers={['Name', 'Identifier']}
-                data={items.map(skill => ({
-                  data: [
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <PickerCheckbox
-                        key={skill.id}
-                        onClick={event => event.stopPropagation()}
-                      >
-                        <Checkbox
-                          label={`Select ${skill.name}`}
-                          hideLabel
-                          checked={selected.has(skill.id)}
-                          disabled={isAdding}
-                          onCheckedChange={checked => toggleSelected(skill, checked)}
-                        />
-                      </PickerCheckbox>
-
-                      <span>{skill.name}</span>
-                    </div>,
-
-                    skill.slug
-                  ],
-                  onClick: () => !isAdding && toggleSelected(skill, !selected.has(skill.id))
-                }))}
-              />
-            );
-          })}
+          <SkillPickerResults
+            skills={skills}
+            linked={linked}
+            selectedIds={selectedIds}
+            search={search}
+            isAdding={isAdding}
+            onToggle={toggleSelected}
+          />
           <PickerActions>
             <Button
               loading={isAdding}
@@ -640,7 +728,6 @@ let PluginForm = (p: {
 }) => {
   let createPlugin = useCreateSkillPlugin();
   let updatePlugin = useUpdateSkillPlugin();
-  let addMarketplacePlugin = useCreateSkillMarketplacePlugin();
   let form = useForm({
     initialValues: { name: p.plugin?.name ?? '', description: p.plugin?.description ?? '' },
     onSubmit: async values => {
@@ -655,16 +742,11 @@ let PluginForm = (p: {
       } else {
         let [plugin] = await createPlugin.mutate({
           instanceId: p.instanceId,
+          skillMarketplaceId: p.skillMarketplaceId,
           name: values.name.trim(),
           description: values.description.trim() || undefined
         });
         if (!plugin) return;
-        let [added] = await addMarketplacePlugin.mutate({
-          instanceId: p.instanceId,
-          skillMarketplaceId: p.skillMarketplaceId,
-          skillPluginId: plugin.id
-        });
-        if (!added) return;
       }
       await p.onChanged();
       p.close();
@@ -675,8 +757,7 @@ let PluginForm = (p: {
         description: yup.string()
       })
   });
-  let loading =
-    createPlugin.isLoading || updatePlugin.isLoading || addMarketplacePlugin.isLoading;
+  let loading = createPlugin.isLoading || updatePlugin.isLoading;
   return (
     <form onSubmit={form.handleSubmit}>
       <FormStack>
@@ -699,7 +780,6 @@ let PluginForm = (p: {
         </Dialog.Actions>
         <createPlugin.RenderError />
         <updatePlugin.RenderError />
-        <addMarketplacePlugin.RenderError />
       </FormStack>
     </form>
   );
@@ -721,33 +801,42 @@ let showPluginForm = (p: Omit<Parameters<typeof PluginForm>[0], 'close'>) =>
 let PluginMenu = (p: {
   plugin: SkillPlugin;
   disabled: boolean;
+  canUpdate: boolean;
+  canAddSkill: boolean;
+  canRemove: boolean;
   onAddSkill: () => void;
   onEdit: () => void;
   onRemove: () => void;
-}) => (
-  <Menu
-    items={[
-      { label: 'Add Skill', onClick: p.onAddSkill },
-      { label: 'Edit Plugin', onClick: p.onEdit },
-      { label: 'Remove from Marketplace', onClick: p.onRemove }
-    ]}
-  >
-    <Button
-      aria-label={`${p.plugin.name} options`}
-      title="Plugin options"
-      size="1"
-      variant="ghost"
-      iconRight={<RiMoreVerticalLine />}
-      disabled={p.disabled}
-    />
-  </Menu>
-);
+  variant?: 'ghost' | 'outline';
+}) => {
+  let items = [
+    ...(p.canAddSkill ? [{ label: 'Add Skill', onClick: p.onAddSkill }] : []),
+    ...(p.canUpdate ? [{ label: 'Edit Plugin', onClick: p.onEdit }] : []),
+    ...(p.canRemove ? [{ label: 'Remove from Marketplace', onClick: p.onRemove }] : [])
+  ];
+  if (!items.length) return null;
+
+  return (
+    <Menu items={items}>
+      <Button
+        aria-label={`${p.plugin.name} options`}
+        title="Plugin options"
+        size="1"
+        variant={p.variant ?? 'ghost'}
+        iconRight={<RiMoreVerticalLine />}
+        disabled={p.disabled}
+      />
+    </Menu>
+  );
+};
 
 let SkillRow = (p: {
   skill: EmbeddedPluginSkill;
   pluginId: string;
   href?: string;
   disabled: boolean;
+  showDragHandle: boolean;
+  muted?: boolean;
   combined?: boolean;
   dropTarget?: boolean;
   actions?: React.ReactNode;
@@ -765,17 +854,24 @@ let SkillRow = (p: {
     </RowMain>
   );
   return (
-    <TreeRow ref={drag.setNodeRef} $dragging={drag.isDragging} $dropTarget={p.dropTarget}>
-      <DragHandle
-        ref={drag.setActivatorNodeRef}
-        {...drag.listeners}
-        {...drag.attributes}
-        data-skill-drag-handle
-        disabled={p.disabled}
-        aria-label={`Move ${p.skill.skill.name}`}
-      >
-        <RiDraggable size={17} />
-      </DragHandle>
+    <TreeRow
+      ref={drag.setNodeRef}
+      $dragging={drag.isDragging}
+      $dropTarget={p.dropTarget}
+      $muted={p.muted}
+    >
+      {p.showDragHandle && (
+        <DragHandle
+          ref={drag.setActivatorNodeRef}
+          {...drag.listeners}
+          {...drag.attributes}
+          data-skill-drag-handle
+          disabled={p.disabled}
+          aria-label={`Move ${p.skill.skill.name}`}
+        >
+          <RiDraggable size={17} />
+        </DragHandle>
+      )}
       {p.href ? (
         <SkillLink
           href={p.href}
@@ -825,52 +921,82 @@ let PluginTreeItem = (p: {
   getSkillPath?: (skillId: string) => string;
   actionsDisabled: boolean;
   dragDisabled: boolean;
+  canCreatePlugins: boolean;
   onAddSkill: () => void;
   onEdit: () => void;
   onRemove: () => void;
 }) => {
   let plugin = p.item.skillPlugin!;
+  let canUpdate = pluginCanUpdate(plugin);
+  let muted = !canUpdate;
+  let showInlineAddSkill = canUpdate && !p.canCreatePlugins;
   let drop = useDroppable({
     id: `plugin:${plugin.id}`,
-    disabled: p.dragDisabled,
+    disabled: p.dragDisabled || !canUpdate,
     data: { pluginId: plugin.id }
   });
-  let menu = (
-    <PluginMenu
-      plugin={plugin}
-      disabled={p.actionsDisabled}
-      onAddSkill={p.onAddSkill}
-      onEdit={p.onEdit}
-      onRemove={p.onRemove}
-    />
+
+  let actions = (
+    <RowActions>
+      <PluginMenu
+        plugin={plugin}
+        disabled={p.actionsDisabled}
+        canUpdate={canUpdate}
+        canAddSkill={canUpdate && !showInlineAddSkill}
+        canRemove={p.canCreatePlugins}
+        onAddSkill={p.onAddSkill}
+        onEdit={p.onEdit}
+        onRemove={p.onRemove}
+        variant={showInlineAddSkill ? 'outline' : 'ghost'}
+      />
+
+      {showInlineAddSkill && (
+        <Button
+          size="1"
+          iconLeft={<RiAddLine />}
+          disabled={p.actionsDisabled}
+          onClick={p.onAddSkill}
+        >
+          Add Skill
+        </Button>
+      )}
+    </RowActions>
   );
+
   let collapsed = isCollapsedMarketplacePlugin(p.item);
+
   return (
     <PluginBranch ref={drop.setNodeRef}>
       <BranchConnector />
+
       {collapsed ? (
         <SkillRow
           skill={plugin.skills[0]}
           pluginId={plugin.id}
           href={p.getSkillPath?.(plugin.skills[0].skillId)}
-          disabled={p.dragDisabled}
+          disabled={p.dragDisabled || !canUpdate}
+          showDragHandle={canUpdate}
+          muted={muted}
           combined
           dropTarget={drop.isOver}
-          actions={menu}
+          actions={actions}
         />
       ) : (
         <>
-          <TreeRow $dropTarget={drop.isOver}>
+          <TreeRow $dropTarget={drop.isOver} $muted={muted}>
             <RowMain>
               <Text size="2" weight="strong">
                 {plugin.name}
               </Text>
             </RowMain>
+
             <Badge size="1" color="gray">
               {p.item.identifier}
             </Badge>
-            {menu}
+
+            {actions}
           </TreeRow>
+
           {plugin.skills.length > 0 && (
             <SkillBranches>
               {plugin.skills.map(skill => (
@@ -879,7 +1005,9 @@ let PluginTreeItem = (p: {
                     skill={skill}
                     pluginId={plugin.id}
                     href={p.getSkillPath?.(skill.skillId)}
-                    disabled={p.dragDisabled}
+                    disabled={p.dragDisabled || !canUpdate}
+                    showDragHandle={canUpdate}
+                    muted={muted}
                   />
                 </SkillRowWrap>
               ))}
@@ -896,6 +1024,8 @@ export let SkillMarketplacePluginsScene = (p: {
   skillMarketplaceId: string | null | undefined;
   getSkillPluginPath?: (skillPluginId: string) => string;
   getSkillPath?: (skillId: string) => string;
+  showHeader?: boolean;
+  showImportPlugin?: boolean;
 }) => {
   let marketplace = useSkillMarketplace(p.instanceId, p.skillMarketplaceId);
   let marketplacePlugins = useAllSkillMarketplacePlugins(p.instanceId, p.skillMarketplaceId, {
@@ -942,6 +1072,29 @@ export let SkillMarketplacePluginsScene = (p: {
     void refresh().finally(() => {
       if (moveVersionRef.current === version) setOptimisticPlugins(null);
     });
+  };
+  let cleanupEmptySourcePlugin = async (sourceItem: SkillMarketplacePlugin) => {
+    if (!shouldDeleteSourcePluginAfterMove(sourceItem) || !p.instanceId) return;
+
+    if (pluginCanDelete(sourceItem.skillPlugin!)) {
+      await deletePlugin.mutate({
+        instanceId: p.instanceId,
+        skillPluginId: sourceItem.skillPlugin!.id
+      });
+      return;
+    }
+
+    if (
+      marketplace.data &&
+      marketplaceCanCreatePlugins(marketplace.data) &&
+      p.skillMarketplaceId
+    ) {
+      await removeMarketplacePlugin.mutate({
+        instanceId: p.instanceId,
+        skillMarketplaceId: p.skillMarketplaceId,
+        skillMarketplacePluginId: sourceItem.id
+      });
+    }
   };
   let actionsDisabled =
     movePending ||
@@ -992,6 +1145,7 @@ export let SkillMarketplacePluginsScene = (p: {
       onSelect: async skill => {
         let [plugin] = await createPlugin.mutate({
           instanceId: p.instanceId!,
+          skillMarketplaceId: p.skillMarketplaceId!,
           name: skill.name,
           description: skill.description ?? undefined
         });
@@ -1001,14 +1155,8 @@ export let SkillMarketplacePluginsScene = (p: {
           skillPluginId: plugin.id,
           ...getNewSkillInput(skill)
         });
-        if (!membership) return false;
-        let [added] = await addMarketplacePlugin.mutate({
-          instanceId: p.instanceId!,
-          skillMarketplaceId: p.skillMarketplaceId!,
-          skillPluginId: plugin.id
-        });
-        if (added) await refresh();
-        return Boolean(added);
+        if (membership) await refresh();
+        return Boolean(membership);
       }
     });
   };
@@ -1041,6 +1189,7 @@ export let SkillMarketplacePluginsScene = (p: {
     let sourcePluginId = p2.sourceItem.skillPlugin!.id;
     let [plugin] = await createPlugin.mutate({
       instanceId: p.instanceId,
+      skillMarketplaceId: p.skillMarketplaceId,
       name: p2.skill.skill.name,
       description: p2.skill.skill.description ?? undefined
     });
@@ -1056,22 +1205,12 @@ export let SkillMarketplacePluginsScene = (p: {
       return;
     }
 
-    let [marketplaceMembership] = await addMarketplacePlugin.mutate({
-      instanceId: p.instanceId,
-      skillMarketplaceId: p.skillMarketplaceId,
-      skillPluginId: plugin.id
+    let marketplaceMembership = asStandaloneMarketplacePlugin({
+      plugin,
+      skill: p2.skill,
+      skillMarketplaceId: p.skillMarketplaceId
     });
-    if (!marketplaceMembership) {
-      await deletePlugin.mutate({ instanceId: p.instanceId, skillPluginId: plugin.id });
-      return;
-    }
-
     let rollbackStandalonePlugin = async () => {
-      await removeMarketplacePlugin.mutate({
-        instanceId: p.instanceId!,
-        skillMarketplaceId: p.skillMarketplaceId!,
-        skillMarketplacePluginId: marketplaceMembership.id
-      });
       await deletePlugin.mutate({
         instanceId: p.instanceId!,
         skillPluginId: plugin.id
@@ -1088,43 +1227,7 @@ export let SkillMarketplacePluginsScene = (p: {
       return;
     }
 
-    if (shouldDeleteSourcePluginAfterMove(p2.sourceItem)) {
-      let [sourceMarketplaceMembershipRemoved] = await removeMarketplacePlugin.mutate({
-        instanceId: p.instanceId,
-        skillMarketplaceId: p.skillMarketplaceId,
-        skillMarketplacePluginId: p2.sourceItem.id
-      });
-      if (!sourceMarketplaceMembershipRemoved) {
-        await addPluginSkill.mutate({
-          instanceId: p.instanceId,
-          skillPluginId: sourcePluginId,
-          ...getMoveSkillInput(p2.skill)
-        });
-        await rollbackStandalonePlugin();
-        await refresh();
-        return;
-      }
-
-      let [sourcePluginDeleted] = await deletePlugin.mutate({
-        instanceId: p.instanceId,
-        skillPluginId: sourcePluginId
-      });
-      if (!sourcePluginDeleted) {
-        await addPluginSkill.mutate({
-          instanceId: p.instanceId,
-          skillPluginId: sourcePluginId,
-          ...getMoveSkillInput(p2.skill)
-        });
-        await addMarketplacePlugin.mutate({
-          instanceId: p.instanceId,
-          skillMarketplaceId: p.skillMarketplaceId,
-          skillPluginId: sourcePluginId
-        });
-        await rollbackStandalonePlugin();
-        await refresh();
-        return;
-      }
-    }
+    await cleanupEmptySourcePlugin(p2.sourceItem);
 
     return marketplaceMembership;
   };
@@ -1135,22 +1238,53 @@ export let SkillMarketplacePluginsScene = (p: {
       | undefined;
     let destinationId = event.over?.data.current?.pluginId as string | undefined;
     let createStandalonePlugin = Boolean(event.over?.data.current?.createStandalonePlugin);
-    setMovingSkill(null);
+    let clearOverlay = () => setMovingSkill(null);
     if (
       !p.instanceId ||
       !data?.pluginId ||
       !data.skill ||
       (!destinationId && !createStandalonePlugin)
-    )
+    ) {
+      clearOverlay();
       return;
+    }
     let sourceItem = displayedPlugins.find(item => item.skillPlugin?.id === data.pluginId);
-    if (!sourceItem?.skillPlugin) return;
+    if (!sourceItem?.skillPlugin || !pluginCanUpdate(sourceItem.skillPlugin)) {
+      clearOverlay();
+      return;
+    }
+    let canCreatePlugins = marketplace.data
+      ? marketplaceCanCreatePlugins(marketplace.data)
+      : false;
+    let removeEmptySource = canCreatePlugins;
 
     if (createStandalonePlugin) {
-      if (isCollapsedMarketplacePlugin(sourceItem)) return;
+      if (
+        !canCreatePlugins ||
+        isCollapsedMarketplacePlugin(sourceItem) ||
+        !p.skillMarketplaceId
+      ) {
+        clearOverlay();
+        return;
+      }
       let moveVersion = ++moveVersionRef.current;
+      let nextPlugins = moveSkillToStandaloneOptimistically(
+        displayedPlugins,
+        data.pluginId,
+        data.skill,
+        asOptimisticStandaloneMarketplacePlugin({
+          sourcePlugin: sourceItem.skillPlugin,
+          skill: data.skill,
+          skillMarketplaceId: p.skillMarketplaceId
+        }),
+        removeEmptySource
+      );
+      flushSync(() => {
+        setOptimisticPlugins(nextPlugins);
+        setMovePending(true);
+      });
+      clearOverlay();
       let moveCompleted = false;
-      setMovePending(true);
       try {
         let standalonePlugin = await moveSkillToStandalonePlugin({
           sourceItem,
@@ -1158,15 +1292,7 @@ export let SkillMarketplacePluginsScene = (p: {
         });
         if (!standalonePlugin) return;
         moveCompleted = true;
-        finishMove(
-          moveVersion,
-          moveSkillToStandaloneOptimistically(
-            displayedPlugins,
-            data.pluginId,
-            data.skill,
-            standalonePlugin
-          )
-        );
+        finishMove(moveVersion, nextPlugins);
       } finally {
         if (!moveCompleted && moveVersionRef.current === moveVersion) {
           setOptimisticPlugins(null);
@@ -1176,24 +1302,34 @@ export let SkillMarketplacePluginsScene = (p: {
       return;
     }
 
-    if (!destinationId || destinationId === data.pluginId) return;
+    if (!destinationId || destinationId === data.pluginId) {
+      clearOverlay();
+      return;
+    }
     let destination = displayedPlugins.find(
       item => item.skillPlugin?.id === destinationId
     )?.skillPlugin;
     if (
       !destination ||
+      !pluginCanUpdate(destination) ||
       destination.skills.some(skill => skill.skillId === data.skill!.skillId)
-    )
+    ) {
+      clearOverlay();
       return;
+    }
     let moveVersion = ++moveVersionRef.current;
     let nextPlugins = moveSkillOptimistically(
       displayedPlugins,
       data.pluginId,
       destinationId,
-      data.skill
+      data.skill,
+      removeEmptySource
     );
-    setOptimisticPlugins(nextPlugins);
-    setMovePending(true);
+    flushSync(() => {
+      setOptimisticPlugins(nextPlugins);
+      setMovePending(true);
+    });
+    clearOverlay();
     let moveCompleted = false;
     try {
       let [created] = await addPluginSkill.mutate({
@@ -1217,53 +1353,7 @@ export let SkillMarketplacePluginsScene = (p: {
         return;
       }
 
-      if (shouldDeleteSourcePluginAfterMove(sourceItem)) {
-        let [marketplaceMembershipRemoved] = await removeMarketplacePlugin.mutate({
-          instanceId: p.instanceId,
-          skillMarketplaceId: p.skillMarketplaceId!,
-          skillMarketplacePluginId: sourceItem.id
-        });
-
-        if (!marketplaceMembershipRemoved) {
-          await addPluginSkill.mutate({
-            instanceId: p.instanceId,
-            skillPluginId: data.pluginId,
-            ...getMoveSkillInput(data.skill)
-          });
-          await removePluginSkill.mutate({
-            instanceId: p.instanceId,
-            skillPluginId: destinationId,
-            skillPluginSkillId: created.id
-          });
-          await refresh();
-          return;
-        }
-
-        let [pluginDeleted] = await deletePlugin.mutate({
-          instanceId: p.instanceId,
-          skillPluginId: data.pluginId
-        });
-
-        if (!pluginDeleted) {
-          await addPluginSkill.mutate({
-            instanceId: p.instanceId,
-            skillPluginId: data.pluginId,
-            ...getMoveSkillInput(data.skill)
-          });
-          await addMarketplacePlugin.mutate({
-            instanceId: p.instanceId,
-            skillMarketplaceId: p.skillMarketplaceId!,
-            skillPluginId: data.pluginId
-          });
-          await removePluginSkill.mutate({
-            instanceId: p.instanceId,
-            skillPluginId: destinationId,
-            skillPluginSkillId: created.id
-          });
-          await refresh();
-          return;
-        }
-      }
+      await cleanupEmptySourcePlugin(sourceItem);
       moveCompleted = true;
       finishMove(moveVersion, nextPlugins);
     } finally {
@@ -1276,106 +1366,124 @@ export let SkillMarketplacePluginsScene = (p: {
 
   let sensors = useSensors(useSensor(SkillPointerSensor), useSensor(KeyboardSensor));
   return renderWithLoader({ marketplace, marketplacePlugins })(
-    ({ marketplace, marketplacePlugins }) => (
-      <PageHeaderSection
-        title="Plugins and Skills"
-        description="Manage plugins and skills for this marketplace. Use plugins to group related skills or add individual skills to the marketplace directly."
-      >
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragStart={onDragStart}
-          onDragCancel={() => setMovingSkill(null)}
-          onDragEnd={onDragEnd}
+    ({ marketplace, marketplacePlugins }) => {
+      let canCreatePlugins = marketplaceCanCreatePlugins(marketplace.data);
+      let body = (
+        <>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={onDragStart}
+            onDragCancel={() => setMovingSkill(null)}
+            onDragEnd={onDragEnd}
+          >
+            <Tree>
+              <MarketplaceHeader
+                marketplaceId={marketplace.data.id}
+                name={marketplace.data.name}
+                disabled={actionsDisabled || !canCreatePlugins}
+                actions={
+                  canCreatePlugins ? (
+                    <RootActions>
+                      <Button
+                        size="2"
+                        variant="outline"
+                        iconLeft={<RiAddLine />}
+                        onClick={addSingleSkill}
+                        disabled={actionsDisabled}
+                      >
+                        Add Skill
+                      </Button>
+                      <Button
+                        size="2"
+                        iconLeft={<RiPuzzle2Line />}
+                        disabled={actionsDisabled}
+                        onClick={() =>
+                          p.instanceId &&
+                          p.skillMarketplaceId &&
+                          showPluginForm({
+                            instanceId: p.instanceId,
+                            skillMarketplaceId: p.skillMarketplaceId,
+                            onChanged: refresh
+                          })
+                        }
+                        menu={
+                          p.showImportPlugin === false
+                            ? undefined
+                            : [{ label: 'Import Plugin', onClick: addExistingPlugin }]
+                        }
+                      >
+                        Add Plugin
+                      </Button>
+                    </RootActions>
+                  ) : null
+                }
+              />
+              {displayedPlugins.length ? (
+                <Branches>
+                  {displayedPlugins
+                    .filter(item => item.skillPlugin)
+                    .map(item => (
+                      <PluginTreeItem
+                        key={item.id}
+                        item={item}
+                        getSkillPath={p.getSkillPath}
+                        actionsDisabled={actionsDisabled}
+                        dragDisabled={movePending}
+                        canCreatePlugins={canCreatePlugins}
+                        onAddSkill={() => addSkillToPlugin(item.skillPlugin!)}
+                        onEdit={() =>
+                          p.instanceId &&
+                          p.skillMarketplaceId &&
+                          showPluginForm({
+                            instanceId: p.instanceId,
+                            skillMarketplaceId: p.skillMarketplaceId,
+                            plugin: item.skillPlugin!,
+                            onChanged: refresh
+                          })
+                        }
+                        onRemove={() => removePlugin(item)}
+                      />
+                    ))}
+                </Branches>
+              ) : (
+                <EmptyState>
+                  <Text color="gray600" size="2">
+                    This marketplace does not include any plugins yet.
+                  </Text>
+                </EmptyState>
+              )}
+            </Tree>
+            <DragOverlay>
+              {movingSkill && (
+                <TreeRow>
+                  <RiDraggable />
+                  <Text size="2" weight="strong">
+                    {movingSkill.skill.name}
+                  </Text>
+                </TreeRow>
+              )}
+            </DragOverlay>
+          </DndContext>
+          <addMarketplacePlugin.RenderError />
+          <removeMarketplacePlugin.RenderError />
+          <createPlugin.RenderError />
+          <addPluginSkill.RenderError />
+          <removePluginSkill.RenderError />
+          <deletePlugin.RenderError />
+        </>
+      );
+
+      if (p.showHeader === false) return body;
+
+      return (
+        <PageHeaderSection
+          title="Plugins and Skills"
+          description="Manage plugins and skills for this marketplace. Use plugins to group related skills or add individual skills to the marketplace directly."
         >
-          <Tree>
-            <MarketplaceHeader
-              marketplaceId={marketplace.data.id}
-              name={marketplace.data.name}
-              disabled={actionsDisabled}
-              actions={
-                <RootActions>
-                  <Button
-                    size="2"
-                    variant="outline"
-                    iconLeft={<RiAddLine />}
-                    onClick={addSingleSkill}
-                    disabled={actionsDisabled}
-                  >
-                    Add Skill
-                  </Button>
-                  <Button
-                    size="2"
-                    iconLeft={<RiPuzzle2Line />}
-                    disabled={actionsDisabled}
-                    onClick={() =>
-                      p.instanceId &&
-                      p.skillMarketplaceId &&
-                      showPluginForm({
-                        instanceId: p.instanceId,
-                        skillMarketplaceId: p.skillMarketplaceId,
-                        onChanged: refresh
-                      })
-                    }
-                    menu={[{ label: 'Import Plugin', onClick: addExistingPlugin }]}
-                  >
-                    Add Plugin
-                  </Button>
-                </RootActions>
-              }
-            />
-            {displayedPlugins.length ? (
-              <Branches>
-                {displayedPlugins
-                  .filter(item => item.skillPlugin)
-                  .map(item => (
-                    <PluginTreeItem
-                      key={item.id}
-                      item={item}
-                      getSkillPath={p.getSkillPath}
-                      actionsDisabled={actionsDisabled}
-                      dragDisabled={movePending}
-                      onAddSkill={() => addSkillToPlugin(item.skillPlugin!)}
-                      onEdit={() =>
-                        p.instanceId &&
-                        p.skillMarketplaceId &&
-                        showPluginForm({
-                          instanceId: p.instanceId,
-                          skillMarketplaceId: p.skillMarketplaceId,
-                          plugin: item.skillPlugin!,
-                          onChanged: refresh
-                        })
-                      }
-                      onRemove={() => removePlugin(item)}
-                    />
-                  ))}
-              </Branches>
-            ) : (
-              <EmptyState>
-                <Text color="gray600" size="2">
-                  This marketplace does not include any plugins yet.
-                </Text>
-              </EmptyState>
-            )}
-          </Tree>
-          <DragOverlay>
-            {movingSkill && (
-              <TreeRow>
-                <RiDraggable />
-                <Text size="2" weight="strong">
-                  {movingSkill.skill.name}
-                </Text>
-              </TreeRow>
-            )}
-          </DragOverlay>
-        </DndContext>
-        <addMarketplacePlugin.RenderError />
-        <removeMarketplacePlugin.RenderError />
-        <createPlugin.RenderError />
-        <addPluginSkill.RenderError />
-        <removePluginSkill.RenderError />
-        <deletePlugin.RenderError />
-      </PageHeaderSection>
-    )
+          {body}
+        </PageHeaderSection>
+      );
+    }
   );
 };

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillPluginSkills.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillPluginSkills.tsx
@@ -24,6 +24,7 @@ import {
   theme
 } from '@metorial/ui';
 import { Box, ItemGrid, Table } from '@metorial/ui-product';
+import { useSearchFilter } from '@metorial/use-search-filter';
 import { RiAddLine, RiMore2Line } from '@remixicon/react';
 import { useMemo, useState } from 'react';
 import styled from 'styled-components';
@@ -65,6 +66,8 @@ let PickerScroll = styled.div`
   padding-right: 2px;
 `;
 
+let paginationOpts = { hidePaginationWhenUnavailable: true };
+
 let Slug = styled.div`
   background: ${theme.colors.gray300};
   min-height: 24px;
@@ -102,20 +105,71 @@ let truncate = (value: string | null | undefined, length = 100) => {
   return `${value.slice(0, length)}...`;
 };
 
+let SkillPickerResults = (p: {
+  skills: ReturnType<typeof useSkills>;
+  excludedSkillIds: Set<string>;
+  search: string;
+  selectedId: string | null;
+  onSelect: (skill: Skill) => void;
+}) =>
+  renderWithPagination(p.skills, paginationOpts)(skills => {
+    let items = skills.data.items.filter(skill => !p.excludedSkillIds.has(skill.id));
+
+    if (items.length === 0) {
+      return (
+        <Text size="2" color="gray600">
+          {p.search.trim()
+            ? 'No skills match your search.'
+            : 'All active skills are already linked to this plugin.'}
+        </Text>
+      );
+    }
+
+    return (
+      <ItemGrid.Root width="270px">
+        {items.map(skill => (
+          <ItemGrid.Item
+            key={skill.id}
+            title={skill.name}
+            description={truncate(skill.description)}
+            height={200}
+            onClick={() => !p.selectedId && p.onSelect(skill)}
+            icon={
+              <Avatar
+                entity={{
+                  name: skill.name,
+                  imageUrl: `https://avatar-cdn.metorial.com/${skill.id}`
+                }}
+                size={30}
+              />
+            }
+            bottom={
+              <div style={{ display: 'flex' }}>
+                <Slug>{skill.slug}</Slug>
+              </div>
+            }
+          />
+        ))}
+      </ItemGrid.Root>
+    );
+  });
+
 let SkillPickerPanel = (p: {
   instanceId: string;
   excludeSkillIds: string[];
   close: () => void;
   onSelect: (skill: Skill) => Promise<void> | void;
 }) => {
-  let [search, setSearch] = useState('');
+  let { search, setSearch, searchQuery } = useSearchFilter(500, {
+    updateSearchParams: false
+  });
   let [selectedId, setSelectedId] = useState<string | null>(null);
   let excludedSkillIds = useMemo(() => new Set(p.excludeSkillIds), [p.excludeSkillIds]);
   let skills = useSkills(p.instanceId, {
     order: 'desc',
     status: ['active'],
     limit: 30,
-    ...(search.trim() ? { search: search.trim() } : {})
+    ...(searchQuery ? { search: searchQuery } : {})
   });
 
   let selectSkill = async (skill: Skill) => {
@@ -147,47 +201,13 @@ let SkillPickerPanel = (p: {
           />
 
           <PickerScroll>
-            {renderWithPagination(skills, { hidePaginationWhenUnavailable: true })(skills => {
-              let items = skills.data.items.filter(skill => !excludedSkillIds.has(skill.id));
-
-              if (items.length === 0) {
-                return (
-                  <Text size="2" color="gray600">
-                    {search.trim()
-                      ? 'No skills match your search.'
-                      : 'All active skills are already linked to this plugin.'}
-                  </Text>
-                );
-              }
-
-              return (
-                <ItemGrid.Root width="270px">
-                  {items.map(skill => (
-                    <ItemGrid.Item
-                      key={skill.id}
-                      title={skill.name}
-                      description={truncate(skill.description)}
-                      height={200}
-                      onClick={() => selectSkill(skill)}
-                      icon={
-                        <Avatar
-                          entity={{
-                            name: skill.name,
-                            imageUrl: `https://avatar-cdn.metorial.com/${skill.id}`
-                          }}
-                          size={30}
-                        />
-                      }
-                      bottom={
-                        <div style={{ display: 'flex' }}>
-                          <Slug>{skill.slug}</Slug>
-                        </div>
-                      }
-                    />
-                  ))}
-                </ItemGrid.Root>
-              );
-            })}
+            <SkillPickerResults
+              skills={skills}
+              excludedSkillIds={excludedSkillIds}
+              search={search}
+              selectedId={selectedId}
+              onSelect={selectSkill}
+            />
           </PickerScroll>
         </PickerStack>
       </Panel.Content>

--- a/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerAccess.ts
+++ b/src/metorial/apis/core/src/controllers/instance/portal/portalConsumerAccess.ts
@@ -3,6 +3,7 @@ import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
 import { skillService } from '@metorial/module-skill';
 import { skillGroupService } from '@metorial/module-skill-groups';
+import { skillPluginService } from '@metorial/module-skill-marketplace';
 import { skillTemplateService } from '@metorial/module-skill-templates';
 import { db } from '@metorial/db';
 import { consumerAccessService } from '@metorial/module-consumer-access';
@@ -62,6 +63,7 @@ export let portalConsumerAccessController = Controller.create(
             skill_template_id: v.optional(v.union([v.string(), v.array(v.string())])),
             skill_group_id: v.optional(v.union([v.string(), v.array(v.string())])),
             skill_marketplace_id: v.optional(v.union([v.string(), v.array(v.string())])),
+            skill_plugin_id: v.optional(v.union([v.string(), v.array(v.string())])),
             consumer_access_listing_id: v.optional(v.union([v.string(), v.array(v.string())])),
             type: v.optional(
               v.union([
@@ -71,7 +73,8 @@ export let portalConsumerAccessController = Controller.create(
                   'skill',
                   'skill_template',
                   'skill_group',
-                  'skill_marketplace'
+                  'skill_marketplace',
+                  'skill_plugin'
                 ]),
                 v.array(
                   v.enumOf([
@@ -80,7 +83,8 @@ export let portalConsumerAccessController = Controller.create(
                     'skill',
                     'skill_template',
                     'skill_group',
-                    'skill_marketplace'
+                    'skill_marketplace',
+                    'skill_plugin'
                   ])
                 )
               ])
@@ -98,6 +102,7 @@ export let portalConsumerAccessController = Controller.create(
           skillTemplateIds: normalizeArrayParam(ctx.query.skill_template_id),
           skillGroupIds: normalizeArrayParam(ctx.query.skill_group_id),
           skillMarketplaceIds: normalizeArrayParam(ctx.query.skill_marketplace_id),
+          skillPluginIds: normalizeArrayParam(ctx.query.skill_plugin_id),
           consumerAccessListingIds: normalizeArrayParam(ctx.query.consumer_access_listing_id),
           types: normalizeArrayParam(ctx.query.type),
           search: ctx.query.search
@@ -160,7 +165,13 @@ export let portalConsumerAccessController = Controller.create(
             }),
             v.object({
               type: v.literal('skill_marketplace'),
-              skill_marketplace_id: v.string()
+              skill_marketplace_id: v.string(),
+              permission: v.optional(v.enumOf(['read', 'manage']))
+            }),
+            v.object({
+              type: v.literal('skill_plugin'),
+              skill_marketplace_id: v.string(),
+              skill_plugin_id: v.string()
             })
           ])
         })
@@ -183,6 +194,7 @@ export let portalConsumerAccessController = Controller.create(
         let localSkillTemplate = null;
         let localSkillGroup = null;
         let localSkillMarketplace = null;
+        let localSkillPlugin = null;
         let cargoAccess = await getInstanceCargoAccess(ctx);
 
         if (access.type == 'skill') {
@@ -210,7 +222,7 @@ export let portalConsumerAccessController = Controller.create(
             allowDeleted: true
           });
         }
-        if (access.type == 'skill_marketplace') {
+        if (access.type == 'skill_marketplace' || access.type == 'skill_plugin') {
           localSkillMarketplace = await db.skillMarketplace.findFirst({
             where: {
               instanceOid: ctx.instance.oid,
@@ -220,6 +232,26 @@ export let portalConsumerAccessController = Controller.create(
           });
           if (!localSkillMarketplace) {
             throw new ServiceError(notFoundError('skill.marketplace'));
+          }
+        }
+        if (access.type == 'skill_plugin') {
+          localSkillPlugin = await skillPluginService.getSkillPluginById({
+            project: cargoAccess.project,
+            instance: cargoAccess.instance,
+            skillPluginId: access.skill_plugin_id
+          });
+          let marketplacePlugin = await db.skillMarketplacePlugin.findFirst({
+            where: {
+              skillMarketplaceOid: localSkillMarketplace!.oid,
+              skillPluginOid: localSkillPlugin.oid,
+              status: 'active'
+            },
+            select: {
+              oid: true
+            }
+          });
+          if (!marketplacePlugin) {
+            throw new ServiceError(notFoundError('skill.plugin'));
           }
         }
         let consumerAccess =
@@ -284,16 +316,29 @@ export let portalConsumerAccessController = Controller.create(
                           skillGroup: localSkillGroup!
                         }
                       })
-                    : await consumerAccessService.createConsumerAccess({
-                        organization: ctx.organization,
-                        consumerSurface: ctx.portal.surface,
-                        consumerGroup,
-                        input,
-                        access: {
-                          type: 'skill_marketplace',
-                          skillMarketplace: localSkillMarketplace!
-                        }
-                      });
+                    : access.type == 'skill_plugin'
+                      ? await consumerAccessService.createConsumerAccess({
+                          organization: ctx.organization,
+                          consumerSurface: ctx.portal.surface,
+                          consumerGroup,
+                          input,
+                          access: {
+                            type: 'skill_plugin',
+                            skillPlugin: localSkillPlugin!,
+                            skillMarketplace: localSkillMarketplace!
+                          }
+                        })
+                      : await consumerAccessService.createConsumerAccess({
+                          organization: ctx.organization,
+                          consumerSurface: ctx.portal.surface,
+                          consumerGroup,
+                          input,
+                          access: {
+                            type: 'skill_marketplace',
+                            skillMarketplace: localSkillMarketplace!,
+                            accessLevel: access.permission == 'manage' ? 'manage' : 'read'
+                          }
+                        });
 
         return consumerAccessPresenter.present({ consumerAccess });
       }),

--- a/src/metorial/apis/core/src/controllers/instance/skills/skillMarketplace.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skillMarketplace.ts
@@ -98,7 +98,10 @@ export let skillMarketplaceController = Controller.create(
         let list = await paginator.run(ctx.query);
 
         return Paginator.present(list, skillMarketplace =>
-          skillMarketplacePresenter.present({ skillMarketplace })
+          skillMarketplacePresenter.present({
+            skillMarketplace,
+            ...getSkillMarketplaceAccessInput(ctx)
+          })
         );
       }),
 
@@ -112,7 +115,10 @@ export let skillMarketplaceController = Controller.create(
       .use(requireConsumerTokenForPublishableKey())
       .output(skillMarketplacePresenter)
       .do(async ctx =>
-        skillMarketplacePresenter.present({ skillMarketplace: ctx.skillMarketplace })
+        skillMarketplacePresenter.present({
+          skillMarketplace: ctx.skillMarketplace,
+          ...getSkillMarketplaceAccessInput(ctx)
+        })
       ),
 
     create: instanceGroup
@@ -144,7 +150,10 @@ export let skillMarketplaceController = Controller.create(
           }
         });
 
-        return skillMarketplacePresenter.present({ skillMarketplace });
+        return skillMarketplacePresenter.present({
+          skillMarketplace,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       }),
 
     update: skillMarketplaceGroup
@@ -174,7 +183,10 @@ export let skillMarketplaceController = Controller.create(
           }
         });
 
-        return skillMarketplacePresenter.present({ skillMarketplace });
+        return skillMarketplacePresenter.present({
+          skillMarketplace,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       }),
 
     archive: skillMarketplaceGroup
@@ -194,7 +206,10 @@ export let skillMarketplaceController = Controller.create(
           skillMarketplace: ctx.skillMarketplace
         });
 
-        return skillMarketplacePresenter.present({ skillMarketplace });
+        return skillMarketplacePresenter.present({
+          skillMarketplace,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       }),
 
     sync: skillMarketplaceGroup
@@ -218,7 +233,10 @@ export let skillMarketplaceController = Controller.create(
           skillMarketplace: ctx.skillMarketplace
         });
 
-        return skillMarketplacePresenter.present({ skillMarketplace });
+        return skillMarketplacePresenter.present({
+          skillMarketplace,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       })
   }
 );

--- a/src/metorial/apis/core/src/controllers/instance/skills/skillMarketplacePlugin.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skillMarketplacePlugin.ts
@@ -1,7 +1,11 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { skillMarketplacePluginService } from '@metorial/module-skill-marketplace';
+import {
+  getArchivableSkillPluginIds,
+  getWritableSkillPluginIds,
+  skillMarketplacePluginService
+} from '@metorial/module-skill-marketplace';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../../lib/dateFilter';
 import { normalizeArrayParam } from '../../../lib/normalizeArrayParam';
@@ -10,11 +14,12 @@ import { hasFlags } from '../../../middleware/hasFlags';
 import { instancePath } from '../../../middleware/instanceGroup';
 import { requireConsumerTokenForPublishableKey } from '../../../middleware/requireConsumerTokenForPublishableKey';
 import { skillMarketplacePluginPresenter } from '@metorial/presenters';
+import { getSkillMarketplaceAccessInput } from './_marketplaceAccess';
 import { skillMarketplaceGroup } from './skillMarketplace';
 import { getSkillPluginAccess } from './skillPlugin';
 
 let readScopes = ['instance.skill:read', 'consumer#instance.skill:read'] as const;
-let writeScopes = ['instance.skill:write'] as const;
+let writeScopes = ['instance.skill:write', 'consumer#instance.skill:write'] as const;
 
 export let skillMarketplacePluginGroup = skillMarketplaceGroup.use(async ctx => {
   if (!ctx.params.skillMarketplacePluginId) {
@@ -86,9 +91,32 @@ export let skillMarketplacePluginController = Controller.create(
           updatedAt: ctx.query.updated_at
         });
         let list = await paginator.run(ctx.query);
+        let accessInput = getSkillMarketplaceAccessInput(ctx);
+        let nestedPlugins = list.items.flatMap(item =>
+          item.skillPlugin ? [item.skillPlugin] : []
+        );
+        let [writablePluginIds, archivablePluginIds] = await Promise.all([
+          getWritableSkillPluginIds({
+            plugins: nestedPlugins,
+            ...accessInput
+          }),
+          getArchivableSkillPluginIds({
+            plugins: nestedPlugins,
+            ...accessInput
+          })
+        ]);
 
         return Paginator.present(list, skillMarketplacePlugin =>
-          skillMarketplacePluginPresenter.present({ skillMarketplacePlugin })
+          skillMarketplacePluginPresenter.present({
+            skillMarketplacePlugin,
+            ...accessInput,
+            pluginAccess: skillMarketplacePlugin.skillPlugin
+              ? {
+                  canUpdate: writablePluginIds.has(skillMarketplacePlugin.skillPlugin.id),
+                  canDelete: archivablePluginIds.has(skillMarketplacePlugin.skillPlugin.id)
+                }
+              : undefined
+          })
         );
       }),
 
@@ -105,6 +133,7 @@ export let skillMarketplacePluginController = Controller.create(
       )
       .use(hasFlags(['skills-enabled']))
       .use(checkAccess({ possibleScopes: [...writeScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
       .body(
         'default',
         v.object({
@@ -115,9 +144,11 @@ export let skillMarketplacePluginController = Controller.create(
       )
       .output(skillMarketplacePluginPresenter)
       .do(async ctx => {
+        let accessInput = getSkillMarketplaceAccessInput(ctx);
         let skillMarketplacePlugin =
           await skillMarketplacePluginService.addSkillMarketplacePlugin({
             ...(await getSkillPluginAccess(ctx)),
+            ...accessInput,
             skillMarketplace: ctx.skillMarketplace,
             input: {
               skillPluginId: ctx.body.skill_plugin_id,
@@ -126,7 +157,10 @@ export let skillMarketplacePluginController = Controller.create(
             }
           });
 
-        return skillMarketplacePluginPresenter.present({ skillMarketplacePlugin });
+        return skillMarketplacePluginPresenter.present({
+          skillMarketplacePlugin,
+          ...accessInput
+        });
       }),
 
     get: skillMarketplacePluginGroup
@@ -146,7 +180,8 @@ export let skillMarketplacePluginController = Controller.create(
       .output(skillMarketplacePluginPresenter)
       .do(async ctx =>
         skillMarketplacePluginPresenter.present({
-          skillMarketplacePlugin: ctx.skillMarketplacePlugin
+          skillMarketplacePlugin: ctx.skillMarketplacePlugin,
+          ...getSkillMarketplaceAccessInput(ctx)
         })
       ),
 
@@ -163,15 +198,21 @@ export let skillMarketplacePluginController = Controller.create(
       )
       .use(hasFlags(['skills-enabled']))
       .use(checkAccess({ possibleScopes: [...writeScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
       .output(skillMarketplacePluginPresenter)
       .do(async ctx => {
+        let accessInput = getSkillMarketplaceAccessInput(ctx);
         let skillMarketplacePlugin =
           await skillMarketplacePluginService.removeSkillMarketplacePlugin({
             ...(await getSkillPluginAccess(ctx)),
+            ...accessInput,
             skillMarketplacePlugin: ctx.skillMarketplacePlugin
           });
 
-        return skillMarketplacePluginPresenter.present({ skillMarketplacePlugin });
+        return skillMarketplacePluginPresenter.present({
+          skillMarketplacePlugin,
+          ...accessInput
+        });
       })
   }
 );

--- a/src/metorial/apis/core/src/controllers/instance/skills/skillPlugin.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skillPlugin.ts
@@ -1,7 +1,11 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
-import { skillPluginService } from '@metorial/module-skill-marketplace';
+import {
+  getArchivableSkillPluginIds,
+  getWritableSkillPluginIds,
+  skillPluginService
+} from '@metorial/module-skill-marketplace';
 import { Controller } from '@metorial/rest';
 import { getInstanceCargoAccess, hasInstanceConsumerAccess } from '../../../lib/cargoAccess';
 import { dateFilterValidator } from '../../../lib/dateFilter';
@@ -15,6 +19,7 @@ import { getSkillMarketplaceAccessInput } from './_marketplaceAccess';
 
 let readScopes = ['instance.skill:read', 'consumer#instance.skill:read'] as const;
 let writeScopes = ['instance.skill:write'] as const;
+let consumerWriteScopes = ['instance.skill:write', 'consumer#instance.skill:write'] as const;
 
 let skillPluginInput = {
   name: v.optional(v.string()),
@@ -112,9 +117,27 @@ export let skillPluginController = Controller.create(
           updatedAt: ctx.query.updated_at
         });
         let list = await paginator.run(ctx.query);
+        let accessInput = getSkillMarketplaceAccessInput(ctx);
+        let [writablePluginIds, archivablePluginIds] = await Promise.all([
+          getWritableSkillPluginIds({
+            plugins: list.items,
+            ...accessInput
+          }),
+          getArchivableSkillPluginIds({
+            plugins: list.items,
+            ...accessInput
+          })
+        ]);
 
         return Paginator.present(list, skillPlugin =>
-          skillPluginPresenter.present({ skillPlugin })
+          skillPluginPresenter.present({
+            skillPlugin,
+            ...accessInput,
+            pluginAccess: {
+              canUpdate: writablePluginIds.has(skillPlugin.id),
+              canDelete: archivablePluginIds.has(skillPlugin.id)
+            }
+          })
         );
       }),
 
@@ -127,7 +150,12 @@ export let skillPluginController = Controller.create(
       .use(checkAccess({ possibleScopes: [...readScopes] }))
       .use(requireConsumerTokenForPublishableKey())
       .output(skillPluginPresenter)
-      .do(async ctx => skillPluginPresenter.present({ skillPlugin: ctx.skillPlugin })),
+      .do(async ctx =>
+        skillPluginPresenter.present({
+          skillPlugin: ctx.skillPlugin,
+          ...getSkillMarketplaceAccessInput(ctx)
+        })
+      ),
 
     create: instanceGroup
       .post(instancePath('skill-plugins', 'skills.plugins.create'), {
@@ -135,12 +163,31 @@ export let skillPluginController = Controller.create(
         description: 'Creates a skill plugin.'
       })
       .use(hasFlags(['skills-enabled']))
-      .use(checkAccess({ possibleScopes: [...writeScopes] }))
-      .body('default', v.object({ ...skillPluginInput, name: v.string() }))
+      .use(checkAccess({ possibleScopes: [...consumerWriteScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
+      .body(
+        'default',
+        v.object({
+          ...skillPluginInput,
+          name: v.string(),
+          skill_marketplace_id: v.optional(v.string())
+        })
+      )
       .output(skillPluginPresenter)
       .do(async ctx => {
+        let accessInput = getSkillMarketplaceAccessInput(ctx);
+        if (accessInput.accessTags && !ctx.body.skill_marketplace_id) {
+          throw new ServiceError(
+            badRequestError({
+              message: 'skill_marketplace_id is required to create a skill plugin.'
+            })
+          );
+        }
+
         let skillPlugin = await skillPluginService.createSkillPlugin({
           ...(await getSkillPluginAccess(ctx)),
+          ...accessInput,
+          skillMarketplaceId: ctx.body.skill_marketplace_id,
           input: {
             name: ctx.body.name,
             description: ctx.body.description,
@@ -151,7 +198,10 @@ export let skillPluginController = Controller.create(
           }
         });
 
-        return skillPluginPresenter.present({ skillPlugin });
+        return skillPluginPresenter.present({
+          skillPlugin,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       }),
 
     update: skillPluginGroup
@@ -160,12 +210,15 @@ export let skillPluginController = Controller.create(
         description: 'Updates a skill plugin.'
       })
       .use(hasFlags(['skills-enabled']))
-      .use(checkAccess({ possibleScopes: [...writeScopes] }))
+      .use(checkAccess({ possibleScopes: [...consumerWriteScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
       .body('default', v.object(skillPluginInput))
       .output(skillPluginPresenter)
       .do(async ctx => {
+        let accessInput = getSkillMarketplaceAccessInput(ctx);
         let skillPlugin = await skillPluginService.updateSkillPlugin({
           ...(await getSkillPluginAccess(ctx)),
+          ...accessInput,
           skillPlugin: ctx.skillPlugin,
           input: {
             name: ctx.body.name,
@@ -177,7 +230,10 @@ export let skillPluginController = Controller.create(
           }
         });
 
-        return skillPluginPresenter.present({ skillPlugin });
+        return skillPluginPresenter.present({
+          skillPlugin,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       }),
 
     archive: skillPluginGroup
@@ -186,15 +242,21 @@ export let skillPluginController = Controller.create(
         description: 'Archives a skill plugin.'
       })
       .use(hasFlags(['skills-enabled']))
-      .use(checkAccess({ possibleScopes: [...writeScopes] }))
+      .use(checkAccess({ possibleScopes: [...consumerWriteScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
       .output(skillPluginPresenter)
       .do(async ctx => {
+        let accessInput = getSkillMarketplaceAccessInput(ctx);
         let skillPlugin = await skillPluginService.archiveSkillPlugin({
           ...(await getSkillPluginAccess(ctx)),
+          ...accessInput,
           skillPlugin: ctx.skillPlugin
         });
 
-        return skillPluginPresenter.present({ skillPlugin });
+        return skillPluginPresenter.present({
+          skillPlugin,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       }),
 
     sync: skillPluginGroup
@@ -212,7 +274,10 @@ export let skillPluginController = Controller.create(
           skillPlugin: ctx.skillPlugin
         });
 
-        return skillPluginPresenter.present({ skillPlugin });
+        return skillPluginPresenter.present({
+          skillPlugin,
+          ...getSkillMarketplaceAccessInput(ctx)
+        });
       })
   }
 );

--- a/src/metorial/apis/core/src/controllers/instance/skills/skillPluginSkill.ts
+++ b/src/metorial/apis/core/src/controllers/instance/skills/skillPluginSkill.ts
@@ -10,10 +10,11 @@ import { hasFlags } from '../../../middleware/hasFlags';
 import { instancePath } from '../../../middleware/instanceGroup';
 import { requireConsumerTokenForPublishableKey } from '../../../middleware/requireConsumerTokenForPublishableKey';
 import { skillPluginSkillPresenter } from '@metorial/presenters';
+import { getSkillMarketplaceAccessInput } from './_marketplaceAccess';
 import { getSkillPluginAccess, skillPluginGroup } from './skillPlugin';
 
 let readScopes = ['instance.skill:read', 'consumer#instance.skill:read'] as const;
-let writeScopes = ['instance.skill:write'] as const;
+let writeScopes = ['instance.skill:write', 'consumer#instance.skill:write'] as const;
 
 let skillPluginSkillInput = {
   client_name: v.optional(v.nullable(v.string())),
@@ -101,6 +102,7 @@ export let skillPluginSkillController = Controller.create(
       })
       .use(hasFlags(['skills-enabled']))
       .use(checkAccess({ possibleScopes: [...writeScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
       .body(
         'default',
         v.object({
@@ -113,6 +115,7 @@ export let skillPluginSkillController = Controller.create(
       .do(async ctx => {
         let skillPluginSkill = await skillPluginSkillService.addSkillPluginSkill({
           ...(await getSkillPluginAccess(ctx)),
+          ...getSkillMarketplaceAccessInput(ctx),
           skillPlugin: ctx.skillPlugin,
           input: {
             skillId: ctx.body.skill_id,
@@ -161,11 +164,13 @@ export let skillPluginSkillController = Controller.create(
       )
       .use(hasFlags(['skills-enabled']))
       .use(checkAccess({ possibleScopes: [...writeScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
       .body('default', v.object(skillPluginSkillInput))
       .output(skillPluginSkillPresenter)
       .do(async ctx => {
         let skillPluginSkill = await skillPluginSkillService.updateSkillPluginSkill({
           ...(await getSkillPluginAccess(ctx)),
+          ...getSkillMarketplaceAccessInput(ctx),
           skillPluginSkill: ctx.skillPluginSkill,
           input: {
             clientName: ctx.body.client_name,
@@ -193,10 +198,12 @@ export let skillPluginSkillController = Controller.create(
       )
       .use(hasFlags(['skills-enabled']))
       .use(checkAccess({ possibleScopes: [...writeScopes] }))
+      .use(requireConsumerTokenForPublishableKey())
       .output(skillPluginSkillPresenter)
       .do(async ctx => {
         let skillPluginSkill = await skillPluginSkillService.removeSkillPluginSkill({
           ...(await getSkillPluginAccess(ctx)),
+          ...getSkillMarketplaceAccessInput(ctx),
           skillPluginSkill: ctx.skillPluginSkill
         });
 

--- a/src/metorial/db/prisma/schema/access/accessTag.prisma
+++ b/src/metorial/db/prisma/schema/access/accessTag.prisma
@@ -66,6 +66,9 @@ model AccessTagEntity {
   skillMarketplaceOid BigInt?
   skillMarketplace    SkillMarketplace? @relation(fields: [skillMarketplaceOid], references: [oid], onDelete: Cascade)
 
+  skillPluginOid BigInt?
+  skillPlugin    SkillPlugin? @relation(fields: [skillPluginOid], references: [oid], onDelete: Cascade)
+
   // serverOAuthSession    ServerOAuthSession? @relation(fields: [serverOAuthSessionOid], references: [oid])
   // serverOAuthSessionOid BigInt?
 
@@ -73,5 +76,7 @@ model AccessTagEntity {
   @@unique([accessTagOid, accessTagPolicyOid, skillTemplateOid])
   @@unique([accessTagOid, accessTagPolicyOid, skillGroupOid])
   @@unique([accessTagOid, accessTagPolicyOid, skillMarketplaceOid])
+  @@unique([accessTagOid, accessTagPolicyOid, skillPluginOid])
   @@index([skillMarketplaceOid])
+  @@index([skillPluginOid])
 }

--- a/src/metorial/db/prisma/schema/consumer/access.prisma
+++ b/src/metorial/db/prisma/schema/consumer/access.prisma
@@ -5,13 +5,20 @@ enum ConsumerAccessTargetType {
   skill_template
   skill_group
   skill_marketplace
+  skill_plugin
+}
+
+enum ConsumerAccessLevel {
+  read
+  manage
 }
 
 model ConsumerAccess {
   oid BigInt @id @default(autoincrement())
   id  String @unique
 
-  type ConsumerAccessTargetType
+  type        ConsumerAccessTargetType
+  accessLevel ConsumerAccessLevel?
 
   surfaceOid BigInt
   surface    ConsumerSurface @relation(fields: [surfaceOid], references: [oid], onDelete: Cascade)
@@ -37,6 +44,9 @@ model ConsumerAccess {
   skillMarketplaceOid BigInt?
   skillMarketplace    SkillMarketplace? @relation("ConsumerAccessSkillMarketplace", fields: [skillMarketplaceOid], references: [oid], onDelete: Cascade)
 
+  skillPluginOid BigInt?
+  skillPlugin    SkillPlugin? @relation("ConsumerAccessSkillPlugin", fields: [skillPluginOid], references: [oid], onDelete: Cascade)
+
   listingOid BigInt?
   listing    ConsumerAccessListing? @relation(fields: [listingOid], references: [oid], onDelete: Cascade)
 
@@ -49,6 +59,7 @@ model ConsumerAccess {
   @@unique([consumerGroupOid, skillTemplateOid])
   @@unique([consumerGroupOid, skillGroupOid])
   @@unique([consumerGroupOid, skillMarketplaceOid])
+  @@unique([consumerGroupOid, skillPluginOid])
 }
 
 model ConsumerAccessListing {
@@ -80,6 +91,9 @@ model ConsumerAccessListing {
   skillMarketplaceOid BigInt?
   skillMarketplace    SkillMarketplace? @relation(fields: [skillMarketplaceOid], references: [oid], onDelete: Cascade)
 
+  skillPluginOid BigInt?
+  skillPlugin    SkillPlugin? @relation(fields: [skillPluginOid], references: [oid], onDelete: Cascade)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -92,4 +106,5 @@ model ConsumerAccessListing {
   @@unique([surfaceOid, skillTemplateOid])
   @@unique([surfaceOid, skillGroupOid])
   @@unique([surfaceOid, skillMarketplaceOid])
+  @@unique([surfaceOid, skillPluginOid])
 }

--- a/src/metorial/db/prisma/schema/skill/plugin.prisma
+++ b/src/metorial/db/prisma/schema/skill/plugin.prisma
@@ -61,6 +61,9 @@ model SkillPlugin {
   skillDestinationItems          SkillDestinationItem[]
   repositories                   SkillPluginRepository[]
   skillExportRefs                SkillExportRef[]
+  accessTagEntities              AccessTagEntity[]
+  consumerAccesses               ConsumerAccess[]                @relation("ConsumerAccessSkillPlugin")
+  consumerAccessListings         ConsumerAccessListing[]
 
   @@index([instanceOid, status])
   @@index([slug])

--- a/src/metorial/presenters/src/implementation/consumer/consumerAccess.ts
+++ b/src/metorial/presenters/src/implementation/consumer/consumerAccess.ts
@@ -88,10 +88,32 @@ let localSkillMarketplacePreview = Object.assign(
   }
 );
 
+let localSkillPluginPreview = Object.assign(
+  (skillPlugin: {
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string | null;
+  }) => ({
+    object: 'skill.plugin' as const,
+    id: skillPlugin.id,
+    status: skillPlugin.status,
+    name: skillPlugin.name
+  }),
+  {
+    schema: v.object({
+      object: v.literal('skill.plugin'),
+      id: v.string(),
+      status: v.enumOf(['active', 'archived', 'deleted']),
+      name: v.nullable(v.string())
+    })
+  }
+);
+
 export let v1ConsumerAccessPresenter = Presenter.create(consumerAccessType)
   .presenter(async ({ consumerAccess }, opts) => ({
     object: 'consumer.access' as const,
     id: consumerAccess.id,
+    access_level: consumerAccess.accessLevel,
     name:
       consumerAccess.listing?.name ??
       (consumerAccess.type == 'provider_template'
@@ -104,7 +126,9 @@ export let v1ConsumerAccessPresenter = Presenter.create(consumerAccessType)
               ? consumerAccess.skillTemplate!.name
               : consumerAccess.type == 'skill_group'
                 ? consumerAccess.skillGroup!.name
-                : consumerAccess.skillMarketplace!.id),
+                : consumerAccess.type == 'skill_plugin'
+                  ? (consumerAccess.skillPlugin!.name ?? consumerAccess.skillPlugin!.id)
+                  : consumerAccess.skillMarketplace!.id),
     description:
       consumerAccess.listing?.description ??
       (consumerAccess.type == 'provider_template'
@@ -151,12 +175,17 @@ export let v1ConsumerAccessPresenter = Presenter.create(consumerAccessType)
                     type: 'skill_group' as const,
                     skill_group: localSkillGroupPreview(consumerAccess.skillGroup!)
                   }
-                : {
-                    type: 'skill_marketplace' as const,
-                    skill_marketplace: localSkillMarketplacePreview(
-                      consumerAccess.skillMarketplace!
-                    )
-                  },
+                : consumerAccess.type == 'skill_plugin'
+                  ? {
+                      type: 'skill_plugin' as const,
+                      skill_plugin: localSkillPluginPreview(consumerAccess.skillPlugin!)
+                    }
+                  : {
+                      type: 'skill_marketplace' as const,
+                      skill_marketplace: localSkillMarketplacePreview(
+                        consumerAccess.skillMarketplace!
+                      )
+                    },
 
     consumer_group: await v1ConsumerGroupPresenter
       .present({ consumerGroup: consumerAccess.consumerGroup }, opts)
@@ -169,6 +198,7 @@ export let v1ConsumerAccessPresenter = Presenter.create(consumerAccessType)
     v.object({
       object: v.literal('consumer.access'),
       id: v.string(),
+      access_level: v.nullable(v.enumOf(['read', 'manage'])),
       name: v.string(),
       description: v.nullable(v.string()),
       readme: v.nullable(v.string()),
@@ -203,6 +233,10 @@ export let v1ConsumerAccessPresenter = Presenter.create(consumerAccessType)
         v.object({
           type: v.literal('skill_marketplace'),
           skill_marketplace: localSkillMarketplacePreview.schema
+        }),
+        v.object({
+          type: v.literal('skill_plugin'),
+          skill_plugin: localSkillPluginPreview.schema
         })
       ]),
       consumer_group: v1ConsumerGroupPresenter.schema,

--- a/src/metorial/presenters/src/implementation/consumer/consumerAccessListing.ts
+++ b/src/metorial/presenters/src/implementation/consumer/consumerAccessListing.ts
@@ -87,6 +87,27 @@ let localSkillMarketplacePreview = Object.assign(
   }
 );
 
+let localSkillPluginPreview = Object.assign(
+  (skillPlugin: {
+    id: string;
+    status: 'active' | 'archived' | 'deleted';
+    name: string | null;
+  }) => ({
+    object: 'skill.plugin' as const,
+    id: skillPlugin.id,
+    status: skillPlugin.status,
+    name: skillPlugin.name
+  }),
+  {
+    schema: v.object({
+      object: v.literal('skill.plugin'),
+      id: v.string(),
+      status: v.enumOf(['active', 'archived', 'deleted']),
+      name: v.nullable(v.string())
+    })
+  }
+);
+
 let consumerSurfaceProviderGroupPreviewSchema = v.object({
   id: v.string(),
   name: v.string(),
@@ -132,12 +153,19 @@ export let v1ConsumerAccessListingPresenter = Presenter.create(consumerAccessLis
                         type: 'skill_group' as const,
                         skill_group: localSkillGroupPreview(consumerAccessListing.skillGroup)
                       }
-                    : {
-                        type: 'skill_marketplace' as const,
-                        skill_marketplace: localSkillMarketplacePreview(
-                          consumerAccessListing.skillMarketplace!
-                        )
-                      })
+                    : consumerAccessListing.skillPlugin != null
+                      ? {
+                          type: 'skill_plugin' as const,
+                          skill_plugin: localSkillPluginPreview(
+                            consumerAccessListing.skillPlugin
+                          )
+                        }
+                      : {
+                          type: 'skill_marketplace' as const,
+                          skill_marketplace: localSkillMarketplacePreview(
+                            consumerAccessListing.skillMarketplace!
+                          )
+                        })
                 },
     groups: consumerAccessListing.consumerSurfaceProviderGroups
       .map(membership => membership.consumerSurfaceProviderGroup)
@@ -182,6 +210,10 @@ export let v1ConsumerAccessListingPresenter = Presenter.create(consumerAccessLis
         v.object({
           type: v.literal('skill_marketplace'),
           skill_marketplace: localSkillMarketplacePreview.schema
+        }),
+        v.object({
+          type: v.literal('skill_plugin'),
+          skill_plugin: localSkillPluginPreview.schema
         })
       ]),
       groups: v.array(consumerSurfaceProviderGroupPreviewSchema),

--- a/src/metorial/presenters/src/implementation/skills/skillMarketplace.ts
+++ b/src/metorial/presenters/src/implementation/skills/skillMarketplace.ts
@@ -1,9 +1,17 @@
 import { v } from '@lowerdeck/validation';
 import { getImageUrl } from '@metorial/db';
+import {
+  getArchivableSkillPluginIds,
+  getWritableSkillPluginIds,
+  hasSkillMarketplaceWriteAccess
+} from '@metorial/module-skill-marketplace';
 import { Presenter } from '@metorial/presenter';
 import { skillMarketplaceType } from '../../types';
 import { skillDestinationSyncStatusPresenter } from './skillDestination';
-import { v1SkillMarketplacePluginPresenter } from './skillMarketplacePlugin';
+import {
+  dashboardSkillMarketplacePluginPresenter,
+  v1SkillMarketplacePluginPresenter
+} from './skillMarketplacePlugin';
 
 export let v1SkillMarketplacePresenter = Presenter.create(skillMarketplaceType)
   .presenter(async ({ skillMarketplace }, opts) => ({
@@ -57,5 +65,68 @@ export let v1SkillMarketplacePresenter = Presenter.create(skillMarketplaceType)
       created_at: v.date(),
       updated_at: v.date()
     })
+  )
+  .build();
+
+export let dashboardSkillMarketplacePresenter = Presenter.create(skillMarketplaceType)
+  .presenter(async (input, opts) => {
+    let inner = await v1SkillMarketplacePresenter.present(input, opts).run();
+    let nestedPlugins = input.skillMarketplace.plugins.flatMap(plugin =>
+      plugin.skillPlugin ? [plugin.skillPlugin] : []
+    );
+    let [canCreatePlugins, writablePluginIds, archivablePluginIds] = await Promise.all([
+      input.skillMarketplace.status == 'active'
+        ? hasSkillMarketplaceWriteAccess({
+            skillMarketplace: input.skillMarketplace,
+            accessTags: input.accessTags
+          })
+        : false,
+      getWritableSkillPluginIds({
+        plugins: nestedPlugins,
+        accessTags: input.accessTags
+      }),
+      getArchivableSkillPluginIds({
+        plugins: nestedPlugins,
+        accessTags: input.accessTags
+      })
+    ]);
+
+    return {
+      ...inner,
+      can_create_plugins: canCreatePlugins,
+      plugins: await Promise.all(
+        input.skillMarketplace.plugins.map(skillMarketplacePlugin =>
+          dashboardSkillMarketplacePluginPresenter
+            .present(
+              {
+                accessTags: input.accessTags,
+                pluginAccess: skillMarketplacePlugin.skillPlugin
+                  ? {
+                      canUpdate: writablePluginIds.has(skillMarketplacePlugin.skillPlugin.id),
+                      canDelete: archivablePluginIds.has(skillMarketplacePlugin.skillPlugin.id)
+                    }
+                  : undefined,
+                skillMarketplacePlugin: {
+                  ...skillMarketplacePlugin,
+                  skillMarketplace: {
+                    id: input.skillMarketplace.id
+                  }
+                }
+              },
+              opts
+            )
+            .run()
+        )
+      )
+    };
+  })
+  .schema(
+    v.intersection([
+      v1SkillMarketplacePresenter.schema,
+      v.object({
+        can_create_plugins: v.boolean(),
+        plugins: v.array(dashboardSkillMarketplacePluginPresenter.schema)
+      })
+    ])
   )
   .build();

--- a/src/metorial/presenters/src/implementation/skills/skillMarketplacePlugin.ts
+++ b/src/metorial/presenters/src/implementation/skills/skillMarketplacePlugin.ts
@@ -1,7 +1,7 @@
 import { v } from '@lowerdeck/validation';
 import { Presenter } from '@metorial/presenter';
 import { skillMarketplacePluginType } from '../../types';
-import { v1SkillPluginPresenter } from './skillPlugin';
+import { dashboardSkillPluginPresenter, v1SkillPluginPresenter } from './skillPlugin';
 
 export let v1SkillMarketplacePluginPresenter = Presenter.create(skillMarketplacePluginType)
   .presenter(async ({ skillMarketplacePlugin }, opts) => ({
@@ -31,5 +31,37 @@ export let v1SkillMarketplacePluginPresenter = Presenter.create(skillMarketplace
       created_at: v.date(),
       updated_at: v.date()
     })
+  )
+  .build();
+
+export let dashboardSkillMarketplacePluginPresenter = Presenter.create(
+  skillMarketplacePluginType
+)
+  .presenter(async (input, opts) => {
+    let inner = await v1SkillMarketplacePluginPresenter.present(input, opts).run();
+
+    return {
+      ...inner,
+      skill_plugin: input.skillMarketplacePlugin.skillPlugin
+        ? await dashboardSkillPluginPresenter
+            .present(
+              {
+                skillPlugin: input.skillMarketplacePlugin.skillPlugin,
+                accessTags: input.accessTags,
+                pluginAccess: input.pluginAccess
+              },
+              opts
+            )
+            .run()
+        : null
+    };
+  })
+  .schema(
+    v.intersection([
+      v1SkillMarketplacePluginPresenter.schema,
+      v.object({
+        skill_plugin: v.nullable(dashboardSkillPluginPresenter.schema)
+      })
+    ])
   )
   .build();

--- a/src/metorial/presenters/src/implementation/skills/skillPlugin.ts
+++ b/src/metorial/presenters/src/implementation/skills/skillPlugin.ts
@@ -1,5 +1,9 @@
 import { v } from '@lowerdeck/validation';
 import { getImageUrl } from '@metorial/db';
+import {
+  hasSkillPluginArchiveAccess,
+  hasSkillPluginWriteAccess
+} from '@metorial/module-skill-marketplace';
 import { Presenter } from '@metorial/presenter';
 import { skillPluginType } from '../../types';
 import { skillDestinationSyncStatusPresenter } from './skillDestination';
@@ -20,9 +24,7 @@ export let v1SkillPluginPresenter = Presenter.create(skillPluginType)
     skill_configuration_id: skillPlugin.skillConfiguration?.id ?? null,
     skills: await Promise.all(
       skillPlugin.skillPluginSkills.map(skillPluginSkill =>
-        v1SkillPluginSkillPresenter
-          .present({ skillPluginSkill }, opts)
-          .run()
+        v1SkillPluginSkillPresenter.present({ skillPluginSkill }, opts).run()
       )
     ),
     created_at: skillPlugin.createdAt,
@@ -45,5 +47,41 @@ export let v1SkillPluginPresenter = Presenter.create(skillPluginType)
       created_at: v.date(),
       updated_at: v.date()
     })
+  )
+  .build();
+
+export let dashboardSkillPluginPresenter = Presenter.create(skillPluginType)
+  .presenter(async (input, opts) => {
+    let inner = await v1SkillPluginPresenter.present(input, opts).run();
+    let isMutable = input.skillPlugin.status == 'active' && !input.skillPlugin.isManaged;
+    let canUpdate = isMutable
+      ? (input.pluginAccess?.canUpdate ??
+        (await hasSkillPluginWriteAccess({
+          skillPlugin: input.skillPlugin,
+          accessTags: input.accessTags
+        })))
+      : false;
+    let canDelete = isMutable
+      ? (input.pluginAccess?.canDelete ??
+        (await hasSkillPluginArchiveAccess({
+          skillPlugin: input.skillPlugin,
+          accessTags: input.accessTags
+        })))
+      : false;
+
+    return {
+      ...inner,
+      can_update: canUpdate,
+      can_delete: canDelete
+    };
+  })
+  .schema(
+    v.intersection([
+      v1SkillPluginPresenter.schema,
+      v.object({
+        can_update: v.boolean(),
+        can_delete: v.boolean()
+      })
+    ])
   )
   .build();

--- a/src/metorial/presenters/src/index.ts
+++ b/src/metorial/presenters/src/index.ts
@@ -25,6 +25,9 @@ import {
   dashboardPortalPresenter,
   dashboardProviderListingPresenter,
   dashboardProviderPresenter,
+  dashboardSkillMarketplacePluginPresenter,
+  dashboardSkillMarketplacePresenter,
+  dashboardSkillPluginPresenter,
   v1AccessPolicyPresenter,
   v1AccessPolicyVersionPresenter,
   v1AccessRolePresenter,
@@ -760,12 +763,12 @@ export let skillForkSyncPresenter = declarePresenter(skillForkSyncType, {
 });
 
 export let skillMarketplacePresenter = declarePresenter(skillMarketplaceType, {
-  mt_2025_01_01_dashboard: v1SkillMarketplacePresenter,
+  mt_2025_01_01_dashboard: dashboardSkillMarketplacePresenter,
   mt_2026_01_01_magnetar: v1SkillMarketplacePresenter
 });
 
 export let skillMarketplacePluginPresenter = declarePresenter(skillMarketplacePluginType, {
-  mt_2025_01_01_dashboard: v1SkillMarketplacePluginPresenter,
+  mt_2025_01_01_dashboard: dashboardSkillMarketplacePluginPresenter,
   mt_2026_01_01_magnetar: v1SkillMarketplacePluginPresenter
 });
 
@@ -778,7 +781,7 @@ export let skillMarketplaceRepositoryPresenter = declarePresenter(
 );
 
 export let skillPluginPresenter = declarePresenter(skillPluginType, {
-  mt_2025_01_01_dashboard: v1SkillPluginPresenter,
+  mt_2025_01_01_dashboard: dashboardSkillPluginPresenter,
   mt_2026_01_01_magnetar: v1SkillPluginPresenter
 });
 

--- a/src/metorial/presenters/src/types.ts
+++ b/src/metorial/presenters/src/types.ts
@@ -135,6 +135,7 @@ import {
   UserStatus,
   UserType
 } from '@metorial/db';
+import type { AnyAccessTagSelector } from '@metorial/module-access';
 import type { AuditLog } from '@metorial/module-audit-log';
 import { EnrichedConsumerSurface } from '@metorial/module-consumer-core';
 import {
@@ -1659,6 +1660,7 @@ export let skillMarketplaceType = PresentableType.create<{
       };
     };
   }>;
+  accessTags?: AnyAccessTagSelector;
 }>()('skillMarketplace');
 
 export let skillMarketplacePluginType = PresentableType.create<{
@@ -1693,6 +1695,11 @@ export let skillMarketplacePluginType = PresentableType.create<{
         };
       };
     }> | null;
+  };
+  accessTags?: AnyAccessTagSelector;
+  pluginAccess?: {
+    canUpdate?: boolean;
+    canDelete?: boolean;
   };
 }>()('skillMarketplacePlugin');
 
@@ -1742,6 +1749,11 @@ export let skillPluginType = PresentableType.create<{
       };
     };
   }>;
+  accessTags?: AnyAccessTagSelector;
+  pluginAccess?: {
+    canUpdate?: boolean;
+    canDelete?: boolean;
+  };
 }>()('skillPlugin');
 
 export let skillPluginRepositoryType = PresentableType.create<{
@@ -2169,6 +2181,7 @@ export let consumerAccessType = PresentableType.create<{
     skillTemplate: SkillTemplate | null;
     skillGroup: SkillGroup | null;
     skillMarketplace: SkillMarketplace | null;
+    skillPlugin: SkillPlugin | null;
     listing: ConsumerAccessListing | null;
   };
 }>()('consumer.access');
@@ -2181,6 +2194,7 @@ export let consumerAccessListingType = PresentableType.create<{
     skillTemplate: SkillTemplate | null;
     skillGroup: SkillGroup | null;
     skillMarketplace: SkillMarketplace | null;
+    skillPlugin: SkillPlugin | null;
     consumerSurfaceProviderGroups: {
       consumerSurfaceProviderGroup: ConsumerSurfaceProviderGroup;
     }[];

--- a/src/metorial/products/core/modules/access/src/definitions/accessRoles.ts
+++ b/src/metorial/products/core/modules/access/src/definitions/accessRoles.ts
@@ -22,6 +22,14 @@ export let consumerAssistantConversationWriteRoles = [
 export let consumerSkillReadRoles = ['consumer#instance.skill:read'] as const;
 export let consumerSkillWriteRoles = ['consumer#instance.skill:write'] as const;
 export let consumerSkillManageAccessRoles = ['consumer#instance.skill:manage_access'] as const;
+export let consumerSkillMarketplaceReadRoles = [
+  'consumer#instance.skill_marketplace:read'
+] as const;
+export let consumerSkillMarketplaceWriteRoles = [
+  'consumer#instance.skill_marketplace:write'
+] as const;
+export let consumerSkillPluginReadRoles = ['consumer#instance.skill_plugin:read'] as const;
+export let consumerSkillPluginWriteRoles = ['consumer#instance.skill_plugin:write'] as const;
 export let consumerMagicMcpReadRoles = ['consumer#instance.magic_mcp:read'] as const;
 export let consumerMagicMcpConnectRoles = ['consumer#instance.magic_mcp:connect'] as const;
 export let consumerMagicMcpWriteRoles = ['consumer#instance.magic_mcp:write'] as const;
@@ -59,6 +67,14 @@ export let consumerSkillAccessRoles = [
   ...consumerSkillReadRoles,
   ...consumerSkillWriteRoles,
   ...consumerSkillManageAccessRoles
+] as const;
+export let consumerSkillMarketplaceAccessRoles = [
+  ...consumerSkillMarketplaceReadRoles,
+  ...consumerSkillMarketplaceWriteRoles
+] as const;
+export let consumerSkillPluginAccessRoles = [
+  ...consumerSkillPluginReadRoles,
+  ...consumerSkillPluginWriteRoles
 ] as const;
 export let consumerMagicMcpAccessRoles = [
   ...consumerMagicMcpReadRoles,

--- a/src/metorial/products/core/modules/access/src/definitions/scopeMetadata.ts
+++ b/src/metorial/products/core/modules/access/src/definitions/scopeMetadata.ts
@@ -325,6 +325,14 @@ let scopeResourceMetadata: Record<string, { name: string; description: string }>
     name: 'Consumer Skills',
     description: 'These endpoints manage consumer skill access and consumer-owned forks.'
   },
+  'consumer#instance.skill_marketplace': {
+    name: 'Consumer Skill Marketplaces',
+    description: 'These endpoints manage consumer access to skill marketplaces.'
+  },
+  'consumer#instance.skill_plugin': {
+    name: 'Consumer Skill Plugins',
+    description: 'These endpoints manage consumer access to skill plugins.'
+  },
   'consumer#instance.provider_template': {
     name: 'Consumer Provider Templates',
     description: 'These endpoints expose provider template access for consumers.'

--- a/src/metorial/products/core/modules/access/src/definitions/scopeValues.ts
+++ b/src/metorial/products/core/modules/access/src/definitions/scopeValues.ts
@@ -143,6 +143,10 @@ export let consumerScopes = [
   'consumer#instance.skill:read' as const,
   'consumer#instance.skill:write' as const,
   'consumer#instance.skill:manage_access' as const,
+  'consumer#instance.skill_marketplace:read' as const,
+  'consumer#instance.skill_marketplace:write' as const,
+  'consumer#instance.skill_plugin:read' as const,
+  'consumer#instance.skill_plugin:write' as const,
 
   'consumer#instance.magic_mcp:read' as const,
   'consumer#instance.magic_mcp:connect' as const,

--- a/src/metorial/products/core/modules/access/test/definitions.test.ts
+++ b/src/metorial/products/core/modules/access/test/definitions.test.ts
@@ -86,6 +86,10 @@ describe('definitions', () => {
       expect(scopes).toContain('consumer#instance.skill:read');
       expect(scopes).toContain('consumer#instance.skill:write');
       expect(scopes).toContain('consumer#instance.skill:manage_access');
+      expect(scopes).toContain('consumer#instance.skill_marketplace:read');
+      expect(scopes).toContain('consumer#instance.skill_marketplace:write');
+      expect(scopes).toContain('consumer#instance.skill_plugin:read');
+      expect(scopes).toContain('consumer#instance.skill_plugin:write');
     });
 
     it('should contain instance.session scopes', () => {
@@ -317,6 +321,18 @@ describe('definitions', () => {
       );
       expect(instancePublishableTokenWithConsumerScopes).toContain(
         'consumer#instance.skill:manage_access'
+      );
+      expect(instancePublishableTokenWithConsumerScopes).toContain(
+        'consumer#instance.skill_marketplace:read'
+      );
+      expect(instancePublishableTokenWithConsumerScopes).toContain(
+        'consumer#instance.skill_marketplace:write'
+      );
+      expect(instancePublishableTokenWithConsumerScopes).toContain(
+        'consumer#instance.skill_plugin:read'
+      );
+      expect(instancePublishableTokenWithConsumerScopes).toContain(
+        'consumer#instance.skill_plugin:write'
       );
     });
   });

--- a/src/metorial/products/skills/modules/skill-marketplace/package.json
+++ b/src/metorial/products/skills/modules/skill-marketplace/package.json
@@ -36,6 +36,7 @@
     "@metorial/cron": "^1.0.0",
     "@metorial/db": "^1.0.0",
     "@metorial/module-access": "^1.0.0",
+    "@metorial/module-consumer-access": "1.0.0",
     "@metorial/module-resource-actor": "^1.0.0",
     "@metorial/queue": "^1.0.0",
     "@metorial/skills-common": "^1.0.0",

--- a/src/metorial/products/skills/modules/skill-marketplace/src/index.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/index.ts
@@ -4,3 +4,4 @@ export {
 } from './queues';
 export { parseSkillDocumentFrontmatter } from './serializers/skill/frontmatter';
 export * from './services';
+export * from './lib/skillMarketplaceAccess';

--- a/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplaceAccess.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplaceAccess.ts
@@ -1,6 +1,14 @@
-import type { AnyAccessTagSelector } from '@metorial/module-access';
-import { accessTagService, consumerSkillReadRoles } from '@metorial/module-access';
+import { forbiddenError, ServiceError } from '@lowerdeck/error';
 import type { Prisma } from '@metorial/db';
+import { db } from '@metorial/db';
+import type { AnyAccessTagSelector } from '@metorial/module-access';
+import {
+  accessTagService,
+  consumerSkillMarketplaceWriteRoles,
+  consumerSkillPluginWriteRoles,
+  consumerSkillReadRoles
+} from '@metorial/module-access';
+import { getConsumerSkillAccessWhere } from '@metorial/module-skill';
 
 export type SkillMarketplaceAccessInput = {
   accessTags?: AnyAccessTagSelector;
@@ -13,8 +21,284 @@ export let getSkillMarketplaceAccessWhere = async (
 
   let accessTagEntities = await accessTagService.getAccessTagFilter({
     tags: d.accessTags,
-    roles: [...consumerSkillReadRoles]
+    roles: [...consumerSkillReadRoles, ...consumerSkillMarketplaceWriteRoles]
   });
 
   return accessTagEntities ? { accessTagEntities } : { oid: { in: [] } };
+};
+
+export let getSkillMarketplaceWriteAccessWhere = async (
+  d: SkillMarketplaceAccessInput
+): Promise<Prisma.SkillMarketplaceWhereInput | undefined> => {
+  if (!d.accessTags) return undefined;
+
+  let accessTagEntities = await accessTagService.getAccessTagFilter({
+    tags: d.accessTags,
+    roles: [...consumerSkillMarketplaceWriteRoles]
+  });
+
+  return accessTagEntities ? { accessTagEntities } : { oid: { in: [] } };
+};
+
+export let getSkillPluginWriteAccessWhere = async (
+  d: SkillMarketplaceAccessInput
+): Promise<Prisma.SkillPluginWhereInput | undefined> => {
+  if (!d.accessTags) return undefined;
+
+  let pluginWriteEntities = await accessTagService.getAccessTagFilter({
+    tags: d.accessTags,
+    roles: [...consumerSkillPluginWriteRoles]
+  });
+  let marketplaceWriteWhere = await getSkillMarketplaceWriteAccessWhere(d);
+
+  return {
+    OR: [
+      pluginWriteEntities ? { accessTagEntities: pluginWriteEntities } : undefined!,
+      marketplaceWriteWhere
+        ? {
+            skillMarketplacePlugins: {
+              some: {
+                status: 'active',
+                skillMarketplace: {
+                  status: 'active',
+                  AND: [marketplaceWriteWhere]
+                }
+              }
+            }
+          }
+        : undefined!
+    ].filter(Boolean) as Prisma.SkillPluginWhereInput[]
+  };
+};
+
+export let hasSkillMarketplaceWriteAccess = async (d: {
+  skillMarketplace: { oid: bigint };
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (!d.accessTags) return true;
+
+  let accessWhere = await getSkillMarketplaceWriteAccessWhere(d);
+  if (!accessWhere) return false;
+
+  let marketplace = await db.skillMarketplace.findFirst({
+    where: {
+      oid: d.skillMarketplace.oid,
+      AND: [accessWhere]
+    },
+    select: {
+      oid: true
+    }
+  });
+
+  return !!marketplace;
+};
+
+export let hasSkillPluginWriteAccess = async (d: {
+  skillPlugin: { oid: bigint };
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (!d.accessTags) return true;
+
+  let accessWhere = await getSkillPluginWriteAccessWhere(d);
+  if (!accessWhere) return false;
+
+  let skillPlugin = await db.skillPlugin.findFirst({
+    where: {
+      oid: d.skillPlugin.oid,
+      AND: [accessWhere]
+    },
+    select: {
+      oid: true
+    }
+  });
+
+  return !!skillPlugin;
+};
+
+export let hasSkillPluginArchiveAccess = async (d: {
+  skillPlugin: { oid: bigint };
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (!d.accessTags) return true;
+
+  let archivableIds = await getArchivableSkillPluginIds({
+    plugins: [{ oid: d.skillPlugin.oid, id: 'plugin' }],
+    accessTags: d.accessTags
+  });
+
+  return archivableIds.has('plugin');
+};
+
+export let getWritableSkillPluginIds = async (d: {
+  plugins: { oid: bigint; id: string }[];
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (!d.accessTags) return new Set(d.plugins.map(plugin => plugin.id));
+  if (!d.plugins.length) return new Set<string>();
+
+  let accessWhere = await getSkillPluginWriteAccessWhere(d);
+  if (!accessWhere) return new Set<string>();
+
+  let writable = await db.skillPlugin.findMany({
+    where: {
+      oid: { in: d.plugins.map(plugin => plugin.oid) },
+      AND: [accessWhere]
+    },
+    select: { id: true }
+  });
+
+  return new Set(writable.map(plugin => plugin.id));
+};
+
+export let getArchivableSkillPluginIds = async (d: {
+  plugins: { oid: bigint; id: string }[];
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (!d.accessTags) return new Set(d.plugins.map(plugin => plugin.id));
+  if (!d.plugins.length) return new Set<string>();
+
+  let marketplaceWriteWhere = await getSkillMarketplaceWriteAccessWhere(d);
+  if (!marketplaceWriteWhere) return new Set<string>();
+
+  let memberships = await db.skillMarketplacePlugin.findMany({
+    where: {
+      skillPluginOid: { in: d.plugins.map(plugin => plugin.oid) },
+      status: 'active',
+      skillMarketplace: {
+        status: 'active'
+      }
+    },
+    select: {
+      skillPluginOid: true,
+      skillMarketplaceOid: true
+    }
+  });
+
+  let marketplaceOids = [
+    ...new Set(memberships.map(membership => membership.skillMarketplaceOid))
+  ];
+  let writableMarketplaces = marketplaceOids.length
+    ? await db.skillMarketplace.findMany({
+        where: {
+          oid: { in: marketplaceOids },
+          AND: [marketplaceWriteWhere]
+        },
+        select: { oid: true }
+      })
+    : [];
+  let writableMarketplaceOids = new Set(
+    writableMarketplaces.map(marketplace => marketplace.oid)
+  );
+
+  let membershipsByPlugin = new Map<bigint, bigint[]>();
+  for (let membership of memberships) {
+    let current = membershipsByPlugin.get(membership.skillPluginOid) ?? [];
+    current.push(membership.skillMarketplaceOid);
+    membershipsByPlugin.set(membership.skillPluginOid, current);
+  }
+
+  let archivable = new Set<string>();
+  for (let plugin of d.plugins) {
+    let pluginMemberships = membershipsByPlugin.get(plugin.oid) ?? [];
+    if (!pluginMemberships.length) continue;
+    if (pluginMemberships.every(oid => writableMarketplaceOids.has(oid))) {
+      archivable.add(plugin.id);
+    }
+  }
+
+  return archivable;
+};
+
+export let assertSkillMarketplaceWriteAccess = async (d: {
+  skillMarketplace: { oid: bigint };
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (await hasSkillMarketplaceWriteAccess(d)) return;
+
+  throw new ServiceError(
+    forbiddenError({
+      message: 'You do not have permission to manage this skill marketplace.'
+    })
+  );
+};
+
+export let assertSkillPluginWriteAccess = async (d: {
+  skillPlugin: { oid: bigint };
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (await hasSkillPluginWriteAccess(d)) return;
+
+  throw new ServiceError(
+    forbiddenError({
+      message: 'You do not have permission to manage this skill plugin.'
+    })
+  );
+};
+
+export let assertSkillPluginArchiveAccess = async (d: {
+  skillPlugin: { oid: bigint };
+  accessTags?: AnyAccessTagSelector;
+}) => {
+  if (await hasSkillPluginArchiveAccess(d)) return;
+
+  throw new ServiceError(
+    forbiddenError({
+      message:
+        'You do not have permission to archive this skill plugin. Unlink it from marketplaces you manage instead.'
+    })
+  );
+};
+
+export let assertConsumerCanAttachSkillToPlugin = async (d: {
+  skill: { oid: bigint };
+  skillPlugin: { oid: bigint };
+  accessTags: AnyAccessTagSelector;
+}) => {
+  let skillAccessWhere = await getConsumerSkillAccessWhere(d);
+  if (skillAccessWhere) {
+    let readableSkill = await db.skill.findFirst({
+      where: {
+        oid: d.skill.oid,
+        AND: [skillAccessWhere]
+      },
+      select: { oid: true }
+    });
+    if (readableSkill) return;
+  }
+
+  let marketplaceAccessWhere = await getSkillMarketplaceAccessWhere(d);
+  if (marketplaceAccessWhere) {
+    let catalogSkill = await db.skillPluginSkill.findFirst({
+      where: {
+        skillOid: d.skill.oid,
+        status: 'active',
+        skillPlugin: {
+          skillMarketplacePlugins: {
+            some: {
+              status: 'active',
+              skillMarketplace: {
+                status: 'active',
+                AND: [marketplaceAccessWhere],
+                plugins: {
+                  some: {
+                    status: 'active',
+                    skillPluginOid: d.skillPlugin.oid
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      select: { oid: true }
+    });
+    if (catalogSkill) return;
+  }
+
+  throw new ServiceError(
+    forbiddenError({
+      message:
+        'You can only add skills that are already in this marketplace catalog or that you can read.'
+    })
+  );
 };

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplace.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplace.ts
@@ -20,6 +20,7 @@ import {
   resolveSkillMarketplaces
 } from '@metorial/list-utils';
 import { skillConfigurationService } from '@metorial/module-skill-configurations';
+import { consumerAccessService } from '@metorial/module-consumer-access';
 import { getProjectTenantIdentifier } from '@metorial/skills-common';
 import { internalImageService } from '@metorial/skills-images';
 import {
@@ -409,6 +410,27 @@ class SkillMarketplaceServiceImpl {
         event: 'archived'
       });
     });
+
+    let memberships = await db.skillMarketplacePlugin.findMany({
+      where: {
+        skillMarketplaceOid: d.skillMarketplace.oid
+      },
+      select: {
+        skillPlugin: {
+          select: {
+            oid: true,
+            organizationOid: true
+          }
+        }
+      }
+    });
+
+    for (let membership of memberships) {
+      await consumerAccessService.reconcileSkillPluginConsumerAccess({
+        skillPlugin: membership.skillPlugin,
+        unlinkFromSkillMarketplaceOid: d.skillMarketplace.oid
+      });
+    }
 
     return await this.getSkillMarketplaceRecord({
       project: d.project,

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplacePlugin.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplacePlugin.ts
@@ -11,6 +11,7 @@ import {
   resolveSkillMarketplacePlugins,
   resolveSkillPlugins
 } from '@metorial/list-utils';
+import { consumerAccessService } from '@metorial/module-consumer-access';
 import { skillConfigurationService } from '@metorial/module-skill-configurations';
 import {
   assertSkillMarketplacePluginLimit,
@@ -18,6 +19,10 @@ import {
   CargoSkillLimitError,
   toCargoSkillLimitServiceError
 } from '../lib/limits';
+import {
+  assertSkillMarketplaceWriteAccess,
+  type SkillMarketplaceAccessInput
+} from '../lib/skillMarketplaceAccess';
 import { enqueueSkillMarketplacePluginLifecycle } from '../queues/lifecycle';
 import type { SkillMarketplaceRecord } from './skillMarketplace';
 import {
@@ -160,12 +165,18 @@ class SkillMarketplacePluginServiceImpl {
     project: Project;
     instance: Instance;
     skillMarketplace: SkillMarketplaceRecord;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
     input: {
       skillPluginId: string;
       pluginSlug?: string;
       skillConfigurationId?: string | null;
     };
   }) {
+    await assertSkillMarketplaceWriteAccess({
+      skillMarketplace: d.skillMarketplace,
+      accessTags: d.accessTags
+    });
+
     let skillPlugin = await skillPluginService.getSkillPluginById({
       project: d.project,
       instance: d.instance,
@@ -293,7 +304,12 @@ class SkillMarketplacePluginServiceImpl {
     project: Project;
     instance: Instance;
     skillMarketplacePlugin: SkillMarketplacePluginRecord;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
   }) {
+    await assertSkillMarketplaceWriteAccess({
+      skillMarketplace: { oid: d.skillMarketplacePlugin.skillMarketplaceOid },
+      accessTags: d.accessTags
+    });
     assertPluginIsNotManaged(d.skillMarketplacePlugin.skillPlugin);
 
     let skillMarketplacePlugin = await db.skillMarketplacePlugin.update({
@@ -310,6 +326,11 @@ class SkillMarketplacePluginServiceImpl {
     await enqueueSkillMarketplacePluginLifecycle({
       skillMarketplacePluginId: skillMarketplacePlugin.id,
       event: 'archived'
+    });
+
+    await consumerAccessService.reconcileSkillPluginConsumerAccess({
+      skillPlugin: d.skillMarketplacePlugin.skillPlugin,
+      unlinkFromSkillMarketplaceOid: d.skillMarketplacePlugin.skillMarketplaceOid
     });
 
     return skillMarketplacePlugin;

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillPlugin.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillPlugin.ts
@@ -22,6 +22,7 @@ import {
   resolveSkillPlugins
 } from '@metorial/list-utils';
 import { skillConfigurationService } from '@metorial/module-skill-configurations';
+import { consumerAccessService } from '@metorial/module-consumer-access';
 import { getProjectTenantIdentifier } from '@metorial/skills-common';
 import { internalImageService } from '@metorial/skills-images';
 import {
@@ -31,10 +32,21 @@ import {
 import { voyager, voyagerIndex, voyagerSource } from '@metorial/skills-search';
 import { forceSkillDestinationSync } from '../lib/destinationSync';
 import {
+  assertSkillMarketplacePluginLimit,
+  CargoSkillLimitError,
+  toCargoSkillLimitServiceError
+} from '../lib/limits';
+import {
+  assertSkillMarketplaceWriteAccess,
+  assertSkillPluginArchiveAccess,
+  assertSkillPluginWriteAccess,
   getSkillMarketplaceAccessWhere,
   type SkillMarketplaceAccessInput
 } from '../lib/skillMarketplaceAccess';
-import { enqueueSkillPluginLifecycle } from '../queues/lifecycle';
+import {
+  enqueueSkillMarketplacePluginLifecycle,
+  enqueueSkillPluginLifecycle
+} from '../queues/lifecycle';
 
 let skillInclude = {
   store: true,
@@ -281,6 +293,8 @@ class SkillPluginServiceImpl {
   async createSkillPlugin(d: {
     project: Project;
     instance: Instance;
+    skillMarketplaceId?: string;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
     input: {
       name: string;
       description?: string | null;
@@ -293,6 +307,50 @@ class SkillPluginServiceImpl {
     };
   }) {
     this.assertName(d.input.name);
+
+    if (d.accessTags && !d.skillMarketplaceId) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'skill_marketplace_id is required to create a skill plugin.'
+        })
+      );
+    }
+
+    let marketplaceAccessWhere = d.accessTags
+      ? await getSkillMarketplaceAccessWhere(d)
+      : undefined;
+    let skillMarketplace = d.skillMarketplaceId
+      ? await db.skillMarketplace.findFirst({
+          where: {
+            projectOid: d.project.oid,
+            instanceOid: d.instance.oid,
+            id: d.skillMarketplaceId,
+            status: 'active',
+            AND: marketplaceAccessWhere ? [marketplaceAccessWhere] : undefined
+          }
+        })
+      : null;
+    if (d.skillMarketplaceId && !skillMarketplace) {
+      throw new ServiceError(notFoundError('skill.marketplace', d.skillMarketplaceId));
+    }
+    if (skillMarketplace) {
+      await assertSkillMarketplaceWriteAccess({
+        skillMarketplace,
+        accessTags: d.accessTags
+      });
+      try {
+        await assertSkillMarketplacePluginLimit({
+          skillMarketplaceOid: skillMarketplace.oid,
+          additionalCount: 1
+        });
+      } catch (error) {
+        if (error instanceof CargoSkillLimitError) {
+          throw toCargoSkillLimitServiceError(error);
+        }
+
+        throw error;
+      }
+    }
 
     let skillConfigurationOid =
       d.input.skillConfigurationId === undefined
@@ -351,6 +409,22 @@ class SkillPluginServiceImpl {
 
       await enqueueSkillPluginLifecycle({ skillPluginId: skillPlugin.id, event: 'created' });
 
+      if (skillMarketplace) {
+        let skillMarketplacePlugin = await db.skillMarketplacePlugin.create({
+          data: {
+            id: await ID.generateId('skillMarketplacePlugin'),
+            status: 'active',
+            pluginSlug: skillPlugin.slug!,
+            skillMarketplaceOid: skillMarketplace.oid,
+            skillPluginOid: skillPlugin.oid
+          }
+        });
+        await enqueueSkillMarketplacePluginLifecycle({
+          skillMarketplacePluginId: skillMarketplacePlugin.id,
+          event: 'created'
+        });
+      }
+
       return skillPlugin;
     });
   }
@@ -359,9 +433,14 @@ class SkillPluginServiceImpl {
     project: Project;
     instance: Instance;
     skillPlugin: SkillPluginRecord;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
     input: SkillPluginInput;
   }) {
     assertPluginIsNotManaged(d.skillPlugin);
+    await assertSkillPluginWriteAccess({
+      skillPlugin: d.skillPlugin,
+      accessTags: d.accessTags
+    });
 
     if (!this.hasUpdate(d.input)) {
       throw new ServiceError(
@@ -437,8 +516,13 @@ class SkillPluginServiceImpl {
     project: Project;
     instance: Instance;
     skillPlugin: SkillPluginRecord;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
   }) {
     assertPluginIsNotManaged(d.skillPlugin);
+    await assertSkillPluginArchiveAccess({
+      skillPlugin: d.skillPlugin,
+      accessTags: d.accessTags
+    });
 
     await withTransaction(async db => {
       await db.skillPluginSkill.updateMany({
@@ -481,6 +565,10 @@ class SkillPluginServiceImpl {
         skillPluginId: d.skillPlugin.id,
         event: 'archived'
       });
+    });
+
+    await consumerAccessService.reconcileSkillPluginConsumerAccess({
+      skillPlugin: d.skillPlugin
     });
 
     return await this.getSkillPluginRecord({

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillPluginSkill.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillPluginSkill.ts
@@ -19,6 +19,11 @@ import {
   CargoSkillLimitError,
   toCargoSkillLimitServiceError
 } from '../lib/limits';
+import {
+  assertConsumerCanAttachSkillToPlugin,
+  assertSkillPluginWriteAccess,
+  type SkillMarketplaceAccessInput
+} from '../lib/skillMarketplaceAccess';
 import { enqueueSkillPluginSkillLifecycle } from '../queues/lifecycle';
 import type { SkillPluginRecord } from './skillPlugin';
 import { assertPluginIsNotManaged, skillPluginInclude } from './skillPlugin';
@@ -183,18 +188,30 @@ class SkillPluginSkillServiceImpl {
     project: Project;
     instance: Instance;
     skillPlugin: SkillPluginRecord;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
     input: {
       skillId: string;
       pluginSkillSlug?: string;
     } & SkillPluginSkillInput;
   }) {
     assertPluginIsNotManaged(d.skillPlugin);
+    await assertSkillPluginWriteAccess({
+      skillPlugin: d.skillPlugin,
+      accessTags: d.accessTags
+    });
 
     let skill = await skillService.getSkillById({
       project: d.project,
       instance: d.instance,
       skillId: d.input.skillId
     });
+    if (d.accessTags) {
+      await assertConsumerCanAttachSkillToPlugin({
+        skill,
+        skillPlugin: d.skillPlugin,
+        accessTags: d.accessTags
+      });
+    }
     let existingSkillPluginSkill = await db.skillPluginSkill.findFirst({
       where: {
         skillPluginOid: d.skillPlugin.oid,
@@ -338,9 +355,14 @@ class SkillPluginSkillServiceImpl {
     project: Project;
     instance: Instance;
     skillPluginSkill: SkillPluginSkillRecord;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
     input: SkillPluginSkillInput;
   }) {
     assertPluginIsNotManaged(d.skillPluginSkill.skillPlugin);
+    await assertSkillPluginWriteAccess({
+      skillPlugin: d.skillPluginSkill.skillPlugin,
+      accessTags: d.accessTags
+    });
 
     if (!this.hasUpdate(d.input)) {
       throw new ServiceError(
@@ -390,8 +412,13 @@ class SkillPluginSkillServiceImpl {
     project: Project;
     instance: Instance;
     skillPluginSkill: SkillPluginSkillRecord;
+    accessTags?: SkillMarketplaceAccessInput['accessTags'];
   }) {
     assertPluginIsNotManaged(d.skillPluginSkill.skillPlugin);
+    await assertSkillPluginWriteAccess({
+      skillPlugin: d.skillPluginSkill.skillPlugin,
+      accessTags: d.accessTags
+    });
 
     let skillPluginSkill = await db.skillPluginSkill.update({
       where: {

--- a/src/metorial/products/workforce/modules/consumer-access/package.json
+++ b/src/metorial/products/workforce/modules/consumer-access/package.json
@@ -12,6 +12,7 @@
     "@lowerdeck/error": "workspace:2.0.0",
     "@lowerdeck/pagination": "workspace:2.0.0",
     "@lowerdeck/service": "workspace:2.0.0",
+    "@metorial/cron": "1.0.0",
     "@metorial/db": "1.0.0",
     "@metorial/module-access": "1.0.0",
     "@metorial/module-email": "1.0.0",

--- a/src/metorial/products/workforce/modules/consumer-access/src/cron/backfillAccessLevel.ts
+++ b/src/metorial/products/workforce/modules/consumer-access/src/cron/backfillAccessLevel.ts
@@ -1,0 +1,30 @@
+import { createCron } from '@metorial/cron';
+import { db } from '@metorial/db';
+
+export let backfillConsumerAccessLevelCron = createCron(
+  {
+    name: 'cons/accessLevel/backfill',
+    cron: '* * * * *'
+  },
+  async () => {
+    await db.consumerAccess.updateMany({
+      where: {
+        type: 'skill_marketplace',
+        accessLevel: null
+      },
+      data: {
+        accessLevel: 'read'
+      }
+    });
+
+    await db.consumerAccess.updateMany({
+      where: {
+        type: { not: 'skill_marketplace' },
+        accessLevel: { not: null }
+      },
+      data: {
+        accessLevel: null
+      }
+    });
+  }
+);

--- a/src/metorial/products/workforce/modules/consumer-access/src/cron/cleanupOrphanedSkillPluginAccess.ts
+++ b/src/metorial/products/workforce/modules/consumer-access/src/cron/cleanupOrphanedSkillPluginAccess.ts
@@ -1,0 +1,39 @@
+import { createCron } from '@metorial/cron';
+import { db } from '@metorial/db';
+import { consumerAccessService } from '../services/consumerAccess';
+
+export let cleanupOrphanedSkillPluginAccessCron = createCron(
+  {
+    name: 'cons/skillPluginAccess/cleanup',
+    cron: '* * * * *'
+  },
+  async () => {
+    let pluginAccesses = await db.consumerAccess.findMany({
+      where: {
+        type: 'skill_plugin',
+        skillPluginOid: {
+          not: null
+        }
+      },
+      distinct: ['skillPluginOid'],
+      take: 100,
+      select: {
+        skillPluginOid: true,
+        skillPlugin: {
+          select: {
+            oid: true,
+            organizationOid: true
+          }
+        }
+      }
+    });
+
+    for (let access of pluginAccesses) {
+      if (!access.skillPlugin) continue;
+
+      await consumerAccessService.reconcileSkillPluginConsumerAccess({
+        skillPlugin: access.skillPlugin
+      });
+    }
+  }
+);

--- a/src/metorial/products/workforce/modules/consumer-access/src/index.ts
+++ b/src/metorial/products/workforce/modules/consumer-access/src/index.ts
@@ -1,4 +1,6 @@
 import { combineQueueProcessors } from '@metorial/queue';
+import { backfillConsumerAccessLevelCron } from './cron/backfillAccessLevel';
+import { cleanupOrphanedSkillPluginAccessCron } from './cron/cleanupOrphanedSkillPluginAccess';
 import { sendApprovedConsumerAccessRequestEmailQueueProcessor } from './queues/accessRequest/sendApprovedConsumerAccessRequestEmail';
 import { sendRejectedConsumerAccessRequestEmailQueueProcessor } from './queues/accessRequest/sendRejectedConsumerAccessRequestEmail';
 import {
@@ -23,5 +25,7 @@ export let consumerAccessQueueProcessor = combineQueueProcessors([
   consumerAccessListingDeleteQueueProcessor,
   consumerAccessDeleteQueueProcessor,
   consumerAccessRequestCreatedQueueProcessor,
-  consumerAccessRequestUpdatedQueueProcessor
+  consumerAccessRequestUpdatedQueueProcessor,
+  backfillConsumerAccessLevelCron,
+  cleanupOrphanedSkillPluginAccessCron
 ]);

--- a/src/metorial/products/workforce/modules/consumer-access/src/queues/lifecycle/consumerAccessCleanup.ts
+++ b/src/metorial/products/workforce/modules/consumer-access/src/queues/lifecycle/consumerAccessCleanup.ts
@@ -11,6 +11,7 @@ let consumerAccessInclude = {
   skillTemplate: true,
   skillGroup: true,
   skillMarketplace: true,
+  skillPlugin: true,
   listing: true
 } satisfies Prisma.ConsumerAccessInclude;
 
@@ -21,6 +22,7 @@ let consumerAccessListingInclude = {
   skillTemplate: true,
   skillGroup: true,
   skillMarketplace: true,
+  skillPlugin: true,
   consumerSurfaceProviderGroups: {
     include: {
       consumerSurfaceProviderGroup: true

--- a/src/metorial/products/workforce/modules/consumer-access/src/services/accessPolicy.ts
+++ b/src/metorial/products/workforce/modules/consumer-access/src/services/accessPolicy.ts
@@ -14,6 +14,7 @@ import {
   Skill,
   SkillGroup,
   SkillMarketplace,
+  SkillPlugin,
   SkillTemplate,
   withTransaction
 } from '@metorial/db';
@@ -23,6 +24,8 @@ import {
   consumerMagicMcpWriteRoles,
   consumerProviderTemplateReadRoles,
   consumerSkillManageAccessRoles,
+  consumerSkillMarketplaceWriteRoles,
+  consumerSkillPluginWriteRoles,
   consumerSkillReadRoles,
   consumerSkillWriteRoles
 } from '@metorial/module-access';
@@ -34,7 +37,9 @@ type ConsumerAccessPermission =
   | 'provider_template_read'
   | 'skill_read'
   | 'skill_write'
-  | 'skill_manage_access';
+  | 'skill_manage_access'
+  | 'skill_marketplace_write'
+  | 'skill_plugin_write';
 
 type ConsumerAccessPolicyScope =
   | {
@@ -56,7 +61,8 @@ type ConsumerAccessResource =
   | { skill: Pick<Skill, 'oid'> }
   | { skillTemplate: Pick<SkillTemplate, 'oid'> }
   | { skillGroup: Pick<SkillGroup, 'oid'> }
-  | { skillMarketplace: Pick<SkillMarketplace, 'oid'> };
+  | { skillMarketplace: Pick<SkillMarketplace, 'oid'> }
+  | { skillPlugin: Pick<SkillPlugin, 'oid'> };
 
 type ConsumerAccessSubject =
   | {
@@ -104,6 +110,16 @@ let consumerAccessPolicies: Record<
     name: 'Metorial Consumer Skill Manage Access',
     systemIdentifier: 'consumer_skill_manage_access',
     roles: [...consumerSkillManageAccessRoles]
+  },
+  skill_marketplace_write: {
+    name: 'Metorial Consumer Skill Marketplace Write',
+    systemIdentifier: 'consumer_skill_marketplace_write',
+    roles: [...consumerSkillMarketplaceWriteRoles]
+  },
+  skill_plugin_write: {
+    name: 'Metorial Consumer Skill Plugin Write',
+    systemIdentifier: 'consumer_skill_plugin_write',
+    roles: [...consumerSkillPluginWriteRoles]
   }
 };
 
@@ -140,6 +156,12 @@ let isSkillPermission = (permission: ConsumerAccessPermission) =>
   permission == 'skill_write' ||
   permission == 'skill_manage_access';
 
+let isSkillMarketplaceWritePermission = (permission: ConsumerAccessPermission) =>
+  permission == 'skill_marketplace_write';
+
+let isSkillPluginWritePermission = (permission: ConsumerAccessPermission) =>
+  permission == 'skill_plugin_write';
+
 let invalidConsumerAccessTargetError = () =>
   new ServiceError(
     preconditionFailedError({
@@ -155,6 +177,7 @@ let getStoredConsumerAccessResource = (
     skillTemplate?: Pick<SkillTemplate, 'oid'> | null;
     skillGroup?: Pick<SkillGroup, 'oid'> | null;
     skillMarketplace?: Pick<SkillMarketplace, 'oid'> | null;
+    skillPlugin?: Pick<SkillPlugin, 'oid'> | null;
   }
 ) => {
   if (consumerAccess.type == 'provider_template') {
@@ -164,7 +187,8 @@ let getStoredConsumerAccessResource = (
       consumerAccess.skill ||
       consumerAccess.skillTemplate ||
       consumerAccess.skillGroup ||
-      consumerAccess.skillMarketplace
+      consumerAccess.skillMarketplace ||
+      consumerAccess.skillPlugin
     ) {
       throw invalidConsumerAccessTargetError();
     }
@@ -182,7 +206,8 @@ let getStoredConsumerAccessResource = (
       consumerAccess.magicMcpServer ||
       consumerAccess.skillTemplate ||
       consumerAccess.skillGroup ||
-      consumerAccess.skillMarketplace
+      consumerAccess.skillMarketplace ||
+      consumerAccess.skillPlugin
     ) {
       throw invalidConsumerAccessTargetError();
     }
@@ -200,7 +225,8 @@ let getStoredConsumerAccessResource = (
       consumerAccess.magicMcpServer ||
       consumerAccess.skill ||
       consumerAccess.skillGroup ||
-      consumerAccess.skillMarketplace
+      consumerAccess.skillMarketplace ||
+      consumerAccess.skillPlugin
     ) {
       throw invalidConsumerAccessTargetError();
     }
@@ -218,7 +244,8 @@ let getStoredConsumerAccessResource = (
       consumerAccess.magicMcpServer ||
       consumerAccess.skill ||
       consumerAccess.skillTemplate ||
-      consumerAccess.skillMarketplace
+      consumerAccess.skillMarketplace ||
+      consumerAccess.skillPlugin
     ) {
       throw invalidConsumerAccessTargetError();
     }
@@ -236,7 +263,8 @@ let getStoredConsumerAccessResource = (
       consumerAccess.magicMcpServer ||
       consumerAccess.skill ||
       consumerAccess.skillTemplate ||
-      consumerAccess.skillGroup
+      consumerAccess.skillGroup ||
+      consumerAccess.skillPlugin
     ) {
       throw invalidConsumerAccessTargetError();
     }
@@ -247,13 +275,33 @@ let getStoredConsumerAccessResource = (
     };
   }
 
+  if (consumerAccess.type == 'skill_plugin') {
+    if (
+      !consumerAccess.skillPlugin ||
+      consumerAccess.providerTemplate ||
+      consumerAccess.magicMcpServer ||
+      consumerAccess.skill ||
+      consumerAccess.skillTemplate ||
+      consumerAccess.skillGroup ||
+      consumerAccess.skillMarketplace
+    ) {
+      throw invalidConsumerAccessTargetError();
+    }
+
+    return {
+      type: 'skill_plugin' as const,
+      skillPlugin: consumerAccess.skillPlugin
+    };
+  }
+
   if (
     !consumerAccess.magicMcpServer ||
     consumerAccess.providerTemplate ||
     consumerAccess.skill ||
     consumerAccess.skillTemplate ||
     consumerAccess.skillGroup ||
-    consumerAccess.skillMarketplace
+    consumerAccess.skillMarketplace ||
+    consumerAccess.skillPlugin
   ) {
     throw invalidConsumerAccessTargetError();
   }
@@ -392,6 +440,12 @@ class ConsumerAccessPolicyServiceImpl {
       };
     }
 
+    if ('skillPlugin' in resource) {
+      return {
+        skillPluginOid: resource.skillPlugin.oid
+      };
+    }
+
     return {
       providerTemplateOid: resource.providerTemplate.oid
     };
@@ -407,6 +461,16 @@ class ConsumerAccessPolicyServiceImpl {
       );
     }
 
+    if (isSkillMarketplaceWritePermission(d.permission) && !('skillMarketplace' in d.resource)) {
+      throw new Error(
+        'Skill marketplace write permissions can only be attached to skill marketplaces'
+      );
+    }
+
+    if (isSkillPluginWritePermission(d.permission) && !('skillPlugin' in d.resource)) {
+      throw new Error('Skill plugin write permissions can only be attached to skill plugins');
+    }
+
     if (
       isSkillPermission(d.permission) &&
       !('skill' in d.resource) &&
@@ -420,6 +484,8 @@ class ConsumerAccessPolicyServiceImpl {
     if (
       !isProviderTemplatePermission(d.permission) &&
       !isSkillPermission(d.permission) &&
+      !isSkillMarketplaceWritePermission(d.permission) &&
+      !isSkillPluginWritePermission(d.permission) &&
       'providerTemplate' in d.resource
     ) {
       throw new Error('Magic MCP permissions can only be attached to Magic MCP resources');
@@ -427,6 +493,7 @@ class ConsumerAccessPolicyServiceImpl {
 
     if (
       !isSkillPermission(d.permission) &&
+      !isSkillMarketplaceWritePermission(d.permission) &&
       ('skill' in d.resource || 'skillTemplate' in d.resource || 'skillGroup' in d.resource)
     ) {
       throw new Error('Non-skill permissions cannot be attached to skill resources');
@@ -522,6 +589,36 @@ class ConsumerAccessPolicyServiceImpl {
     });
   }
 
+  async revokeAccessByPolicyScope(d: {
+    organization: Organization;
+    permission: ConsumerAccessPermission;
+    subject: ConsumerAccessSubject;
+    policyScope: Exclude<ConsumerAccessPolicyScope, undefined>;
+  }) {
+    await withTransaction(async db => {
+      let policy = await this.getPolicy({
+        organization: d.organization,
+        permission: d.permission,
+        policyScope: d.policyScope
+      });
+      if (!policy) {
+        return;
+      }
+      let accessTagOids = await this.getSubjectAccessTagOids({
+        subject: d.subject
+      });
+
+      await db.accessTagEntity.deleteMany({
+        where: {
+          accessTagOid: {
+            in: accessTagOids
+          },
+          accessTagPolicyOid: policy.oid
+        }
+      });
+    });
+  }
+
   async revokeSkillParticipantAccessForPersonalGroup(d: {
     organization: Organization;
     consumerProfile: Pick<ConsumerProfile, 'personalConsumerGroupOid'>;
@@ -570,6 +667,7 @@ class ConsumerAccessPolicyServiceImpl {
       skillTemplate?: Pick<SkillTemplate, 'oid'> | null;
       skillGroup?: Pick<SkillGroup, 'oid'> | null;
       skillMarketplace?: Pick<SkillMarketplace, 'oid'> | null;
+      skillPlugin?: Pick<SkillPlugin, 'oid'> | null;
     };
   }) {
     let resource = getStoredConsumerAccessResource(d.consumerAccess);
@@ -653,14 +751,47 @@ class ConsumerAccessPolicyServiceImpl {
     }
 
     if (resource.type == 'skill_marketplace') {
+      for (let permission of ['skill_read', 'skill_marketplace_write'] as const) {
+        await this.revokeAccess({
+          organization: d.organization,
+          permission,
+          subject: {
+            consumerGroup: d.consumerAccess.consumerGroup
+          },
+          resource: {
+            skillMarketplace: resource.skillMarketplace
+          },
+          policyScope: {
+            type: 'consumer_access',
+            consumerAccessId: d.consumerAccess.id
+          }
+        });
+      }
+
+      return;
+    }
+
+    if (resource.type == 'skill_plugin') {
       await this.revokeAccess({
         organization: d.organization,
-        permission: 'skill_read',
+        permission: 'skill_plugin_write',
         subject: {
           consumerGroup: d.consumerAccess.consumerGroup
         },
         resource: {
-          skillMarketplace: resource.skillMarketplace
+          skillPlugin: resource.skillPlugin
+        },
+        policyScope: {
+          type: 'consumer_access',
+          consumerAccessId: d.consumerAccess.id
+        }
+      });
+
+      await this.revokeAccessByPolicyScope({
+        organization: d.organization,
+        permission: 'skill_read',
+        subject: {
+          consumerGroup: d.consumerAccess.consumerGroup
         },
         policyScope: {
           type: 'consumer_access',

--- a/src/metorial/products/workforce/modules/consumer-access/src/services/consumerAccess.ts
+++ b/src/metorial/products/workforce/modules/consumer-access/src/services/consumerAccess.ts
@@ -16,6 +16,7 @@ import {
   Skill,
   SkillGroup,
   SkillMarketplace,
+  SkillPlugin,
   SkillTemplate,
   withTransaction
 } from '@metorial/db';
@@ -30,6 +31,7 @@ let include = {
   skillTemplate: true,
   skillGroup: true,
   skillMarketplace: true,
+  skillPlugin: true,
   listing: true
 } as const;
 
@@ -57,6 +59,12 @@ type ConsumerAccessCreateInput =
   | {
       type: 'skill_marketplace';
       skillMarketplace: SkillMarketplace;
+      accessLevel?: 'read' | 'manage';
+    }
+  | {
+      type: 'skill_plugin';
+      skillPlugin: SkillPlugin;
+      skillMarketplace: SkillMarketplace;
     };
 
 type ConsumerAccessWithRelations = ConsumerAccess & {
@@ -67,6 +75,7 @@ type ConsumerAccessWithRelations = ConsumerAccess & {
   skillTemplate: SkillTemplate | null;
   skillGroup: SkillGroup | null;
   skillMarketplace: SkillMarketplace | null;
+  skillPlugin: SkillPlugin | null;
   listing: ConsumerAccessListing | null;
 };
 
@@ -110,6 +119,14 @@ class ConsumerAccessServiceImpl {
       return {
         name: access.skillMarketplace!.id,
         description: null,
+        readme: null
+      };
+    }
+
+    if (access.type == 'skill_plugin') {
+      return {
+        name: access.skillPlugin!.name ?? access.skillPlugin!.id,
+        description: access.skillPlugin!.description,
         readme: null
       };
     }
@@ -170,12 +187,19 @@ class ConsumerAccessServiceImpl {
                           skillGroupOid: d.access.skillGroup!.oid
                         }
                       }
-                    : {
-                        surfaceOid_skillMarketplaceOid: {
-                          surfaceOid: d.consumerSurface.oid,
-                          skillMarketplaceOid: d.access.skillMarketplace!.oid
+                    : d.access.type == 'skill_plugin'
+                      ? {
+                          surfaceOid_skillPluginOid: {
+                            surfaceOid: d.consumerSurface.oid,
+                            skillPluginOid: d.access.skillPlugin!.oid
+                          }
                         }
-                      },
+                      : {
+                          surfaceOid_skillMarketplaceOid: {
+                            surfaceOid: d.consumerSurface.oid,
+                            skillMarketplaceOid: d.access.skillMarketplace!.oid
+                          }
+                        },
         create: {
           id: await ID.generateId('consumerAccess'),
           surfaceOid: d.consumerSurface.oid,
@@ -189,6 +213,8 @@ class ConsumerAccessServiceImpl {
           skillGroupOid: d.access.type == 'skill_group' ? d.access.skillGroup!.oid : undefined,
           skillMarketplaceOid:
             d.access.type == 'skill_marketplace' ? d.access.skillMarketplace!.oid : undefined,
+          skillPluginOid:
+            d.access.type == 'skill_plugin' ? d.access.skillPlugin!.oid : undefined,
           name: d.input.name ?? defaults.name,
           description: d.input.description ?? defaults.description,
           readme: d.input.readme ?? defaults.readme
@@ -227,10 +253,15 @@ class ConsumerAccessServiceImpl {
                         surfaceOid: d.consumerSurface.oid,
                         skillGroupOid: d.access.skillGroup!.oid
                       }
-                    : {
-                        surfaceOid: d.consumerSurface.oid,
-                        skillMarketplaceOid: d.access.skillMarketplace!.oid
-                      },
+                    : d.access.type == 'skill_plugin'
+                      ? {
+                          surfaceOid: d.consumerSurface.oid,
+                          skillPluginOid: d.access.skillPlugin!.oid
+                        }
+                      : {
+                          surfaceOid: d.consumerSurface.oid,
+                          skillMarketplaceOid: d.access.skillMarketplace!.oid
+                        },
         data: {
           listingOid: listing.oid
         }
@@ -249,6 +280,7 @@ class ConsumerAccessServiceImpl {
     skillTemplateIds?: string[];
     skillGroupIds?: string[];
     skillMarketplaceIds?: string[];
+    skillPluginIds?: string[];
     consumerAccessListingIds?: string[];
     types?: ConsumerAccessTargetType[];
     search?: string;
@@ -261,6 +293,7 @@ class ConsumerAccessServiceImpl {
     let hasSkillTemplateFilter = !!d.skillTemplateIds?.length;
     let hasSkillGroupFilter = !!d.skillGroupIds?.length;
     let hasSkillMarketplaceFilter = !!d.skillMarketplaceIds?.length;
+    let hasSkillPluginFilter = !!d.skillPluginIds?.length;
     let hasConsumerAccessListingFilter = !!d.consumerAccessListingIds?.length;
 
     let consumerGroups = hasConsumerGroupFilter
@@ -354,6 +387,19 @@ class ConsumerAccessServiceImpl {
           }
         })
       : undefined;
+    let skillPlugins = hasSkillPluginFilter
+      ? await db.skillPlugin.findMany({
+          where: {
+            instanceOid: d.consumerSurface.instanceOid,
+            id: {
+              in: d.skillPluginIds
+            }
+          },
+          select: {
+            oid: true
+          }
+        })
+      : undefined;
     let consumerAccessListings = hasConsumerAccessListingFilter
       ? await db.consumerAccessListing.findMany({
           where: {
@@ -412,6 +458,11 @@ class ConsumerAccessServiceImpl {
                   ? {
                       in:
                         skillMarketplaces?.map(skillMarketplace => skillMarketplace.oid) ?? []
+                    }
+                  : undefined,
+                skillPluginOid: hasSkillPluginFilter
+                  ? {
+                      in: skillPlugins?.map(skillPlugin => skillPlugin.oid) ?? []
                     }
                   : undefined,
                 listingOid: hasConsumerAccessListingFilter
@@ -481,6 +532,14 @@ class ConsumerAccessServiceImpl {
                             mode: 'insensitive'
                           }
                         }
+                      },
+                      {
+                        skillPlugin: {
+                          name: {
+                            contains: search,
+                            mode: 'insensitive'
+                          }
+                        }
                       }
                     ]
                   }
@@ -520,6 +579,12 @@ class ConsumerAccessServiceImpl {
                   {
                     type: 'skill_marketplace',
                     skillMarketplace: {
+                      status: 'active'
+                    }
+                  },
+                  {
+                    type: 'skill_plugin',
+                    skillPlugin: {
                       status: 'active'
                     }
                   }
@@ -577,6 +642,12 @@ class ConsumerAccessServiceImpl {
             skillMarketplace: {
               status: 'active'
             }
+          },
+          {
+            type: 'skill_plugin',
+            skillPlugin: {
+              status: 'active'
+            }
           }
         ]
       },
@@ -623,7 +694,9 @@ class ConsumerAccessServiceImpl {
       ('skillGroup' in d.access &&
         d.access.skillGroup.instanceOid != d.consumerSurface.instanceOid) ||
       ('skillMarketplace' in d.access &&
-        d.access.skillMarketplace.instanceOid != d.consumerSurface.instanceOid)
+        d.access.skillMarketplace.instanceOid != d.consumerSurface.instanceOid) ||
+      ('skillPlugin' in d.access &&
+        d.access.skillPlugin.instanceOid != d.consumerSurface.instanceOid)
     ) {
       throw new ServiceError(notFoundError('consumer.access.resource'));
     }
@@ -672,6 +745,14 @@ class ConsumerAccessServiceImpl {
       throw new ServiceError(
         preconditionFailedError({
           message: 'Cannot create access for an inactive skill marketplace.'
+        })
+      );
+    }
+
+    if ('skillPlugin' in d.access && d.access.skillPlugin.status != 'active') {
+      throw new ServiceError(
+        preconditionFailedError({
+          message: 'Cannot create access for an inactive skill plugin.'
         })
       );
     }
@@ -730,16 +811,29 @@ class ConsumerAccessServiceImpl {
                               skillGroupOid: d.access.skillGroup.oid
                             }
                           }
-                        : {
-                            consumerGroupOid_skillMarketplaceOid: {
-                              consumerGroupOid: d.consumerGroup.oid,
-                              skillMarketplaceOid: d.access.skillMarketplace.oid
+                        : d.access.type == 'skill_plugin'
+                          ? {
+                              consumerGroupOid_skillPluginOid: {
+                                consumerGroupOid: d.consumerGroup.oid,
+                                skillPluginOid: d.access.skillPlugin.oid
+                              }
                             }
-                          })
+                          : {
+                              consumerGroupOid_skillMarketplaceOid: {
+                                consumerGroupOid: d.consumerGroup.oid,
+                                skillMarketplaceOid: d.access.skillMarketplace.oid
+                              }
+                            })
                     },
         create: {
           id: await ID.generateId('consumerAccess'),
           type: d.access.type,
+          accessLevel:
+            d.access.type == 'skill_marketplace'
+              ? d.access.accessLevel == 'manage'
+                ? 'manage'
+                : 'read'
+              : null,
           surfaceOid: d.consumerSurface.oid,
           consumerGroupOid: d.consumerGroup.oid,
           providerTemplateOid:
@@ -751,9 +845,13 @@ class ConsumerAccessServiceImpl {
             d.access.type == 'skill_template' ? d.access.skillTemplate.oid : undefined,
           skillGroupOid: d.access.type == 'skill_group' ? d.access.skillGroup.oid : undefined,
           skillMarketplaceOid:
-            d.access.type == 'skill_marketplace' ? d.access.skillMarketplace.oid : undefined
+            d.access.type == 'skill_marketplace' ? d.access.skillMarketplace.oid : undefined,
+          skillPluginOid: d.access.type == 'skill_plugin' ? d.access.skillPlugin.oid : undefined
         },
-        update: {},
+        update:
+          d.access.type == 'skill_marketplace' && d.access.accessLevel == 'manage'
+            ? { accessLevel: 'manage' }
+            : {},
         include
       });
 
@@ -849,6 +947,51 @@ class ConsumerAccessServiceImpl {
             consumerAccessId: consumerAccess.id
           }
         });
+        if (consumerAccess.accessLevel == 'manage') {
+          await consumerAccessPolicyService.grantAccess({
+            organization: d.organization,
+            permission: 'skill_marketplace_write',
+            subject: {
+              consumerGroup: d.consumerGroup
+            },
+            resource: {
+              skillMarketplace: d.access.skillMarketplace
+            },
+            policyScope: {
+              type: 'consumer_access',
+              consumerAccessId: consumerAccess.id
+            }
+          });
+        }
+      } else if (d.access.type == 'skill_plugin') {
+        await consumerAccessPolicyService.grantAccess({
+          organization: d.organization,
+          permission: 'skill_read',
+          subject: {
+            consumerGroup: d.consumerGroup
+          },
+          resource: {
+            skillMarketplace: d.access.skillMarketplace
+          },
+          policyScope: {
+            type: 'consumer_access',
+            consumerAccessId: consumerAccess.id
+          }
+        });
+        await consumerAccessPolicyService.grantAccess({
+          organization: d.organization,
+          permission: 'skill_plugin_write',
+          subject: {
+            consumerGroup: d.consumerGroup
+          },
+          resource: {
+            skillPlugin: d.access.skillPlugin
+          },
+          policyScope: {
+            type: 'consumer_access',
+            consumerAccessId: consumerAccess.id
+          }
+        });
       }
 
       await this.upsertSharedListing({
@@ -892,10 +1035,204 @@ class ConsumerAccessServiceImpl {
     });
   }
 
+  async deleteSkillPluginConsumerAccessForMarketplace(d: {
+    organization: Organization;
+    consumerGroupOid: bigint;
+    surfaceOid: bigint;
+    skillMarketplaceOid: bigint;
+  }) {
+    let memberships = await db.skillMarketplacePlugin.findMany({
+      where: {
+        skillMarketplaceOid: d.skillMarketplaceOid
+      },
+      select: {
+        skillPluginOid: true
+      }
+    });
+    let skillPluginOids = [
+      ...new Set(memberships.map(membership => membership.skillPluginOid.toString()))
+    ].map(oid => BigInt(oid));
+    if (!skillPluginOids.length) return;
+
+    let pluginAccesses = await db.consumerAccess.findMany({
+      where: {
+        type: 'skill_plugin',
+        consumerGroupOid: d.consumerGroupOid,
+        surfaceOid: d.surfaceOid,
+        skillPluginOid: {
+          in: skillPluginOids
+        }
+      },
+      include
+    });
+
+    for (let consumerAccess of pluginAccesses) {
+      await this.deleteConsumerAccess({
+        organization: d.organization,
+        consumerAccess
+      });
+    }
+  }
+
+  async reconcileSkillPluginConsumerAccess(d: {
+    skillPlugin: Pick<SkillPlugin, 'oid' | 'organizationOid'>;
+    unlinkFromSkillMarketplaceOid?: bigint;
+  }) {
+    let organization = await db.organization.findUnique({
+      where: {
+        oid: d.skillPlugin.organizationOid
+      }
+    });
+    if (!organization) return;
+
+    let pluginAccesses = await db.consumerAccess.findMany({
+      where: {
+        type: 'skill_plugin',
+        skillPluginOid: d.skillPlugin.oid
+      },
+      include
+    });
+    if (!pluginAccesses.length) return;
+
+    for (let consumerAccess of pluginAccesses) {
+      await this.revokeStalePluginCatalogAccess({
+        organization,
+        consumerAccess,
+        skillPluginOid: d.skillPlugin.oid,
+        unlinkFromSkillMarketplaceOid: d.unlinkFromSkillMarketplaceOid
+      });
+    }
+
+    let remainingMemberships = await db.skillMarketplacePlugin.count({
+      where: {
+        skillPluginOid: d.skillPlugin.oid,
+        status: 'active',
+        skillMarketplace: {
+          status: 'active'
+        }
+      }
+    });
+    if (remainingMemberships) return;
+
+    let remainingAccesses = await db.consumerAccess.findMany({
+      where: {
+        type: 'skill_plugin',
+        skillPluginOid: d.skillPlugin.oid
+      },
+      include
+    });
+
+    for (let consumerAccess of remainingAccesses) {
+      await this.deleteConsumerAccess({
+        organization,
+        consumerAccess
+      });
+    }
+  }
+
+  private async revokeStalePluginCatalogAccess(d: {
+    organization: Organization;
+    consumerAccess: ConsumerAccessWithRelations;
+    skillPluginOid: bigint;
+    unlinkFromSkillMarketplaceOid?: bigint;
+  }) {
+    if (d.unlinkFromSkillMarketplaceOid) {
+      await consumerAccessPolicyService.revokeAccess({
+        organization: d.organization,
+        permission: 'skill_read',
+        subject: {
+          consumerGroup: d.consumerAccess.consumerGroup
+        },
+        resource: {
+          skillMarketplace: {
+            oid: d.unlinkFromSkillMarketplaceOid
+          }
+        },
+        policyScope: {
+          type: 'consumer_access',
+          consumerAccessId: d.consumerAccess.id
+        }
+      });
+    }
+
+    let policy = await db.accessTagPolicy.findFirst({
+      where: {
+        organizationOid: d.organization.oid,
+        systemIdentifier: `consumer_access:${d.consumerAccess.id}:skill_read`
+      },
+      select: {
+        oid: true
+      }
+    });
+    if (!policy) return;
+
+    let catalogEntities = await db.accessTagEntity.findMany({
+      where: {
+        accessTagPolicyOid: policy.oid,
+        accessTagOid: d.consumerAccess.consumerGroup.accessTagOid,
+        skillMarketplaceOid: {
+          not: null
+        }
+      },
+      select: {
+        skillMarketplaceOid: true
+      }
+    });
+
+    for (let entity of catalogEntities) {
+      if (!entity.skillMarketplaceOid) continue;
+
+      let activeMembership = await db.skillMarketplacePlugin.findFirst({
+        where: {
+          skillPluginOid: d.skillPluginOid,
+          skillMarketplaceOid: entity.skillMarketplaceOid,
+          status: 'active',
+          skillMarketplace: {
+            status: 'active'
+          }
+        },
+        select: {
+          oid: true
+        }
+      });
+      if (activeMembership) continue;
+
+      await consumerAccessPolicyService.revokeAccess({
+        organization: d.organization,
+        permission: 'skill_read',
+        subject: {
+          consumerGroup: d.consumerAccess.consumerGroup
+        },
+        resource: {
+          skillMarketplace: {
+            oid: entity.skillMarketplaceOid
+          }
+        },
+        policyScope: {
+          type: 'consumer_access',
+          consumerAccessId: d.consumerAccess.id
+        }
+      });
+    }
+  }
+
   async deleteConsumerAccess(d: {
     organization: Organization;
     consumerAccess: ConsumerAccessWithRelations;
   }) {
+    if (
+      d.consumerAccess.type == 'skill_marketplace' &&
+      d.consumerAccess.accessLevel == 'manage' &&
+      d.consumerAccess.skillMarketplaceOid
+    ) {
+      await this.deleteSkillPluginConsumerAccessForMarketplace({
+        organization: d.organization,
+        consumerGroupOid: d.consumerAccess.consumerGroupOid,
+        surfaceOid: d.consumerAccess.surfaceOid,
+        skillMarketplaceOid: d.consumerAccess.skillMarketplaceOid
+      });
+    }
+
     return await withTransaction(async tx => {
       let consumerAccess: ConsumerAccessWithRelations;
       try {

--- a/src/metorial/products/workforce/modules/consumer-access/src/services/consumerAccessListing.ts
+++ b/src/metorial/products/workforce/modules/consumer-access/src/services/consumerAccessListing.ts
@@ -15,6 +15,7 @@ import {
   Skill,
   SkillGroup,
   SkillMarketplace,
+  SkillPlugin,
   SkillTemplate,
   withTransaction
 } from '@metorial/db';
@@ -28,6 +29,7 @@ let include = {
   skillTemplate: true,
   skillGroup: true,
   skillMarketplace: true,
+  skillPlugin: true,
   consumerSurfaceProviderGroups: {
     include: {
       consumerSurfaceProviderGroup: true
@@ -42,6 +44,7 @@ export type ConsumerAccessListingWithRelations = ConsumerAccessListing & {
   skillTemplate: SkillTemplate | null;
   skillGroup: SkillGroup | null;
   skillMarketplace: SkillMarketplace | null;
+  skillPlugin: SkillPlugin | null;
   consumerSurfaceProviderGroups: {
     consumerSurfaceProviderGroup: ConsumerSurfaceProviderGroup;
   }[];
@@ -363,6 +366,9 @@ class ConsumerAccessListingServiceImpl {
           if (d.types.includes('skill_marketplace')) {
             typeFilters.push({ skillMarketplaceOid: { not: null } });
           }
+          if (d.types.includes('skill_plugin')) {
+            typeFilters.push({ skillPluginOid: { not: null } });
+          }
 
           if (typeFilters.length) {
             filters.push({ OR: typeFilters });
@@ -482,6 +488,14 @@ class ConsumerAccessListingServiceImpl {
                 skillMarketplace: {
                   id: { contains: search, mode: 'insensitive' }
                 }
+              },
+              {
+                skillPlugin: {
+                  OR: [
+                    { id: { contains: search, mode: 'insensitive' } },
+                    { name: { contains: search, mode: 'insensitive' } }
+                  ]
+                }
               }
             ]
           });
@@ -516,6 +530,11 @@ class ConsumerAccessListingServiceImpl {
             },
             {
               skillMarketplace: {
+                status: 'active'
+              }
+            },
+            {
+              skillPlugin: {
                 status: 'active'
               }
             }
@@ -567,6 +586,11 @@ class ConsumerAccessListingServiceImpl {
           },
           {
             skillMarketplace: {
+              status: 'active'
+            }
+          },
+          {
+            skillPlugin: {
               status: 'active'
             }
           }
@@ -699,6 +723,7 @@ class ConsumerAccessListingServiceImpl {
         skillTemplate: true,
         skillGroup: true,
         skillMarketplace: true,
+        skillPlugin: true,
         listing: true
       }
     });

--- a/src/metorial/products/workforce/modules/consumer-core/src/queues/lifecycle/consumerGroup.ts
+++ b/src/metorial/products/workforce/modules/consumer-core/src/queues/lifecycle/consumerGroup.ts
@@ -1,6 +1,6 @@
 import { db } from '@metorial/db';
-import { createQueue } from '@metorial/queue';
 import { consumerAccessService } from '@metorial/module-consumer-access';
+import { createQueue } from '@metorial/queue';
 import { indexConsumerGroupSearchQueue } from '../search/consumerGroup';
 
 export let consumerGroupCreatedQueue = createQueue<{ consumerGroupId: string }>({
@@ -60,6 +60,7 @@ export let consumerGroupArchivedQueueProcessor = consumerGroupArchivedQueue.proc
         skillTemplate: true,
         skillGroup: true,
         skillMarketplace: true,
+        skillPlugin: true,
         listing: true,
         surface: { include: { organization: true } }
       }

--- a/src/metorial/products/workforce/modules/consumer-entities/src/services/consumerSkill.ts
+++ b/src/metorial/products/workforce/modules/consumer-entities/src/services/consumerSkill.ts
@@ -33,7 +33,10 @@ import {
   createResourceAuthorization
 } from '@metorial/module-access';
 import { resourceActorService } from '@metorial/module-resource-actor';
-import { consumerAccessPolicyService, consumerAccessService } from '@metorial/module-consumer-access';
+import {
+  consumerAccessPolicyService,
+  consumerAccessService
+} from '@metorial/module-consumer-access';
 
 export type ConsumerProfileForSkill = ConsumerProfile & {
   consumer: Consumer;
@@ -324,6 +327,7 @@ class ConsumerSkillServiceImpl {
         skillTemplate: true,
         skillGroup: true,
         skillMarketplace: true,
+        skillPlugin: true,
         listing: true
       }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large authorization changes (new DB enums/relations, portal access create/delete, and enforced write paths on marketplace/plugin APIs) that could mis-grant or block access if misconfigured.
> 
> **Overview**
> Adds **Marketplace Managers** so teams can grant portal **groups or accounts** either full marketplace management or **plugin-scoped** management, with a new marketplace **Managers & Access** tab, tables, and a multi-step assignment panel wired to portal consumer access APIs.
> 
> On the backend, consumer access gains **`skill_plugin`** targets and **`read` / `manage`** levels for marketplaces, with access-tag enforcement, new consumer scopes, and dashboard API fields like **`can_create_plugins`**, **`can_update`**, and **`can_delete`** so the marketplace plugin tree and drag-and-drop honor manager permissions. Plugin creation can be tied to a **`skill_marketplace_id`** for consumer tokens.
> 
> Also includes a skills **Upload Folder** action, CI tests targeting **`products/**`**, and a small paginated-loader dedupe fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ccdeae642a14960c1bbc0b219190b9ebaf9de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->