### PR TITLE
Add chat adapter integrations

### DIFF
--- a/src/metorial/subspace/apps/worker/package.json
+++ b/src/metorial/subspace/apps/worker/package.json
@@ -26,6 +26,7 @@
     "@metorial-subspace/module-connection": "^1.0.0",
     "@metorial-subspace/module-deployment": "^1.0.0",
     "@metorial-subspace/module-integration": "^1.0.0",
+    "@metorial-subspace/module-chat": "^1.0.0",
     "@metorial-subspace/module-monitor": "^1.0.0",
     "@metorial-subspace/module-provider-internal": "^1.0.0",
     "@lowerdeck/telemetry": "workspace:2.0.0",

--- a/src/metorial/subspace/apps/worker/src/worker.ts
+++ b/src/metorial/subspace/apps/worker/src/worker.ts
@@ -12,6 +12,7 @@ import { deploymentQueueProcessor } from '@metorial-subspace/module-deployment/s
 import { enclaveQueueProcessor } from '@metorial-subspace/module-enclave/src/queues';
 import { identityQueueProcessor } from '@metorial-subspace/module-identity/src/queues';
 import { integrationQueueProcessor } from '@metorial-subspace/module-integration/src/queues';
+import { chatQueueProcessor } from '@metorial-subspace/module-chat/src/queues';
 import { monitorQueueProcessor } from '@metorial-subspace/module-monitor/src/queues';
 import { syncProtoGuardFilters } from '@metorial-subspace/module-connection/src/protoguard/registry';
 import { providerInternalQueueProcessor } from '@metorial-subspace/module-provider-internal/src/queues';
@@ -41,6 +42,7 @@ runQueueProcessors([
   callbackQueueProcessor,
   identityQueueProcessor,
   integrationQueueProcessor,
+  chatQueueProcessor,
   monitorQueueProcessor,
   agentQueueProcessor
 ]);

--- a/src/metorial/subspace/db/prisma/schema/adapter/instance.prisma
+++ b/src/metorial/subspace/db/prisma/schema/adapter/instance.prisma
@@ -1,0 +1,117 @@
+enum AdapterIntegrationInstanceStatus {
+  draft
+  active
+  archived
+  deleted
+}
+
+model AdapterIntegrationInstance {
+  oid BigInt @id
+  id  String @unique
+
+  status       AdapterIntegrationInstanceStatus
+  isStandalone Boolean
+
+  adapterIntegrationOid BigInt
+  adapterIntegration    AdapterIntegration @relation(fields: [adapterIntegrationOid], references: [oid], onDelete: Cascade)
+
+  integrationInstanceOid BigInt
+  integrationInstance    IntegrationInstance @relation(fields: [integrationInstanceOid], references: [oid], onDelete: Cascade)
+
+  integrationOid BigInt
+  integration    Integration @relation(fields: [integrationOid], references: [oid], onDelete: Cascade)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid])
+
+  createdAt DateTime @default(now())
+
+  providers AdapterIntegrationInstanceProvider[]
+
+  chatIntegrationInstance          ChatIntegrationInstance?
+  chatIntegrationInstanceProviders ChatIntegrationInstanceProvider[]
+
+  @@unique([adapterIntegrationOid, integrationInstanceOid])
+  @@index([tenantOid, solutionOid, environmentOid, status])
+  @@index([adapterIntegrationOid, status])
+  @@index([integrationOid, status])
+  @@index([status])
+  @@index([isStandalone])
+  @@index([projectOid])
+  @@index([instanceOid])
+}
+
+enum AdapterIntegrationInstanceProviderStatus {
+  active
+  archived
+  deleted
+}
+
+model AdapterIntegrationInstanceProvider {
+  oid BigInt @id
+  id  String @unique
+
+  status AdapterIntegrationInstanceProviderStatus
+
+  adapterIntegrationInstanceOid BigInt
+  adapterIntegrationInstance    AdapterIntegrationInstance @relation(fields: [adapterIntegrationInstanceOid], references: [oid], onDelete: Cascade, map: "aiip_aii_fkey")
+
+  adapterIntegrationProviderOid BigInt
+  adapterIntegrationProvider    AdapterIntegrationProvider @relation(fields: [adapterIntegrationProviderOid], references: [oid], onDelete: Cascade, map: "aiip_aip_fkey")
+
+  adapterIntegrationOid BigInt
+  adapterIntegration    AdapterIntegration @relation(fields: [adapterIntegrationOid], references: [oid], onDelete: Cascade, map: "aiip_ain_fkey")
+
+  integrationInstanceProviderOid BigInt
+  integrationInstanceProvider    IntegrationInstanceProvider @relation(fields: [integrationInstanceProviderOid], references: [oid], onDelete: Cascade, map: "aiip_iip_fkey")
+
+  integrationInstanceOid BigInt
+  integrationInstance    IntegrationInstance @relation(fields: [integrationInstanceOid], references: [oid], onDelete: Cascade, map: "aiip_ini_fkey")
+
+  integrationProviderOid BigInt
+  integrationProvider    IntegrationProvider @relation(fields: [integrationProviderOid], references: [oid], onDelete: Cascade, map: "aiip_inp_fkey")
+
+  integrationOid BigInt
+  integration    Integration @relation(fields: [integrationOid], references: [oid], onDelete: Cascade, map: "aiip_int_fkey")
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  chatIntegrationInstanceProviders ChatIntegrationInstanceProvider[]
+
+  @@unique([adapterIntegrationInstanceOid, adapterIntegrationProviderOid], map: "aiip_instance_provider_key")
+  @@index([tenantOid, solutionOid, environmentOid, status])
+  @@index([adapterIntegrationInstanceOid, status], map: "aiip_aii_status_idx")
+  @@index([adapterIntegrationProviderOid, status], map: "aiip_aip_status_idx")
+  @@index([integrationInstanceProviderOid, status], map: "aiip_iip_status_idx")
+  @@index([integrationProviderOid, status])
+  @@index([status])
+  @@index([projectOid])
+  @@index([instanceOid])
+}

--- a/src/metorial/subspace/db/prisma/schema/adapter/integration.prisma
+++ b/src/metorial/subspace/db/prisma/schema/adapter/integration.prisma
@@ -1,0 +1,110 @@
+enum AdapterIntegrationType {
+  chat
+}
+
+enum AdapterIntegrationStatus {
+  active
+  archived
+  deleted
+}
+
+model AdapterIntegration {
+  oid BigInt @id
+  id  String @unique
+
+  type         AdapterIntegrationType
+  status       AdapterIntegrationStatus
+  isStandalone Boolean
+
+  adapterGlobalOid BigInt
+  adapterGlobal    ProviderAdapterGlobal @relation(fields: [adapterGlobalOid], references: [oid])
+
+  integrationOid BigInt
+  integration    Integration @relation(fields: [integrationOid], references: [oid], onDelete: Cascade)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid])
+
+  createdAt DateTime @default(now())
+
+  providers         AdapterIntegrationProvider[]
+  instances         AdapterIntegrationInstance[]
+  instanceProviders AdapterIntegrationInstanceProvider[]
+
+  chatIntegration                  ChatIntegration?
+  chatIntegrationProviders         ChatIntegrationProvider[]
+  chatIntegrationInstances         ChatIntegrationInstance[]
+  chatIntegrationInstanceProviders ChatIntegrationInstanceProvider[]
+
+  @@index([createdAt])
+  @@index([type])
+  @@index([status])
+  @@index([isStandalone])
+  @@index([adapterGlobalOid])
+  @@index([integrationOid, type])
+  @@index([projectOid])
+  @@index([instanceOid])
+}
+
+enum AdapterIntegrationProviderStatus {
+  active
+  archived
+  deleted
+}
+
+model AdapterIntegrationProvider {
+  oid BigInt @id
+  id  String @unique
+
+  status AdapterIntegrationProviderStatus
+
+  adapterIntegrationOid BigInt
+  adapterIntegration    AdapterIntegration @relation(fields: [adapterIntegrationOid], references: [oid], onDelete: Cascade)
+
+  integrationOid BigInt
+  integration    Integration @relation(fields: [integrationOid], references: [oid], onDelete: Cascade)
+
+  integrationProviderOid BigInt
+  integrationProvider    IntegrationProvider @relation(fields: [integrationProviderOid], references: [oid], onDelete: Cascade)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  instanceProviders AdapterIntegrationInstanceProvider[]
+
+  chatIntegrationProviders         ChatIntegrationProvider[]
+  chatIntegrationInstanceProviders ChatIntegrationInstanceProvider[]
+
+  @@unique([adapterIntegrationOid, integrationProviderOid])
+  @@index([createdAt])
+  @@index([status])
+  @@index([adapterIntegrationOid, status])
+  @@index([projectOid])
+  @@index([instanceOid])
+}

--- a/src/metorial/subspace/db/prisma/schema/chat/instance.prisma
+++ b/src/metorial/subspace/db/prisma/schema/chat/instance.prisma
@@ -1,0 +1,125 @@
+enum ChatIntegrationInstanceStatus {
+  draft
+  active
+  archived
+  deleted
+}
+
+model ChatIntegrationInstance {
+  oid BigInt @id
+  id  String @unique
+
+  status          ChatIntegrationInstanceStatus
+  isParentDeleted Boolean                       @default(false)
+  archivedAt      DateTime?
+
+  name            String
+  description     String?
+  metadata        Json?
+  privateMetadata Json?
+
+  chatIntegrationOid BigInt
+  chatIntegration    ChatIntegration @relation(fields: [chatIntegrationOid], references: [oid], onDelete: Cascade)
+
+  adapterIntegrationInstanceOid BigInt                     @unique
+  adapterIntegrationInstance    AdapterIntegrationInstance @relation(fields: [adapterIntegrationInstanceOid], references: [oid], onDelete: Cascade)
+
+  adapterIntegrationOid BigInt
+  adapterIntegration    AdapterIntegration @relation(fields: [adapterIntegrationOid], references: [oid], onDelete: Cascade)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  providers ChatIntegrationInstanceProvider[]
+
+  @@index([tenantOid, solutionOid, environmentOid, status])
+  @@index([chatIntegrationOid, status])
+  @@index([adapterIntegrationOid, status])
+  @@index([status, archivedAt])
+  @@index([projectOid])
+  @@index([instanceOid])
+}
+
+enum ChatIntegrationInstanceProviderStatus {
+  active
+  archived
+  deleted
+}
+
+model ChatIntegrationInstanceProvider {
+  oid BigInt @id
+  id  String @unique
+
+  status          ChatIntegrationInstanceProviderStatus
+  isParentDeleted Boolean                               @default(false)
+  archivedAt      DateTime?
+
+  name            String
+  description     String?
+  metadata        Json?
+  privateMetadata Json?
+
+  chatIntegrationInstanceOid BigInt
+  chatIntegrationInstance    ChatIntegrationInstance @relation(fields: [chatIntegrationInstanceOid], references: [oid], onDelete: Cascade)
+
+  chatIntegrationProviderOid BigInt
+  chatIntegrationProvider    ChatIntegrationProvider @relation(fields: [chatIntegrationProviderOid], references: [oid], onDelete: Cascade)
+
+  chatIntegrationOid BigInt
+  chatIntegration    ChatIntegration @relation(fields: [chatIntegrationOid], references: [oid], onDelete: Cascade)
+
+  adapterIntegrationInstanceProviderOid BigInt                             @unique
+  adapterIntegrationInstanceProvider    AdapterIntegrationInstanceProvider @relation(fields: [adapterIntegrationInstanceProviderOid], references: [oid], onDelete: Cascade, map: "ciip_aiip_fkey")
+
+  adapterIntegrationInstanceOid BigInt
+  adapterIntegrationInstance    AdapterIntegrationInstance @relation(fields: [adapterIntegrationInstanceOid], references: [oid], onDelete: Cascade, map: "ciip_aii_fkey")
+
+  adapterIntegrationProviderOid BigInt
+  adapterIntegrationProvider    AdapterIntegrationProvider @relation(fields: [adapterIntegrationProviderOid], references: [oid], onDelete: Cascade, map: "ciip_aip_fkey")
+
+  adapterIntegrationOid BigInt
+  adapterIntegration    AdapterIntegration @relation(fields: [adapterIntegrationOid], references: [oid], onDelete: Cascade, map: "ciip_ain_fkey")
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([chatIntegrationInstanceOid, chatIntegrationProviderOid], map: "ciip_instance_provider_key")
+  @@index([tenantOid, solutionOid, environmentOid, status])
+  @@index([chatIntegrationInstanceOid, status], map: "ciip_cii_status_idx")
+  @@index([chatIntegrationProviderOid, status], map: "ciip_cip_status_idx")
+  @@index([adapterIntegrationInstanceProviderOid, status], map: "ciip_aiip_status_idx")
+  @@index([adapterIntegrationProviderOid, status], map: "ciip_aip_status_idx")
+  @@index([status, archivedAt])
+  @@index([projectOid])
+  @@index([instanceOid])
+}

