### PR TITLE
Add provider auth filters

### DIFF
--- a/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
+++ b/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
@@ -70,6 +70,26 @@ export let providerController = Controller.create(
               description: 'Filter by provider ID(s)'
             }),
 
+            search: v.optional(v.string(), {
+              description: 'Search providers by name, description, or readme'
+            }),
+
+            auth_method: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description:
+                'Filter by auth method — matches an auth method ID, auth method global ID, key, name, or type (oauth, token, service_account, custom)'
+            }),
+
+            auth_setup: v.optional(
+              v.union([
+                v.enumOf(['configured', 'not_configured']),
+                v.array(v.enumOf(['configured', 'not_configured']))
+              ]),
+              {
+                description:
+                  'Filter by auth setup status. "configured" matches providers with a token or custom auth method, or with auth credentials already configured. "not_configured" matches providers with only OAuth auth methods and no auth credentials configured.'
+              }
+            ),
+
             capabilities: v.optional(
               v.object({
                 supportsConfig: v.optional(v.boolean()),
@@ -89,6 +109,9 @@ export let providerController = Controller.create(
           instance: ctx.instance,
 
           ids: normalizeArrayParam(ctx.query.id),
+          search: ctx.query.search,
+          authMethods: normalizeArrayParam(ctx.query.auth_method),
+          authSetup: normalizeArrayParam(ctx.query.auth_setup),
           capabilities: ctx.query.capabilities
         });
 

--- a/src/metorial/subspace/modules/catalog/src/services/provider.ts
+++ b/src/metorial/subspace/modules/catalog/src/services/provider.ts
@@ -5,12 +5,15 @@ import {
   db,
   type EntityImage,
   type Environment,
+  type Prisma,
+  ProviderAuthMethodType,
   type Provider,
   type Solution,
   type Tenant
 } from '@metorial-subspace/db';
 import type { ProviderTypeWhereInput } from '@metorial-subspace/db/prisma/generated/models';
 import { providerInternalService } from '@metorial-subspace/module-provider-internal';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
 import {
   getMetorialSolution,
   type MetorialFacing,
@@ -113,6 +116,76 @@ export let getProviderCapabilityFilter = (d: ProviderCapabilityFilter) => {
   };
 };
 
+let configuredAuthMethodTypes = [ProviderAuthMethodType.token, ProviderAuthMethodType.custom];
+
+export type ProviderAuthSetupFilter = 'configured' | 'not_configured';
+
+export let getProviderAuthMethodFilter = (values?: string[]) => {
+  if (!values?.length) return undefined;
+
+  let validTypes = new Set<string>(Object.values(ProviderAuthMethodType));
+
+  return {
+    providerAuthMethodGlobals: {
+      some: {
+        OR: values.flatMap(value =>
+          [
+            { id: value },
+            { key: value },
+            { providerAuthMethods: { some: { id: value } } },
+            { currentInstance: { name: { contains: value, mode: 'insensitive' as const } } },
+            validTypes.has(value)
+              ? { currentInstance: { type: value as ProviderAuthMethodType } }
+              : undefined!
+          ].filter(Boolean)
+        )
+      }
+    }
+  };
+};
+
+export let getProviderAuthSetupFilter = (
+  values: ProviderAuthSetupFilter[] | undefined,
+  d: { tenantOid?: bigint; environmentOid?: bigint }
+) => {
+  if (!values?.length) return undefined;
+
+  let hasConfiguredAuthMethod = {
+    providerAuthMethodGlobals: {
+      some: { currentInstance: { type: { in: configuredAuthMethodTypes } } }
+    }
+  };
+
+  let hasAuthCredentials =
+    d.tenantOid && d.environmentOid
+      ? {
+          providerAuthCredentials: {
+            some: {
+              tenantOid: d.tenantOid,
+              environmentOid: d.environmentOid,
+              status: 'active' as const
+            }
+          }
+        }
+      : undefined;
+
+  let clauses = [
+    values.includes('configured')
+      ? { OR: [hasConfiguredAuthMethod, hasAuthCredentials ?? undefined!].filter(Boolean) }
+      : undefined!,
+    values.includes('not_configured')
+      ? {
+          AND: [
+            { NOT: hasConfiguredAuthMethod },
+            hasAuthCredentials ? { NOT: hasAuthCredentials } : undefined!
+          ].filter(Boolean)
+        }
+      : undefined!
+  ].filter(Boolean);
+
+  return clauses.length ? { OR: clauses } : undefined;
+};
+
 type GetProviderByIdParams = {
   providerId: string;
   includeDeprecated?: boolean;
@@ -121,6 +194,8 @@ type GetProviderByIdParams = {
 type ListProvidersParams = {
   search?: string;
   ids?: string[];
+  authMethods?: string[];
+  authSetup?: ProviderAuthSetupFilter[];
   capabilities?: ProviderCapabilityFilter;
   includeDeprecated?: boolean;
 };
@@ -196,44 +271,64 @@ class providerServiceImpl {
     let solution = await getMetorialSolution();
 
     let capFilters = getProviderCapabilityFilter(d.capabilities || {});
+    let authMethodFilter = getProviderAuthMethodFilter(d.authMethods);
+    let authSetupFilter = getProviderAuthSetupFilter(d.authSetup, {
+      tenantOid: d.tenant?.oid,
+      environmentOid: d.environment?.oid
+    });
     let includeDeprecated = d.includeDeprecated || !!d.ids?.length;
 
+    let search = d.search?.trim();
+
     return Paginator.create(({ prisma }) =>
-      prisma(
-        async opts =>
-          await db.provider.findMany({
-            ...opts,
-            where: {
-              AND: [
-                { status: 'active' },
-                getProviderTenantFilter({
-                  ...d,
-                  solution,
-                  includeDeprecated
-                }),
-                {
-                  AND: [
-                    d.ids
-                      ? {
-                          OR: [
-                            { id: { in: d.ids } },
-                            { slug: { in: d.ids } },
-                            { globalIdentifier: { in: d.ids } },
-                            { listing: { id: { in: d.ids } } },
-                            { listing: { slug: { in: d.ids } } },
-                            { listing: { prettySlug: { in: d.ids } } },
-                            { listing: { aliases: { hasSome: d.ids } } }
-                          ]
-                        }
-                      : undefined!,
-                    capFilters ? { type: capFilters } : undefined!
-                  ].filter(Boolean)
-                }
-              ]
-            },
-            include
-          })
-      )
+      prisma(async opts => {
+        let searchResults = search
+          ? await voyager.record.search({
+              tenantId: d.tenant?.id,
+              sourceId: (await voyagerSource).id,
+              indexId: voyagerIndex.providerListing.id,
+              query: search
+            })
+          : null;
+
+        let and: Prisma.ProviderWhereInput[] = [
+          { status: 'active' as const },
+          getProviderTenantFilter({
+            ...d,
+            solution,
+            includeDeprecated
+          }),
+          searchResults
+            ? { listing: { id: { in: searchResults.map(r => r.documentId) } } }
+            : undefined!,
+          {
+            AND: [
+              d.ids
+                ? {
+                    OR: [
+                      { id: { in: d.ids } },
+                      { slug: { in: d.ids } },
+                      { globalIdentifier: { in: d.ids } },
+                      { listing: { id: { in: d.ids } } },
+                      { listing: { slug: { in: d.ids } } },
+                      { listing: { prettySlug: { in: d.ids } } },
+                      { listing: { aliases: { hasSome: d.ids } } }
+                    ]
+                  }
+                : undefined!,
+              capFilters ? { type: capFilters } : undefined!,
+              authMethodFilter ?? undefined!,
+              authSetupFilter ?? undefined!
+            ].filter(Boolean)
+          }
+        ].filter(Boolean);
+
+        return db.provider.findMany({
+          ...opts,
+          where: { AND: and },
+          include
+        });
+      })
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes provider listing query behavior and auth/credential scoping; incorrect filter logic could hide or misclassify providers for a tenant/environment.
> 
> **Overview**
> Extends **list providers** on the default API with **`search`**, **`auth_method`**, and **`auth_setup`** query parameters and wires them through `providerService.listProviders`.
> 
> **`search`** runs a Voyager index query on provider listings and restricts results to matching listing IDs. **`auth_method`** filters providers whose auth method globals match any supplied ID, key, name fragment, or auth type. **`auth_setup`** (`configured` / `not_configured`) uses Prisma rules tied to the current tenant/environment: configured means token/custom auth methods or active credentials; not configured means no such methods and no active credentials.
> 
> Listing logic is refactored to compose these filters with existing ID and capability filters in a single `AND` where clause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392f332cd98310d25ba877692e166fad60652b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->