### PR TITLE
Add skill directory import

### DIFF
--- a/src/metorial-frontend/scenes/skills/package.json
+++ b/src/metorial-frontend/scenes/skills/package.json
@@ -24,6 +24,7 @@
     "@metorial/state": "^1.0.0",
     "@metorial/ui": "^1.0.0",
     "@metorial/ui-product": "^1.0.0",
+    "@metorial/use-search-filter": "^1.0.0",
     "@radix-ui/react-dialog": "^1.1.11",
     "@radix-ui/react-popover": "^1.1.13",
     "@remixicon/react": "^4.6.0",

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillImport.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillImport.tsx
@@ -203,12 +203,76 @@ export let useSkillImportActions = (p: {
     return true;
   };
 
+  let importUploadedFile = async (file: File) => {
+    let [uploadedFile, uploadError] = await uploadFile.mutate({
+      instanceId: p.instanceId,
+      file,
+      title: file.name,
+      purpose: 'generic'
+    });
+    if (uploadError) throw uploadError;
+    if (!uploadedFile) throw new Error('Upload completed without a file');
+
+    if (
+      !(await createImport({
+        type: 'file',
+        fileId: uploadedFile.id
+      }))
+    ) {
+      throw new Error('Failed to start the skill import');
+    }
+  };
+
+  let uploadWithToast = (run: () => Promise<void>) => {
+    toast.promise(run, {
+      loading: 'Uploading skill...',
+      success: 'Skill uploaded',
+      error: error => error?.data?.message ?? error?.message ?? 'Failed to upload skill'
+    });
+  };
+
+  let uploadSelectedFile = (file: File) => {
+    uploadWithToast(() => importUploadedFile(file));
+  };
+
+  let uploadSkillDirectory = () => {
+    let input = document.createElement('input');
+    input.type = 'file';
+    input.multiple = true;
+    input.webkitdirectory = true;
+    input.setAttribute('webkitdirectory', '');
+    input.setAttribute('directory', '');
+    input.onchange = async () => {
+      let files = Array.from(input.files ?? []);
+      if (!files.length) return;
+
+      let { createSkillImportZipFromDirectory, validateSkillImportDirectory } = await import(
+        './skillImportZip'
+      );
+
+      let validationError = validateSkillImportDirectory(files);
+      if (validationError) {
+        showSkillImportFileError(validationError);
+        return;
+      }
+
+      uploadWithToast(async () => {
+        let zipFile = await createSkillImportZipFromDirectory(files);
+        let zipValidationError = validateSkillImportFile(zipFile);
+        if (zipValidationError) throw new Error(zipValidationError);
+        await importUploadedFile(zipFile);
+      });
+    };
+    input.click();
+    void import('./skillImportZip');
+  };
+
   let uploadSkill = () => {
     let input = document.createElement('input');
     input.type = 'file';
     input.accept = '.zip,.md,.markdown,application/zip,text/markdown,text/plain';
     input.multiple = false;
-    input.onchange = async () => {
+    input.onchange = () => {
       let file = input.files?.[0];
       if (!file) return;
 
@@ -218,32 +282,7 @@ export let useSkillImportActions = (p: {
         return;
       }
 
-      toast.promise(
-        async () => {
-          let [uploadedFile, uploadError] = await uploadFile.mutate({
-            instanceId: p.instanceId,
-            file,
-            title: file.name,
-            purpose: 'generic'
-          });
-          if (uploadError) throw uploadError;
-          if (!uploadedFile) throw new Error('Upload completed without a file');
-
-          if (
-            !(await createImport({
-              type: 'file',
-              fileId: uploadedFile.id
-            }))
-          ) {
-            throw new Error('Failed to start the skill import');
-          }
-        },
-        {
-          loading: 'Uploading skill...',
-          success: 'Skill uploaded',
-          error: error => error?.data?.message ?? error?.message ?? 'Failed to upload skill'
-        }
-      );
+      uploadSelectedFile(file);
     };
     input.click();
   };
@@ -251,6 +290,7 @@ export let useSkillImportActions = (p: {
   return {
     createImport,
     uploadSkill,
+    uploadSkillDirectory,
     isLoading: uploadFile.isLoading || createSkillImport.isLoading,
     RenderError: () => (
       <>

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillImportZip.test.ts
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillImportZip.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSkillImportZipFromDirectory,
+  createStoredZipArchive,
+  getSkillImportZipPath,
+  validateSkillImportDirectory
+} from './skillImportZip';
+
+let fileFromPath = (path: string, content: string) => {
+  let file = new File([content], path.split('/').at(-1)!, { type: 'text/plain' });
+  Object.defineProperty(file, 'webkitRelativePath', { value: path });
+  return file;
+};
+
+describe('getSkillImportZipPath', () => {
+  it('uses the browser relative path and skips junk files', () => {
+    expect(getSkillImportZipPath(fileFromPath('reviewer/SKILL.md', '#'))).toBe(
+      'reviewer/SKILL.md'
+    );
+    expect(getSkillImportZipPath(fileFromPath('reviewer/.DS_Store', ''))).toBeNull();
+    expect(getSkillImportZipPath(fileFromPath('reviewer/.git/config', 'gitdir'))).toBeNull();
+    expect(
+      getSkillImportZipPath(fileFromPath('reviewer/node_modules/pkg/index.js', 'js'))
+    ).toBeNull();
+    expect(getSkillImportZipPath({ name: '../outside.md' })).toBeNull();
+  });
+});
+
+describe('validateSkillImportDirectory', () => {
+  it('requires at least one real file and enforces the zip size limit', () => {
+    expect(validateSkillImportDirectory([fileFromPath('reviewer/.DS_Store', '')])).toBe(
+      'Choose a folder that contains at least one file.'
+    );
+    expect(
+      validateSkillImportDirectory([
+        {
+          name: 'SKILL.md',
+          size: 10 * 1024 * 1024 + 1,
+          webkitRelativePath: 'reviewer/SKILL.md'
+        }
+      ])
+    ).toBe('ZIP skill archives must be 10 MB or smaller.');
+    expect(
+      validateSkillImportDirectory([fileFromPath('reviewer/SKILL.md', '# Skill')])
+    ).toBeNull();
+  });
+});
+
+describe('createSkillImportZipFromDirectory', () => {
+  it('zips the selected folder and preserves file contents', async () => {
+    let zipFile = await createSkillImportZipFromDirectory([
+      fileFromPath('reviewer/SKILL.md', '# Reviewer'),
+      fileFromPath('reviewer/scripts/check.sh', 'echo ok'),
+      fileFromPath('reviewer/.DS_Store', 'junk')
+    ]);
+
+    expect(zipFile.name).toBe('reviewer.zip');
+    expect(zipFile.type).toBe('application/zip');
+
+    let bytes = new Uint8Array(await zipFile.arrayBuffer());
+    expect(Array.from(bytes.slice(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
+    expect(new TextDecoder().decode(bytes)).toContain('reviewer/SKILL.md');
+    expect(new TextDecoder().decode(bytes)).toContain('# Reviewer');
+    expect(new TextDecoder().decode(bytes)).toContain('echo ok');
+    expect(new TextDecoder().decode(bytes)).not.toContain('.DS_Store');
+  });
+
+  it('creates a stored zip archive with a central directory', () => {
+    let zip = createStoredZipArchive([
+      { path: 'SKILL.md', data: new TextEncoder().encode('# Root') }
+    ]);
+    let decoded = new TextDecoder().decode(zip);
+
+    expect(decoded).toContain('PK');
+    expect(decoded).toContain('SKILL.md');
+    expect(decoded).toContain('# Root');
+  });
+});

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillImportZip.ts
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillImportZip.ts
@@ -1,0 +1,194 @@
+let maxSkillImportZipBytes = 10 * 1024 * 1024;
+let ignoredFileNames = new Set(['.ds_store', 'thumbs.db', 'desktop.ini']);
+let ignoredDirectoryNames = new Set(['.git', 'node_modules', '__macosx']);
+
+let crcTable = new Uint32Array(256);
+for (let i = 0; i < 256; i++) {
+  let crc = i;
+  for (let bit = 0; bit < 8; bit++) {
+    crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+  }
+  crcTable[i] = crc >>> 0;
+}
+
+let crc32 = (data: Uint8Array) => {
+  let crc = 0xffffffff;
+  for (let index = 0; index < data.length; index++) {
+    crc = crcTable[(crc ^ data[index]!) & 0xff]! ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+let concatBytes = (parts: Uint8Array[]) => {
+  let output = new Uint8Array(parts.reduce((total, part) => total + part.byteLength, 0));
+  let offset = 0;
+  for (let part of parts) {
+    output.set(part, offset);
+    offset += part.byteLength;
+  }
+  return output;
+};
+
+let u16 = (value: number) => {
+  let bytes = new Uint8Array(2);
+  new DataView(bytes.buffer).setUint16(0, value, true);
+  return bytes;
+};
+
+let u32 = (value: number) => {
+  let bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, value, true);
+  return bytes;
+};
+
+let toDosDateTime = (date: Date) => {
+  let year = Math.max(date.getFullYear(), 1980);
+  return {
+    time:
+      (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2),
+    date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate()
+  };
+};
+
+export let getSkillImportZipPath = (
+  file: Pick<File, 'name'> & { webkitRelativePath?: string }
+) => {
+  let relativePath = (file.webkitRelativePath || file.name)
+    .replaceAll('\\', '/')
+    .replace(/^\/+/, '');
+  let segments = relativePath.split('/').filter(Boolean);
+  if (!segments.length || segments.some(segment => segment == '.' || segment == '..')) {
+    return null;
+  }
+
+  let hasIgnoredDirectory = segments
+    .slice(0, -1)
+    .some(segment => ignoredDirectoryNames.has(segment.toLowerCase()));
+  let fileName = segments.at(-1)!.toLowerCase();
+  if (
+    hasIgnoredDirectory ||
+    ignoredDirectoryNames.has(fileName) ||
+    ignoredFileNames.has(fileName)
+  ) {
+    return null;
+  }
+
+  return segments.join('/');
+};
+
+export let validateSkillImportDirectory = (
+  files: Array<Pick<File, 'name' | 'size'> & { webkitRelativePath?: string }>
+) => {
+  let selected = files.filter(file => getSkillImportZipPath(file));
+  if (!selected.length) return 'Choose a folder that contains at least one file.';
+
+  let totalBytes = selected.reduce((total, file) => total + file.size, 0);
+  if (totalBytes > maxSkillImportZipBytes) {
+    return 'ZIP skill archives must be 10 MB or smaller.';
+  }
+
+  return null;
+};
+
+let getSkillImportZipName = (paths: string[]) => {
+  let root = paths[0]?.split('/')[0];
+  if (root && paths.every(path => path == root || path.startsWith(`${root}/`))) {
+    return root.toLowerCase().endsWith('.zip') ? root : `${root}.zip`;
+  }
+
+  return 'skills.zip';
+};
+
+export let createStoredZipArchive = (
+  entries: { path: string; data: Uint8Array; modifiedAt?: Date }[]
+) => {
+  let localParts: Uint8Array[] = [];
+  let centralParts: Uint8Array[] = [];
+  let offset = 0;
+  let encoder = new TextEncoder();
+
+  for (let entry of entries) {
+    let nameBytes = encoder.encode(entry.path);
+    let { time, date } = toDosDateTime(entry.modifiedAt ?? new Date());
+    let checksum = crc32(entry.data);
+    let localHeader = concatBytes([
+      u32(0x04034b50),
+      u16(20),
+      u16(0x0800),
+      u16(0),
+      u16(time),
+      u16(date),
+      u32(checksum),
+      u32(entry.data.byteLength),
+      u32(entry.data.byteLength),
+      u16(nameBytes.byteLength),
+      u16(0),
+      nameBytes
+    ]);
+
+    localParts.push(localHeader, entry.data);
+    centralParts.push(
+      concatBytes([
+        u32(0x02014b50),
+        u16(20),
+        u16(20),
+        u16(0x0800),
+        u16(0),
+        u16(time),
+        u16(date),
+        u32(checksum),
+        u32(entry.data.byteLength),
+        u32(entry.data.byteLength),
+        u16(nameBytes.byteLength),
+        u16(0),
+        u16(0),
+        u16(0),
+        u16(0),
+        u32(0),
+        u32(offset),
+        nameBytes
+      ])
+    );
+    offset += localHeader.byteLength + entry.data.byteLength;
+  }
+
+  let centralDirectory = concatBytes(centralParts);
+  return concatBytes([
+    ...localParts,
+    centralDirectory,
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(entries.length),
+    u16(entries.length),
+    u32(centralDirectory.byteLength),
+    u32(offset),
+    u16(0)
+  ]);
+};
+
+export let createSkillImportZipFromDirectory = async (files: File[]) => {
+  let validationError = validateSkillImportDirectory(files);
+  if (validationError) throw new Error(validationError);
+
+  let entries: { path: string; data: Uint8Array; modifiedAt: Date }[] = [];
+  for (let file of files) {
+    let path = getSkillImportZipPath(file);
+    if (!path) continue;
+
+    entries.push({
+      path,
+      data: new Uint8Array(await file.arrayBuffer()),
+      modifiedAt: new Date(file.lastModified)
+    });
+  }
+
+  let zipBytes = createStoredZipArchive(entries);
+  if (zipBytes.byteLength > maxSkillImportZipBytes) {
+    throw new Error('ZIP skill archives must be 10 MB or smaller.');
+  }
+
+  return new File([zipBytes], getSkillImportZipName(entries.map(entry => entry.path)), {
+    type: 'application/zip'
+  });
+};

--- a/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
+++ b/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
@@ -70,6 +70,26 @@ export let providerController = Controller.create(
               description: 'Filter by provider ID(s)'
             }),
 
+            search: v.optional(v.string(), {
+              description: 'Search providers by name, description, or readme'
+            }),
+
+            auth_method: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description:
+                'Filter by auth method — matches an auth method ID, auth method global ID, key, name, or type (oauth, token, service_account, custom)'
+            }),
+
+            auth_setup: v.optional(
+              v.union([
+                v.enumOf(['configured', 'not_configured']),
+                v.array(v.enumOf(['configured', 'not_configured']))
+              ]),
+              {
+                description:
+                  'Filter by auth setup status. "configured" matches providers with a token or custom auth method, or with auth credentials already configured. "not_configured" matches providers with only OAuth auth methods and no auth credentials configured.'
+              }
+            ),
+
             capabilities: v.optional(
               v.object({
                 supportsConfig: v.optional(v.boolean()),
@@ -89,6 +109,9 @@ export let providerController = Controller.create(
           instance: ctx.instance,
 
           ids: normalizeArrayParam(ctx.query.id),
+          search: ctx.query.search,
+          authMethods: normalizeArrayParam(ctx.query.auth_method),
+          authSetup: normalizeArrayParam(ctx.query.auth_setup),
           capabilities: ctx.query.capabilities
         });
 

--- a/src/metorial/subspace/modules/catalog/src/services/provider.ts
+++ b/src/metorial/subspace/modules/catalog/src/services/provider.ts
@@ -5,12 +5,15 @@ import {
   db,
   type EntityImage,
   type Environment,
+  type Prisma,
+  ProviderAuthMethodType,
   type Provider,
   type Solution,
   type Tenant
 } from '@metorial-subspace/db';
 import type { ProviderTypeWhereInput } from '@metorial-subspace/db/prisma/generated/models';
 import { providerInternalService } from '@metorial-subspace/module-provider-internal';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
 import {
   getMetorialSolution,
   type MetorialFacing,
@@ -113,6 +116,76 @@ export let getProviderCapabilityFilter = (d: ProviderCapabilityFilter) => {
   };
 };
 
+let configuredAuthMethodTypes = [ProviderAuthMethodType.token, ProviderAuthMethodType.custom];
+
+export type ProviderAuthSetupFilter = 'configured' | 'not_configured';
+
+export let getProviderAuthMethodFilter = (values?: string[]) => {
+  if (!values?.length) return undefined;
+
+  let validTypes = new Set<string>(Object.values(ProviderAuthMethodType));
+
+  return {
+    providerAuthMethodGlobals: {
+      some: {
+        OR: values.flatMap(value =>
+          [
+            { id: value },
+            { key: value },
+            { providerAuthMethods: { some: { id: value } } },
+            { currentInstance: { name: { contains: value, mode: 'insensitive' as const } } },
+            validTypes.has(value)
+              ? { currentInstance: { type: value as ProviderAuthMethodType } }
+              : undefined!
+          ].filter(Boolean)
+        )
+      }
+    }
+  };
+};
+
+export let getProviderAuthSetupFilter = (
+  values: ProviderAuthSetupFilter[] | undefined,
+  d: { tenantOid?: bigint; environmentOid?: bigint }
+) => {
+  if (!values?.length) return undefined;
+
+  let hasConfiguredAuthMethod = {
+    providerAuthMethodGlobals: {
+      some: { currentInstance: { type: { in: configuredAuthMethodTypes } } }
+    }
+  };
+
+  let hasAuthCredentials =
+    d.tenantOid && d.environmentOid
+      ? {
+          providerAuthCredentials: {
+            some: {
+              tenantOid: d.tenantOid,
+              environmentOid: d.environmentOid,
+              status: 'active' as const
+            }
+          }
+        }
+      : undefined;
+
+  let clauses = [
+    values.includes('configured')
+      ? { OR: [hasConfiguredAuthMethod, hasAuthCredentials ?? undefined!].filter(Boolean) }
+      : undefined!,
+    values.includes('not_configured')
+      ? {
+          AND: [
+            { NOT: hasConfiguredAuthMethod },
+            hasAuthCredentials ? { NOT: hasAuthCredentials } : undefined!
+          ].filter(Boolean)
+        }
+      : undefined!
+  ].filter(Boolean);
+
+  return clauses.length ? { OR: clauses } : undefined;
+};
+
 type GetProviderByIdParams = {
   providerId: string;
   includeDeprecated?: boolean;
@@ -121,6 +194,8 @@ type GetProviderByIdParams = {
 type ListProvidersParams = {
   search?: string;
   ids?: string[];
+  authMethods?: string[];
+  authSetup?: ProviderAuthSetupFilter[];
   capabilities?: ProviderCapabilityFilter;
   includeDeprecated?: boolean;
 };
@@ -196,44 +271,64 @@ class providerServiceImpl {
     let solution = await getMetorialSolution();
 
     let capFilters = getProviderCapabilityFilter(d.capabilities || {});
+    let authMethodFilter = getProviderAuthMethodFilter(d.authMethods);
+    let authSetupFilter = getProviderAuthSetupFilter(d.authSetup, {
+      tenantOid: d.tenant?.oid,
+      environmentOid: d.environment?.oid
+    });
     let includeDeprecated = d.includeDeprecated || !!d.ids?.length;
 
+    let search = d.search?.trim();
+
     return Paginator.create(({ prisma }) =>
-      prisma(
-        async opts =>
-          await db.provider.findMany({
-            ...opts,
-            where: {
-              AND: [
-                { status: 'active' },
-                getProviderTenantFilter({
-                  ...d,
-                  solution,
-                  includeDeprecated
-                }),
-                {
-                  AND: [
-                    d.ids
-                      ? {
-                          OR: [
-                            { id: { in: d.ids } },
-                            { slug: { in: d.ids } },
-                            { globalIdentifier: { in: d.ids } },
-                            { listing: { id: { in: d.ids } } },
-                            { listing: { slug: { in: d.ids } } },
-                            { listing: { prettySlug: { in: d.ids } } },
-                            { listing: { aliases: { hasSome: d.ids } } }
-                          ]
-                        }
-                      : undefined!,
-                    capFilters ? { type: capFilters } : undefined!
-                  ].filter(Boolean)
-                }
-              ]
-            },
-            include
-          })
-      )
+      prisma(async opts => {
+        let searchResults = search
+          ? await voyager.record.search({
+              tenantId: d.tenant?.id,
+              sourceId: (await voyagerSource).id,
+              indexId: voyagerIndex.providerListing.id,
+              query: search
+            })
+          : null;
+
+        let and: Prisma.ProviderWhereInput[] = [
+          { status: 'active' as const },
+          getProviderTenantFilter({
+            ...d,
+            solution,
+            includeDeprecated
+          }),
+          searchResults
+            ? { listing: { id: { in: searchResults.map(r => r.documentId) } } }
+            : undefined!,
+          {
+            AND: [
+              d.ids
+                ? {
+                    OR: [
+                      { id: { in: d.ids } },
+                      { slug: { in: d.ids } },
+                      { globalIdentifier: { in: d.ids } },
+                      { listing: { id: { in: d.ids } } },
+                      { listing: { slug: { in: d.ids } } },
+                      { listing: { prettySlug: { in: d.ids } } },
+                      { listing: { aliases: { hasSome: d.ids } } }
+                    ]
+                  }
+                : undefined!,
+              capFilters ? { type: capFilters } : undefined!,
+              authMethodFilter ?? undefined!,
+              authSetupFilter ?? undefined!
+            ].filter(Boolean)
+          }
+        ].filter(Boolean);
+
+        return db.provider.findMany({
+          ...opts,
+          where: { AND: and },
+          include
+        });
+      })
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Client-side ZIP assembly is new surface area for path/size validation; provider list changes touch auth credential queries and search integration on a core catalog endpoint.
> 
> **Overview**
> Users can **import a local skill folder** without manually zipping it first. `useSkillImportActions` adds `uploadSkillDirectory`, which opens a directory picker, validates the selection, builds a ZIP in the browser via new `skillImportZip` helpers (path sanitization, skips `.git`/`node_modules`/junk files, 10 MB cap), then reuses the existing upload + file import flow. Single-file upload is refactored to share `importUploadedFile` and toast handling.
> 
> The **instance providers list API** gains optional `search`, `auth_method`, and `auth_setup` query params. `listProvidersInternal` applies Voyager search on provider listings when `search` is set, and new Prisma filters match auth methods (id/key/name/type) and configured vs not-configured auth (token/custom methods or active credentials vs OAuth-only with no credentials).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438b1a600d6b5e7a7bf100d8f8bdc59d5c53e096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->