--- a/src/metorial/subspace/db/prisma/schema/chat/integration.prisma
+++ b/src/metorial/subspace/db/prisma/schema/chat/integration.prisma
@@ -1,0 +1,105 @@
+enum ChatIntegrationStatus {
+  active
+  archived
+  deleted
+}
+
+model ChatIntegration {
+  oid BigInt @id
+  id  String @unique
+
+  status     ChatIntegrationStatus
+  archivedAt DateTime?
+
+  slug            String  @unique
+  name            String
+  description     String?
+  metadata        Json?
+  privateMetadata Json?
+
+  adapterIntegrationOid BigInt             @unique
+  adapterIntegration    AdapterIntegration @relation(fields: [adapterIntegrationOid], references: [oid], onDelete: Cascade)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  providers         ChatIntegrationProvider[]
+  instances         ChatIntegrationInstance[]
+  instanceProviders ChatIntegrationInstanceProvider[]
+
+  @@index([createdAt])
+  @@index([updatedAt])
+  @@index([status])
+  @@index([projectOid])
+  @@index([instanceOid])
+}
+
+enum ChatIntegrationProviderStatus {
+  active
+  archived
+  deleted
+}
+
+model ChatIntegrationProvider {
+  oid BigInt @id
+  id  String @unique
+
+  status     ChatIntegrationProviderStatus
+  archivedAt DateTime?
+
+  name        String
+  description String?
+  metadata    Json?
+
+  chatIntegrationOid BigInt
+  chatIntegration    ChatIntegration @relation(fields: [chatIntegrationOid], references: [oid], onDelete: Cascade)
+
+  adapterIntegrationOid BigInt
+  adapterIntegration    AdapterIntegration @relation(fields: [adapterIntegrationOid], references: [oid], onDelete: Cascade)
+
+  adapterIntegrationProviderOid BigInt                     @unique
+  adapterIntegrationProvider    AdapterIntegrationProvider @relation(fields: [adapterIntegrationProviderOid], references: [oid], onDelete: Cascade)
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid])
+
+  projectOid BigInt
+  project    Project @relation(fields: [projectOid], references: [oid])
+
+  environmentOid BigInt
+  environment    Environment @relation(fields: [environmentOid], references: [oid], onDelete: Cascade)
+
+  instanceOid BigInt
+  instance    Instance @relation(fields: [instanceOid], references: [oid])
+
+  solutionOid Int
+  solution    Solution @relation(fields: [solutionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  instanceProviders ChatIntegrationInstanceProvider[]
+
+  @@index([createdAt])
+  @@index([updatedAt])
+  @@index([status])
+  @@index([chatIntegrationOid, status])
+  @@index([adapterIntegrationOid, status])
+  @@index([projectOid])
+  @@index([instanceOid])
+}

--- a/src/metorial/subspace/db/prisma/schema/intergration/instance.prisma
+++ b/src/metorial/subspace/db/prisma/schema/intergration/instance.prisma
@@ -15,6 +15,7 @@ model IntegrationInstance {
   archivedAt      DateTime?
 
   isMagicMcpBacking Boolean @default(false)
+  isAdapterBacking  Boolean @default(false)
 
   name            String
   description     String?
@@ -59,7 +60,9 @@ model IntegrationInstance {
   sessionTemplates                  SessionTemplate[]
   integrationInstanceGroupSources   IntegrationInstanceGroupSource[]
   integrationInstanceGroupProviders IntegrationInstanceGroupProvider[]
-  magicMcpServerBackings            MagicMcpServerBacking[]
+  magicMcpServerBackings               MagicMcpServerBacking[]
+  adapterIntegrationInstances          AdapterIntegrationInstance[]
+  adapterIntegrationInstanceProviders  AdapterIntegrationInstanceProvider[]
 
   @@index([tenantOid, solutionOid, environmentOid, status, isHiddenDraft])
   @@index([integrationOid, status])
@@ -127,7 +130,8 @@ model IntegrationInstanceProvider {
   sessionTemplateProviders            SessionTemplateProvider[]
   integrationInstanceGroupProviders   IntegrationInstanceGroupProvider[]
   integrationSetupSessionProviders    IntegrationSetupSessionProvider[]
-  magicMcpServerProviders             MagicMcpServerProvider[]
+  magicMcpServerProviders              MagicMcpServerProvider[]
+  adapterIntegrationInstanceProviders  AdapterIntegrationInstanceProvider[]
 
   @@unique([integrationInstanceOid, integrationProviderOid])
   @@index([tenantOid, solutionOid, environmentOid, status])

--- a/src/metorial/subspace/db/prisma/schema/intergration/integration.prisma
+++ b/src/metorial/subspace/db/prisma/schema/intergration/integration.prisma
@@ -12,6 +12,7 @@ model Integration {
   archivedAt DateTime?
 
   isMagicMcpBacking Boolean @default(false)
+  isAdapterBacking  Boolean @default(false)
 
   slug            String  @unique
   name            String
@@ -57,8 +58,12 @@ model Integration {
   providerTemplateBacking           ProviderTemplateBacking?
   ownerMagicMcpServerBackings       MagicMcpServerBacking[]            @relation("MagicMcpServerOwnerIntegration")
   magicMcpServerBacking             MagicMcpServerBacking?             @relation("MagicMcpServerBackingIntegration")
-  skillIntegrations                 SkillIntegration[]
-  skillTemplateItems                SkillTemplateItem[]
+  skillIntegrations                    SkillIntegration[]
+  skillTemplateItems                   SkillTemplateItem[]
+  adapterIntegrations                  AdapterIntegration[]
+  adapterIntegrationProviders          AdapterIntegrationProvider[]
+  adapterIntegrationInstances          AdapterIntegrationInstance[]
+  adapterIntegrationInstanceProviders  AdapterIntegrationInstanceProvider[]
 
   @@index([createdAt])
   @@index([updatedAt])
@@ -120,7 +125,9 @@ model IntegrationProvider {
   integrationInstanceProviders      IntegrationInstanceProvider[]
   integrationInstanceGroupProviders IntegrationInstanceGroupProvider[]
   integrationSetupSessionProviders  IntegrationSetupSessionProvider[]
-  magicMcpServerProviders           MagicMcpServerProvider[]
+  magicMcpServerProviders              MagicMcpServerProvider[]
+  adapterIntegrationProviders          AdapterIntegrationProvider[]
+  adapterIntegrationInstanceProviders  AdapterIntegrationInstanceProvider[]
 
   @@unique([integrationOid, providerOid])
   @@index([createdAt])

--- a/src/metorial/subspace/db/prisma/schema/provider/adapter.prisma
+++ b/src/metorial/subspace/db/prisma/schema/provider/adapter.prisma
@@ -9,6 +9,7 @@ model ProviderAdapterGlobal {
   updatedAt DateTime @default(now()) @updatedAt
 
   providerAdapters          ProviderAdapter[]
+  adapterIntegrations       AdapterIntegration[]
   sessions                  Session[]
   sessionConnections        SessionConnection[]
   ephemeralManagedSessions  EphemeralManagedSession[]

--- a/src/metorial/subspace/db/prisma/schema/solution.prisma
+++ b/src/metorial/subspace/db/prisma/schema/solution.prisma
@@ -72,4 +72,12 @@ model Solution {
   protoGuardAlerts                         ProtoGuardAlert[]
   monitors                                 Monitor[]
   monitorAlerts                            MonitorAlert[]
+  adapterIntegrations                      AdapterIntegration[]
+  adapterIntegrationProviders              AdapterIntegrationProvider[]
+  adapterIntegrationInstances              AdapterIntegrationInstance[]
+  adapterIntegrationInstanceProviders      AdapterIntegrationInstanceProvider[]
+  chatIntegrations                         ChatIntegration[]
+  chatIntegrationProviders                 ChatIntegrationProvider[]
+  chatIntegrationInstances                 ChatIntegrationInstance[]
+  chatIntegrationInstanceProviders         ChatIntegrationInstanceProvider[]
 }

--- a/src/metorial/subspace/db/prisma/schema/tenant/instance.prisma
+++ b/src/metorial/subspace/db/prisma/schema/tenant/instance.prisma
@@ -101,4 +101,12 @@ model Instance {
   slateInstanceConfigurations              SlateInstanceConfiguration[]
   toolCalls                                ToolCall[]
   upcomingCustomProviders                  UpcomingCustomProvider[]
+  adapterIntegrations                      AdapterIntegration[]
+  adapterIntegrationProviders              AdapterIntegrationProvider[]
+  adapterIntegrationInstances              AdapterIntegrationInstance[]
+  adapterIntegrationInstanceProviders      AdapterIntegrationInstanceProvider[]
+  chatIntegrations                         ChatIntegration[]
+  chatIntegrationProviders                 ChatIntegrationProvider[]
+  chatIntegrationInstances                 ChatIntegrationInstance[]
+  chatIntegrationInstanceProviders         ChatIntegrationInstanceProvider[]
 }

--- a/src/metorial/subspace/db/prisma/schema/tenant/legacy.prisma
+++ b/src/metorial/subspace/db/prisma/schema/tenant/legacy.prisma
@@ -140,6 +140,14 @@ model Tenant {
   monitors                                 Monitor[]
   monitorAlerts                            MonitorAlert[]
   projects                                 Project[]
+  adapterIntegrations                      AdapterIntegration[]
+  adapterIntegrationProviders              AdapterIntegrationProvider[]
+  adapterIntegrationInstances              AdapterIntegrationInstance[]
+  adapterIntegrationInstanceProviders      AdapterIntegrationInstanceProvider[]
+  chatIntegrations                         ChatIntegration[]
+  chatIntegrationProviders                 ChatIntegrationProvider[]
+  chatIntegrationInstances                 ChatIntegrationInstance[]
+  chatIntegrationInstanceProviders         ChatIntegrationInstanceProvider[]
 
   @@index([retiredAt])
 }
@@ -240,6 +248,14 @@ model Environment {
   monitors                                 Monitor[]
   monitorAlerts                            MonitorAlert[]
   instances                                Instance[]
+  adapterIntegrations                      AdapterIntegration[]
+  adapterIntegrationProviders              AdapterIntegrationProvider[]
+  adapterIntegrationInstances              AdapterIntegrationInstance[]
+  adapterIntegrationInstanceProviders      AdapterIntegrationInstanceProvider[]
+  chatIntegrations                         ChatIntegration[]
+  chatIntegrationProviders                 ChatIntegrationProvider[]
+  chatIntegrationInstances                 ChatIntegrationInstance[]
+  chatIntegrationInstanceProviders         ChatIntegrationInstanceProvider[]
 
   @@index([projectOid])
 }

--- a/src/metorial/subspace/db/prisma/schema/tenant/project.prisma
+++ b/src/metorial/subspace/db/prisma/schema/tenant/project.prisma
@@ -118,4 +118,12 @@ model Project {
   tenantOAuthCallbackUrls                  TenantOAuthCallbackUrl[]
   toolCalls                                ToolCall[]
   upcomingCustomProviders                  UpcomingCustomProvider[]
+  adapterIntegrations                      AdapterIntegration[]
+  adapterIntegrationProviders              AdapterIntegrationProvider[]
+  adapterIntegrationInstances              AdapterIntegrationInstance[]
+  adapterIntegrationInstanceProviders      AdapterIntegrationInstanceProvider[]
+  chatIntegrations                         ChatIntegration[]
+  chatIntegrationProviders                 ChatIntegrationProvider[]
+  chatIntegrationInstances                 ChatIntegrationInstance[]
+  chatIntegrationInstanceProviders         ChatIntegrationInstanceProvider[]
 }

--- a/src/metorial/subspace/db/src/id.ts
+++ b/src/metorial/subspace/db/src/id.ts
@@ -182,6 +182,16 @@ export let ID = createIdGenerator({
   integrationSetupSessionStep: idType.sorted('isst'),
   integrationSetupSessionEvent: idType.sorted('ise'),
 
+  adapterIntegration: idType.sorted('ain'),
+  adapterIntegrationProvider: idType.sorted('aip'),
+  adapterIntegrationInstance: idType.sorted('aii'),
+  adapterIntegrationInstanceProvider: idType.sorted('aiip'),
+
+  chatIntegration: idType.sorted('cin'),
+  chatIntegrationProvider: idType.sorted('cip'),
+  chatIntegrationInstance: idType.sorted('cii'),
+  chatIntegrationInstanceProvider: idType.sorted('ciip'),
+
   skillEntity: idType.sorted('ske'),
   skill: idType.sorted('skl'),
   skillFork: idType.sorted('skf'),

--- a/src/metorial/subspace/modules/chat/package.json
+++ b/src/metorial/subspace/modules/chat/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@metorial-subspace/module-chat",
+  "version": "1.0.0",
+  "author": "Tobias Herber",
+  "license": "FSL-1.1",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "lint": "prettier src/**/*.ts --check"
+  },
+  "dependencies": {
+    "@lowerdeck/cron": "workspace:2.0.0",
+    "@lowerdeck/env": "workspace:2.0.0",
+    "@lowerdeck/error": "workspace:2.0.0",
+    "@lowerdeck/id": "workspace:2.0.0",
+    "@lowerdeck/pagination": "workspace:2.0.0",
+    "@lowerdeck/queue": "workspace:2.0.0",
+    "@lowerdeck/service": "workspace:2.0.0",
+    "@lowerdeck/slugify": "workspace:2.0.0",
+    "@lowerdeck/validation": "workspace:2.0.0",
+    "@metorial-subspace/db": "^1.0.0",
+    "@metorial-subspace/list-utils": "^1.0.0",
+    "@metorial-subspace/module-integration": "^1.0.0",
+    "@metorial-subspace/module-search": "^1.0.0",
+    "@metorial-subspace/module-tenant": "^1.0.0",
+    "date-fns": "^4.1.0"
+  },
+  "devDependencies": {
+    "@metorial-subspace/tsconfig": "^1.0.0",
+    "typescript": "5.8.2",
+    "vitest": "^3.1.2"
+  }
+}

--- a/src/metorial/subspace/modules/chat/src/env.ts
+++ b/src/metorial/subspace/modules/chat/src/env.ts
@@ -1,0 +1,8 @@
+import { createValidatedEnv } from '@lowerdeck/env';
+import { v } from '@lowerdeck/validation';
+
+export let env = createValidatedEnv({
+  service: {
+    REDIS_URL: v.string()
+  }
+});

--- a/src/metorial/subspace/modules/chat/src/index.ts
+++ b/src/metorial/subspace/modules/chat/src/index.ts
@@ -1,0 +1,2 @@
+export * from './services';
+import './listener';

--- a/src/metorial/subspace/modules/chat/src/lib/project.ts
+++ b/src/metorial/subspace/modules/chat/src/lib/project.ts
@@ -1,0 +1,340 @@
+import { generatePlainId } from '@lowerdeck/id';
+import { slugify } from '@lowerdeck/slugify';
+import {
+  type AdapterIntegration,
+  type AdapterIntegrationInstance,
+  type AdapterIntegrationInstanceProvider,
+  type AdapterIntegrationProvider,
+  getId,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  isLiveAdapterInstanceStatus,
+  isLiveAdapterStatus
+} from '@metorial-subspace/module-integration';
+import {
+  enqueueChatIntegrationArchived,
+  enqueueChatIntegrationCreated,
+  enqueueChatIntegrationInstanceArchived,
+  enqueueChatIntegrationInstanceCreated,
+  enqueueChatIntegrationInstanceUpdated,
+  enqueueChatIntegrationUpdated
+} from '../queues/lifecycle';
+
+let now = () => new Date();
+
+let getSlug = (name: string) =>
+  `${slugify(name)}-${generatePlainId(7).toLowerCase()}`.toLowerCase();
+
+export let archiveChatIntegrationProjection = async (adapterIntegrationOid: bigint) => {
+  return withTransaction(async db => {
+    let archivedAt = now();
+
+    await db.chatIntegrationInstanceProvider.updateMany({
+      where: { adapterIntegrationOid, status: { not: 'deleted' } },
+      data: { status: 'archived', archivedAt, isParentDeleted: true }
+    });
+    await db.chatIntegrationInstance.updateMany({
+      where: { adapterIntegrationOid, status: { not: 'deleted' } },
+      data: { status: 'archived', archivedAt, isParentDeleted: true }
+    });
+    await db.chatIntegrationProvider.updateMany({
+      where: { adapterIntegrationOid, status: { not: 'deleted' } },
+      data: { status: 'archived', archivedAt }
+    });
+    await db.chatIntegration.updateMany({
+      where: { adapterIntegrationOid, status: { not: 'deleted' } },
+      data: { status: 'archived', archivedAt }
+    });
+  });
+};
+
+export let upsertChatIntegrationProjection = async (
+  adapterIntegration: AdapterIntegration,
+  input?: { name?: string; description?: string | null; metadata?: Record<string, any> | null }
+) => {
+  return withTransaction(async db => {
+    if (!isLiveAdapterStatus(adapterIntegration.status)) {
+      await archiveChatIntegrationProjection(adapterIntegration.oid);
+      let archived = await db.chatIntegration.findUnique({
+        where: { adapterIntegrationOid: adapterIntegration.oid }
+      });
+      if (archived) await enqueueChatIntegrationArchived(archived.id);
+      return archived;
+    }
+
+    let existing = await db.chatIntegration.findUnique({
+      where: { adapterIntegrationOid: adapterIntegration.oid }
+    });
+    if (existing) {
+      if (existing.status === 'archived') {
+        let restored = await db.chatIntegration.update({
+          where: { oid: existing.oid },
+          data: {
+            status: 'active',
+            archivedAt: null
+          }
+        });
+        await enqueueChatIntegrationUpdated(restored.id);
+        return restored;
+      }
+      if (existing.status === 'deleted') return existing;
+      await enqueueChatIntegrationUpdated(existing.id);
+      return existing;
+    }
+
+    let integration = await db.integration.findUniqueOrThrow({
+      where: { oid: adapterIntegration.integrationOid }
+    });
+    let name = input?.name?.trim() || integration.name;
+
+    let created = await db.chatIntegration.create({
+      data: {
+        ...getId('chatIntegration'),
+        status: 'active',
+        slug: getSlug(name),
+        name,
+        description: input?.description?.trim() || null,
+        metadata: input?.metadata ?? {},
+        adapterIntegrationOid: adapterIntegration.oid,
+        tenantOid: adapterIntegration.tenantOid,
+        projectOid: adapterIntegration.projectOid,
+        environmentOid: adapterIntegration.environmentOid,
+        instanceOid: adapterIntegration.instanceOid,
+        solutionOid: adapterIntegration.solutionOid
+      }
+    });
+    await enqueueChatIntegrationCreated(created.id);
+    return created;
+  });
+};
+
+export let upsertChatProviderProjection = async (
+  adapterProvider: AdapterIntegrationProvider
+) => {
+  return withTransaction(async db => {
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { adapterIntegrationOid: adapterProvider.adapterIntegrationOid }
+    });
+    if (!chatIntegration) return null;
+
+    let existing = await db.chatIntegrationProvider.findUnique({
+      where: { adapterIntegrationProviderOid: adapterProvider.oid }
+    });
+
+    if (!isLiveAdapterStatus(adapterProvider.status)) {
+      if (!existing || existing.status === 'deleted') return existing;
+      let archived = await db.chatIntegrationProvider.update({
+        where: { oid: existing.oid },
+        data: { status: 'archived', archivedAt: now() }
+      });
+      await enqueueChatIntegrationUpdated(chatIntegration.id);
+      return archived;
+    }
+
+    let integrationProvider = await db.integrationProvider.findUnique({
+      where: { oid: adapterProvider.integrationProviderOid }
+    });
+    let name = existing?.name || integrationProvider?.name || 'Provider';
+
+    if (existing) {
+      if (existing.status === 'deleted') return existing;
+      let updated = await db.chatIntegrationProvider.update({
+        where: { oid: existing.oid },
+        data: { status: 'active', archivedAt: null, name }
+      });
+      await enqueueChatIntegrationUpdated(chatIntegration.id);
+      return updated;
+    }
+
+    let created = await db.chatIntegrationProvider.create({
+      data: {
+        ...getId('chatIntegrationProvider'),
+        status: 'active',
+        name,
+        description: integrationProvider?.description ?? null,
+        metadata: {},
+        chatIntegrationOid: chatIntegration.oid,
+        adapterIntegrationOid: adapterProvider.adapterIntegrationOid,
+        adapterIntegrationProviderOid: adapterProvider.oid,
+        tenantOid: adapterProvider.tenantOid,
+        projectOid: adapterProvider.projectOid,
+        environmentOid: adapterProvider.environmentOid,
+        instanceOid: adapterProvider.instanceOid,
+        solutionOid: adapterProvider.solutionOid
+      }
+    });
+    await enqueueChatIntegrationUpdated(chatIntegration.id);
+    return created;
+  });
+};
+
+export let upsertChatInstanceProjection = async (
+  adapterInstance: AdapterIntegrationInstance,
+  input?: { name?: string; description?: string | null; metadata?: Record<string, any> | null }
+) => {
+  return withTransaction(async db => {
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { adapterIntegrationOid: adapterInstance.adapterIntegrationOid }
+    });
+    if (!chatIntegration) return null;
+
+    let existing = await db.chatIntegrationInstance.findUnique({
+      where: { adapterIntegrationInstanceOid: adapterInstance.oid }
+    });
+
+    if (!isLiveAdapterInstanceStatus(adapterInstance.status)) {
+      if (!existing || existing.status === 'deleted') return existing;
+      let archived = await db.chatIntegrationInstance.update({
+        where: { oid: existing.oid },
+        data: {
+          status: 'archived',
+          archivedAt: now(),
+          isParentDeleted: chatIntegration.status !== 'active'
+        }
+      });
+      await enqueueChatIntegrationInstanceArchived(archived.id);
+      return archived;
+    }
+
+    let integrationInstance = await db.integrationInstance.findUnique({
+      where: { oid: adapterInstance.integrationInstanceOid }
+    });
+    let name = input?.name?.trim() || existing?.name || integrationInstance?.name || 'Instance';
+    let status = adapterInstance.status;
+
+    if (existing) {
+      if (existing.status === 'deleted') return existing;
+      let updated = await db.chatIntegrationInstance.update({
+        where: { oid: existing.oid },
+        data: {
+          status,
+          archivedAt: null,
+          isParentDeleted: false,
+          name
+        }
+      });
+      await enqueueChatIntegrationInstanceUpdated(updated.id);
+      return updated;
+    }
+
+    let created = await db.chatIntegrationInstance.create({
+      data: {
+        ...getId('chatIntegrationInstance'),
+        status,
+        name,
+        description: input?.description?.trim() || integrationInstance?.description || null,
+        metadata: input?.metadata ?? {},
+        chatIntegrationOid: chatIntegration.oid,
+        adapterIntegrationInstanceOid: adapterInstance.oid,
+        adapterIntegrationOid: adapterInstance.adapterIntegrationOid,
+        tenantOid: adapterInstance.tenantOid,
+        projectOid: adapterInstance.projectOid,
+        environmentOid: adapterInstance.environmentOid,
+        instanceOid: adapterInstance.instanceOid,
+        solutionOid: adapterInstance.solutionOid
+      }
+    });
+    await enqueueChatIntegrationInstanceCreated(created.id);
+    return created;
+  });
+};
+
+export let upsertChatInstanceProviderProjection = async (
+  adapterInstanceProvider: AdapterIntegrationInstanceProvider
+) => {
+  return withTransaction(async db => {
+    let chatInstance = await db.chatIntegrationInstance.findUnique({
+      where: {
+        adapterIntegrationInstanceOid: adapterInstanceProvider.adapterIntegrationInstanceOid
+      }
+    });
+    let chatProvider = await db.chatIntegrationProvider.findUnique({
+      where: {
+        adapterIntegrationProviderOid: adapterInstanceProvider.adapterIntegrationProviderOid
+      }
+    });
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { adapterIntegrationOid: adapterInstanceProvider.adapterIntegrationOid }
+    });
+    if (!chatInstance || !chatProvider || !chatIntegration) return null;
+
+    let existing = await db.chatIntegrationInstanceProvider.findUnique({
+      where: {
+        adapterIntegrationInstanceProviderOid: adapterInstanceProvider.oid
+      }
+    });
+
+    if (!isLiveAdapterStatus(adapterInstanceProvider.status)) {
+      if (!existing || existing.status === 'deleted') return existing;
+      let archived = await db.chatIntegrationInstanceProvider.update({
+        where: { oid: existing.oid },
+        data: { status: 'archived', archivedAt: now() }
+      });
+      await enqueueChatIntegrationInstanceUpdated(chatInstance.id);
+      return archived;
+    }
+
+    if (existing) {
+      if (existing.status === 'deleted') return existing;
+      let updated = await db.chatIntegrationInstanceProvider.update({
+        where: { oid: existing.oid },
+        data: { status: 'active', archivedAt: null, isParentDeleted: false }
+      });
+      await enqueueChatIntegrationInstanceUpdated(chatInstance.id);
+      return updated;
+    }
+
+    let created = await db.chatIntegrationInstanceProvider.create({
+      data: {
+        ...getId('chatIntegrationInstanceProvider'),
+        status: 'active',
+        name: chatProvider.name,
+        chatIntegrationInstanceOid: chatInstance.oid,
+        chatIntegrationProviderOid: chatProvider.oid,
+        chatIntegrationOid: chatIntegration.oid,
+        adapterIntegrationInstanceProviderOid: adapterInstanceProvider.oid,
+        adapterIntegrationInstanceOid: adapterInstanceProvider.adapterIntegrationInstanceOid,
+        adapterIntegrationProviderOid: adapterInstanceProvider.adapterIntegrationProviderOid,
+        adapterIntegrationOid: adapterInstanceProvider.adapterIntegrationOid,
+        tenantOid: adapterInstanceProvider.tenantOid,
+        projectOid: adapterInstanceProvider.projectOid,
+        environmentOid: adapterInstanceProvider.environmentOid,
+        instanceOid: adapterInstanceProvider.instanceOid,
+        solutionOid: adapterInstanceProvider.solutionOid
+      }
+    });
+    await enqueueChatIntegrationInstanceUpdated(chatInstance.id);
+    return created;
+  });
+};
+
+export let projectChatFromAdapterIntegration = async (
+  adapterIntegration: AdapterIntegration
+) => {
+  await upsertChatIntegrationProjection(adapterIntegration);
+
+  await withTransaction(async db => {
+    let providers = await db.adapterIntegrationProvider.findMany({
+      where: { adapterIntegrationOid: adapterIntegration.oid }
+    });
+    for (let provider of providers) {
+      await upsertChatProviderProjection(provider);
+    }
+
+    let instances = await db.adapterIntegrationInstance.findMany({
+      where: { adapterIntegrationOid: adapterIntegration.oid }
+    });
+    for (let instance of instances) {
+      await upsertChatInstanceProjection(instance);
+      let instanceProviders = await db.adapterIntegrationInstanceProvider.findMany({
+        where: { adapterIntegrationInstanceOid: instance.oid }
+      });
+      for (let instanceProvider of instanceProviders) {
+        await upsertChatInstanceProviderProjection(instanceProvider);
+      }
+    }
+  });
+};
+
+export { getSlug };

--- a/src/metorial/subspace/modules/chat/src/listener.ts
+++ b/src/metorial/subspace/modules/chat/src/listener.ts
@@ -1,0 +1,69 @@
+import { withTransaction } from '@metorial-subspace/db';
+import {
+  registerIntegrationTransactionListener,
+  type IntegrationTransactionEvent
+} from '@metorial-subspace/module-integration';
+import { projectChatFromAdapterIntegration } from './lib/project';
+
+let projectAdaptersForIntegration = async (integrationOid: bigint) => {
+  await withTransaction(async db => {
+    let adapters = await db.adapterIntegration.findMany({
+      where: { integrationOid, type: 'chat' }
+    });
+    for (let adapter of adapters) {
+      await projectChatFromAdapterIntegration(adapter);
+    }
+  });
+};
+
+let projectAdaptersForInstance = async (integrationInstanceOid: bigint) => {
+  await withTransaction(async db => {
+    let adapterInstances = await db.adapterIntegrationInstance.findMany({
+      where: { integrationInstanceOid },
+      include: { adapterIntegration: true }
+    });
+    let seen = new Set<bigint>();
+    for (let adapterInstance of adapterInstances) {
+      if (adapterInstance.adapterIntegration.type !== 'chat') continue;
+      if (seen.has(adapterInstance.adapterIntegrationOid)) continue;
+      seen.add(adapterInstance.adapterIntegrationOid);
+      await projectChatFromAdapterIntegration(adapterInstance.adapterIntegration);
+    }
+  });
+};
+
+export let chatIntegrationTransactionListener = {
+  async onEvent(event: IntegrationTransactionEvent) {
+    if (
+      event.kind === 'integration.created' ||
+      event.kind === 'integration.updated' ||
+      event.kind === 'integration.archived' ||
+      event.kind === 'integrationProvider.created' ||
+      event.kind === 'integrationProvider.updated' ||
+      event.kind === 'integrationProvider.archived'
+    ) {
+      await projectAdaptersForIntegration(event.integration.oid);
+      return;
+    }
+
+    if (
+      event.kind === 'integrationInstance.created' ||
+      event.kind === 'integrationInstance.updated' ||
+      event.kind === 'integrationInstance.archived' ||
+      event.kind === 'integrationInstanceProvider.set' ||
+      event.kind === 'integrationInstanceProvider.archived'
+    ) {
+      await projectAdaptersForInstance(event.integrationInstance.oid);
+    }
+  }
+};
+
+let registered = false;
+
+export let registerChatIntegrationListener = () => {
+  if (registered) return;
+  registered = true;
+  registerIntegrationTransactionListener(chatIntegrationTransactionListener);
+};
+
+registerChatIntegrationListener();

--- a/src/metorial/subspace/modules/chat/src/project.test.ts
+++ b/src/metorial/subspace/modules/chat/src/project.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { tx } = vi.hoisted(() => {
+  let createModel = () => ({
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn()
+  });
+
+  return {
+    tx: {
+      adapterIntegration: createModel(),
+      adapterIntegrationProvider: createModel(),
+      adapterIntegrationInstance: createModel(),
+      adapterIntegrationInstanceProvider: createModel(),
+      chatIntegration: createModel(),
+      chatIntegrationProvider: createModel(),
+      chatIntegrationInstance: createModel(),
+      chatIntegrationInstanceProvider: createModel(),
+      integration: createModel(),
+      integrationProvider: createModel(),
+      integrationInstance: createModel()
+    }
+  };
+});
+
+vi.mock('@metorial-subspace/db', () => ({
+  getId: (kind: string) => ({ id: `${kind}_new`, oid: 500n }),
+  withTransaction: async (cb: (db: any) => Promise<any>) => await cb(tx),
+  addAfterTransactionHook: async (hook: () => any) => await hook()
+}));
+
+vi.mock('@metorial-subspace/module-integration', () => ({
+  registerIntegrationTransactionListener: vi.fn(),
+  isLiveAdapterStatus: (status: string) => status === 'active',
+  isLiveAdapterInstanceStatus: (status: string) => status === 'draft' || status === 'active'
+}));
+
+vi.mock('./queues/lifecycle', () => ({
+  enqueueChatIntegrationArchived: vi.fn(),
+  enqueueChatIntegrationCreated: vi.fn(),
+  enqueueChatIntegrationUpdated: vi.fn(),
+  enqueueChatIntegrationInstanceArchived: vi.fn(),
+  enqueueChatIntegrationInstanceCreated: vi.fn(),
+  enqueueChatIntegrationInstanceUpdated: vi.fn()
+}));
+
+import { projectChatFromAdapterIntegration } from './lib/project';
+
+describe('chat projection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tx.chatIntegration.findUnique.mockResolvedValue(null);
+    tx.chatIntegration.create.mockResolvedValue({ oid: 500n });
+    tx.chatIntegration.updateMany.mockResolvedValue({ count: 1 });
+    tx.chatIntegrationProvider.updateMany.mockResolvedValue({ count: 0 });
+    tx.chatIntegrationInstance.updateMany.mockResolvedValue({ count: 0 });
+    tx.chatIntegrationInstanceProvider.updateMany.mockResolvedValue({ count: 0 });
+    tx.adapterIntegrationProvider.findMany.mockResolvedValue([]);
+    tx.adapterIntegrationInstance.findMany.mockResolvedValue([]);
+    tx.integration.findUniqueOrThrow.mockResolvedValue({ name: 'Support' });
+  });
+
+  it('creates a chat integration for a live adapter link', async () => {
+    await projectChatFromAdapterIntegration({
+      oid: 100n,
+      status: 'active',
+      integrationOid: 20n,
+      tenantOid: 1n,
+      projectOid: 11n,
+      environmentOid: 3n,
+      instanceOid: 33n,
+      solutionOid: 2
+    } as any);
+
+    expect(tx.chatIntegration.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'Support',
+          adapterIntegrationOid: 100n
+        })
+      })
+    );
+  });
+
+  it('archives chat rows when the adapter integration is archived', async () => {
+    await projectChatFromAdapterIntegration({
+      oid: 100n,
+      status: 'archived',
+      integrationOid: 20n
+    } as any);
+
+    expect(tx.chatIntegration.updateMany).toHaveBeenCalled();
+    expect(tx.chatIntegration.create).not.toHaveBeenCalled();
+  });
+
+  it('projects draft instance status from the adapter instance', async () => {
+    tx.chatIntegration.findUnique.mockResolvedValue({ oid: 500n, status: 'active' });
+    tx.adapterIntegrationInstance.findMany.mockResolvedValue([
+      {
+        oid: 300n,
+        status: 'draft',
+        adapterIntegrationOid: 100n,
+        integrationInstanceOid: 40n,
+        tenantOid: 1n,
+        projectOid: 11n,
+        environmentOid: 3n,
+        instanceOid: 33n,
+        solutionOid: 2
+      }
+    ]);
+    tx.adapterIntegrationInstanceProvider.findMany.mockResolvedValue([]);
+    tx.chatIntegrationInstance.findUnique.mockResolvedValue(null);
+    tx.integrationInstance.findUnique.mockResolvedValue({
+      name: 'Bot',
+      description: null
+    });
+    tx.chatIntegrationInstance.create.mockResolvedValue({ oid: 700n });
+
+    await projectChatFromAdapterIntegration({
+      oid: 100n,
+      status: 'active',
+      integrationOid: 20n,
+      tenantOid: 1n,
+      projectOid: 11n,
+      environmentOid: 3n,
+      instanceOid: 33n,
+      solutionOid: 2
+    } as any);
+
+    expect(tx.chatIntegrationInstance.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'draft' })
+      })
+    );
+  });
+});

