### PR TITLE
Harden org upsert

### DIFF
--- a/src/metorial/multi-region/src/sync/fromDeployment/organization.ts
+++ b/src/metorial/multi-region/src/sync/fromDeployment/organization.ts
@@ -21,11 +21,34 @@ export let upsertOrganization = async (organizationId: string) => {
     deletedAt: organization.deletedAt
   };
 
-  await globalDB.organization.upsert({
-    where: { id: organization.id },
-    update: inner,
-    create: { id: organization.id, ...inner, ownerOid: (await cell).oid }
-  });
+  try {
+    await globalDB.organization.upsert({
+      where: { id: organization.id },
+      update: inner,
+      create: { id: organization.id, ...inner, ownerOid: (await cell).oid }
+    });
+  } catch (err: any) {
+    if (err.code !== 'P2002') throw err;
+
+    let existing = await globalDB.organization.findUnique({
+      where: { id: organization.id }
+    });
+    if (!existing) return;
+
+    try {
+      await globalDB.organization.update({
+        where: { id: organization.id },
+        data: inner
+      });
+    } catch (updateErr: any) {
+      if (updateErr.code !== 'P2002') throw updateErr;
+
+      await globalDB.organization.update({
+        where: { id: organization.id },
+        data: { ...inner, slug: existing.slug }
+      });
+    }
+  }
 };
 
 export let syncOrgsCron = createCron(

--- a/src/metorial/subspace/modules/tenant/src/lib/mirrorRecords.test.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/mirrorRecords.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mocks = vi.hoisted(() => ({
   organizationFindMany: vi.fn(),
+  organizationFindFirst: vi.fn(),
+  organizationFindUnique: vi.fn(),
+  organizationUpdate: vi.fn(),
   organizationUpsert: vi.fn(),
   projectFindMany: vi.fn(),
   projectFindUnique: vi.fn(),
@@ -26,6 +29,9 @@ vi.mock('@metorial-subspace/db', () => ({
   db: {
     organization: {
       findMany: mocks.organizationFindMany,
+      findFirst: mocks.organizationFindFirst,
+      findUnique: mocks.organizationFindUnique,
+      update: mocks.organizationUpdate,
       upsert: mocks.organizationUpsert
     },
     project: {
@@ -64,7 +70,8 @@ import {
   ensureOrganizationActorMirror,
   ensureProjectMirror,
   linkEnvironmentToInstanceMirror,
-  linkTenantToProjectMirror
+  linkTenantToProjectMirror,
+  upsertOrganizationMirror
 } from './mirrorRecords';
 
 let createdAt = new Date('2026-01-01T00:00:00.000Z');
@@ -376,5 +383,75 @@ describe('Mirror record creation', () => {
       })
     ).rejects.toThrow('the instance mirror could not be created');
     expect(mocks.environmentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a stale organization mirror that still holds the claimed slug', async () => {
+    let conflict = { oid: 9n, id: 'org_old', slug: 'acme' };
+    mocks.organizationUpsert
+      .mockRejectedValueOnce({ code: 'P2002' })
+      .mockResolvedValueOnce(organization);
+    mocks.organizationFindFirst.mockResolvedValue(conflict);
+    mocks.metorialOrganizationFindUnique.mockResolvedValue({
+      ...organization,
+      oid: 9n,
+      id: 'org_old',
+      slug: 'acme-renamed'
+    });
+
+    await expect(upsertOrganizationMirror(organization as any)).resolves.toEqual(organization);
+
+    expect(mocks.organizationUpdate).toHaveBeenCalledWith({
+      where: { oid: 9n },
+      data: expect.objectContaining({ slug: 'acme-renamed' })
+    });
+    expect(mocks.organizationUpsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('parks the occupant slug when Metorial no longer owns it', async () => {
+    let conflict = { oid: 9n, id: 'org_old', slug: 'acme' };
+    mocks.organizationUpsert
+      .mockRejectedValueOnce({ code: 'P2002' })
+      .mockResolvedValueOnce(organization);
+    mocks.organizationFindFirst.mockResolvedValue(conflict);
+    mocks.metorialOrganizationFindUnique.mockResolvedValue(null);
+
+    await expect(upsertOrganizationMirror(organization as any)).resolves.toEqual(organization);
+
+    expect(mocks.organizationUpdate).toHaveBeenCalledWith({
+      where: { oid: 9n },
+      data: { slug: 'acme--org_old' }
+    });
+  });
+
+  it('updates the existing organization when the slug conflict is a create/update race', async () => {
+    mocks.organizationUpsert.mockRejectedValue({ code: 'P2002' });
+    mocks.organizationFindFirst.mockResolvedValue(null);
+    mocks.organizationUpdate.mockResolvedValue(organization);
+
+    await expect(upsertOrganizationMirror(organization as any)).resolves.toEqual(organization);
+
+    expect(mocks.organizationUpdate).toHaveBeenCalledWith({
+      where: { oid: 1n },
+      data: expect.objectContaining({ slug: 'acme', name: 'Acme' })
+    });
+  });
+
+  it('returns the existing organization when the follow-up update still conflicts', async () => {
+    mocks.organizationUpsert.mockRejectedValue({ code: 'P2002' });
+    mocks.organizationFindFirst.mockResolvedValue(null);
+    mocks.organizationUpdate.mockRejectedValue({ code: 'P2002' });
+    mocks.organizationFindUnique.mockResolvedValue(organization);
+
+    await expect(upsertOrganizationMirror(organization as any)).resolves.toEqual(organization);
+  });
+
+  it('rethrows unique conflicts when the organization cannot be recovered', async () => {
+    let error = { code: 'P2002' };
+    mocks.organizationUpsert.mockRejectedValue(error);
+    mocks.organizationFindFirst.mockResolvedValue(null);
+    mocks.organizationUpdate.mockRejectedValue({ code: 'P2002' });
+    mocks.organizationFindUnique.mockResolvedValue(null);
+
+    await expect(upsertOrganizationMirror(organization as any)).rejects.toBe(error);
   });
 });

--- a/src/metorial/subspace/modules/tenant/src/lib/mirrorRecords.ts
+++ b/src/metorial/subspace/modules/tenant/src/lib/mirrorRecords.ts
@@ -1,10 +1,10 @@
+import { db as subspaceDb } from '@metorial-subspace/db';
 import type {
   Instance as MetorialInstance,
   Organization as MetorialOrganization,
   OrganizationActor as MetorialOrganizationActor,
   Project as MetorialProject
 } from '@metorial/db';
-import { db as subspaceDb } from '@metorial-subspace/db';
 import { metorialDb } from './metorialDb';
 
 export let assertMirrorIdentity = (
@@ -26,6 +26,101 @@ export let assertMirrorIdentity = (
   }
 };
 
+let isUniqueConstraintError = (error: any) => error?.code === 'P2002';
+
+let getOrganizationMirrorWrite = (organization: MetorialOrganization) => ({
+  type: organization.type,
+  status: organization.status,
+  slug: organization.slug,
+  name: organization.name,
+  image: organization.image,
+  deletedAt: organization.deletedAt,
+  createdAt: organization.createdAt,
+  updatedAt: organization.updatedAt
+});
+
+let writeOrganizationMirror = async (organization: MetorialOrganization) => {
+  let write = getOrganizationMirrorWrite(organization);
+  return await subspaceDb.organization.upsert({
+    where: { oid: organization.oid },
+    update: write,
+    create: {
+      oid: organization.oid,
+      id: organization.id,
+      ...write
+    }
+  });
+};
+
+let releaseOrganizationMirrorSlug = async (d: {
+  conflict: { oid: bigint; id: string; slug: string };
+  claimedSlug: string;
+}) => {
+  let current = await metorialDb.organization.findUnique({
+    where: { oid: d.conflict.oid }
+  });
+
+  if (current && current.slug !== d.claimedSlug) {
+    try {
+      await subspaceDb.organization.update({
+        where: { oid: d.conflict.oid },
+        data: {
+          type: current.type,
+          status: current.status,
+          slug: current.slug,
+          name: current.name,
+          image: current.image,
+          deletedAt: current.deletedAt,
+          updatedAt: current.updatedAt
+        }
+      });
+      return;
+    } catch (error: any) {
+      if (!isUniqueConstraintError(error)) throw error;
+    }
+  }
+
+  await subspaceDb.organization.update({
+    where: { oid: d.conflict.oid },
+    data: { slug: `${d.conflict.slug}--${d.conflict.id}` }
+  });
+};
+
+let recoverOrganizationMirrorFromSlugConflict = async (
+  organization: MetorialOrganization,
+  error: unknown
+) => {
+  let conflict = await subspaceDb.organization.findFirst({
+    where: {
+      slug: organization.slug,
+      oid: { not: organization.oid }
+    },
+    select: { oid: true, id: true, slug: true }
+  });
+
+  if (conflict) {
+    await releaseOrganizationMirrorSlug({
+      conflict,
+      claimedSlug: organization.slug
+    });
+    return await writeOrganizationMirror(organization);
+  }
+
+  try {
+    return await subspaceDb.organization.update({
+      where: { oid: organization.oid },
+      data: getOrganizationMirrorWrite(organization)
+    });
+  } catch (updateError: any) {
+    if (!isUniqueConstraintError(updateError)) throw updateError;
+    let existing = await subspaceDb.organization.findUnique({
+      where: { oid: organization.oid }
+    });
+    if (existing) return existing;
+    throw error;
+  }
+};
+
 export let upsertOrganizationMirror = async (organization: MetorialOrganization) => {
   let matches = await subspaceDb.organization.findMany({
     where: {
@@ -35,31 +130,12 @@ export let upsertOrganizationMirror = async (organization: MetorialOrganization)
   });
   assertMirrorIdentity('organization', organization, matches);
 
-  return await subspaceDb.organization.upsert({
-    where: { oid: organization.oid },
-    update: {
-      type: organization.type,
-      status: organization.status,
-      slug: organization.slug,
-      name: organization.name,
-      image: organization.image,
-      deletedAt: organization.deletedAt,
-      createdAt: organization.createdAt,
-      updatedAt: organization.updatedAt
-    },
-    create: {
-      oid: organization.oid,
-      id: organization.id,
-      type: organization.type,
-      status: organization.status,
-      slug: organization.slug,
-      name: organization.name,
-      image: organization.image,
-      deletedAt: organization.deletedAt,
-      createdAt: organization.createdAt,
-      updatedAt: organization.updatedAt
-    }
-  });
+  try {
+    return await writeOrganizationMirror(organization);
+  } catch (error: any) {
+    if (!isUniqueConstraintError(error)) throw error;
+    return await recoverOrganizationMirrorFromSlugConflict(organization, error);
+  }
 };
 
 export let upsertProjectMirror = async (d: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how organization slugs are written under concurrency and conflicts across global and Subspace DBs; incorrect recovery could leave stale or duplicated slug state, though behavior is narrowly scoped to P2002 handling.
> 
> **Overview**
> **Organization sync and Subspace mirroring** now recover from Prisma `P2002` unique-constraint failures on `slug` instead of failing the job.
> 
> In **multi-region deployment → global DB** sync (`upsertOrganization`), upserts are wrapped so a slug collision triggers a load-by-id and a normal update; if the update still conflicts, the row is updated with the **incoming fields but the existing slug** preserved.
> 
> In **Subspace** `upsertOrganizationMirror`, the same error drives a richer path: find another mirror row holding the slug, **release** it (sync slug from Metorial when the org still exists, or **park** as `{slug}--{id}` when it does not), then retry the upsert. If no cross-row conflict is found, it treats the case as a create/update race—update by `oid`, return the existing row if update still conflicts, or rethrow when nothing can be recovered.
> 
> Vitest coverage was added for stale-slug refresh, parked slugs, race updates, graceful return on double conflict, and unrecoverable rethrow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea0d81a8f8dae06ed93ec3028ee11eacdefa4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->