### PR TITLE
Update explorer copy

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/product/pages/explorer/index.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/explorer/index.tsx
@@ -4,10 +4,11 @@ import type {
   ProviderListingsGetOutput
 } from '@metorial/dashboard-sdk';
 import { renderWithLoader } from '@metorial/data-hooks';
+import { Explainer } from '@metorial/explainer';
 import { Paths } from '@metorial/frontend-config';
 import {
-  useCreateProviderDeployment,
   useCreateProviderConfig,
+  useCreateProviderDeployment,
   useCreateSession,
   useCurrentInstance,
   useProvider,
@@ -36,11 +37,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { Explainer } from '@metorial/explainer';
-import {
-  OpenExplorerButton,
-  type OpenExplorerMode
-} from '../../components/openExplorer';
+import { OpenExplorerButton, type OpenExplorerMode } from '../../components/openExplorer';
 import {
   emptyConfigurationSelection,
   type ConfigurationSelection
@@ -168,8 +165,7 @@ export let ExplorerPage = () => {
   let sessionIdParam = search.get('session_id');
   let modeParam = search.get('mode');
   let hasExplorerModeParam = modeParam == 'manual' || modeParam == 'assistant';
-  let initialExplorerMode: ExplorerTabMode =
-    modeParam == 'assistant' ? 'assistant' : 'manual';
+  let initialExplorerMode: ExplorerTabMode = modeParam == 'assistant' ? 'assistant' : 'manual';
   let sessionTemplateIdFromState =
     (location.state as { sessionTemplateId?: string } | null)?.sessionTemplateId ?? null;
   let magicMcpServerIdFromState =
@@ -349,7 +345,9 @@ export let ExplorerPage = () => {
     [resetSessionSetupSelections]
   );
   let providerIdToResolve =
-    !isSessionFirstMode && !providerDeploymentId ? (selectedProvider?.id ?? providerIdParam) : null;
+    !isSessionFirstMode && !providerDeploymentId
+      ? (selectedProvider?.id ?? providerIdParam)
+      : null;
   let deploymentsFilter = useMemo(
     () => (providerIdToResolve ? { providerId: providerIdToResolve } : undefined),
     [providerIdToResolve]
@@ -408,19 +406,14 @@ export let ExplorerPage = () => {
 
     let matchingDeployments = (deployments.data?.items ?? [])
       .filter(deployment => deployment.providerId === providerIdToResolve)
-      .sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      );
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
     if (matchingDeployments[0]) {
       selectDeployment(matchingDeployments[0].id);
       return;
     }
 
-    if (
-      createMutation.isPending ||
-      resolvingProviderIdRef.current === providerIdToResolve
-    ) {
+    if (createMutation.isPending || resolvingProviderIdRef.current === providerIdToResolve) {
       return;
     }
 
@@ -532,10 +525,7 @@ export let ExplorerPage = () => {
       resolvingProviderIdRef.current === providerIdToResolve);
 
   let createSessionWithSelectedSetup = useCallback(
-    async (
-      deploymentId: string,
-      options?: { name?: string; mode?: OpenExplorerMode }
-    ) => {
+    async (deploymentId: string, options?: { name?: string; mode?: OpenExplorerMode }) => {
       let providerConfigId =
         selectedConfiguration.kind === 'config' ? selectedConfiguration.id : undefined;
       let providerConfigVaultId =
@@ -856,7 +846,10 @@ export let ExplorerPage = () => {
 
                 {!isSessionFirstMode && (
                   <>
-                    {(providerDeploymentId || selectedProvider || providerIdParam || sessionId) && (
+                    {(providerDeploymentId ||
+                      selectedProvider ||
+                      providerIdParam ||
+                      sessionId) && (
                       <>
                         <Flex justify="space-between" align="center">
                           <Button
@@ -911,7 +904,7 @@ export let ExplorerPage = () => {
             {isResolvingProviderDeployment ? (
               <CenteredSpinner />
             ) : (
-              <p>Click on a provider to start</p>
+              <p>Choose a provider to continue</p>
             )}
           </MainEmpty>
         )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy-only user-facing string change plus cosmetic formatting; no logic or API changes.
> 
> **Overview**
> Updates the Explorer main empty state when no deployment or session is selected: the placeholder text changes from **"Click on a provider to start"** to **"Choose a provider to continue"**.
> 
> The rest of the diff is import reordering and formatting in `explorer/index.tsx` (no behavior changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ea48dc5757c29bd7c6b949eb47a0429672b3f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->