--- a/src/metorial/subspace/modules/chat/src/queues.ts
+++ b/src/metorial/subspace/modules/chat/src/queues.ts
@@ -1,0 +1,11 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import './listener';
+import { deleteQueues } from './queues/delete';
+import { lifecycleQueues } from './queues/lifecycle';
+import { searchQueues } from './queues/search';
+
+export let chatQueueProcessor = combineQueueProcessors([
+  lifecycleQueues,
+  searchQueues,
+  deleteQueues
+]);

--- a/src/metorial/subspace/modules/chat/src/queues/delete/_config.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/delete/_config.ts
@@ -1,0 +1,3 @@
+import { subDays } from 'date-fns';
+
+export let getCutoffDate = () => subDays(new Date(), 14);

--- a/src/metorial/subspace/modules/chat/src/queues/delete/chatIntegration.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/delete/chatIntegration.ts
@@ -1,0 +1,110 @@
+import { createCron } from '@lowerdeck/cron';
+import { createQueue } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { chatIntegrationDeletedQueue } from '../lifecycle/chatIntegration';
+import { getCutoffDate } from './_config';
+
+export let chatIntegrationArchivedCleanupCron = createCron(
+  {
+    name: 'sub/cht/cron/integrationArchivedCleanup',
+    cron: '0 0 * * *',
+    redisUrl: env.service.REDIS_URL
+  },
+  async () => {
+    await chatIntegrationDeleteManyQueue.add({}, { id: 'many' });
+  }
+);
+
+export let chatIntegrationDeleteManyQueue = createQueue<{ cursor?: string }>({
+  name: 'sub/cht/delete/integration/many',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let chatIntegrationDeleteManyQueueProcessor = chatIntegrationDeleteManyQueue.process(
+  async data => {
+    let chatIntegrations = await db.chatIntegration.findMany({
+      where: {
+        status: 'archived',
+        archivedAt: { lt: getCutoffDate() },
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: 100,
+      select: { id: true }
+    });
+    if (chatIntegrations.length === 0) return;
+
+    await chatIntegrationDeleteQueue.addMany(
+      chatIntegrations.map(chatIntegration => ({
+        chatIntegrationId: chatIntegration.id
+      }))
+    );
+
+    let lastChatIntegration = chatIntegrations[chatIntegrations.length - 1];
+    if (!lastChatIntegration) return;
+
+    await chatIntegrationDeleteManyQueue.add({
+      cursor: lastChatIntegration.id
+    });
+  }
+);
+
+export let chatIntegrationDeleteQueue = createQueue<{ chatIntegrationId: string }>({
+  name: 'sub/cht/delete/integration',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let chatIntegrationDeleteQueueProcessor = chatIntegrationDeleteQueue.process(
+  async data => {
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { id: data.chatIntegrationId }
+    });
+    if (!chatIntegration || chatIntegration.status !== 'archived') return;
+
+    await db.chatIntegrationInstanceProvider.updateMany({
+      where: { chatIntegrationOid: chatIntegration.oid, status: { not: 'deleted' } },
+      data: {
+        status: 'deleted',
+        name: '[deleted]',
+        description: null,
+        metadata: {},
+        privateMetadata: {}
+      }
+    });
+
+    await db.chatIntegrationInstance.updateMany({
+      where: { chatIntegrationOid: chatIntegration.oid, status: { not: 'deleted' } },
+      data: {
+        status: 'deleted',
+        name: '[deleted]',
+        description: null,
+        metadata: {},
+        privateMetadata: {}
+      }
+    });
+
+    await db.chatIntegrationProvider.updateMany({
+      where: { chatIntegrationOid: chatIntegration.oid, status: { not: 'deleted' } },
+      data: {
+        status: 'deleted',
+        name: '[deleted]',
+        description: null,
+        metadata: {}
+      }
+    });
+
+    await db.chatIntegration.updateMany({
+      where: { oid: chatIntegration.oid },
+      data: {
+        status: 'deleted',
+        name: '[deleted]',
+        description: null,
+        metadata: {},
+        privateMetadata: {}
+      }
+    });
+
+    await chatIntegrationDeletedQueue.add({ chatIntegrationId: chatIntegration.id });
+  }
+);

--- a/src/metorial/subspace/modules/chat/src/queues/delete/chatIntegrationInstance.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/delete/chatIntegrationInstance.ts
@@ -1,0 +1,94 @@
+import { createCron } from '@lowerdeck/cron';
+import { createQueue } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { chatIntegrationInstanceDeletedQueue } from '../lifecycle/chatIntegration';
+import { getCutoffDate } from './_config';
+
+export let chatIntegrationInstanceArchivedCleanupCron = createCron(
+  {
+    name: 'sub/cht/cron/integrationInstanceArchivedCleanup',
+    cron: '0 0 * * *',
+    redisUrl: env.service.REDIS_URL
+  },
+  async () => {
+    await chatIntegrationInstanceDeleteManyQueue.add({}, { id: 'many' });
+  }
+);
+
+export let chatIntegrationInstanceDeleteManyQueue = createQueue<{ cursor?: string }>({
+  name: 'sub/cht/delete/integrationInstance/many',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let chatIntegrationInstanceDeleteManyQueueProcessor =
+  chatIntegrationInstanceDeleteManyQueue.process(async data => {
+    let instances = await db.chatIntegrationInstance.findMany({
+      where: {
+        status: 'archived',
+        archivedAt: { lt: getCutoffDate() },
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: 100,
+      select: { id: true }
+    });
+    if (instances.length === 0) return;
+
+    await chatIntegrationInstanceDeleteQueue.addMany(
+      instances.map(instance => ({
+        chatIntegrationInstanceId: instance.id
+      }))
+    );
+
+    let lastInstance = instances[instances.length - 1];
+    if (!lastInstance) return;
+
+    await chatIntegrationInstanceDeleteManyQueue.add({
+      cursor: lastInstance.id
+    });
+  });
+
+export let chatIntegrationInstanceDeleteQueue = createQueue<{
+  chatIntegrationInstanceId: string;
+}>({
+  name: 'sub/cht/delete/integrationInstance',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let chatIntegrationInstanceDeleteQueueProcessor =
+  chatIntegrationInstanceDeleteQueue.process(async data => {
+    let chatIntegrationInstance = await db.chatIntegrationInstance.findUnique({
+      where: { id: data.chatIntegrationInstanceId }
+    });
+    if (!chatIntegrationInstance || chatIntegrationInstance.status !== 'archived') return;
+
+    await db.chatIntegrationInstanceProvider.updateMany({
+      where: {
+        chatIntegrationInstanceOid: chatIntegrationInstance.oid,
+        status: { not: 'deleted' }
+      },
+      data: {
+        status: 'deleted',
+        name: '[deleted]',
+        description: null,
+        metadata: {},
+        privateMetadata: {}
+      }
+    });
+
+    await db.chatIntegrationInstance.updateMany({
+      where: { oid: chatIntegrationInstance.oid },
+      data: {
+        status: 'deleted',
+        name: '[deleted]',
+        description: null,
+        metadata: {},
+        privateMetadata: {}
+      }
+    });
+
+    await chatIntegrationInstanceDeletedQueue.add({
+      chatIntegrationInstanceId: chatIntegrationInstance.id
+    });
+  });

--- a/src/metorial/subspace/modules/chat/src/queues/delete/index.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/delete/index.ts
@@ -1,0 +1,20 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import {
+  chatIntegrationArchivedCleanupCron,
+  chatIntegrationDeleteManyQueueProcessor,
+  chatIntegrationDeleteQueueProcessor
+} from './chatIntegration';
+import {
+  chatIntegrationInstanceArchivedCleanupCron,
+  chatIntegrationInstanceDeleteManyQueueProcessor,
+  chatIntegrationInstanceDeleteQueueProcessor
+} from './chatIntegrationInstance';
+
+export let deleteQueues = combineQueueProcessors([
+  chatIntegrationArchivedCleanupCron,
+  chatIntegrationDeleteManyQueueProcessor,
+  chatIntegrationDeleteQueueProcessor,
+  chatIntegrationInstanceArchivedCleanupCron,
+  chatIntegrationInstanceDeleteManyQueueProcessor,
+  chatIntegrationInstanceDeleteQueueProcessor
+]);

--- a/src/metorial/subspace/modules/chat/src/queues/lifecycle/chatIntegration.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/lifecycle/chatIntegration.ts
@@ -1,0 +1,279 @@
+import { createQueue } from '@lowerdeck/queue';
+import { addAfterTransactionHook, db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { indexChatIntegrationQueue } from '../search/chatIntegration';
+import { indexChatIntegrationInstanceQueue } from '../search/chatIntegrationInstance';
+
+export let chatIntegrationCreatedQueue = createQueue<{ chatIntegrationId: string }>({
+  name: 'sub/cht/lc/integration/created',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationCreated = (chatIntegrationId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationCreatedQueue.add({ chatIntegrationId });
+  });
+
+export let chatIntegrationCreatedQueueProcessor = chatIntegrationCreatedQueue.process(
+  async data => {
+    await indexChatIntegrationQueue.add({ chatIntegrationId: data.chatIntegrationId });
+  }
+);
+
+export let chatIntegrationUpdatedQueue = createQueue<{ chatIntegrationId: string }>({
+  name: 'sub/cht/lc/integration/updated',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationUpdated = (chatIntegrationId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationUpdatedQueue.add({ chatIntegrationId });
+  });
+
+export let chatIntegrationUpdatedQueueProcessor = chatIntegrationUpdatedQueue.process(
+  async data => {
+    await indexChatIntegrationQueue.add({ chatIntegrationId: data.chatIntegrationId });
+  }
+);
+
+export let chatIntegrationArchivedQueue = createQueue<{ chatIntegrationId: string }>({
+  name: 'sub/cht/lc/integration/archived',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationArchived = (chatIntegrationId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationArchivedQueue.add({ chatIntegrationId });
+  });
+
+export let chatIntegrationArchivedQueueProcessor = chatIntegrationArchivedQueue.process(
+  async data => {
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { id: data.chatIntegrationId }
+    });
+    if (!chatIntegration || chatIntegration.status !== 'archived') return;
+
+    await indexChatIntegrationQueue.add({ chatIntegrationId: data.chatIntegrationId });
+    await chatIntegrationArchiveInstancesManyQueue.add({
+      chatIntegrationId: data.chatIntegrationId
+    });
+    await chatIntegrationArchiveProvidersManyQueue.add({
+      chatIntegrationId: data.chatIntegrationId
+    });
+  }
+);
+
+export let chatIntegrationArchiveInstancesManyQueue = createQueue<{
+  chatIntegrationId: string;
+  cursor?: string;
+}>({
+  name: 'sub/cht/lc/integration/archiveInstancesMany',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let chatIntegrationArchiveInstancesManyQueueProcessor =
+  chatIntegrationArchiveInstancesManyQueue.process(async data => {
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { id: data.chatIntegrationId }
+    });
+    if (!chatIntegration || chatIntegration.status !== 'archived') return;
+
+    let instances = await db.chatIntegrationInstance.findMany({
+      where: {
+        chatIntegrationOid: chatIntegration.oid,
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: 100,
+      select: { oid: true, id: true }
+    });
+    if (instances.length === 0) return;
+
+    let archivedAt = chatIntegration.archivedAt ?? new Date();
+
+    await db.chatIntegrationInstance.updateMany({
+      where: { oid: { in: instances.map(instance => instance.oid) } },
+      data: { isParentDeleted: true }
+    });
+    await db.chatIntegrationInstance.updateMany({
+      where: {
+        oid: { in: instances.map(instance => instance.oid) },
+        status: { not: 'deleted' }
+      },
+      data: { status: 'archived', archivedAt, isParentDeleted: true }
+    });
+    await db.chatIntegrationInstanceProvider.updateMany({
+      where: {
+        chatIntegrationInstanceOid: { in: instances.map(instance => instance.oid) },
+        status: { not: 'deleted' }
+      },
+      data: { status: 'archived', archivedAt, isParentDeleted: true }
+    });
+
+    await indexChatIntegrationInstanceQueue.addMany(
+      instances.map(instance => ({ chatIntegrationInstanceId: instance.id }))
+    );
+
+    let lastInstance = instances[instances.length - 1];
+    if (!lastInstance) return;
+
+    await chatIntegrationArchiveInstancesManyQueue.add({
+      chatIntegrationId: data.chatIntegrationId,
+      cursor: lastInstance.id
+    });
+  });
+
+export let chatIntegrationArchiveProvidersManyQueue = createQueue<{
+  chatIntegrationId: string;
+  cursor?: string;
+}>({
+  name: 'sub/cht/lc/integration/archiveProvidersMany',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let chatIntegrationArchiveProvidersManyQueueProcessor =
+  chatIntegrationArchiveProvidersManyQueue.process(async data => {
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { id: data.chatIntegrationId }
+    });
+    if (!chatIntegration || chatIntegration.status !== 'archived') return;
+
+    let providers = await db.chatIntegrationProvider.findMany({
+      where: {
+        chatIntegrationOid: chatIntegration.oid,
+        status: 'active',
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: 1000,
+      select: { oid: true, id: true }
+    });
+    if (providers.length === 0) return;
+
+    let archivedAt = chatIntegration.archivedAt ?? new Date();
+
+    await db.chatIntegrationProvider.updateMany({
+      where: { oid: { in: providers.map(provider => provider.oid) } },
+      data: { status: 'archived', archivedAt }
+    });
+
+    await indexChatIntegrationQueue.add({ chatIntegrationId: data.chatIntegrationId });
+
+    let lastProvider = providers[providers.length - 1];
+    if (!lastProvider) return;
+
+    await chatIntegrationArchiveProvidersManyQueue.add({
+      chatIntegrationId: data.chatIntegrationId,
+      cursor: lastProvider.id
+    });
+  });
+
+export let chatIntegrationDeletedQueue = createQueue<{ chatIntegrationId: string }>({
+  name: 'sub/cht/lc/integration/deleted',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationDeleted = (chatIntegrationId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationDeletedQueue.add({ chatIntegrationId });
+  });
+
+export let chatIntegrationDeletedQueueProcessor = chatIntegrationDeletedQueue.process(
+  async data => {
+    await indexChatIntegrationQueue.add({ chatIntegrationId: data.chatIntegrationId });
+  }
+);
+
+export let chatIntegrationInstanceCreatedQueue = createQueue<{
+  chatIntegrationInstanceId: string;
+}>({
+  name: 'sub/cht/lc/integrationInstance/created',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationInstanceCreated = (chatIntegrationInstanceId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationInstanceCreatedQueue.add({ chatIntegrationInstanceId });
+  });
+
+export let chatIntegrationInstanceCreatedQueueProcessor =
+  chatIntegrationInstanceCreatedQueue.process(async data => {
+    await indexChatIntegrationInstanceQueue.add({
+      chatIntegrationInstanceId: data.chatIntegrationInstanceId
+    });
+  });
+
+export let chatIntegrationInstanceUpdatedQueue = createQueue<{
+  chatIntegrationInstanceId: string;
+}>({
+  name: 'sub/cht/lc/integrationInstance/updated',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationInstanceUpdated = (chatIntegrationInstanceId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationInstanceUpdatedQueue.add({ chatIntegrationInstanceId });
+  });
+
+export let chatIntegrationInstanceUpdatedQueueProcessor =
+  chatIntegrationInstanceUpdatedQueue.process(async data => {
+    await indexChatIntegrationInstanceQueue.add({
+      chatIntegrationInstanceId: data.chatIntegrationInstanceId
+    });
+  });
+
+export let chatIntegrationInstanceArchivedQueue = createQueue<{
+  chatIntegrationInstanceId: string;
+}>({
+  name: 'sub/cht/lc/integrationInstance/archived',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationInstanceArchived = (chatIntegrationInstanceId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationInstanceArchivedQueue.add({ chatIntegrationInstanceId });
+  });
+
+export let chatIntegrationInstanceArchivedQueueProcessor =
+  chatIntegrationInstanceArchivedQueue.process(async data => {
+    let chatIntegrationInstance = await db.chatIntegrationInstance.findUnique({
+      where: { id: data.chatIntegrationInstanceId }
+    });
+    if (!chatIntegrationInstance || chatIntegrationInstance.status !== 'archived') return;
+
+    let archivedAt = chatIntegrationInstance.archivedAt ?? new Date();
+
+    await db.chatIntegrationInstanceProvider.updateMany({
+      where: {
+        chatIntegrationInstanceOid: chatIntegrationInstance.oid,
+        status: 'active'
+      },
+      data: {
+        status: 'archived',
+        archivedAt
+      }
+    });
+
+    await indexChatIntegrationInstanceQueue.add({
+      chatIntegrationInstanceId: data.chatIntegrationInstanceId
+    });
+  });
+
+export let chatIntegrationInstanceDeletedQueue = createQueue<{
+  chatIntegrationInstanceId: string;
+}>({
+  name: 'sub/cht/lc/integrationInstance/deleted',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatIntegrationInstanceDeleted = (chatIntegrationInstanceId: string) =>
+  addAfterTransactionHook(async () => {
+    await chatIntegrationInstanceDeletedQueue.add({ chatIntegrationInstanceId });
+  });
+
+export let chatIntegrationInstanceDeletedQueueProcessor =
+  chatIntegrationInstanceDeletedQueue.process(async data => {
+    await indexChatIntegrationInstanceQueue.add({
+      chatIntegrationInstanceId: data.chatIntegrationInstanceId
+    });
+  });

--- a/src/metorial/subspace/modules/chat/src/queues/lifecycle/index.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/lifecycle/index.ts
@@ -1,0 +1,37 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import {
+  chatIntegrationArchiveInstancesManyQueueProcessor,
+  chatIntegrationArchiveProvidersManyQueueProcessor,
+  chatIntegrationArchivedQueueProcessor,
+  chatIntegrationCreatedQueueProcessor,
+  chatIntegrationDeletedQueueProcessor,
+  chatIntegrationInstanceArchivedQueueProcessor,
+  chatIntegrationInstanceCreatedQueueProcessor,
+  chatIntegrationInstanceDeletedQueueProcessor,
+  chatIntegrationInstanceUpdatedQueueProcessor,
+  chatIntegrationUpdatedQueueProcessor
+} from './chatIntegration';
+
+export let lifecycleQueues = combineQueueProcessors([
+  chatIntegrationCreatedQueueProcessor,
+  chatIntegrationUpdatedQueueProcessor,
+  chatIntegrationArchivedQueueProcessor,
+  chatIntegrationArchiveInstancesManyQueueProcessor,
+  chatIntegrationArchiveProvidersManyQueueProcessor,
+  chatIntegrationDeletedQueueProcessor,
+  chatIntegrationInstanceCreatedQueueProcessor,
+  chatIntegrationInstanceUpdatedQueueProcessor,
+  chatIntegrationInstanceArchivedQueueProcessor,
+  chatIntegrationInstanceDeletedQueueProcessor
+]);
+
+export {
+  enqueueChatIntegrationArchived,
+  enqueueChatIntegrationCreated,
+  enqueueChatIntegrationDeleted,
+  enqueueChatIntegrationInstanceArchived,
+  enqueueChatIntegrationInstanceCreated,
+  enqueueChatIntegrationInstanceDeleted,
+  enqueueChatIntegrationInstanceUpdated,
+  enqueueChatIntegrationUpdated
+} from './chatIntegration';

--- a/src/metorial/subspace/modules/chat/src/queues/search/chatIntegration.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/search/chatIntegration.ts
@@ -1,0 +1,52 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import { env } from '../../env';
+
+export let indexChatIntegrationQueue = createQueue<{ chatIntegrationId: string }>({
+  name: 'sub/cht/sidx/integration',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let indexChatIntegrationQueueProcessor = indexChatIntegrationQueue.process(
+  async data => {
+    let chatIntegration = await db.chatIntegration.findUnique({
+      where: { id: data.chatIntegrationId },
+      include: {
+        tenant: true,
+        providers: {
+          where: { status: 'active' }
+        }
+      }
+    });
+    if (!chatIntegration) throw new QueueRetryError();
+
+    if (chatIntegration.status !== 'active' || (!chatIntegration.name && !chatIntegration.description)) {
+      await voyager.record.delete({
+        sourceId: (await voyagerSource).id,
+        indexId: voyagerIndex.chatIntegration.id,
+        documentIds: [chatIntegration.id]
+      });
+      return;
+    }
+
+    await voyager.record.index({
+      sourceId: (await voyagerSource).id,
+      indexId: voyagerIndex.chatIntegration.id,
+
+      documentId: chatIntegration.id,
+      tenantIds: [chatIntegration.tenant.id],
+
+      fields: {
+        chatIntegrationId: chatIntegration.id
+      },
+
+      body: {
+        name: chatIntegration.name,
+        description: chatIntegration.description,
+        slug: chatIntegration.slug,
+        providerNames: chatIntegration.providers.map(provider => provider.name)
+      }
+    });
+  }
+);

--- a/src/metorial/subspace/modules/chat/src/queues/search/chatIntegrationInstance.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/search/chatIntegrationInstance.ts
@@ -1,0 +1,62 @@
+import { createQueue, QueueRetryError } from '@lowerdeck/queue';
+import { db } from '@metorial-subspace/db';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import { env } from '../../env';
+
+export let indexChatIntegrationInstanceQueue = createQueue<{
+  chatIntegrationInstanceId: string;
+}>({
+  name: 'sub/cht/sidx/integrationInstance',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let indexChatIntegrationInstanceQueueProcessor =
+  indexChatIntegrationInstanceQueue.process(async data => {
+    let chatIntegrationInstance = await db.chatIntegrationInstance.findUnique({
+      where: { id: data.chatIntegrationInstanceId },
+      include: {
+        tenant: true,
+        chatIntegration: true,
+        providers: {
+          where: { status: 'active', isParentDeleted: false },
+          include: { chatIntegrationProvider: true }
+        }
+      }
+    });
+    if (!chatIntegrationInstance) throw new QueueRetryError();
+
+    if (
+      chatIntegrationInstance.status !== 'active' ||
+      chatIntegrationInstance.isParentDeleted ||
+      (!chatIntegrationInstance.name && !chatIntegrationInstance.description)
+    ) {
+      await voyager.record.delete({
+        sourceId: (await voyagerSource).id,
+        indexId: voyagerIndex.chatIntegrationInstance.id,
+        documentIds: [chatIntegrationInstance.id]
+      });
+      return;
+    }
+
+    await voyager.record.index({
+      sourceId: (await voyagerSource).id,
+      indexId: voyagerIndex.chatIntegrationInstance.id,
+
+      documentId: chatIntegrationInstance.id,
+      tenantIds: [chatIntegrationInstance.tenant.id],
+
+      fields: {
+        chatIntegrationInstanceId: chatIntegrationInstance.id,
+        chatIntegrationId: chatIntegrationInstance.chatIntegration.id
+      },
+      body: {
+        name: chatIntegrationInstance.name,
+        description: chatIntegrationInstance.description,
+        chatIntegrationName: chatIntegrationInstance.chatIntegration.name,
+        chatIntegrationSlug: chatIntegrationInstance.chatIntegration.slug,
+        providerNames: chatIntegrationInstance.providers.map(
+          provider => provider.chatIntegrationProvider.name
+        )
+      }
+    });
+  });

--- a/src/metorial/subspace/modules/chat/src/queues/search/index.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/search/index.ts
@@ -1,0 +1,8 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import { indexChatIntegrationQueueProcessor } from './chatIntegration';
+import { indexChatIntegrationInstanceQueueProcessor } from './chatIntegrationInstance';
+
+export let searchQueues = combineQueueProcessors([
+  indexChatIntegrationQueueProcessor,
+  indexChatIntegrationInstanceQueueProcessor
+]);

--- a/src/metorial/subspace/modules/chat/src/services/chatIntegration.test.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatIntegration.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { tx, ensureAdapterIntegration, applyAdapterIntegrationPresentation } = vi.hoisted(
+  () => {
+    let createModel = () => ({
+      findUnique: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn()
+    });
+
+    return {
+      tx: {
+        chatIntegration: createModel(),
+        adapterIntegration: createModel()
+      },
+      ensureAdapterIntegration: vi.fn(),
+      applyAdapterIntegrationPresentation: vi.fn()
+    };
+  }
+);
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_name, factory) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('@lowerdeck/pagination', () => ({
+  Paginator: { create: vi.fn() }
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: tx,
+  getId: (kind: string) => ({ id: `${kind}_new`, oid: 600n }),
+  withTransaction: async (cb: (db: any) => Promise<any>) => await cb(tx),
+  addAfterTransactionHook: async (hook: () => any) => await hook()
+}));
+
+vi.mock('@metorial-subspace/list-utils', () => ({
+  checkDeletedEdit: vi.fn(),
+  normalizeDateFilter: vi.fn(),
+  normalizeStatusForGet: vi.fn(() => ({ noParent: {} })),
+  normalizeStatusForList: vi.fn(() => ({ noParent: {} }))
+}));
+
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  checkTenant: vi.fn(),
+  getMetorialSolution: vi.fn(async () => ({ oid: 2 })),
+  resolveMetorialFacing: vi.fn()
+}));
+
+vi.mock('@metorial-subspace/module-integration', () => ({
+  ensureAdapterIntegration,
+  applyAdapterIntegrationPresentation,
+  removeAdapterIntegration: vi.fn(),
+  resolveAdapterGlobal: vi.fn(async () => ({ oid: 9n, identifier: 'chat' }))
+}));
+
+vi.mock('@metorial-subspace/module-search', () => ({
+  voyager: { record: { search: vi.fn() } },
+  voyagerIndex: { chatIntegration: { id: 'idx' }, chatIntegrationInstance: { id: 'idx2' } },
+  voyagerSource: Promise.resolve({ id: 'src' })
+}));
+
+vi.mock('../queues/lifecycle', () => ({
+  enqueueChatIntegrationArchived: vi.fn(),
+  enqueueChatIntegrationCreated: vi.fn(),
+  enqueueChatIntegrationUpdated: vi.fn(),
+  enqueueChatIntegrationInstanceArchived: vi.fn(),
+  enqueueChatIntegrationInstanceCreated: vi.fn(),
+  enqueueChatIntegrationInstanceUpdated: vi.fn()
+}));
+
+vi.mock('../lib/project', () => ({
+  archiveChatIntegrationProjection: vi.fn(),
+  getSlug: (name: string) => `slug-${name}`,
+  projectChatFromAdapterIntegration: vi.fn()
+}));
+
+import { chatIntegrationService } from './chatIntegration';
+
+let tenant = { oid: 1n, projectOid: 11n } as any;
+let environment = { oid: 3n, instanceOid: 33n } as any;
+
+describe('chatIntegrationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ensureAdapterIntegration.mockResolvedValue({
+      oid: 100n,
+      tenantOid: 1n,
+      projectOid: 11n,
+      environmentOid: 3n,
+      instanceOid: 33n,
+      solutionOid: 2,
+      integration: { name: 'Support', description: '', metadata: {} }
+    });
+    tx.chatIntegration.findUnique.mockResolvedValue(null);
+    tx.chatIntegration.create.mockResolvedValue({
+      oid: 600n,
+      name: 'Support',
+      adapterIntegration: { isStandalone: true }
+    });
+    tx.chatIntegration.update.mockResolvedValue({
+      oid: 600n,
+      name: 'Renamed',
+      adapterIntegration: { isStandalone: true, oid: 100n }
+    });
+  });
+
+  it('creates a standalone chat integration through adapter primitives', async () => {
+    await chatIntegrationService.createChatIntegrationInternal({
+      tenant,
+      environment,
+      mode: 'standalone',
+      input: { name: 'Support', description: 'hello', metadata: { a: 1 } }
+    });
+
+    expect(ensureAdapterIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isStandalone: true,
+        type: 'chat',
+        presentation: { name: 'Support' }
+      })
+    );
+    expect(tx.chatIntegration.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'Support',
+          description: 'hello'
+        })
+      })
+    );
+  });
+
+  it('copies standalone name updates through applyAdapterIntegrationPresentation', async () => {
+    await chatIntegrationService.updateChatIntegrationInternal({
+      tenant,
+      environment,
+      chatIntegration: {
+        oid: 600n,
+        name: 'Support',
+        description: 'hello',
+        metadata: {},
+        privateMetadata: {},
+        tenantOid: 1n,
+        adapterIntegrationOid: 100n
+      } as any,
+      input: { name: 'Renamed' }
+    });
+
+    expect(applyAdapterIntegrationPresentation).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Renamed' })
+    );
+  });
+});

--- a/src/metorial/subspace/modules/chat/src/services/chatIntegration.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatIntegration.ts
@@ -1,0 +1,386 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import {
+  type ChatIntegration,
+  type ChatIntegrationStatus,
+  db,
+  type Environment,
+  getId,
+  type Integration,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  checkDeletedEdit,
+  type DateFilter,
+  normalizeDateFilter,
+  normalizeStatusForGet,
+  normalizeStatusForList
+} from '@metorial-subspace/list-utils';
+import {
+  applyAdapterIntegrationPresentation,
+  ensureAdapterIntegration,
+  removeAdapterIntegration,
+  resolveAdapterGlobal
+} from '@metorial-subspace/module-integration';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import {
+  checkTenant,
+  getMetorialSolution,
+  type MetorialFacing,
+  resolveMetorialFacing
+} from '@metorial-subspace/module-tenant';
+import {
+  archiveChatIntegrationProjection,
+  getSlug,
+  projectChatFromAdapterIntegration
+} from '../lib/project';
+import {
+  enqueueChatIntegrationArchived,
+  enqueueChatIntegrationCreated,
+  enqueueChatIntegrationUpdated
+} from '../queues/lifecycle';
+
+export let chatIntegrationInclude = {
+  adapterIntegration: true
+} as const;
+
+export type ListChatIntegrationsParams = {
+  search?: string;
+  status?: ChatIntegrationStatus[];
+  allowDeleted?: boolean;
+  ids?: string[];
+  createdAt?: DateFilter;
+  updatedAt?: DateFilter;
+};
+
+export type GetChatIntegrationByIdParams = {
+  chatIntegrationId: string;
+  allowDeleted?: boolean;
+};
+
+export type CreateChatIntegrationParams =
+  | {
+      mode: 'standalone';
+      input: {
+        name: string;
+        description?: string;
+        metadata?: Record<string, any>;
+        privateMetadata?: Record<string, any>;
+      };
+    }
+  | {
+      mode: 'existing';
+      integration: Integration;
+      input?: {
+        name?: string;
+        description?: string;
+        metadata?: Record<string, any>;
+        privateMetadata?: Record<string, any>;
+      };
+    };
+
+export type UpdateChatIntegrationParams = {
+  chatIntegration: ChatIntegration;
+  input: {
+    name?: string;
+    description?: string | null;
+    metadata?: Record<string, any> | null;
+    privateMetadata?: Record<string, any> | null;
+  };
+};
+
+export type ArchiveChatIntegrationParams = {
+  chatIntegration: ChatIntegration;
+};
+
+class chatIntegrationServiceImpl {
+  async listChatIntegrations(d: MetorialFacing<ListChatIntegrationsParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.listChatIntegrationsInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async listChatIntegrationsInternal(
+    d: { tenant: Tenant; environment: Environment } & ListChatIntegrationsParams
+  ) {
+    let solution = await getMetorialSolution();
+
+    d.search = d.search?.trim();
+    if (!d.search?.length) d.search = undefined;
+
+    let search = d.search
+      ? await voyager.record.search({
+          tenantId: d.tenant.id,
+          sourceId: (await voyagerSource).id,
+          indexId: voyagerIndex.chatIntegration.id,
+          query: d.search
+        })
+      : null;
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.chatIntegration.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+              solutionOid: solution.oid,
+              environmentOid: d.environment.oid,
+              ...normalizeStatusForList(d).noParent,
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
+              ].filter(Boolean)
+            },
+            include: chatIntegrationInclude
+          })
+      )
+    );
+  }
+
+  async getChatIntegrationById(d: MetorialFacing<GetChatIntegrationByIdParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.getChatIntegrationByIdInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async getChatIntegrationByIdInternal(
+    d: { tenant: Tenant; environment: Environment } & GetChatIntegrationByIdParams
+  ) {
+    let solution = await getMetorialSolution();
+
+    let chatIntegration = await db.chatIntegration.findFirst({
+      where: {
+        id: d.chatIntegrationId,
+        tenantOid: d.tenant.oid,
+        solutionOid: solution.oid,
+        environmentOid: d.environment.oid,
+        ...normalizeStatusForGet(d).noParent
+      },
+      include: chatIntegrationInclude
+    });
+    if (!chatIntegration) {
+      throw new ServiceError(notFoundError('chat.integration', d.chatIntegrationId));
+    }
+
+    return chatIntegration;
+  }
+
+  async createChatIntegration(d: MetorialFacing<CreateChatIntegrationParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.createChatIntegrationInternal({
+      ...(rest as CreateChatIntegrationParams),
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async createChatIntegrationInternal(
+    d: { tenant: Tenant; environment: Environment } & CreateChatIntegrationParams
+  ) {
+    let adapterGlobal = await resolveAdapterGlobal('chat');
+
+    return withTransaction(async db => {
+      let adapterIntegration = await ensureAdapterIntegration(
+        d.mode === 'standalone'
+          ? {
+              tenant: d.tenant,
+              environment: d.environment,
+              type: 'chat',
+              adapterGlobal,
+              isStandalone: true,
+              presentation: { name: d.input.name }
+            }
+          : {
+              tenant: d.tenant,
+              environment: d.environment,
+              type: 'chat',
+              adapterGlobal,
+              isStandalone: false,
+              integration: d.integration
+            }
+      );
+
+      let name =
+        d.mode === 'standalone'
+          ? d.input.name.trim()
+          : d.input?.name?.trim() || adapterIntegration.integration.name;
+
+      let existing = await db.chatIntegration.findUnique({
+        where: { adapterIntegrationOid: adapterIntegration.oid }
+      });
+
+      let chatIntegration = existing
+        ? await db.chatIntegration.update({
+            where: { oid: existing.oid },
+            data: {
+              status: 'active',
+              archivedAt: null,
+              name,
+              description:
+                d.mode === 'standalone'
+                  ? d.input.description?.trim() || null
+                  : d.input?.description?.trim() || existing.description,
+              metadata:
+                d.mode === 'standalone'
+                  ? (d.input.metadata ?? {})
+                  : (d.input?.metadata ?? existing.metadata),
+              privateMetadata:
+                d.mode === 'standalone'
+                  ? (d.input.privateMetadata ?? {})
+                  : (d.input?.privateMetadata ?? existing.privateMetadata)
+            },
+            include: chatIntegrationInclude
+          })
+        : await db.chatIntegration.create({
+            data: {
+              ...getId('chatIntegration'),
+              status: 'active',
+              slug: getSlug(name),
+              name,
+              description:
+                d.mode === 'standalone'
+                  ? d.input.description?.trim() || null
+                  : d.input?.description?.trim() || null,
+              metadata:
+                d.mode === 'standalone' ? (d.input.metadata ?? {}) : (d.input?.metadata ?? {}),
+              privateMetadata:
+                d.mode === 'standalone'
+                  ? (d.input.privateMetadata ?? {})
+                  : (d.input?.privateMetadata ?? {}),
+              adapterIntegrationOid: adapterIntegration.oid,
+              tenantOid: adapterIntegration.tenantOid,
+              projectOid: adapterIntegration.projectOid,
+              environmentOid: adapterIntegration.environmentOid,
+              instanceOid: adapterIntegration.instanceOid,
+              solutionOid: adapterIntegration.solutionOid
+            },
+            include: chatIntegrationInclude
+          });
+
+      await projectChatFromAdapterIntegration(adapterIntegration);
+
+      if (existing) await enqueueChatIntegrationUpdated(chatIntegration.id);
+      else await enqueueChatIntegrationCreated(chatIntegration.id);
+
+      return chatIntegration;
+    });
+  }
+
+  async updateChatIntegration(d: MetorialFacing<UpdateChatIntegrationParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.updateChatIntegrationInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async updateChatIntegrationInternal(
+    d: { tenant: Tenant; environment: Environment } & UpdateChatIntegrationParams
+  ) {
+    checkTenant(d, d.chatIntegration);
+    checkDeletedEdit(d.chatIntegration, 'update');
+
+    return withTransaction(async db => {
+      let chatIntegration = await db.chatIntegration.update({
+        where: { oid: d.chatIntegration.oid },
+        data: {
+          name: d.input.name?.trim() ?? d.chatIntegration.name,
+          description:
+            d.input.description === undefined
+              ? d.chatIntegration.description
+              : d.input.description?.trim() || null,
+          metadata:
+            d.input.metadata === undefined ? d.chatIntegration.metadata : d.input.metadata,
+          privateMetadata:
+            d.input.privateMetadata === undefined
+              ? d.chatIntegration.privateMetadata
+              : d.input.privateMetadata
+        },
+        include: { ...chatIntegrationInclude }
+      });
+
+      if (d.input.name?.trim()) {
+        await applyAdapterIntegrationPresentation({
+          tenant: d.tenant,
+          environment: d.environment,
+          adapterIntegration: chatIntegration.adapterIntegration,
+          name: d.input.name.trim()
+        });
+      }
+
+      await enqueueChatIntegrationUpdated(chatIntegration.id);
+
+      return chatIntegration;
+    });
+  }
+
+  async archiveChatIntegration(d: MetorialFacing<ArchiveChatIntegrationParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.archiveChatIntegrationInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async archiveChatIntegrationInternal(
+    d: { tenant: Tenant; environment: Environment } & ArchiveChatIntegrationParams
+  ) {
+    checkTenant(d, d.chatIntegration);
+    checkDeletedEdit(d.chatIntegration, 'archive');
+
+    return withTransaction(async db => {
+      await archiveChatIntegrationProjection(d.chatIntegration.adapterIntegrationOid);
+
+      let adapterIntegration = await db.adapterIntegration.findUniqueOrThrow({
+        where: { oid: d.chatIntegration.adapterIntegrationOid }
+      });
+
+      await removeAdapterIntegration({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterIntegration,
+        cause: 'product'
+      });
+
+      await enqueueChatIntegrationArchived(d.chatIntegration.id);
+
+      return db.chatIntegration.findUniqueOrThrow({
+        where: { oid: d.chatIntegration.oid },
+        include: chatIntegrationInclude
+      });
+    });
+  }
+
+  async deleteChatIntegration(d: MetorialFacing<ArchiveChatIntegrationParams>) {
+    return this.archiveChatIntegration(d);
+  }
+
+  async deleteChatIntegrationInternal(
+    d: { tenant: Tenant; environment: Environment } & ArchiveChatIntegrationParams
+  ) {
+    return this.archiveChatIntegrationInternal(d);
+  }
+}
+
+export let chatIntegrationService = Service.create(
+  'chatIntegration',
+  () => new chatIntegrationServiceImpl()
+).build();

--- a/src/metorial/subspace/modules/chat/src/services/chatIntegrationInstance.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatIntegrationInstance.ts
@@ -1,0 +1,386 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import {
+  type ChatIntegration,
+  type ChatIntegrationInstance,
+  type ChatIntegrationInstanceStatus,
+  db,
+  type Environment,
+  getId,
+  type IntegrationInstance,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  checkDeletedEdit,
+  type DateFilter,
+  normalizeDateFilter,
+  normalizeStatusForGet,
+  normalizeStatusForList
+} from '@metorial-subspace/list-utils';
+import {
+  applyAdapterInstancePresentation,
+  ensureAdapterInstance,
+  removeAdapterInstance,
+  type SetIntegrationInstanceProviderInput
+} from '@metorial-subspace/module-integration';
+import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
+import {
+  checkTenant,
+  getMetorialSolution,
+  type MetorialFacing,
+  resolveMetorialFacing
+} from '@metorial-subspace/module-tenant';
+import { upsertChatInstanceProjection } from '../lib/project';
+import {
+  enqueueChatIntegrationInstanceArchived,
+  enqueueChatIntegrationInstanceCreated,
+  enqueueChatIntegrationInstanceUpdated
+} from '../queues/lifecycle';
+
+export let chatIntegrationInstanceInclude = {
+  chatIntegration: true,
+  adapterIntegrationInstance: true
+} as const;
+
+export type ListChatIntegrationInstancesParams = {
+  search?: string;
+  status?: ChatIntegrationInstanceStatus[];
+  allowDeleted?: boolean;
+  ids?: string[];
+  chatIntegrationIds?: string[];
+  createdAt?: DateFilter;
+  updatedAt?: DateFilter;
+};
+
+export type GetChatIntegrationInstanceByIdParams = {
+  chatIntegrationInstanceId: string;
+  allowDeleted?: boolean;
+};
+
+export type CreateChatIntegrationInstanceParams = {
+  chatIntegration: ChatIntegration;
+  integrationInstance?: IntegrationInstance;
+  createStandaloneInstance?: {
+    name?: string;
+    identity?: { identityActorId?: string | null; identityId?: string | null };
+    providers?: SetIntegrationInstanceProviderInput[];
+  };
+  input?: {
+    name?: string;
+    description?: string;
+    metadata?: Record<string, any>;
+    privateMetadata?: Record<string, any>;
+  };
+};
+
+export type UpdateChatIntegrationInstanceParams = {
+  chatIntegrationInstance: ChatIntegrationInstance;
+  input: {
+    name?: string;
+    description?: string | null;
+    metadata?: Record<string, any> | null;
+    privateMetadata?: Record<string, any> | null;
+  };
+};
+
+export type ArchiveChatIntegrationInstanceParams = {
+  chatIntegrationInstance: ChatIntegrationInstance;
+};
+
+class chatIntegrationInstanceServiceImpl {
+  async listChatIntegrationInstances(d: MetorialFacing<ListChatIntegrationInstancesParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.listChatIntegrationInstancesInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async listChatIntegrationInstancesInternal(
+    d: { tenant: Tenant; environment: Environment } & ListChatIntegrationInstancesParams
+  ) {
+    let solution = await getMetorialSolution();
+
+    d.search = d.search?.trim();
+    if (!d.search?.length) d.search = undefined;
+
+    let search = d.search
+      ? await voyager.record.search({
+          tenantId: d.tenant.id,
+          sourceId: (await voyagerSource).id,
+          indexId: voyagerIndex.chatIntegrationInstance.id,
+          query: d.search
+        })
+      : null;
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.chatIntegrationInstance.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+              solutionOid: solution.oid,
+              environmentOid: d.environment.oid,
+              ...normalizeStatusForList(d).hasParent,
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                d.chatIntegrationIds
+                  ? { chatIntegration: { id: { in: d.chatIntegrationIds } } }
+                  : undefined!,
+                search ? { id: { in: search.map(r => r.documentId) } } : undefined!,
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
+              ].filter(Boolean)
+            },
+            include: chatIntegrationInstanceInclude
+          })
+      )
+    );
+  }
+
+  async getChatIntegrationInstanceById(
+    d: MetorialFacing<GetChatIntegrationInstanceByIdParams>
+  ) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.getChatIntegrationInstanceByIdInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async getChatIntegrationInstanceByIdInternal(
+    d: { tenant: Tenant; environment: Environment } & GetChatIntegrationInstanceByIdParams
+  ) {
+    let solution = await getMetorialSolution();
+    let chatIntegrationInstance = await db.chatIntegrationInstance.findFirst({
+      where: {
+        id: d.chatIntegrationInstanceId,
+        tenantOid: d.tenant.oid,
+        solutionOid: solution.oid,
+        environmentOid: d.environment.oid,
+        ...normalizeStatusForGet(d).hasParent
+      },
+      include: chatIntegrationInstanceInclude
+    });
+    if (!chatIntegrationInstance) {
+      throw new ServiceError(
+        notFoundError('chat.integration.instance', d.chatIntegrationInstanceId)
+      );
+    }
+
+    return chatIntegrationInstance;
+  }
+
+  async createChatIntegrationInstance(d: MetorialFacing<CreateChatIntegrationInstanceParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.createChatIntegrationInstanceInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async createChatIntegrationInstanceInternal(
+    d: { tenant: Tenant; environment: Environment } & CreateChatIntegrationInstanceParams
+  ) {
+    checkTenant(d, d.chatIntegration);
+    checkDeletedEdit(d.chatIntegration, 'update');
+
+    return withTransaction(async db => {
+      let adapterIntegration = await db.adapterIntegration.findUniqueOrThrow({
+        where: { oid: d.chatIntegration.adapterIntegrationOid }
+      });
+
+      let adapterInstance = await ensureAdapterInstance({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterIntegration,
+        integrationInstance: d.integrationInstance,
+        createStandaloneInstance: d.createStandaloneInstance
+      });
+
+      let name = d.input?.name?.trim() || adapterInstance.integrationInstance.name;
+      let status =
+        adapterInstance.status === 'draft' || adapterInstance.status === 'active'
+          ? adapterInstance.status
+          : ('active' as const);
+
+      let existing = await db.chatIntegrationInstance.findUnique({
+        where: { adapterIntegrationInstanceOid: adapterInstance.oid }
+      });
+
+      let chatIntegrationInstance = existing
+        ? await db.chatIntegrationInstance.update({
+            where: { oid: existing.oid },
+            data: {
+              status,
+              archivedAt: null,
+              isParentDeleted: false,
+              name,
+              description: d.input?.description?.trim() || existing.description,
+              metadata: d.input?.metadata ?? existing.metadata,
+              privateMetadata: d.input?.privateMetadata ?? existing.privateMetadata
+            },
+            include: chatIntegrationInstanceInclude
+          })
+        : await db.chatIntegrationInstance.create({
+            data: {
+              ...getId('chatIntegrationInstance'),
+              status,
+              name,
+              description: d.input?.description?.trim() || null,
+              metadata: d.input?.metadata ?? {},
+              privateMetadata: d.input?.privateMetadata ?? {},
+              chatIntegrationOid: d.chatIntegration.oid,
+              adapterIntegrationInstanceOid: adapterInstance.oid,
+              adapterIntegrationOid: adapterIntegration.oid,
+              tenantOid: adapterInstance.tenantOid,
+              projectOid: adapterInstance.projectOid,
+              environmentOid: adapterInstance.environmentOid,
+              instanceOid: adapterInstance.instanceOid,
+              solutionOid: adapterInstance.solutionOid
+            },
+            include: chatIntegrationInstanceInclude
+          });
+
+      await upsertChatInstanceProjection(adapterInstance, d.input);
+
+      if (existing) await enqueueChatIntegrationInstanceUpdated(chatIntegrationInstance.id);
+      else await enqueueChatIntegrationInstanceCreated(chatIntegrationInstance.id);
+
+      return chatIntegrationInstance;
+    });
+  }
+
+  async updateChatIntegrationInstance(d: MetorialFacing<UpdateChatIntegrationInstanceParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.updateChatIntegrationInstanceInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async updateChatIntegrationInstanceInternal(
+    d: { tenant: Tenant; environment: Environment } & UpdateChatIntegrationInstanceParams
+  ) {
+    checkTenant(d, d.chatIntegrationInstance);
+    checkDeletedEdit(d.chatIntegrationInstance, 'update');
+
+    return withTransaction(async db => {
+      let chatIntegrationInstance = await db.chatIntegrationInstance.update({
+        where: { oid: d.chatIntegrationInstance.oid },
+        data: {
+          name: d.input.name?.trim() ?? d.chatIntegrationInstance.name,
+          description:
+            d.input.description === undefined
+              ? d.chatIntegrationInstance.description
+              : d.input.description?.trim() || null,
+          metadata:
+            d.input.metadata === undefined
+              ? d.chatIntegrationInstance.metadata
+              : d.input.metadata,
+          privateMetadata:
+            d.input.privateMetadata === undefined
+              ? d.chatIntegrationInstance.privateMetadata
+              : d.input.privateMetadata
+        },
+        include: chatIntegrationInstanceInclude
+      });
+
+      if (d.input.name?.trim()) {
+        let adapterInstance = await db.adapterIntegrationInstance.findUniqueOrThrow({
+          where: { oid: d.chatIntegrationInstance.adapterIntegrationInstanceOid }
+        });
+        await applyAdapterInstancePresentation({
+          tenant: d.tenant,
+          environment: d.environment,
+          adapterInstance,
+          name: d.input.name.trim()
+        });
+      }
+
+      await enqueueChatIntegrationInstanceUpdated(chatIntegrationInstance.id);
+
+      return chatIntegrationInstance;
+    });
+  }
+
+  async archiveChatIntegrationInstance(
+    d: MetorialFacing<ArchiveChatIntegrationInstanceParams>
+  ) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.archiveChatIntegrationInstanceInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async archiveChatIntegrationInstanceInternal(
+    d: { tenant: Tenant; environment: Environment } & ArchiveChatIntegrationInstanceParams
+  ) {
+    checkTenant(d, d.chatIntegrationInstance);
+    checkDeletedEdit(d.chatIntegrationInstance, 'archive');
+
+    return withTransaction(async db => {
+      await db.chatIntegrationInstanceProvider.updateMany({
+        where: {
+          chatIntegrationInstanceOid: d.chatIntegrationInstance.oid,
+          status: { not: 'deleted' }
+        },
+        data: { status: 'archived', archivedAt: new Date(), isParentDeleted: true }
+      });
+
+      await db.chatIntegrationInstance.update({
+        where: { oid: d.chatIntegrationInstance.oid },
+        data: { status: 'archived', archivedAt: new Date() }
+      });
+
+      let adapterInstance = await db.adapterIntegrationInstance.findUniqueOrThrow({
+        where: { oid: d.chatIntegrationInstance.adapterIntegrationInstanceOid }
+      });
+
+      await removeAdapterInstance({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterInstance,
+        cause: 'product'
+      });
+
+      await enqueueChatIntegrationInstanceArchived(d.chatIntegrationInstance.id);
+
+      return db.chatIntegrationInstance.findUniqueOrThrow({
+        where: { oid: d.chatIntegrationInstance.oid },
+        include: chatIntegrationInstanceInclude
+      });
+    });
+  }
+
+  async deleteChatIntegrationInstance(
+    d: MetorialFacing<ArchiveChatIntegrationInstanceParams>
+  ) {
+    return this.archiveChatIntegrationInstance(d);
+  }
+
+  async deleteChatIntegrationInstanceInternal(
+    d: { tenant: Tenant; environment: Environment } & ArchiveChatIntegrationInstanceParams
+  ) {
+    return this.archiveChatIntegrationInstanceInternal(d);
+  }
+}
+
+export let chatIntegrationInstanceService = Service.create(
+  'chatIntegrationInstance',
+  () => new chatIntegrationInstanceServiceImpl()
+).build();

--- a/src/metorial/subspace/modules/chat/src/services/chatIntegrationInstanceProvider.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatIntegrationInstanceProvider.ts
@@ -1,0 +1,196 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import {
+  type ChatIntegrationInstance,
+  type ChatIntegrationInstanceProviderStatus,
+  db,
+  type Environment,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  type DateFilter,
+  normalizeDateFilter,
+  normalizeStatusForGet,
+  normalizeStatusForList
+} from '@metorial-subspace/list-utils';
+import {
+  setAdapterInstanceProvider,
+  type SetIntegrationInstanceProviderInput
+} from '@metorial-subspace/module-integration';
+import {
+  checkTenant,
+  getMetorialSolution,
+  type MetorialFacing,
+  resolveMetorialFacing
+} from '@metorial-subspace/module-tenant';
+import { upsertChatInstanceProviderProjection } from '../lib/project';
+import { enqueueChatIntegrationInstanceUpdated } from '../queues/lifecycle';
+
+export let chatIntegrationInstanceProviderInclude = {
+  chatIntegrationInstance: true,
+  chatIntegrationProvider: true,
+  adapterIntegrationInstanceProvider: true
+} as const;
+
+export type ListChatIntegrationInstanceProvidersParams = {
+  search?: string;
+  status?: ChatIntegrationInstanceProviderStatus[];
+  allowDeleted?: boolean;
+  ids?: string[];
+  chatIntegrationInstanceIds?: string[];
+  createdAt?: DateFilter;
+  updatedAt?: DateFilter;
+};
+
+export type GetChatIntegrationInstanceProviderByIdParams = {
+  chatIntegrationInstanceProviderId: string;
+  allowDeleted?: boolean;
+};
+
+export type SetChatIntegrationInstanceProviderParams = {
+  chatIntegrationInstance: ChatIntegrationInstance;
+  input: SetIntegrationInstanceProviderInput;
+};
+
+class chatIntegrationInstanceProviderServiceImpl {
+  async listChatIntegrationInstanceProviders(
+    d: MetorialFacing<ListChatIntegrationInstanceProvidersParams>
+  ) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.listChatIntegrationInstanceProvidersInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async listChatIntegrationInstanceProvidersInternal(
+    d: {
+      tenant: Tenant;
+      environment: Environment;
+    } & ListChatIntegrationInstanceProvidersParams
+  ) {
+    let solution = await getMetorialSolution();
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.chatIntegrationInstanceProvider.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+              solutionOid: solution.oid,
+              environmentOid: d.environment.oid,
+              ...normalizeStatusForList(d).hasParent,
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                d.chatIntegrationInstanceIds
+                  ? { chatIntegrationInstance: { id: { in: d.chatIntegrationInstanceIds } } }
+                  : undefined!,
+                d.search
+                  ? { name: { contains: d.search, mode: 'insensitive' as const } }
+                  : undefined!,
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
+              ].filter(Boolean)
+            },
+            include: chatIntegrationInstanceProviderInclude
+          })
+      )
+    );
+  }
+
+  async getChatIntegrationInstanceProviderById(
+    d: MetorialFacing<GetChatIntegrationInstanceProviderByIdParams>
+  ) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.getChatIntegrationInstanceProviderByIdInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async getChatIntegrationInstanceProviderByIdInternal(
+    d: {
+      tenant: Tenant;
+      environment: Environment;
+    } & GetChatIntegrationInstanceProviderByIdParams
+  ) {
+    let solution = await getMetorialSolution();
+    let chatIntegrationInstanceProvider = await db.chatIntegrationInstanceProvider.findFirst({
+      where: {
+        id: d.chatIntegrationInstanceProviderId,
+        tenantOid: d.tenant.oid,
+        solutionOid: solution.oid,
+        environmentOid: d.environment.oid,
+        ...normalizeStatusForGet(d).hasParent
+      },
+      include: chatIntegrationInstanceProviderInclude
+    });
+    if (!chatIntegrationInstanceProvider) {
+      throw new ServiceError(
+        notFoundError(
+          'chat.integration.instance.provider',
+          d.chatIntegrationInstanceProviderId
+        )
+      );
+    }
+
+    return chatIntegrationInstanceProvider;
+  }
+
+  async setChatIntegrationInstanceProvider(
+    d: MetorialFacing<SetChatIntegrationInstanceProviderParams>
+  ) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.setChatIntegrationInstanceProviderInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async setChatIntegrationInstanceProviderInternal(
+    d: { tenant: Tenant; environment: Environment } & SetChatIntegrationInstanceProviderParams
+  ) {
+    checkTenant(d, d.chatIntegrationInstance);
+
+    return withTransaction(async db => {
+      let adapterInstance = await db.adapterIntegrationInstance.findUniqueOrThrow({
+        where: { oid: d.chatIntegrationInstance.adapterIntegrationInstanceOid }
+      });
+
+      let links = await setAdapterInstanceProvider({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterInstance,
+        input: d.input
+      });
+
+      for (let link of links) {
+        await upsertChatInstanceProviderProjection(link);
+      }
+
+      await enqueueChatIntegrationInstanceUpdated(d.chatIntegrationInstance.id);
+
+      return db.chatIntegrationInstanceProvider.findMany({
+        where: {
+          chatIntegrationInstanceOid: d.chatIntegrationInstance.oid,
+          status: 'active'
+        },
+        include: chatIntegrationInstanceProviderInclude
+      });
+    });
+  }
+}
+
+export let chatIntegrationInstanceProviderService = Service.create(
+  'chatIntegrationInstanceProvider',
+  () => new chatIntegrationInstanceProviderServiceImpl()
+).build();

