### PR TITLE
Fix provider filters

### DIFF
--- a/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
+++ b/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
@@ -46,7 +46,27 @@ export let providerController = Controller.create(
           v.object({
             id: v.optional(v.union([v.string(), v.array(v.string())]), {
               description: 'Filter by provider ID(s)'
-            })
+            }),
+
+            search: v.optional(v.string(), {
+              description: 'Search providers by name, description, or readme'
+            }),
+
+            auth_method: v.optional(v.union([v.string(), v.array(v.string())]), {
+              description:
+                'Filter by auth method — matches an auth method ID, auth method global ID, key, name, or type (oauth, token, service_account, custom)'
+            }),
+
+            auth_setup: v.optional(
+              v.union([
+                v.enumOf(['configured', 'not_configured']),
+                v.array(v.enumOf(['configured', 'not_configured']))
+              ]),
+              {
+                description:
+                  'Filter by auth setup status. "configured" matches providers with a token or custom auth method, or with auth credentials already configured. "not_configured" matches providers with only OAuth auth methods and no auth credentials configured.'
+              }
+            )
           })
         ),
         v => v


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only list endpoint query validation only; no changes to auth, data writes, or service logic.
> 
> **Overview**
> **Fixes provider list filtering for the `mt_2026_01_01_magnetar` API version** by declaring the same optional query params already supported on the default schema: `search`, `auth_method`, and `auth_setup` (plus the existing `id` filter).
> 
> The list handler already forwards these fields to `providerService.listProviders`; magnetar clients could not pass them through validation before. The consumer API version is unchanged and still only allows `id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4a1593fa59335faceb7a756fc7367d665c4da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->