--- a/src/metorial/subspace/modules/chat/src/services/chatIntegrationProvider.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatIntegrationProvider.ts
@@ -1,0 +1,335 @@
+import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import {
+  type ChatIntegration,
+  type ChatIntegrationProvider,
+  type ChatIntegrationProviderStatus,
+  db,
+  type Environment,
+  getId,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import {
+  checkDeletedEdit,
+  type DateFilter,
+  normalizeDateFilter,
+  normalizeStatusForGet,
+  normalizeStatusForList
+} from '@metorial-subspace/list-utils';
+import {
+  ensureAdapterProvider,
+  removeAdapterProvider,
+  updateAdapterProvider
+} from '@metorial-subspace/module-integration';
+import {
+  checkTenant,
+  getMetorialSolution,
+  type MetorialFacing,
+  resolveMetorialFacing
+} from '@metorial-subspace/module-tenant';
+import { upsertChatProviderProjection } from '../lib/project';
+import { enqueueChatIntegrationUpdated } from '../queues/lifecycle';
+
+export let chatIntegrationProviderInclude = {
+  chatIntegration: true,
+  adapterIntegrationProvider: true
+} as const;
+
+export type ListChatIntegrationProvidersParams = {
+  search?: string;
+  status?: ChatIntegrationProviderStatus[];
+  allowDeleted?: boolean;
+  ids?: string[];
+  chatIntegrationIds?: string[];
+  createdAt?: DateFilter;
+  updatedAt?: DateFilter;
+};
+
+export type GetChatIntegrationProviderByIdParams = {
+  chatIntegrationProviderId: string;
+  allowDeleted?: boolean;
+};
+
+export type CreateChatIntegrationProviderParams = {
+  chatIntegration: ChatIntegration;
+  input: {
+    providerId: string;
+    providerDeploymentId?: string | null;
+    providerAuthMethodId?: string | null;
+    providerAuthCredentialsId?: string | null;
+    providerConfigId?: string | null;
+    name?: string;
+    description?: string;
+    metadata?: Record<string, any>;
+    toolFilters?: any;
+  };
+};
+
+export type UpdateChatIntegrationProviderParams = {
+  chatIntegrationProvider: ChatIntegrationProvider;
+  input: {
+    providerDeploymentId?: string;
+    providerAuthMethodId?: string | null;
+    providerAuthCredentialsId?: string | null;
+    providerConfigId?: string | null;
+    name?: string;
+    description?: string | null;
+    metadata?: Record<string, any> | null;
+    toolFilters?: any;
+  };
+};
+
+export type ArchiveChatIntegrationProviderParams = {
+  chatIntegrationProvider: ChatIntegrationProvider;
+};
+
+class chatIntegrationProviderServiceImpl {
+  async listChatIntegrationProviders(d: MetorialFacing<ListChatIntegrationProvidersParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.listChatIntegrationProvidersInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async listChatIntegrationProvidersInternal(
+    d: { tenant: Tenant; environment: Environment } & ListChatIntegrationProvidersParams
+  ) {
+    let solution = await getMetorialSolution();
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.chatIntegrationProvider.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+              solutionOid: solution.oid,
+              environmentOid: d.environment.oid,
+              ...normalizeStatusForList(d).noParent,
+              AND: [
+                d.ids ? { id: { in: d.ids } } : undefined!,
+                d.chatIntegrationIds
+                  ? { chatIntegration: { id: { in: d.chatIntegrationIds } } }
+                  : undefined!,
+                d.search
+                  ? { name: { contains: d.search, mode: 'insensitive' as const } }
+                  : undefined!,
+                d.createdAt ? { createdAt: normalizeDateFilter(d.createdAt) } : undefined!,
+                d.updatedAt ? { updatedAt: normalizeDateFilter(d.updatedAt) } : undefined!
+              ].filter(Boolean)
+            },
+            include: chatIntegrationProviderInclude
+          })
+      )
+    );
+  }
+
+  async getChatIntegrationProviderById(
+    d: MetorialFacing<GetChatIntegrationProviderByIdParams>
+  ) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.getChatIntegrationProviderByIdInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async getChatIntegrationProviderByIdInternal(
+    d: { tenant: Tenant; environment: Environment } & GetChatIntegrationProviderByIdParams
+  ) {
+    let solution = await getMetorialSolution();
+    let chatIntegrationProvider = await db.chatIntegrationProvider.findFirst({
+      where: {
+        id: d.chatIntegrationProviderId,
+        tenantOid: d.tenant.oid,
+        solutionOid: solution.oid,
+        environmentOid: d.environment.oid,
+        ...normalizeStatusForGet(d).noParent
+      },
+      include: chatIntegrationProviderInclude
+    });
+    if (!chatIntegrationProvider) {
+      throw new ServiceError(
+        notFoundError('chat.integration.provider', d.chatIntegrationProviderId)
+      );
+    }
+
+    return chatIntegrationProvider;
+  }
+
+  async createChatIntegrationProvider(d: MetorialFacing<CreateChatIntegrationProviderParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.createChatIntegrationProviderInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async createChatIntegrationProviderInternal(
+    d: { tenant: Tenant; environment: Environment } & CreateChatIntegrationProviderParams
+  ) {
+    checkTenant(d, d.chatIntegration);
+    checkDeletedEdit(d.chatIntegration, 'update');
+
+    return withTransaction(async db => {
+      let adapterIntegration = await db.adapterIntegration.findUniqueOrThrow({
+        where: { oid: d.chatIntegration.adapterIntegrationOid }
+      });
+
+      let adapterProvider = await ensureAdapterProvider({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterIntegration,
+        input: d.input
+      });
+
+      let existing = await db.chatIntegrationProvider.findUnique({
+        where: { adapterIntegrationProviderOid: adapterProvider.oid }
+      });
+
+      let chatIntegrationProvider = existing
+        ? await db.chatIntegrationProvider.update({
+            where: { oid: existing.oid },
+            data: {
+              status: 'active',
+              archivedAt: null,
+              name: d.input.name?.trim() || existing.name,
+              description: d.input.description?.trim() || existing.description,
+              metadata: d.input.metadata ?? existing.metadata
+            },
+            include: chatIntegrationProviderInclude
+          })
+        : await db.chatIntegrationProvider.create({
+            data: {
+              ...getId('chatIntegrationProvider'),
+              status: 'active',
+              name: d.input.name?.trim() || 'Provider',
+              description: d.input.description?.trim() || null,
+              metadata: d.input.metadata ?? {},
+              chatIntegrationOid: d.chatIntegration.oid,
+              adapterIntegrationOid: adapterIntegration.oid,
+              adapterIntegrationProviderOid: adapterProvider.oid,
+              tenantOid: adapterProvider.tenantOid,
+              projectOid: adapterProvider.projectOid,
+              environmentOid: adapterProvider.environmentOid,
+              instanceOid: adapterProvider.instanceOid,
+              solutionOid: adapterProvider.solutionOid
+            },
+            include: chatIntegrationProviderInclude
+          });
+
+      await upsertChatProviderProjection(adapterProvider);
+
+      await enqueueChatIntegrationUpdated(d.chatIntegration.id);
+
+      return chatIntegrationProvider;
+    });
+  }
+
+  async updateChatIntegrationProvider(d: MetorialFacing<UpdateChatIntegrationProviderParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.updateChatIntegrationProviderInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async updateChatIntegrationProviderInternal(
+    d: { tenant: Tenant; environment: Environment } & UpdateChatIntegrationProviderParams
+  ) {
+    checkTenant(d, d.chatIntegrationProvider);
+    checkDeletedEdit(d.chatIntegrationProvider, 'update');
+
+    return withTransaction(async db => {
+      let adapterProvider = await db.adapterIntegrationProvider.findUniqueOrThrow({
+        where: { oid: d.chatIntegrationProvider.adapterIntegrationProviderOid }
+      });
+
+      await updateAdapterProvider({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterIntegrationProvider: adapterProvider,
+        input: d.input
+      });
+
+      let updated = await db.chatIntegrationProvider.update({
+        where: { oid: d.chatIntegrationProvider.oid },
+        data: {
+          name: d.input.name?.trim() ?? d.chatIntegrationProvider.name,
+          description:
+            d.input.description === undefined
+              ? d.chatIntegrationProvider.description
+              : d.input.description?.trim() || null,
+          metadata:
+            d.input.metadata === undefined
+              ? d.chatIntegrationProvider.metadata
+              : d.input.metadata
+        },
+        include: chatIntegrationProviderInclude
+      });
+
+      await enqueueChatIntegrationUpdated(updated.chatIntegration.id);
+
+      return updated;
+    });
+  }
+
+  async archiveChatIntegrationProvider(
+    d: MetorialFacing<ArchiveChatIntegrationProviderParams>
+  ) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+    return this.archiveChatIntegrationProviderInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async archiveChatIntegrationProviderInternal(
+    d: { tenant: Tenant; environment: Environment } & ArchiveChatIntegrationProviderParams
+  ) {
+    checkTenant(d, d.chatIntegrationProvider);
+    checkDeletedEdit(d.chatIntegrationProvider, 'archive');
+
+    return withTransaction(async db => {
+      let adapterProvider = await db.adapterIntegrationProvider.findUniqueOrThrow({
+        where: { oid: d.chatIntegrationProvider.adapterIntegrationProviderOid }
+      });
+
+      await db.chatIntegrationProvider.update({
+        where: { oid: d.chatIntegrationProvider.oid },
+        data: { status: 'archived', archivedAt: new Date() }
+      });
+
+      await removeAdapterProvider({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterIntegrationProvider: adapterProvider
+      });
+
+      let archived = await db.chatIntegrationProvider.findUniqueOrThrow({
+        where: { oid: d.chatIntegrationProvider.oid },
+        include: chatIntegrationProviderInclude
+      });
+      await enqueueChatIntegrationUpdated(archived.chatIntegration.id);
+      return archived;
+    });
+  }
+}
+
+export let chatIntegrationProviderService = Service.create(
+  'chatIntegrationProvider',
+  () => new chatIntegrationProviderServiceImpl()
+).build();

--- a/src/metorial/subspace/modules/chat/src/services/index.ts
+++ b/src/metorial/subspace/modules/chat/src/services/index.ts
@@ -1,0 +1,4 @@
+export * from './chatIntegration';
+export * from './chatIntegrationInstance';
+export * from './chatIntegrationInstanceProvider';
+export * from './chatIntegrationProvider';

--- a/src/metorial/subspace/modules/chat/tsconfig.json
+++ b/src/metorial/subspace/modules/chat/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@metorial-subspace/tsconfig/base.json",
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "jsx": "react",
+    "outDir": "dist"
+  }
+}

--- a/src/metorial/subspace/modules/integration/src/adapter/helpers.ts
+++ b/src/metorial/subspace/modules/integration/src/adapter/helpers.ts
@@ -1,0 +1,150 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import {
+  type AdapterIntegration,
+  type AdapterIntegrationInstance,
+  type AdapterIntegrationInstanceStatus,
+  type IntegrationInstanceStatus,
+  type ProviderAdapterGlobal,
+  withTransaction
+} from '@metorial-subspace/db';
+
+export let adapterLiveStatuses = ['active'] as const;
+export let adapterInstanceLiveStatuses = ['draft', 'active'] as const;
+
+export let isLiveAdapterStatus = (status: string) => status === 'active';
+
+export let isLiveAdapterInstanceStatus = (status: string) =>
+  status === 'draft' || status === 'active';
+
+export let toAdapterInstanceStatus = (
+  status: IntegrationInstanceStatus
+): AdapterIntegrationInstanceStatus => {
+  if (status === 'draft') return 'draft';
+  if (status === 'active') return 'active';
+  if (status === 'archived') return 'archived';
+  return 'deleted';
+};
+
+export let resolveAdapterGlobal = async (identifier: string) => {
+  return withTransaction(async db => {
+    let adapter = await db.providerAdapterGlobal.findUnique({
+      where: { identifier }
+    });
+    if (!adapter) {
+      throw new ServiceError(notFoundError('provider.adapter', identifier));
+    }
+
+    return adapter;
+  });
+};
+
+export let assertProviderImplementsAdapter = async (d: {
+  providerOid: bigint;
+  adapterGlobalOid: bigint;
+}) => {
+  return withTransaction(async db => {
+    let match = await db.providerAdapter.findFirst({
+      where: {
+        providerOid: d.providerOid,
+        globalOid: d.adapterGlobalOid
+      },
+      select: { oid: true }
+    });
+    if (!match) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'provider_does_not_implement_adapter',
+          message: 'The provider does not implement the requested adapter.'
+        })
+      );
+    }
+  });
+};
+
+export let listAdapterCapableIntegrationProviders = async (d: {
+  integrationOid: bigint;
+  adapterGlobalOid: bigint;
+}) => {
+  return withTransaction(async db => {
+    return db.integrationProvider.findMany({
+      where: {
+        integrationOid: d.integrationOid,
+        status: 'active',
+        archivedAt: null,
+        provider: {
+          providerAdapters: {
+            some: { globalOid: d.adapterGlobalOid }
+          }
+        }
+      },
+      include: { provider: true }
+    });
+  });
+};
+
+export let listAdapterCapableIntegrationInstanceProviders = async (d: {
+  integrationInstanceOid: bigint;
+  adapterGlobalOid: bigint;
+}) => {
+  return withTransaction(async db => {
+    return db.integrationInstanceProvider.findMany({
+      where: {
+        integrationInstanceOid: d.integrationInstanceOid,
+        status: 'active',
+        archivedAt: null,
+        isParentDeleted: false,
+        integrationProvider: {
+          status: 'active',
+          archivedAt: null,
+          provider: {
+            providerAdapters: {
+              some: { globalOid: d.adapterGlobalOid }
+            }
+          }
+        }
+      },
+      include: {
+        integrationProvider: true,
+        integrationInstance: true
+      }
+    });
+  });
+};
+
+export let adapterScopeFromIntegration = (d: {
+  tenantOid: bigint;
+  projectOid: bigint | null;
+  environmentOid: bigint;
+  instanceOid: bigint | null;
+  solutionOid: number;
+}) => ({
+  tenantOid: d.tenantOid,
+  projectOid: d.projectOid!,
+  environmentOid: d.environmentOid,
+  instanceOid: d.instanceOid!,
+  solutionOid: d.solutionOid
+});
+
+export let requireLiveAdapterIntegration = (adapterIntegration: AdapterIntegration) => {
+  if (!isLiveAdapterStatus(adapterIntegration.status)) {
+    throw new ServiceError(
+      badRequestError({
+        code: 'adapter_integration_archived',
+        message: 'The adapter integration is archived.'
+      })
+    );
+  }
+};
+
+export let requireLiveAdapterInstance = (adapterInstance: AdapterIntegrationInstance) => {
+  if (!isLiveAdapterInstanceStatus(adapterInstance.status)) {
+    throw new ServiceError(
+      badRequestError({
+        code: 'adapter_instance_archived',
+        message: 'The adapter instance is archived.'
+      })
+    );
+  }
+};
+
+export type { ProviderAdapterGlobal };

--- a/src/metorial/subspace/modules/integration/src/adapter/index.ts
+++ b/src/metorial/subspace/modules/integration/src/adapter/index.ts
@@ -1,0 +1,2 @@
+export * from './helpers';
+export * from './primitives';

--- a/src/metorial/subspace/modules/integration/src/adapter/listener.test.ts
+++ b/src/metorial/subspace/modules/integration/src/adapter/listener.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+let { removeAdapterInstance, syncAdapterInstanceProviders, syncAdapterInstanceStatus, syncAdapterProviders } =
+  vi.hoisted(() => ({
+    removeAdapterInstance: vi.fn(),
+    syncAdapterInstanceProviders: vi.fn(),
+    syncAdapterInstanceStatus: vi.fn(),
+    syncAdapterProviders: vi.fn()
+  }));
+
+let { tx } = vi.hoisted(() => {
+  let createModel = () => ({
+    findMany: vi.fn(),
+    findUniqueOrThrow: vi.fn()
+  });
+  return {
+    tx: {
+      adapterIntegration: createModel(),
+      adapterIntegrationInstance: createModel(),
+      tenant: createModel(),
+      environment: createModel()
+    }
+  };
+});
+
+vi.mock('@metorial-subspace/db', () => ({
+  withTransaction: async (cb: (db: any) => Promise<any>) => await cb(tx)
+}));
+
+vi.mock('./primitives', () => ({
+  removeAdapterInstance,
+  removeAdapterIntegration: vi.fn(),
+  syncAdapterInstanceProviders,
+  syncAdapterInstanceStatus,
+  syncAdapterProviders
+}));
+
+import { adapterCoordinationListener } from './listener';
+
+describe('adapter coordination listener', () => {
+  it('does not auto-create an adapter instance when an integration instance is created', async () => {
+    tx.adapterIntegrationInstance.findMany.mockResolvedValue([]);
+
+    await adapterCoordinationListener.onEvent({
+      kind: 'integrationInstance.created',
+      integration: { oid: 21n } as any,
+      integrationInstance: { oid: 55n, tenantOid: 1n, environmentOid: 3n } as any
+    });
+
+    expect(tx.adapterIntegrationInstance.findMany).toHaveBeenCalled();
+    expect(syncAdapterInstanceStatus).not.toHaveBeenCalled();
+    expect(syncAdapterInstanceProviders).not.toHaveBeenCalled();
+  });
+
+  it('syncs draft and active adapter instance status from the integration instance', async () => {
+    tx.adapterIntegrationInstance.findMany.mockResolvedValue([{ oid: 300n }]);
+
+    await adapterCoordinationListener.onEvent({
+      kind: 'integrationInstance.updated',
+      integration: { oid: 21n } as any,
+      integrationInstance: {
+        oid: 55n,
+        status: 'active',
+        tenantOid: 1n,
+        environmentOid: 3n
+      } as any
+    });
+
+    expect(syncAdapterInstanceStatus).toHaveBeenCalled();
+  });
+
+  it('syncs adapter providers when an integration provider is created', async () => {
+    tx.adapterIntegration.findMany.mockResolvedValue([{ oid: 100n }]);
+
+    await adapterCoordinationListener.onEvent({
+      kind: 'integrationProvider.created',
+      integration: { oid: 21n } as any,
+      integrationProvider: { oid: 70n } as any
+    });
+
+    expect(syncAdapterProviders).toHaveBeenCalled();
+  });
+});

--- a/src/metorial/subspace/modules/integration/src/adapter/listener.ts
+++ b/src/metorial/subspace/modules/integration/src/adapter/listener.ts
@@ -1,0 +1,121 @@
+import { withTransaction } from '@metorial-subspace/db';
+import type { IntegrationTransactionEvent } from '../listeners';
+import { adapterInstanceLiveStatuses, adapterLiveStatuses } from './helpers';
+import {
+  removeAdapterInstance,
+  removeAdapterIntegration,
+  syncAdapterInstanceProviders,
+  syncAdapterInstanceStatus,
+  syncAdapterProviders
+} from './primitives';
+
+let loadScope = async (d: { tenantOid: bigint; environmentOid: bigint }) =>
+  withTransaction(async db => {
+    let tenant = await db.tenant.findUniqueOrThrow({ where: { oid: d.tenantOid } });
+    let environment = await db.environment.findUniqueOrThrow({
+      where: { oid: d.environmentOid }
+    });
+    return { tenant, environment };
+  });
+
+export let adapterCoordinationListener = {
+  async onEvent(event: IntegrationTransactionEvent) {
+    if (event.kind === 'integration.archived') {
+      await withTransaction(async db => {
+        let adapters = await db.adapterIntegration.findMany({
+          where: {
+            integrationOid: event.integration.oid,
+            status: { in: [...adapterLiveStatuses] }
+          }
+        });
+        if (adapters.length === 0) return;
+
+        let scope = await loadScope(event.integration);
+        for (let adapterIntegration of adapters) {
+          await removeAdapterIntegration({
+            ...scope,
+            adapterIntegration,
+            cause: 'integration'
+          });
+        }
+      });
+      return;
+    }
+
+    if (
+      event.kind === 'integrationProvider.created' ||
+      event.kind === 'integrationProvider.updated' ||
+      event.kind === 'integrationProvider.archived'
+    ) {
+      await withTransaction(async db => {
+        let adapters = await db.adapterIntegration.findMany({
+          where: {
+            integrationOid: event.integration.oid,
+            status: { in: [...adapterLiveStatuses] }
+          }
+        });
+        for (let adapterIntegration of adapters) {
+          await syncAdapterProviders({ adapterIntegration });
+        }
+      });
+      return;
+    }
+
+    if (event.kind === 'integrationInstance.archived') {
+      await withTransaction(async db => {
+        let adapterInstances = await db.adapterIntegrationInstance.findMany({
+          where: {
+            integrationInstanceOid: event.integrationInstance.oid,
+            status: { in: [...adapterInstanceLiveStatuses] }
+          }
+        });
+        if (adapterInstances.length === 0) return;
+
+        let scope = await loadScope(event.integrationInstance);
+        for (let adapterInstance of adapterInstances) {
+          await removeAdapterInstance({
+            ...scope,
+            adapterInstance,
+            cause: 'integration'
+          });
+        }
+      });
+      return;
+    }
+
+    if (
+      event.kind === 'integrationInstance.created' ||
+      event.kind === 'integrationInstance.updated'
+    ) {
+      await withTransaction(async db => {
+        let adapterInstances = await db.adapterIntegrationInstance.findMany({
+          where: {
+            integrationInstanceOid: event.integrationInstance.oid,
+            status: { in: [...adapterInstanceLiveStatuses] }
+          }
+        });
+        for (let adapterInstance of adapterInstances) {
+          await syncAdapterInstanceStatus({ adapterInstance });
+        }
+      });
+      return;
+    }
+
+    if (
+      event.kind === 'integrationInstanceProvider.set' ||
+      event.kind === 'integrationInstanceProvider.archived'
+    ) {
+      await withTransaction(async db => {
+        let adapterInstances = await db.adapterIntegrationInstance.findMany({
+          where: {
+            integrationInstanceOid: event.integrationInstance.oid,
+            status: { in: [...adapterInstanceLiveStatuses] }
+          }
+        });
+        for (let adapterInstance of adapterInstances) {
+          await syncAdapterInstanceProviders({ adapterIntegrationInstance: adapterInstance });
+        }
+      });
+    }
+  }
+};

--- a/src/metorial/subspace/modules/integration/src/adapter/primitives.test.ts
+++ b/src/metorial/subspace/modules/integration/src/adapter/primitives.test.ts
@@ -1,0 +1,430 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  tx,
+  createIntegrationInternal,
+  updateIntegrationInternal,
+  archiveIntegrationInternal,
+  createIntegrationInstanceInternal,
+  updateIntegrationInstanceInternal,
+  archiveIntegrationInstanceInternal,
+  createIntegrationProviderInternal,
+  archiveIntegrationProviderInternal,
+  setIntegrationInstanceProviderInternal
+} = vi.hoisted(() => {
+  let createModel = () => ({
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn()
+  });
+
+  return {
+    tx: {
+      adapterIntegration: createModel(),
+      adapterIntegrationProvider: createModel(),
+      adapterIntegrationInstance: createModel(),
+      adapterIntegrationInstanceProvider: createModel(),
+      integration: createModel(),
+      integrationProvider: createModel(),
+      integrationInstance: createModel(),
+      integrationInstanceProvider: createModel(),
+      provider: createModel(),
+      providerAdapter: createModel(),
+      providerAdapterGlobal: createModel(),
+      tenant: createModel(),
+      environment: createModel()
+    },
+    createIntegrationInternal: vi.fn(),
+    updateIntegrationInternal: vi.fn(),
+    archiveIntegrationInternal: vi.fn(),
+    createIntegrationInstanceInternal: vi.fn(),
+    updateIntegrationInstanceInternal: vi.fn(),
+    archiveIntegrationInstanceInternal: vi.fn(),
+    createIntegrationProviderInternal: vi.fn(),
+    archiveIntegrationProviderInternal: vi.fn(),
+    setIntegrationInstanceProviderInternal: vi.fn()
+  };
+});
+
+vi.mock('@metorial-subspace/db', () => ({
+  getId: (kind: string) => ({ id: `${kind}_new`, oid: 100n }),
+  withTransaction: async (cb: (db: any) => Promise<any>) => await cb(tx)
+}));
+
+vi.mock('../services/integration', () => ({
+  integrationService: {
+    createIntegrationInternal,
+    updateIntegrationInternal,
+    archiveIntegrationInternal
+  }
+}));
+
+vi.mock('../services/integrationInstance', () => ({
+  integrationInstanceService: {
+    createIntegrationInstanceInternal,
+    updateIntegrationInstanceInternal,
+    archiveIntegrationInstanceInternal
+  }
+}));
+
+vi.mock('../services/integrationProvider', () => ({
+  integrationProviderService: {
+    createIntegrationProviderInternal,
+    archiveIntegrationProviderInternal
+  }
+}));
+
+vi.mock('../services/integrationInstanceProvider', () => ({
+  integrationInstanceProviderService: {
+    setIntegrationInstanceProviderInternal
+  }
+}));
+
+import {
+  applyAdapterIntegrationPresentation,
+  ensureAdapterInstance,
+  ensureAdapterIntegration,
+  ensureAdapterProvider,
+  removeAdapterInstance,
+  removeAdapterIntegration
+} from './primitives';
+
+let tenant = { oid: 1n, projectOid: 11n } as any;
+let environment = { oid: 3n, instanceOid: 33n } as any;
+let adapterGlobal = { oid: 9n, identifier: 'chat' } as any;
+
+let hiddenIntegration = {
+  oid: 20n,
+  id: 'int_hidden',
+  name: 'Support',
+  description: '',
+  metadata: {},
+  isMagicMcpBacking: false,
+  isAdapterBacking: true,
+  tenantOid: 1n,
+  projectOid: 11n,
+  environmentOid: 3n,
+  instanceOid: 33n,
+  solutionOid: 2
+};
+
+let visibleIntegration = {
+  ...hiddenIntegration,
+  oid: 21n,
+  id: 'int_visible',
+  isAdapterBacking: false
+};
+
+let adapterIntegrationRow = {
+  oid: 100n,
+  id: 'adapterIntegration_new',
+  type: 'chat',
+  isStandalone: true,
+  status: 'active',
+  adapterGlobalOid: 9n,
+  integrationOid: 20n,
+  tenantOid: 1n,
+  projectOid: 11n,
+  environmentOid: 3n,
+  instanceOid: 33n,
+  solutionOid: 2,
+  integration: hiddenIntegration,
+  adapterGlobal
+};
+
+describe('adapter primitives', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tx.adapterIntegration.findFirst.mockResolvedValue(null);
+    tx.adapterIntegration.findUniqueOrThrow.mockResolvedValue(adapterIntegrationRow);
+    tx.adapterIntegration.create.mockResolvedValue(adapterIntegrationRow);
+    tx.adapterIntegration.update.mockImplementation(async ({ data }: any) => ({
+      ...adapterIntegrationRow,
+      ...data
+    }));
+    tx.adapterIntegrationProvider.findUnique.mockResolvedValue(null);
+    tx.adapterIntegrationProvider.findMany.mockResolvedValue([]);
+    tx.adapterIntegrationProvider.create.mockImplementation(async ({ data }: any) => ({
+      oid: 200n,
+      ...data
+    }));
+    tx.adapterIntegrationProvider.update.mockImplementation(async ({ data }: any) => data);
+    tx.adapterIntegrationProvider.updateMany.mockResolvedValue({ count: 0 });
+    tx.adapterIntegrationInstance.findMany.mockResolvedValue([]);
+    tx.adapterIntegrationInstance.findUnique.mockResolvedValue(null);
+    tx.adapterIntegrationInstance.findUniqueOrThrow.mockResolvedValue({
+      oid: 300n,
+      status: 'active',
+      isStandalone: true,
+      integrationInstanceOid: 40n,
+      adapterIntegrationOid: 100n,
+      adapterIntegration: adapterIntegrationRow,
+      integrationInstance: { oid: 40n, name: 'Inst', isAdapterBacking: true, status: 'active' }
+    });
+    tx.adapterIntegrationInstance.create.mockImplementation(async ({ data }: any) => ({
+      oid: 300n,
+      ...data
+    }));
+    tx.adapterIntegrationInstance.update.mockImplementation(async ({ data }: any) => ({
+      oid: 300n,
+      ...data
+    }));
+    tx.adapterIntegrationInstanceProvider.findUnique.mockResolvedValue(null);
+    tx.adapterIntegrationInstanceProvider.findMany.mockResolvedValue([]);
+    tx.adapterIntegrationInstanceProvider.updateMany.mockResolvedValue({ count: 0 });
+    tx.integrationProvider.findMany.mockResolvedValue([]);
+    tx.integrationInstanceProvider.findMany.mockResolvedValue([]);
+    tx.provider.findFirst.mockResolvedValue({ oid: 8n, id: 'pro_slack' });
+    tx.providerAdapter.findFirst.mockResolvedValue({ oid: 1n });
+    createIntegrationInternal.mockResolvedValue(hiddenIntegration);
+    createIntegrationInstanceInternal.mockResolvedValue({
+      oid: 40n,
+      name: 'Inst',
+      isAdapterBacking: true,
+      integrationOid: 20n,
+      status: 'draft'
+    });
+    createIntegrationProviderInternal.mockResolvedValue({ oid: 70n, providerOid: 8n });
+  });
+
+  it('standalone create hides the integration and copies name only', async () => {
+    let result = await ensureAdapterIntegration({
+      tenant,
+      environment,
+      type: 'chat',
+      adapterGlobal,
+      isStandalone: true,
+      presentation: { name: 'Support' }
+    });
+
+    expect(createIntegrationInternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isAdapterBacking: true,
+        slug: 'adapter-chat-adapterIntegration_new',
+        input: expect.objectContaining({
+          name: 'Support',
+          description: '',
+          metadata: {}
+        })
+      })
+    );
+    expect(result.isStandalone).toBe(true);
+
+    tx.adapterIntegration.findUniqueOrThrow.mockResolvedValue(adapterIntegrationRow);
+    await applyAdapterIntegrationPresentation({
+      tenant,
+      environment,
+      adapterIntegration: adapterIntegrationRow as any,
+      name: 'New name'
+    });
+    expect(updateIntegrationInternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: { name: 'New name' }
+      })
+    );
+  });
+
+  it('rejects attaching a Magic MCP integration and integrations with no capable providers', async () => {
+    let err = await ensureAdapterIntegration({
+      tenant,
+      environment,
+      type: 'chat',
+      adapterGlobal,
+      isStandalone: false,
+      integration: { ...visibleIntegration, isMagicMcpBacking: true } as any
+    }).catch((error: any) => error);
+    expect(err?.data?.code ?? err?.error?.code ?? String(err)).toMatch(
+      /adapter_integration_magic_mcp_blocked|Magic MCP/
+    );
+
+    tx.integrationProvider.findMany.mockResolvedValue([]);
+    let missing = await ensureAdapterIntegration({
+      tenant,
+      environment,
+      type: 'chat',
+      adapterGlobal,
+      isStandalone: false,
+      integration: visibleIntegration as any
+    }).catch((error: any) => error);
+    expect(missing?.data?.code ?? missing?.error?.code ?? String(missing)).toMatch(
+      /adapter_integration_no_capable_providers|no providers/
+    );
+  });
+
+  it('filters capable providers and reuses one live row per type', async () => {
+    tx.integrationProvider.findMany.mockResolvedValue([
+      { oid: 2n, providerOid: 2n },
+      { oid: 3n, providerOid: 3n }
+    ]);
+    tx.adapterIntegration.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      ...adapterIntegrationRow,
+      isStandalone: false,
+      integrationOid: 21n,
+      integration: visibleIntegration
+    });
+    tx.adapterIntegration.create.mockResolvedValue({
+      ...adapterIntegrationRow,
+      isStandalone: false,
+      integrationOid: 21n
+    });
+    tx.adapterIntegration.findUniqueOrThrow.mockResolvedValue({
+      ...adapterIntegrationRow,
+      isStandalone: false,
+      integrationOid: 21n,
+      integration: visibleIntegration
+    });
+
+    let first = await ensureAdapterIntegration({
+      tenant,
+      environment,
+      type: 'chat',
+      adapterGlobal,
+      isStandalone: false,
+      integration: visibleIntegration as any
+    });
+    expect(createIntegrationInternal).not.toHaveBeenCalled();
+    expect(tx.adapterIntegrationProvider.create).toHaveBeenCalledTimes(2);
+
+    let second = await ensureAdapterIntegration({
+      tenant,
+      environment,
+      type: 'chat',
+      adapterGlobal,
+      isStandalone: false,
+      integration: visibleIntegration as any
+    });
+    expect(second.oid).toBe(first.oid);
+    expect(tx.adapterIntegration.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects definition provider writes on existing adapter integrations', async () => {
+    tx.adapterIntegration.findUniqueOrThrow.mockResolvedValue({
+      ...adapterIntegrationRow,
+      isStandalone: false,
+      integration: visibleIntegration
+    });
+
+    let err = await ensureAdapterProvider({
+      tenant,
+      environment,
+      adapterIntegration: adapterIntegrationRow as any,
+      input: { providerId: 'pro_slack' }
+    }).catch((error: any) => error);
+    expect(err?.data?.code ?? err?.error?.code ?? String(err)).toMatch(
+      /adapter_integration_providers_managed_by_integration|managed by the integration/
+    );
+  });
+
+  it('archives the hidden integration on standalone product archive', async () => {
+    await removeAdapterIntegration({
+      tenant,
+      environment,
+      adapterIntegration: adapterIntegrationRow as any,
+      cause: 'product'
+    });
+
+    expect(archiveIntegrationInternal).toHaveBeenCalledWith(
+      expect.objectContaining({ _canModifyAdapterBacking: true })
+    );
+  });
+
+  it('does not archive a visible integration on product archive', async () => {
+    tx.adapterIntegration.findUniqueOrThrow.mockResolvedValue({
+      ...adapterIntegrationRow,
+      isStandalone: false,
+      integration: visibleIntegration
+    });
+
+    await removeAdapterIntegration({
+      tenant,
+      environment,
+      adapterIntegration: { ...adapterIntegrationRow, isStandalone: false } as any,
+      cause: 'product'
+    });
+
+    expect(archiveIntegrationInternal).not.toHaveBeenCalled();
+  });
+
+  it('creates a hidden instance for standalone parent adapters and instance-only standalone otherwise', async () => {
+    await ensureAdapterInstance({
+      tenant,
+      environment,
+      adapterIntegration: adapterIntegrationRow as any,
+      createStandaloneInstance: { name: 'Bot' }
+    });
+    expect(createIntegrationInstanceInternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isAdapterBacking: true,
+        input: expect.objectContaining({ name: 'Bot' })
+      })
+    );
+    expect(tx.adapterIntegrationInstance.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'draft' })
+      })
+    );
+
+    tx.adapterIntegration.findUniqueOrThrow.mockResolvedValue({
+      ...adapterIntegrationRow,
+      isStandalone: false,
+      integrationOid: 21n,
+      integration: visibleIntegration
+    });
+    createIntegrationInstanceInternal.mockClear();
+
+    await ensureAdapterInstance({
+      tenant,
+      environment,
+      adapterIntegration: { ...adapterIntegrationRow, isStandalone: false } as any,
+      createStandaloneInstance: { name: 'Hidden inst' }
+    });
+    expect(createIntegrationInstanceInternal).toHaveBeenCalled();
+
+    createIntegrationInstanceInternal.mockClear();
+    let visibleInstance = {
+      oid: 55n,
+      integrationOid: 21n,
+      name: 'Visible',
+      isAdapterBacking: false,
+      status: 'active'
+    } as any;
+    await ensureAdapterInstance({
+      tenant,
+      environment,
+      adapterIntegration: { ...adapterIntegrationRow, isStandalone: false } as any,
+      integrationInstance: visibleInstance
+    });
+    expect(createIntegrationInstanceInternal).not.toHaveBeenCalled();
+  });
+
+  it('archives a standalone instance backing on product archive and leaves a linked instance', async () => {
+    await removeAdapterInstance({
+      tenant,
+      environment,
+      adapterInstance: { oid: 300n } as any,
+      cause: 'product'
+    });
+    expect(archiveIntegrationInstanceInternal).toHaveBeenCalled();
+
+    archiveIntegrationInstanceInternal.mockClear();
+    tx.adapterIntegrationInstance.findUniqueOrThrow.mockResolvedValue({
+      oid: 301n,
+      status: 'active',
+      isStandalone: false,
+      adapterIntegration: { ...adapterIntegrationRow, isStandalone: false },
+      integrationInstance: { oid: 55n }
+    });
+
+    await removeAdapterInstance({
+      tenant,
+      environment,
+      adapterInstance: { oid: 301n } as any,
+      cause: 'product'
+    });
+    expect(archiveIntegrationInstanceInternal).not.toHaveBeenCalled();
+  });
+});

--- a/src/metorial/subspace/modules/integration/src/adapter/primitives.ts
+++ b/src/metorial/subspace/modules/integration/src/adapter/primitives.ts
@@ -1,0 +1,727 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import {
+  type AdapterIntegration,
+  type AdapterIntegrationInstance,
+  type AdapterIntegrationInstanceProvider,
+  type AdapterIntegrationProvider,
+  type AdapterIntegrationType,
+  type Environment,
+  getId,
+  type Integration,
+  type IntegrationInstance,
+  type ProviderAdapterGlobal,
+  type Tenant,
+  withTransaction
+} from '@metorial-subspace/db';
+import { integrationService } from '../services/integration';
+import { integrationInstanceService } from '../services/integrationInstance';
+import {
+  integrationInstanceProviderService,
+  type SetIntegrationInstanceProviderInput
+} from '../services/integrationInstanceProvider';
+import {
+  integrationProviderService,
+  type CreateIntegrationProviderParams,
+  type UpdateIntegrationProviderParams
+} from '../services/integrationProvider';
+import {
+  adapterInstanceLiveStatuses,
+  adapterLiveStatuses,
+  adapterScopeFromIntegration,
+  assertProviderImplementsAdapter,
+  isLiveAdapterInstanceStatus,
+  isLiveAdapterStatus,
+  listAdapterCapableIntegrationInstanceProviders,
+  listAdapterCapableIntegrationProviders,
+  requireLiveAdapterIntegration,
+  requireLiveAdapterInstance,
+  toAdapterInstanceStatus
+} from './helpers';
+
+export type { SetIntegrationInstanceProviderInput };
+
+export type AdapterCause = 'product' | 'integration';
+
+export type EnsureAdapterIntegrationParams = {
+  tenant: Tenant;
+  environment: Environment;
+  type: AdapterIntegrationType;
+  adapterGlobal: ProviderAdapterGlobal;
+  isStandalone: boolean;
+  presentation?: { name: string };
+  integration?: Integration;
+};
+
+export type CreateStandaloneAdapterInstanceInput = {
+  name?: string;
+  identity?: { identityActorId?: string | null; identityId?: string | null };
+  providers?: SetIntegrationInstanceProviderInput[];
+};
+
+let loadAdapterIntegration = (oid: bigint) =>
+  withTransaction(async db =>
+    db.adapterIntegration.findUniqueOrThrow({
+      where: { oid },
+      include: { integration: true, adapterGlobal: true }
+    })
+  );
+
+let loadAdapterInstance = (oid: bigint) =>
+  withTransaction(async db =>
+    db.adapterIntegrationInstance.findUniqueOrThrow({
+      where: { oid },
+      include: {
+        adapterIntegration: { include: { adapterGlobal: true, integration: true } },
+        integrationInstance: true
+      }
+    })
+  );
+
+let rejectExistingProviderMutation = () => {
+  throw new ServiceError(
+    badRequestError({
+      code: 'adapter_integration_providers_managed_by_integration',
+      message:
+        'Definition providers for an existing adapter integration are managed by the integration.'
+    })
+  );
+};
+
+let liveInstanceStatus = (integrationInstance: IntegrationInstance) =>
+  isLiveAdapterInstanceStatus(integrationInstance.status)
+    ? toAdapterInstanceStatus(integrationInstance.status)
+    : ('active' as const);
+
+export let syncAdapterProviders = async (d: { adapterIntegration: AdapterIntegration }) => {
+  return withTransaction(async db => {
+    let adapterIntegration = await loadAdapterIntegration(d.adapterIntegration.oid);
+    requireLiveAdapterIntegration(adapterIntegration);
+
+    let capable = await listAdapterCapableIntegrationProviders({
+      integrationOid: adapterIntegration.integrationOid,
+      adapterGlobalOid: adapterIntegration.adapterGlobalOid
+    });
+    let capableOids = new Set(capable.map(provider => provider.oid));
+    let links: AdapterIntegrationProvider[] = [];
+
+    for (let integrationProvider of capable) {
+      let existing = await db.adapterIntegrationProvider.findUnique({
+        where: {
+          adapterIntegrationOid_integrationProviderOid: {
+            adapterIntegrationOid: adapterIntegration.oid,
+            integrationProviderOid: integrationProvider.oid
+          }
+        }
+      });
+
+      let link = existing
+        ? await db.adapterIntegrationProvider.update({
+            where: { oid: existing.oid },
+            data: { status: 'active' }
+          })
+        : await db.adapterIntegrationProvider.create({
+            data: {
+              ...getId('adapterIntegrationProvider'),
+              status: 'active',
+              ...adapterScopeFromIntegration(adapterIntegration.integration),
+              adapterIntegrationOid: adapterIntegration.oid,
+              integrationOid: adapterIntegration.integrationOid,
+              integrationProviderOid: integrationProvider.oid
+            }
+          });
+
+      links.push(link);
+    }
+
+    await db.adapterIntegrationProvider.updateMany({
+      where: {
+        adapterIntegrationOid: adapterIntegration.oid,
+        status: { in: [...adapterLiveStatuses] },
+        integrationProviderOid: { notIn: [...capableOids] }
+      },
+      data: { status: 'archived' }
+    });
+
+    return links;
+  });
+};
+
+export let syncAdapterInstanceProviders = async (d: {
+  adapterIntegrationInstance: AdapterIntegrationInstance;
+}) => {
+  return withTransaction(async db => {
+    let adapterInstance = await loadAdapterInstance(d.adapterIntegrationInstance.oid);
+    if (!isLiveAdapterInstanceStatus(adapterInstance.status)) return [];
+
+    let adapterIntegration = adapterInstance.adapterIntegration;
+    requireLiveAdapterIntegration(adapterIntegration);
+
+    let capable = await listAdapterCapableIntegrationInstanceProviders({
+      integrationInstanceOid: adapterInstance.integrationInstanceOid,
+      adapterGlobalOid: adapterIntegration.adapterGlobalOid
+    });
+    let adapterProviders = await db.adapterIntegrationProvider.findMany({
+      where: {
+        adapterIntegrationOid: adapterIntegration.oid,
+        status: { in: [...adapterLiveStatuses] }
+      }
+    });
+    let adapterProviderByIntegrationProviderOid = new Map(
+      adapterProviders.map(provider => [provider.integrationProviderOid, provider])
+    );
+
+    let keepOids: bigint[] = [];
+    let links: AdapterIntegrationInstanceProvider[] = [];
+
+    for (let instanceProvider of capable) {
+      let adapterProvider = adapterProviderByIntegrationProviderOid.get(
+        instanceProvider.integrationProviderOid
+      );
+      if (!adapterProvider) continue;
+
+      let existing = await db.adapterIntegrationInstanceProvider.findUnique({
+        where: {
+          adapterIntegrationInstanceOid_adapterIntegrationProviderOid: {
+            adapterIntegrationInstanceOid: adapterInstance.oid,
+            adapterIntegrationProviderOid: adapterProvider.oid
+          }
+        }
+      });
+
+      let link = existing
+        ? await db.adapterIntegrationInstanceProvider.update({
+            where: { oid: existing.oid },
+            data: { status: 'active' }
+          })
+        : await db.adapterIntegrationInstanceProvider.create({
+            data: {
+              ...getId('adapterIntegrationInstanceProvider'),
+              status: 'active',
+              ...adapterScopeFromIntegration(adapterIntegration.integration),
+              adapterIntegrationInstanceOid: adapterInstance.oid,
+              adapterIntegrationProviderOid: adapterProvider.oid,
+              adapterIntegrationOid: adapterIntegration.oid,
+              integrationInstanceProviderOid: instanceProvider.oid,
+              integrationInstanceOid: adapterInstance.integrationInstanceOid,
+              integrationProviderOid: instanceProvider.integrationProviderOid,
+              integrationOid: adapterIntegration.integrationOid
+            }
+          });
+
+      keepOids.push(link.oid);
+      links.push(link);
+    }
+
+    await db.adapterIntegrationInstanceProvider.updateMany({
+      where: {
+        adapterIntegrationInstanceOid: adapterInstance.oid,
+        status: { in: [...adapterLiveStatuses] },
+        oid: { notIn: keepOids }
+      },
+      data: { status: 'archived' }
+    });
+
+    return links;
+  });
+};
+
+export let syncAdapterInstanceStatus = async (d: {
+  adapterInstance: AdapterIntegrationInstance;
+}) => {
+  return withTransaction(async db => {
+    let adapterInstance = await loadAdapterInstance(d.adapterInstance.oid);
+    if (!isLiveAdapterInstanceStatus(adapterInstance.status)) return adapterInstance;
+
+    let nextStatus = toAdapterInstanceStatus(adapterInstance.integrationInstance.status);
+    if (!isLiveAdapterInstanceStatus(nextStatus)) return adapterInstance;
+    if (adapterInstance.status === nextStatus) return adapterInstance;
+
+    return db.adapterIntegrationInstance.update({
+      where: { oid: adapterInstance.oid },
+      data: { status: nextStatus }
+    });
+  });
+};
+
+export let ensureAdapterIntegration = async (d: EnsureAdapterIntegrationParams) => {
+  return withTransaction(async db => {
+    if (d.isStandalone) {
+      if (!d.presentation?.name?.trim()) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'adapter_integration_name_required',
+            message: 'A name is required to create a standalone adapter integration.'
+          })
+        );
+      }
+
+      let adapterId = getId('adapterIntegration');
+      let integration = await integrationService.createIntegrationInternal({
+        tenant: d.tenant,
+        environment: d.environment,
+        slug: `adapter-${d.type}-${adapterId.id}`,
+        isAdapterBacking: true,
+        input: {
+          name: d.presentation.name.trim(),
+          description: '',
+          metadata: {}
+        }
+      });
+
+      let adapterIntegration = await db.adapterIntegration.create({
+        data: {
+          ...adapterId,
+          type: d.type,
+          status: 'active',
+          isStandalone: true,
+          adapterGlobalOid: d.adapterGlobal.oid,
+          ...adapterScopeFromIntegration(integration),
+          integrationOid: integration.oid
+        }
+      });
+
+      await syncAdapterProviders({ adapterIntegration });
+
+      return loadAdapterIntegration(adapterIntegration.oid);
+    }
+
+    if (!d.integration) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'adapter_integration_required',
+          message: 'An existing integration is required when isStandalone is false.'
+        })
+      );
+    }
+
+    if (d.integration.isMagicMcpBacking) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'adapter_integration_magic_mcp_blocked',
+          message: 'Magic MCP owned integrations cannot be attached to an adapter.'
+        })
+      );
+    }
+
+    let capable = await listAdapterCapableIntegrationProviders({
+      integrationOid: d.integration.oid,
+      adapterGlobalOid: d.adapterGlobal.oid
+    });
+    if (capable.length === 0) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'adapter_integration_no_capable_providers',
+          message: 'The integration has no providers that implement the requested adapter.'
+        })
+      );
+    }
+
+    let live = await db.adapterIntegration.findFirst({
+      where: {
+        integrationOid: d.integration.oid,
+        type: d.type,
+        status: { in: [...adapterLiveStatuses] }
+      }
+    });
+
+    let adapterIntegration =
+      live ??
+      (await db.adapterIntegration.create({
+        data: {
+          ...getId('adapterIntegration'),
+          type: d.type,
+          status: 'active',
+          isStandalone: false,
+          adapterGlobalOid: d.adapterGlobal.oid,
+          ...adapterScopeFromIntegration(d.integration),
+          integrationOid: d.integration.oid
+        }
+      }));
+
+    await syncAdapterProviders({ adapterIntegration });
+
+    return loadAdapterIntegration(adapterIntegration.oid);
+  });
+};
+
+export let applyAdapterIntegrationPresentation = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterIntegration: AdapterIntegration;
+  name: string;
+}) => {
+  return withTransaction(async () => {
+    let adapterIntegration = await loadAdapterIntegration(d.adapterIntegration.oid);
+    if (!adapterIntegration.isStandalone) return adapterIntegration.integration;
+
+    return integrationService.updateIntegrationInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      integration: adapterIntegration.integration,
+      input: { name: d.name }
+    });
+  });
+};
+
+export let ensureAdapterProvider = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterIntegration: AdapterIntegration;
+  input: CreateIntegrationProviderParams['input'];
+}) => {
+  return withTransaction(async db => {
+    let adapterIntegration = await loadAdapterIntegration(d.adapterIntegration.oid);
+    requireLiveAdapterIntegration(adapterIntegration);
+    if (!adapterIntegration.isStandalone) rejectExistingProviderMutation();
+
+    let provider = await db.provider.findFirst({
+      where: { id: d.input.providerId }
+    });
+    if (provider) {
+      await assertProviderImplementsAdapter({
+        providerOid: provider.oid,
+        adapterGlobalOid: adapterIntegration.adapterGlobalOid
+      });
+    }
+
+    let integrationProvider = await integrationProviderService.createIntegrationProviderInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      integration: adapterIntegration.integration,
+      input: d.input
+    });
+
+    let links = await syncAdapterProviders({ adapterIntegration });
+    let link = links.find(item => item.integrationProviderOid === integrationProvider.oid);
+    if (!link) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'adapter_integration_provider_not_synced',
+          message: 'The adapter provider link could not be created.'
+        })
+      );
+    }
+
+    return db.adapterIntegrationProvider.findUniqueOrThrow({ where: { oid: link.oid } });
+  });
+};
+
+export let updateAdapterProvider = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterIntegrationProvider: AdapterIntegrationProvider;
+  input: UpdateIntegrationProviderParams['input'];
+}) => {
+  return withTransaction(async db => {
+    let adapterProvider = await db.adapterIntegrationProvider.findUniqueOrThrow({
+      where: { oid: d.adapterIntegrationProvider.oid },
+      include: {
+        adapterIntegration: { include: { integration: true, adapterGlobal: true } },
+        integrationProvider: true
+      }
+    });
+    requireLiveAdapterIntegration(adapterProvider.adapterIntegration);
+    if (!adapterProvider.adapterIntegration.isStandalone) rejectExistingProviderMutation();
+
+    await integrationProviderService.updateIntegrationProviderInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      integrationProvider: adapterProvider.integrationProvider,
+      input: d.input
+    });
+
+    await syncAdapterProviders({ adapterIntegration: adapterProvider.adapterIntegration });
+
+    return db.adapterIntegrationProvider.findUniqueOrThrow({
+      where: { oid: adapterProvider.oid }
+    });
+  });
+};
+
+export let removeAdapterProvider = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterIntegrationProvider: AdapterIntegrationProvider;
+}) => {
+  return withTransaction(async db => {
+    let adapterProvider = await db.adapterIntegrationProvider.findUniqueOrThrow({
+      where: { oid: d.adapterIntegrationProvider.oid },
+      include: {
+        adapterIntegration: { include: { integration: true, adapterGlobal: true } },
+        integrationProvider: true
+      }
+    });
+    requireLiveAdapterIntegration(adapterProvider.adapterIntegration);
+    if (!adapterProvider.adapterIntegration.isStandalone) rejectExistingProviderMutation();
+
+    await integrationProviderService.archiveIntegrationProviderInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      integrationProvider: adapterProvider.integrationProvider
+    });
+
+    await syncAdapterProviders({ adapterIntegration: adapterProvider.adapterIntegration });
+
+    return db.adapterIntegrationProvider.findUniqueOrThrow({
+      where: { oid: adapterProvider.oid }
+    });
+  });
+};
+
+export let removeAdapterInstance = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterInstance: AdapterIntegrationInstance;
+  cause: AdapterCause;
+}) => {
+  return withTransaction(async db => {
+    let adapterInstance = await loadAdapterInstance(d.adapterInstance.oid);
+    if (!isLiveAdapterInstanceStatus(adapterInstance.status)) return adapterInstance;
+
+    await db.adapterIntegrationInstanceProvider.updateMany({
+      where: {
+        adapterIntegrationInstanceOid: adapterInstance.oid,
+        status: { not: 'deleted' }
+      },
+      data: { status: 'archived' }
+    });
+
+    let archived = await db.adapterIntegrationInstance.update({
+      where: { oid: adapterInstance.oid },
+      data: { status: 'archived' }
+    });
+
+    if (adapterInstance.isStandalone && d.cause === 'product') {
+      await integrationInstanceService.archiveIntegrationInstanceInternal({
+        tenant: d.tenant,
+        environment: d.environment,
+        integrationInstance: adapterInstance.integrationInstance,
+        _canModifyAdapterBacking: true
+      });
+    }
+
+    return archived;
+  });
+};
+
+export let removeAdapterIntegration = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterIntegration: AdapterIntegration;
+  cause: AdapterCause;
+}) => {
+  return withTransaction(async db => {
+    let adapterIntegration = await loadAdapterIntegration(d.adapterIntegration.oid);
+    if (!isLiveAdapterStatus(adapterIntegration.status)) return adapterIntegration;
+
+    let instances = await db.adapterIntegrationInstance.findMany({
+      where: {
+        adapterIntegrationOid: adapterIntegration.oid,
+        status: { in: [...adapterInstanceLiveStatuses] }
+      }
+    });
+    for (let instance of instances) {
+      await removeAdapterInstance({
+        tenant: d.tenant,
+        environment: d.environment,
+        adapterInstance: instance,
+        cause: d.cause
+      });
+    }
+
+    await db.adapterIntegrationProvider.updateMany({
+      where: {
+        adapterIntegrationOid: adapterIntegration.oid,
+        status: { not: 'deleted' }
+      },
+      data: { status: 'archived' }
+    });
+
+    let archived = await db.adapterIntegration.update({
+      where: { oid: adapterIntegration.oid },
+      data: { status: 'archived' }
+    });
+
+    if (adapterIntegration.isStandalone && d.cause === 'product') {
+      await integrationService.archiveIntegrationInternal({
+        tenant: d.tenant,
+        environment: d.environment,
+        integration: adapterIntegration.integration,
+        _canModifyAdapterBacking: true
+      });
+    }
+
+    return archived;
+  });
+};
+
+export let ensureAdapterInstance = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterIntegration: AdapterIntegration;
+  integrationInstance?: IntegrationInstance;
+  createStandaloneInstance?: CreateStandaloneAdapterInstanceInput;
+}) => {
+  return withTransaction(async db => {
+    let adapterIntegration = await loadAdapterIntegration(d.adapterIntegration.oid);
+    requireLiveAdapterIntegration(adapterIntegration);
+
+    let createHiddenInstance = async (input: CreateStandaloneAdapterInstanceInput) => {
+      let integrationInstance = await integrationInstanceService.createIntegrationInstanceInternal(
+        {
+          tenant: d.tenant,
+          environment: d.environment,
+          integration: adapterIntegration.integration,
+          isAdapterBacking: true,
+          input: {
+            name: input.name?.trim() || adapterIntegration.integration.name,
+            identityActorId: input.identity?.identityActorId,
+            identityId: input.identity?.identityId,
+            providers: input.providers
+          }
+        }
+      );
+
+      return { integrationInstance, isStandalone: true as const };
+    };
+
+    let resolved: { integrationInstance: IntegrationInstance; isStandalone: boolean };
+
+    if (adapterIntegration.isStandalone) {
+      if (d.integrationInstance) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'adapter_instance_link_blocked_for_standalone',
+            message:
+              'Standalone adapter integrations always create hidden instances and cannot link a visible instance.'
+          })
+        );
+      }
+
+      resolved = await createHiddenInstance(d.createStandaloneInstance ?? {});
+    } else if (d.integrationInstance) {
+      if (d.integrationInstance.integrationOid !== adapterIntegration.integrationOid) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'adapter_instance_integration_mismatch',
+            message: 'The integration instance does not belong to this integration.'
+          })
+        );
+      }
+
+      resolved = { integrationInstance: d.integrationInstance, isStandalone: false };
+    } else if (d.createStandaloneInstance) {
+      resolved = await createHiddenInstance(d.createStandaloneInstance);
+    } else {
+      throw new ServiceError(
+        badRequestError({
+          code: 'adapter_instance_source_required',
+          message:
+            'Provide an existing integration instance or createStandaloneInstance for a non-standalone adapter integration.'
+        })
+      );
+    }
+
+    let existing = await db.adapterIntegrationInstance.findUnique({
+      where: {
+        adapterIntegrationOid_integrationInstanceOid: {
+          adapterIntegrationOid: adapterIntegration.oid,
+          integrationInstanceOid: resolved.integrationInstance.oid
+        }
+      }
+    });
+
+    let status = liveInstanceStatus(resolved.integrationInstance);
+
+    let adapterInstance = existing
+      ? await db.adapterIntegrationInstance.update({
+          where: { oid: existing.oid },
+          data: { status, isStandalone: resolved.isStandalone }
+        })
+      : await db.adapterIntegrationInstance.create({
+          data: {
+            ...getId('adapterIntegrationInstance'),
+            status,
+            isStandalone: resolved.isStandalone,
+            ...adapterScopeFromIntegration(adapterIntegration.integration),
+            adapterIntegrationOid: adapterIntegration.oid,
+            integrationInstanceOid: resolved.integrationInstance.oid,
+            integrationOid: adapterIntegration.integrationOid
+          }
+        });
+
+    await syncAdapterInstanceProviders({ adapterIntegrationInstance: adapterInstance });
+
+    return loadAdapterInstance(adapterInstance.oid);
+  });
+};
+
+export let applyAdapterInstancePresentation = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterInstance: AdapterIntegrationInstance;
+  name: string;
+}) => {
+  return withTransaction(async () => {
+    let adapterInstance = await loadAdapterInstance(d.adapterInstance.oid);
+    if (!adapterInstance.isStandalone) return adapterInstance.integrationInstance;
+
+    return integrationInstanceService.updateIntegrationInstanceInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      integrationInstance: adapterInstance.integrationInstance,
+      input: { name: d.name }
+    });
+  });
+};
+
+export let setAdapterInstanceProvider = async (d: {
+  tenant: Tenant;
+  environment: Environment;
+  adapterInstance: AdapterIntegrationInstance;
+  input: SetIntegrationInstanceProviderInput;
+}) => {
+  return withTransaction(async db => {
+    let adapterInstance = await loadAdapterInstance(d.adapterInstance.oid);
+    requireLiveAdapterIntegration(adapterInstance.adapterIntegration);
+    requireLiveAdapterInstance(adapterInstance);
+
+    let provider = await db.provider.findFirst({ where: { id: d.input.providerId } });
+    if (provider) {
+      await assertProviderImplementsAdapter({
+        providerOid: provider.oid,
+        adapterGlobalOid: adapterInstance.adapterIntegration.adapterGlobalOid
+      });
+    } else {
+      let integrationProvider = await db.integrationProvider.findFirst({
+        where: { id: d.input.providerId }
+      });
+      if (!integrationProvider) {
+        throw new ServiceError(
+          badRequestError({
+            code: 'provider_not_found',
+            message: 'The provider could not be found.'
+          })
+        );
+      }
+
+      await assertProviderImplementsAdapter({
+        providerOid: integrationProvider.providerOid,
+        adapterGlobalOid: adapterInstance.adapterIntegration.adapterGlobalOid
+      });
+    }
+
+    await integrationInstanceProviderService.setIntegrationInstanceProviderInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      integrationInstance: adapterInstance.integrationInstance,
+      input: d.input
+    });
+
+    let links = await syncAdapterInstanceProviders({
+      adapterIntegrationInstance: adapterInstance
+    });
+
+    return links;
+  });
+};

--- a/src/metorial/subspace/modules/integration/src/adapter/register.ts
+++ b/src/metorial/subspace/modules/integration/src/adapter/register.ts
@@ -1,0 +1,12 @@
+import { registerIntegrationTransactionListener } from '../listeners';
+import { adapterCoordinationListener } from './listener';
+
+let registered = false;
+
+export let registerAdapterCoordinationListener = () => {
+  if (registered) return;
+  registered = true;
+  registerIntegrationTransactionListener(adapterCoordinationListener);
+};
+
+registerAdapterCoordinationListener();

--- a/src/metorial/subspace/modules/integration/src/index.ts
+++ b/src/metorial/subspace/modules/integration/src/index.ts
@@ -1,1 +1,4 @@
 export * from './services';
+export * from './adapter';
+export * from './listeners';
+import './adapter/register';

--- a/src/metorial/subspace/modules/integration/src/listeners.ts
+++ b/src/metorial/subspace/modules/integration/src/listeners.ts
@@ -1,0 +1,48 @@
+import type {
+  Integration,
+  IntegrationInstance,
+  IntegrationInstanceProvider,
+  IntegrationProvider
+} from '@metorial-subspace/db';
+
+export type IntegrationTransactionEvent =
+  | {
+      kind: 'integration.created' | 'integration.updated' | 'integration.archived';
+      integration: Integration;
+    }
+  | {
+      kind:
+        | 'integrationProvider.created'
+        | 'integrationProvider.updated'
+        | 'integrationProvider.archived';
+      integration: Integration;
+      integrationProvider: IntegrationProvider;
+    }
+  | {
+      kind: 'integrationInstance.created' | 'integrationInstance.updated' | 'integrationInstance.archived';
+      integration: Integration;
+      integrationInstance: IntegrationInstance;
+    }
+  | {
+      kind: 'integrationInstanceProvider.set' | 'integrationInstanceProvider.archived';
+      integrationInstance: IntegrationInstance;
+      integrationInstanceProvider: IntegrationInstanceProvider;
+    };
+
+export type IntegrationTransactionListener = {
+  onEvent(event: IntegrationTransactionEvent): Promise<void>;
+};
+
+let listeners: IntegrationTransactionListener[] = [];
+
+export let registerIntegrationTransactionListener = (
+  listener: IntegrationTransactionListener
+) => {
+  listeners.push(listener);
+};
+
+export let notifyIntegrationTransaction = async (event: IntegrationTransactionEvent) => {
+  for (let listener of listeners) {
+    await listener.onEvent(event);
+  }
+};

--- a/src/metorial/subspace/modules/integration/src/queues/delete/integration.ts
+++ b/src/metorial/subspace/modules/integration/src/queues/delete/integration.ts
@@ -61,6 +61,23 @@ export let integrationDeleteQueueProcessor = integrationDeleteQueue.process(asyn
   });
   if (!integration || integration.status !== 'archived') return;
 
+  await db.adapterIntegrationInstanceProvider.updateMany({
+    where: { integrationOid: integration.oid, status: { not: 'deleted' } },
+    data: { status: 'deleted' }
+  });
+  await db.adapterIntegrationInstance.updateMany({
+    where: { integrationOid: integration.oid, status: { not: 'deleted' } },
+    data: { status: 'deleted' }
+  });
+  await db.adapterIntegrationProvider.updateMany({
+    where: { integrationOid: integration.oid, status: { not: 'deleted' } },
+    data: { status: 'deleted' }
+  });
+  await db.adapterIntegration.updateMany({
+    where: { integrationOid: integration.oid, status: { not: 'deleted' } },
+    data: { status: 'deleted' }
+  });
+
   await db.integrationProvider.updateMany({
     where: { integrationOid: integration.oid, status: 'active' },
     data: {

--- a/src/metorial/subspace/modules/integration/src/queues/delete/integrationInstance.ts
+++ b/src/metorial/subspace/modules/integration/src/queues/delete/integrationInstance.ts
@@ -61,6 +61,21 @@ export let integrationInstanceDeleteQueueProcessor = integrationInstanceDeleteQu
     });
     if (!integrationInstance || integrationInstance.status !== 'archived') return;
 
+    await db.adapterIntegrationInstanceProvider.updateMany({
+      where: {
+        integrationInstanceOid: integrationInstance.oid,
+        status: { not: 'deleted' }
+      },
+      data: { status: 'deleted' }
+    });
+    await db.adapterIntegrationInstance.updateMany({
+      where: {
+        integrationInstanceOid: integrationInstance.oid,
+        status: { not: 'deleted' }
+      },
+      data: { status: 'deleted' }
+    });
+
     await db.integrationInstanceProvider.updateMany({
       where: { integrationInstanceOid: integrationInstance.oid, status: { not: 'deleted' } },
       data: {

--- a/src/metorial/subspace/modules/integration/src/services/integration.ts
+++ b/src/metorial/subspace/modules/integration/src/services/integration.ts
@@ -13,6 +13,7 @@ import {
   type Tenant,
   withTransaction
 } from '@metorial-subspace/db';
+import { notifyIntegrationTransaction } from '../listeners';
 import {
   checkDeletedEdit,
   type DateFilter,
@@ -91,6 +92,7 @@ type IntegrationWriteInput = {
 export type ListIntegrationsParams = {
   search?: string;
   includeMagicMcpBackings?: boolean;
+  includeAdapterBackings?: boolean;
 
   status?: IntegrationStatus[];
   allowDeleted?: boolean;
@@ -109,6 +111,8 @@ export type GetIntegrationByIdParams = {
 };
 
 export type CreateIntegrationParams = {
+  slug?: string;
+  isAdapterBacking?: boolean;
   input: {
     name: string;
     description?: string;
@@ -153,6 +157,7 @@ export type UpdateIntegrationParams = {
 export type ArchiveIntegrationParams = {
   integration: Integration;
   _canModifyMagicMcpBacking?: boolean;
+  _canModifyAdapterBacking?: boolean;
 };
 
 class integrationServiceImpl {
@@ -164,6 +169,7 @@ class integrationServiceImpl {
     slug: string;
     input: IntegrationWriteInput;
     isMagicMcpBacking?: boolean;
+    isAdapterBacking?: boolean;
   }) {
     let canOverrideToolFilters = d.input.canOverrideToolFilters ?? false;
 
@@ -171,6 +177,7 @@ class integrationServiceImpl {
       ...d.id,
       status: 'active' as const,
       isMagicMcpBacking: !!d.isMagicMcpBacking,
+      isAdapterBacking: !!d.isAdapterBacking,
       slug: slugify(d.slug),
       name: d.input.name.trim(),
       description: d.input.description?.trim() || null,
@@ -255,6 +262,7 @@ class integrationServiceImpl {
               OR: d.includeMagicMcpBackings
                 ? undefined
                 : [{ isMagicMcpBacking: false }, { providerTemplateBacking: { isNot: null } }],
+              isAdapterBacking: d.includeAdapterBackings ? undefined : false,
 
               ...normalizeStatusForList(d).noParent,
 
@@ -339,8 +347,9 @@ class integrationServiceImpl {
           solution,
           environment: d.environment,
           id: newId,
-          slug: getSlug(d.input),
-          input: d.input
+          slug: d.slug ?? getSlug(d.input),
+          input: d.input,
+          isAdapterBacking: d.isAdapterBacking
         })
       });
 
@@ -354,6 +363,11 @@ class integrationServiceImpl {
       await addAfterTransactionHook(async () =>
         integrationCreatedQueue.add({ integrationId: res.id })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integration.created',
+        integration: res
+      });
 
       return res;
     });
@@ -474,6 +488,11 @@ class integrationServiceImpl {
         integrationUpdatedQueue.add({ integrationId: integration.id })
       );
 
+      await notifyIntegrationTransaction({
+        kind: 'integration.updated',
+        integration
+      });
+
       return integration;
     });
   }
@@ -511,6 +530,14 @@ class integrationServiceImpl {
         })
       );
     }
+    if (d.integration.isAdapterBacking && !d._canModifyAdapterBacking) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Adapter backed integrations cannot be deleted directly.',
+          code: 'adapter_backing_integration_delete_blocked'
+        })
+      );
+    }
 
     return await withTransaction(async db => {
       let integration = await db.integration.update({
@@ -530,6 +557,11 @@ class integrationServiceImpl {
       await addAfterTransactionHook(async () =>
         integrationArchivedQueue.add({ integrationId: integration.id })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integration.archived',
+        integration
+      });
 
       return integration;
     });

--- a/src/metorial/subspace/modules/integration/src/services/integrationInstance.ts
+++ b/src/metorial/subspace/modules/integration/src/services/integrationInstance.ts
@@ -51,6 +51,7 @@ import {
 } from '@metorial-subspace/module-tenant';
 import { Fabric } from '@metorial/fabric';
 import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
+import { notifyIntegrationTransaction } from '../listeners';
 import {
   integrationInstanceArchivedQueue,
   integrationInstanceCreatedQueue,
@@ -188,6 +189,7 @@ let resolveIntegrationIdentity = async (d: {
 export type ListIntegrationInstancesParams = {
   search?: string;
   includeMagicMcpBackings?: boolean;
+  includeAdapterBackings?: boolean;
 
   status?: IntegrationInstanceStatus[];
   allowDeleted?: boolean;
@@ -216,6 +218,7 @@ export type GetIntegrationInstanceByIdParams = {
 export type CreateIntegrationInstanceParams = {
   integration: Integration;
   isHiddenDraft?: boolean;
+  isAdapterBacking?: boolean;
   input: {
     name: string;
     description?: string;
@@ -280,6 +283,7 @@ export type CreateSessionForIntegrationInstanceParams = {
 export type ArchiveIntegrationInstanceParams = {
   integrationInstance: IntegrationInstance;
   _canModifyMagicMcpBacking?: boolean;
+  _canModifyAdapterBacking?: boolean;
 };
 
 class integrationInstanceServiceImpl {
@@ -291,6 +295,7 @@ class integrationInstanceServiceImpl {
     id: ReturnType<typeof getId>;
     input: IntegrationInstanceWriteInput;
     isMagicMcpBacking?: boolean;
+    isAdapterBacking?: boolean;
     isHiddenDraft?: boolean;
   }) {
     return {
@@ -298,6 +303,7 @@ class integrationInstanceServiceImpl {
       status: 'draft' as const,
       isHiddenDraft: d.isHiddenDraft ?? false,
       isMagicMcpBacking: !!d.isMagicMcpBacking,
+      isAdapterBacking: !!d.isAdapterBacking,
       name: d.input.name.trim(),
       description: d.input.description?.trim() || null,
       metadata: d.input.metadata,
@@ -537,6 +543,7 @@ class integrationInstanceServiceImpl {
               environmentOid: d.environment.oid,
               isMagicMcpBacking:
                 d.includeMagicMcpBackings || integrations?.oids.length ? undefined : false,
+              isAdapterBacking: d.includeAdapterBackings ? undefined : false,
               isHiddenDraft: false,
 
               ...normalizeStatusForList(d).hasParent,
@@ -715,7 +722,8 @@ class integrationInstanceServiceImpl {
           integration: d.integration,
           id: newId,
           input: d.input,
-          isHiddenDraft: d.isHiddenDraft
+          isHiddenDraft: d.isHiddenDraft,
+          isAdapterBacking: d.isAdapterBacking
         }),
         include: integrationInstanceInclude
       });
@@ -738,6 +746,12 @@ class integrationInstanceServiceImpl {
       await addAfterTransactionHook(async () =>
         integrationInstanceCreatedQueue.add({ integrationInstanceId: integrationInstance.id })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integrationInstance.created',
+        integration: d.integration,
+        integrationInstance
+      });
 
       return integrationInstance;
     });
@@ -896,6 +910,12 @@ class integrationInstanceServiceImpl {
       await addAfterTransactionHook(async () =>
         integrationInstanceUpdatedQueue.add({ integrationInstanceId: integrationInstance.id })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integrationInstance.updated',
+        integration: integrationInstance.integration,
+        integrationInstance
+      });
 
       return integrationInstance;
     });
@@ -1087,6 +1107,14 @@ class integrationInstanceServiceImpl {
         })
       );
     }
+    if (d.integrationInstance.isAdapterBacking && !d._canModifyAdapterBacking) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Adapter backed integration instances cannot be deleted directly.',
+          code: 'adapter_backing_integration_instance_delete_blocked'
+        })
+      );
+    }
 
     return await withTransaction(async db => {
       let integrationInstance = await db.integrationInstance.update({
@@ -1106,6 +1134,12 @@ class integrationInstanceServiceImpl {
       await addAfterTransactionHook(async () =>
         integrationInstanceArchivedQueue.add({ integrationInstanceId: integrationInstance.id })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integrationInstance.archived',
+        integration: integrationInstance.integration,
+        integrationInstance
+      });
 
       return integrationInstance;
     });

--- a/src/metorial/subspace/modules/integration/src/services/integrationInstanceProvider.ts
+++ b/src/metorial/subspace/modules/integration/src/services/integrationInstanceProvider.ts
@@ -44,6 +44,7 @@ import {
   normalizeIntegrationProviderToolFilter,
   refreshIntegrationInstanceStatus
 } from '../lib/versions';
+import { notifyIntegrationTransaction } from '../listeners';
 import {
   enqueueIntegrationInstanceProviderSet,
   enqueueIntegrationInstanceProvidersSet
@@ -173,6 +174,7 @@ export type SetIntegrationInstanceProviderInput = {
 export type ListIntegrationInstanceProvidersParams = {
   search?: string;
   includeMagicMcpBackings?: boolean;
+  includeAdapterBackings?: boolean;
 
   status?: IntegrationInstanceProviderStatus[];
   allowDeleted?: boolean;
@@ -245,9 +247,11 @@ class integrationInstanceProviderServiceImpl {
               tenantOid: d.tenant.oid,
               solutionOid: solution.oid,
               environmentOid: d.environment.oid,
-              integrationInstance: d.includeMagicMcpBackings
-                ? { isHiddenDraft: false }
-                : { isMagicMcpBacking: false, isHiddenDraft: false },
+              integrationInstance: {
+                isHiddenDraft: false,
+                isMagicMcpBacking: d.includeMagicMcpBackings ? undefined : false,
+                isAdapterBacking: d.includeAdapterBackings ? undefined : false
+              },
 
               ...normalizeStatusForList(d).hasParent,
 
@@ -820,6 +824,14 @@ class integrationInstanceProviderServiceImpl {
         )
       );
 
+      for (let integrationInstanceProvider of orderedRes) {
+        await notifyIntegrationTransaction({
+          kind: 'integrationInstanceProvider.set',
+          integrationInstance: d.integrationInstance,
+          integrationInstanceProvider
+        });
+      }
+
       return orderedRes;
     });
   }
@@ -998,6 +1010,12 @@ class integrationInstanceProviderServiceImpl {
           integrationInstanceProviderId: res.id
         })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integrationInstanceProvider.archived',
+        integrationInstance: res.integrationInstance,
+        integrationInstanceProvider: res
+      });
 
       return res;
     });

--- a/src/metorial/subspace/modules/integration/src/services/integrationProvider.ts
+++ b/src/metorial/subspace/modules/integration/src/services/integrationProvider.ts
@@ -49,6 +49,7 @@ import {
   resolveMetorialFacing
 } from '@metorial-subspace/module-tenant';
 import { integrationProviderVersionInclude } from '../lib/integrationIncludes';
+import { notifyIntegrationTransaction } from '../listeners';
 import {
   createIntegrationProviderVersion,
   createIntegrationVersion,
@@ -258,6 +259,7 @@ let inferReconciliationAuthMaterial = async (d: {
 export type ListIntegrationProvidersParams = {
   search?: string;
   includeMagicMcpBackings?: boolean;
+  includeAdapterBackings?: boolean;
 
   status?: IntegrationProviderStatus[];
   allowDeleted?: boolean;
@@ -415,6 +417,9 @@ class integrationProviderServiceImpl {
               ...normalizeStatusForList(d).noParent,
 
               AND: [
+                d.includeAdapterBackings
+                  ? undefined!
+                  : { integration: { isAdapterBacking: false } },
                 d.ids ? { id: { in: d.ids } } : undefined!,
                 integrations ? { integrationOid: integrations.in } : undefined!,
                 providers ? { providerOid: providers.in } : undefined!,
@@ -591,6 +596,12 @@ class integrationProviderServiceImpl {
       await addAfterTransactionHook(async () =>
         integrationProviderCreatedQueue.add({ integrationProviderId: res.id })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integrationProvider.created',
+        integration: res.integration,
+        integrationProvider: res
+      });
 
       return res;
     });
@@ -841,6 +852,12 @@ class integrationProviderServiceImpl {
         integrationProviderUpdatedQueue.add({ integrationProviderId: res.id })
       );
 
+      await notifyIntegrationTransaction({
+        kind: 'integrationProvider.updated',
+        integration: res.integration,
+        integrationProvider: res
+      });
+
       return res;
     });
   }
@@ -905,6 +922,12 @@ class integrationProviderServiceImpl {
       await addAfterTransactionHook(async () =>
         integrationProviderArchivedQueue.add({ integrationProviderId: res.id })
       );
+
+      await notifyIntegrationTransaction({
+        kind: 'integrationProvider.archived',
+        integration: res.integration,
+        integrationProvider: res
+      });
 
       return res;
     });

--- a/src/metorial/subspace/modules/search/src/index.ts
+++ b/src/metorial/subspace/modules/search/src/index.ts
@@ -123,5 +123,17 @@ export let voyagerIndex = {
     sourceId: (await voyagerSource).id,
     identifier: getIndexName('identity_delegation_config'),
     name: 'Identity Delegation Configs'
+  }),
+
+  chatIntegration: await voyager.index.upsert({
+    sourceId: (await voyagerSource).id,
+    identifier: getIndexName('chat_integration'),
+    name: 'Chat Integrations'
+  }),
+
+  chatIntegrationInstance: await voyager.index.upsert({
+    sourceId: (await voyagerSource).id,
+    identifier: getIndexName('chat_integration_instance'),
+    name: 'Chat Integration Instances'
   })
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core integration create/update/archive paths, new Prisma models with cascade relations, and worker queue processors. Lifecycle listeners can archive hidden backing integrations and instances.
> 
> **Overview**
> Adds a reusable **adapter** layer on top of integrations, plus a **chat** product that projects chat integrations/instances/providers from adapter links.
> 
> Standalone chat creates hidden `isAdapterBacking` integrations (similar to Magic MCP). Existing integrations can be attached only if they have adapter-capable providers and are not Magic MCP-owned. Adapter coordination listens to integration transactions to sync/archive links without auto-creating instances.
> 
> The new `module-chat` services CRUD chat entities through adapter primitives, project rows, index them for search, and hard-delete archived records after 14 days. Worker now runs `chatQueueProcessor`. Integration lists hide adapter-backed rows unless opted in, and direct delete of those backings is blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e58fad83eef1dc9b4f775c837faddd527f80354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->