### PR TITLE
Add public tools

### DIFF
--- a/src/metorial/subspace/modules/session/src/services/index.ts
+++ b/src/metorial/subspace/modules/session/src/services/index.ts
@@ -3,6 +3,7 @@ export * from './adminProviderTelemetryErrorGroup';
 export * from './ephemeralManagedSession';
 export * from './internalToolCall';
 export * from './providerInvocation';
+export * from './providerPublicToolCall';
 export * from './providerRun';
 export * from './providerRunLogs';
 export * from './providerRunUsageRecord';

--- a/src/metorial/subspace/modules/session/src/services/providerPublicToolCall.ts
+++ b/src/metorial/subspace/modules/session/src/services/providerPublicToolCall.ts
@@ -1,0 +1,82 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import type { Environment, Tenant } from '@metorial-subspace/db';
+import { providerService, providerVersionService } from '@metorial-subspace/module-catalog';
+import { type MetorialFacing, resolveMetorialFacing } from '@metorial-subspace/module-tenant';
+import { getBackend } from '@metorial-subspace/provider';
+
+export type CallProviderPublicToolParams = {
+  providerId: string;
+  providerVersionId?: string;
+
+  toolKey: string;
+  input: Record<string, any>;
+
+  caller?: {
+    id: string;
+    name: string;
+    description?: string;
+  };
+};
+
+class providerPublicToolCallServiceImpl {
+  async callPublicTool(d: MetorialFacing<CallProviderPublicToolParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+
+    return this.callPublicToolInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async callPublicToolInternal(
+    d: { tenant: Tenant; environment: Environment } & CallProviderPublicToolParams
+  ) {
+    let provider = await providerService.getProviderByIdInternal({
+      providerId: d.providerId,
+      tenant: d.tenant,
+      environment: d.environment
+    });
+
+    let providerVariant = provider.defaultVariant;
+    if (!providerVariant) {
+      throw new ServiceError(notFoundError('provider.variant'));
+    }
+
+    let providerVersion = d.providerVersionId
+      ? await providerVersionService.getProviderVersionByIdInternal({
+          providerVersionId: d.providerVersionId,
+          tenant: d.tenant,
+          environment: d.environment
+        })
+      : providerVariant.currentVersion;
+
+    if (!providerVersion) {
+      throw new ServiceError(
+        badRequestError({ message: 'Provider does not have a current version set.' })
+      );
+    }
+    if (providerVersion.providerOid !== provider.oid) {
+      throw new ServiceError(notFoundError('provider.version', d.providerVersionId));
+    }
+
+    let backend = await getBackend({ entity: providerVersion });
+
+    return backend.providerRun.callPublicTool({
+      tenant: d.tenant,
+      provider,
+      providerVariant,
+      providerVersion,
+      toolKey: d.toolKey,
+      input: d.input,
+      caller: d.caller
+    });
+  }
+}
+
+export let providerPublicToolCallService = Service.create(
+  'providerPublicToolCallService',
+  () => new providerPublicToolCallServiceImpl()
+).build();

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
@@ -172,31 +172,33 @@ export class ProviderCapabilities extends IProviderCapabilities {
         capabilities: {},
         metadata: {}
       })),
-      tools: specRecord.tools.map(t => {
-        let tool = t as typeof t & { authMethods?: string[] | null };
+      tools: specRecord.tools
+        .filter(t => !t.isPublic)
+        .map(t => {
+          let tool = t as typeof t & { authMethods?: string[] | null };
 
-        return {
-          specId: t.id,
-          specUniqueIdentifier: t.identifier,
-          callableId: t.key,
-          key: t.key,
-          name: t.name,
-          description: t.description,
-          inputJsonSchema: t.inputSchema,
-          outputJsonSchema: t.outputSchema,
-          constraints: t.constraints ?? [],
-          instructions: t.instructions ?? [],
-          capabilities: {},
-          mcpToolType: {
-            type: 'tool.callable'
-          },
-          scopes: t.scopes ?? null,
-          authMethods: tool.authMethods ?? null,
-          tags: t.tags,
-          metadata: {},
-          adapterIdentifier: t.adapter?.slateIdentifier ?? null
-        };
-      })
+          return {
+            specId: t.id,
+            specUniqueIdentifier: t.identifier,
+            callableId: t.key,
+            key: t.key,
+            name: t.name,
+            description: t.description,
+            inputJsonSchema: t.inputSchema,
+            outputJsonSchema: t.outputSchema,
+            constraints: t.constraints ?? [],
+            instructions: t.instructions ?? [],
+            capabilities: {},
+            mcpToolType: {
+              type: 'tool.callable'
+            },
+            scopes: t.scopes ?? null,
+            authMethods: tool.authMethods ?? null,
+            tags: t.tags,
+            metadata: {},
+            adapterIdentifier: t.adapter?.slateIdentifier ?? null
+          };
+        })
     };
   }
 }

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
@@ -14,6 +14,8 @@ import type {
   ProviderRunLogsParam,
   ProviderRunLogsRes,
   ProviderRuntimeBehavior,
+  PublicToolInvocationParam,
+  PublicToolInvocationRes,
   ToolInvocationCreateParam,
   ToolInvocationCreateRes
 } from '@metorial-subspace/provider-utils';
@@ -115,6 +117,46 @@ export class ProviderRun extends IProviderRun {
       connectTimeoutMs: 30_000,
       requestTimeoutMs: 120_000,
       messageTtlExtensionMs: 1000 * 30
+    };
+  }
+
+  override async callPublicTool(data: PublicToolInvocationParam): Promise<PublicToolInvocationRes> {
+    if (!data.providerVersion.slateVersionOid) {
+      throw new Error('Provider version does not have a slate associated with it');
+    }
+
+    let tenant = await getTenantForSlates(data.tenant);
+
+    let slateVersion = await db.slateVersion.findUniqueOrThrow({
+      where: { oid: data.providerVersion.slateVersionOid },
+      include: { slate: true }
+    });
+
+    let res = await slates.slatePublicToolCall.call({
+      tenantId: tenant.id,
+      slateId: slateVersion.slate.id,
+      slateVersionId: slateVersion.id,
+      toolId: data.toolKey,
+      input: data.input,
+      participants: [
+        {
+          type: 'consumer',
+          id: data.caller?.id ?? 'subspace',
+          name: data.caller?.name ?? 'Subspace',
+          description: data.caller?.description
+        }
+      ]
+    });
+
+    if (res.status === 'error') {
+      return { status: 'error', error: res.error };
+    }
+
+    return {
+      status: 'success',
+      output: res.output,
+      message: res.message,
+      attachments: res.attachments
     };
   }
 }

--- a/src/metorial/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
@@ -11,8 +11,8 @@ import {
   publisherInternalService
 } from '@metorial-subspace/module-provider-internal';
 import { normalizeJsonSchema } from '@metorial-subspace/provider-utils';
-import { backend } from '../../backend';
 import { canonicalizeAdapterCapabilities } from '../../adapterCapabilities';
+import { backend } from '../../backend';
 import { slates } from '../../client';
 import { env } from '../../env';
 
@@ -95,7 +95,7 @@ let buildProviderListingDocs = (spec: any): PrismaJson.ProviderListingDocs | und
     }))
     .filter((authMethod: any) => authMethod.docs.length > 0);
   let actions = [...(spec.tools ?? []), ...(spec.triggers ?? [])]
-    .filter((action: any) => !action.adapter)
+    .filter((action: any) => !action.adapter && !action.isPublic)
     .map((action: any) => ({
       key: action.key,
       name: action.name,

--- a/src/metorial/subspace/provider-backends/provider-utils/src/interfaces/providerRun.ts
+++ b/src/metorial/subspace/provider-backends/provider-utils/src/interfaces/providerRun.ts
@@ -33,6 +33,10 @@ export abstract class IProviderRun extends IProviderFunctionality {
   abstract getProviderRunLogs(data: ProviderRunLogsParam): Promise<ProviderRunLogsRes>;
 
   abstract getRuntimeBehavior(): ProviderRuntimeBehavior;
+
+  async callPublicTool(data: PublicToolInvocationParam): Promise<PublicToolInvocationRes> {
+    throw new Error(`Backend "${this.backend.type}" does not support calling public tools`);
+  }
 }
 
 export abstract class IProviderRunConnection {
@@ -172,4 +176,30 @@ export interface ProviderRunLog {
 
 export interface ProviderRunLogsRes {
   logs: ProviderRunLog[];
+}
+
+export interface PublicToolInvocationParam {
+  tenant: Tenant;
+  provider: Provider;
+  providerVariant: ProviderVariant;
+  providerVersion: ProviderVersion;
+
+  toolKey: string;
+  input: Record<string, any>;
+
+  caller?: {
+    id: string;
+    name: string;
+    description?: string;
+  };
+}
+
+export interface PublicToolInvocationRes {
+  status: 'success' | 'error';
+
+  output?: Record<string, any>;
+  message?: string;
+  attachments?: any[];
+
+  error?: ProviderInvocationError;
 }

--- a/src/metorial/subspace/provider-backends/provider-utils/src/types/specification.ts
+++ b/src/metorial/subspace/provider-backends/provider-utils/src/types/specification.ts
@@ -85,6 +85,7 @@ export interface SpecificationTool {
 
   scopes?: SpecificationActionScopes | null;
   authMethods?: string[] | null;
+  isPublic?: boolean;
 
   metadata: Record<string, any>;
 

--- a/src/slates/apps/hub/prisma/schema/invocation.prisma
+++ b/src/slates/apps/hub/prisma/schema/invocation.prisma
@@ -26,6 +26,7 @@ model SlateInvocation {
   slateInstanceOAuthSetupEvents SlateInstanceOAuthSetupEvent[]
   slateAuthConfigEvents         SlateAuthConfigEvent[]
   slateSessionToolCalls         SlateSessionToolCall[]
+  slatePublicToolCalls          SlatePublicToolCall[]
   slateTriggerInvocations       SlateTriggerInvocation[]
   slateTriggerEvents            SlateTriggerEvent[]
   slateInvocationAttachment     SlateInvocationAttachment[]

--- a/src/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/slates/apps/hub/prisma/schema/slate.prisma
@@ -41,6 +41,7 @@ model Slate {
   slateInstanceOAuthSetups  SlateInstanceOAuthSetup[]
   slateAuthConfigs          SlateAuthConfig[]
   slateSessions             SlateSession[]
+  slatePublicToolCalls      SlatePublicToolCall[]
   slateTriggerReceivers     SlateTriggerReceiver[]
   slateTriggerEvents        SlateTriggerEvent[]
   slateTriggerEventInputs   SlateTriggerEventInput[]
@@ -108,6 +109,7 @@ model SlateVersion {
   slateInstanceOAuthSetups   SlateInstanceOAuthSetup[]
   slateSessions              SlateSession[]
   slateSessionToolCalls      SlateSessionToolCall[]
+  slatePublicToolCalls       SlatePublicToolCall[]
   changeNotifications        ChangeNotification[]
   slateErrors                SlateError[]
   slateVersionAdapters       SlateVersionAdapter[]
@@ -219,6 +221,8 @@ model SlateAction {
   key  String
   name String
 
+  isPublic Boolean @default(false)
+
   /// [SlateAction]
   spec Json
 
@@ -235,6 +239,7 @@ model SlateAction {
 
   slateSpecifications          SlateSpecificationAction[]
   slateSessionToolCalls        SlateSessionToolCall[]
+  slatePublicToolCalls         SlatePublicToolCall[]
   slateTriggerReceiverTriggers SlateTriggerReceiverTrigger[]
   slateTriggerEvents           SlateTriggerEvent[]
   slateTriggerEventInputs      SlateTriggerEventInput[]

--- a/src/slates/apps/hub/prisma/schema/tenant.prisma
+++ b/src/slates/apps/hub/prisma/schema/tenant.prisma
@@ -23,6 +23,7 @@ model Tenant {
   slateInstanceConfigs        SlateInstanceConfig[]
   slateInstanceEvents         SlateInstanceEvent[]
   slateSessions               SlateSession[]
+  slatePublicToolCalls        SlatePublicToolCall[]
   slateTriggerDestinations    SlateTriggerDestination[]    @ignore
   slateTriggerReceivers       SlateTriggerReceiver[]
   slateErrors                 SlateError[]

--- a/src/slates/apps/hub/prisma/schema/tool.prisma
+++ b/src/slates/apps/hub/prisma/schema/tool.prisma
@@ -56,3 +56,37 @@ model SlateSessionToolCall {
 
   slateErrors SlateError[]
 }
+
+enum SlatePublicToolCallStatus {
+  succeeded
+  failed
+}
+
+model SlatePublicToolCall {
+  oid    BigInt                    @id
+  id     String                    @unique
+  status SlatePublicToolCallStatus
+
+  errorCode    String?
+  errorMessage String?
+  durationMs   Int?
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)
+
+  actionOid BigInt
+  action    SlateAction @relation(fields: [actionOid], references: [oid], onDelete: Cascade)
+
+  invocationOid BigInt
+  invocation    SlateInvocation @relation(fields: [invocationOid], references: [oid], onDelete: Cascade)
+
+  slateOid BigInt
+  slate    Slate @relation(fields: [slateOid], references: [oid], onDelete: Cascade)
+
+  slateVersionOid BigInt
+  slateVersion    SlateVersion @relation(fields: [slateVersionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@index([tenantOid, createdAt])
+}

--- a/src/slates/apps/hub/src/apis/internal/index.ts
+++ b/src/slates/apps/hub/src/apis/internal/index.ts
@@ -18,6 +18,7 @@ import { slateInvocationController } from './slateInvocation';
 import { slateOAuthCredentialsController } from './slateOAuthCredentials';
 import { slateOAuthSetupController } from './slateOAuthSetup';
 import { slateOAuthSetupEventController } from './slateOAuthSetupEvent';
+import { slatePublicToolCallController } from './slatePublicToolCall';
 import { slateSessionController } from './slateSession';
 import { slateSessionToolCallController } from './slateSessionToolCall';
 import { slateSpecificationController } from './slateSpecification';
@@ -56,6 +57,7 @@ export let rootController = app.controller({
   slateAuthConfigEvent: slateAuthConfigEventController,
   slateSession: slateSessionController,
   slateSessionToolCall: slateSessionToolCallController,
+  slatePublicToolCall: slatePublicToolCallController,
 
   slateTriggerReceiver: slateTriggerReceiverController,
   slateTriggerEvent: slateTriggerEventController,

--- a/src/slates/apps/hub/src/apis/internal/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/apis/internal/slatePublicToolCall.ts
@@ -1,0 +1,140 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import {
+  slatePublicToolCallLogsPresenter,
+  slatePublicToolCallPresenter
+} from '../../presenters';
+import { slatePublicToolCallService } from '../../services';
+import { app } from './_app';
+import { tenantApp } from './tenant';
+
+export let slatePublicToolCallApp = tenantApp.use(async ctx => {
+  let slatePublicToolCallId = ctx.body.slatePublicToolCallId;
+  if (!slatePublicToolCallId) throw new Error('Slate Public Tool Call ID is required');
+
+  let slatePublicToolCall = await slatePublicToolCallService.getPublicToolCallById({
+    id: slatePublicToolCallId,
+    tenant: ctx.tenant
+  });
+
+  return { slatePublicToolCall };
+});
+
+export let slatePublicToolCallController = app.controller({
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          slateIds: v.optional(v.array(v.string()))
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await slatePublicToolCallService.listPublicToolCalls({
+        tenant: ctx.tenant,
+        slateIds: ctx.input.slateIds
+      });
+
+      let list = await paginator.run(ctx.input);
+
+      return await Paginator.presentLight(list, slatePublicToolCallPresenter);
+    }),
+
+  call: app
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slateId: v.string(),
+        slateVersionId: v.optional(v.string()),
+        toolId: v.string(),
+        enclaveId: v.optional(v.string()),
+        egressPolicy: v.optional(
+          v.object({
+            direction: v.literal('egress'),
+            entries: v.array(
+              v.object({
+                cidr: v.string(),
+                portRange: v.optional(
+                  v.object({
+                    from: v.number(),
+                    to: v.number()
+                  })
+                )
+              })
+            )
+          })
+        ),
+        input: v.record(v.any()),
+        participants: v.array(
+          v.object({
+            type: v.enumOf(['consumer', 'hub']),
+            id: v.string(),
+            name: v.string(),
+            description: v.optional(v.string()),
+            metadata: v.optional(v.record(v.any()))
+          })
+        )
+      })
+    )
+    .do(async ctx => {
+      let res = await slatePublicToolCallService.createPublicToolCall({
+        input: {
+          tenantId: ctx.input.tenantId,
+          slateId: ctx.input.slateId,
+          slateVersionId: ctx.input.slateVersionId,
+          toolId: ctx.input.toolId,
+          enclaveId: ctx.input.enclaveId,
+          egressPolicy: ctx.input.egressPolicy,
+          input: ctx.input.input,
+          participants: ctx.input.participants
+        }
+      });
+
+      return {
+        ...res,
+        call: undefined,
+        toolCallId: res.call.id,
+        invocationId: res.invocationId
+      };
+    }),
+
+  get: slatePublicToolCallApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slatePublicToolCallId: v.string()
+      })
+    )
+    .do(async ctx => await slatePublicToolCallPresenter(ctx.slatePublicToolCall)),
+
+  getLogs: slatePublicToolCallApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slatePublicToolCallId: v.string()
+      })
+    )
+    .do(async ctx => slatePublicToolCallLogsPresenter(ctx.slatePublicToolCall)),
+
+  getMany: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slatePublicToolCallIds: v.array(v.string())
+      })
+    )
+    .do(async ctx => {
+      let slatePublicToolCalls = await slatePublicToolCallService.getManyPublicToolCallsByIds({
+        ids: ctx.input.slatePublicToolCallIds,
+        tenant: ctx.tenant
+      });
+
+      return await Promise.all(slatePublicToolCalls.map(slatePublicToolCallPresenter));
+    })
+});

--- a/src/slates/apps/hub/src/id.ts
+++ b/src/slates/apps/hub/src/id.ts
@@ -41,6 +41,7 @@ export let ID = createIdGenerator({
 
   slateOAuthCredentials: idType.sorted('shoc'),
   slateToolCall: idType.sorted('shtc'),
+  slatePublicToolCall: idType.sorted('shptc'),
   slateSession: idType.sorted('shses'),
 
   slateTriggerReceiver: idType.sorted('shtr'),

--- a/src/slates/apps/hub/src/lib/invocation/attachments.ts
+++ b/src/slates/apps/hub/src/lib/invocation/attachments.ts
@@ -1,0 +1,92 @@
+import { addDays } from 'date-fns';
+import { PublicUrlPurpose } from 'object-storage-client';
+import type { SlateInvocation } from '../../../prisma/generated/client';
+import { db } from '../../db';
+import { getId } from '../../id';
+import { invocationsBucketRecord, storage } from '../../storage';
+import { getStoredAttachmentsStorageKey } from './store';
+
+export type SlateToolCallAttachment = {
+  content:
+    | {
+        type: 'url';
+        url: string;
+      }
+    | {
+        type: 'content';
+        encoding: 'base64' | 'utf-8';
+        content: string;
+      };
+  mimeType?: string;
+};
+
+let ATTACHMENT_EXPIRATION_DAYS = 7;
+
+export let ensureSlateInvocationAttachment = async (d: {
+  content: SlateToolCallAttachment['content'];
+  mimeType?: string | undefined;
+  invocation: SlateInvocation;
+}) => {
+  if (d.content.type === 'url') {
+    return {
+      type: 'url' as const,
+      url: d.content.url,
+      mimeType: d.mimeType
+    };
+  }
+
+  let contentBuffer = Buffer.from(d.content.content, d.content.encoding);
+  let digest = new Uint8Array(await crypto.subtle.digest('SHA-256', contentBuffer));
+  let digestString = Buffer.from(digest).toString('hex');
+  let storageKey = getStoredAttachmentsStorageKey(digestString);
+
+  let attachment = await db.slateAttachment.findFirst({
+    where: { digest }
+  });
+  if (!attachment) {
+    await storage.putObject(
+      invocationsBucketRecord.bucket,
+      storageKey,
+      contentBuffer,
+      d.mimeType ?? 'application/octet-stream'
+    );
+  }
+
+  let expiresAt = addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS);
+  let inner = {
+    digest,
+    expiresAt,
+    lastCreatedAt: new Date()
+  };
+
+  attachment = await db.slateAttachment.upsert({
+    where: { digest },
+    create: {
+      ...getId('slateAttachment'),
+      ...inner
+    },
+    update: inner
+  });
+
+  await db.slateInvocationAttachment.createMany({
+    data: {
+      ...getId('slateInvocationAttachment'),
+      invocationOid: d.invocation.oid,
+      attachmentsOid: attachment.oid
+    }
+  });
+
+  let url = await storage.getPublicURL(
+    invocationsBucketRecord.bucket,
+    storageKey,
+    ATTACHMENT_EXPIRATION_DAYS * 24 * 60 * 60,
+    PublicUrlPurpose.Retrieve
+  );
+
+  return {
+    type: 'url' as const,
+    url: url.url,
+    mimeType: d.mimeType,
+    urlExpiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS)
+  };
+};

--- a/src/slates/apps/hub/src/presenters/index.ts
+++ b/src/slates/apps/hub/src/presenters/index.ts
@@ -19,6 +19,7 @@ export * from './slateOAuthCredentials';
 export * from './slateOAuthSetup';
 export * from './slateOAuthSetupEvent';
 export * from './slateOAuthSetupLogs';
+export * from './slatePublicToolCall';
 export * from './slateSession';
 export * from './slateSessionToolCall';
 export * from './slateSpecification';

--- a/src/slates/apps/hub/src/presenters/slateAction.ts
+++ b/src/slates/apps/hub/src/presenters/slateAction.ts
@@ -20,6 +20,7 @@ export let slateActionPresenter = (
     name: method.name,
     key: method.key,
     type: method.type,
+    isPublic: method.isPublic,
 
     capabilities: method.spec.capabilities,
     invocation: method.spec.type === 'action.trigger' ? method.spec.invocation : undefined,

--- a/src/slates/apps/hub/src/presenters/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/presenters/slatePublicToolCall.ts
@@ -1,0 +1,92 @@
+import type { SlateAction } from '../../prisma/generated/browser';
+import type {
+  Slate,
+  SlateAttachment,
+  SlateInvocation,
+  SlatePublicToolCall,
+  SlateVersion
+} from '../../prisma/generated/client';
+import { slateInvocationAttachmentsPresenter } from './slateAttachment';
+import { slateInvocationLitePresenter } from './slateInvocation';
+
+type InvocationWithStoredAttachments = SlateInvocation & {
+  slateInvocationAttachment?: Array<{
+    attachments: SlateAttachment;
+  }>;
+};
+
+export let slatePublicToolCallPresenter = async (
+  call: SlatePublicToolCall & {
+    action: SlateAction;
+    invocation: InvocationWithStoredAttachments;
+    slate: Slate;
+    slateVersion: SlateVersion;
+  }
+) => {
+  return {
+    object: 'slate.public_tool_call',
+
+    id: call.id,
+    status: call.status,
+    slateId: call.slate.id,
+    slateVersionId: call.slateVersion.id,
+
+    error: call.errorCode
+      ? {
+          code: call.errorCode,
+          message: call.errorMessage ?? call.errorCode
+        }
+      : null,
+    durationMs: call.durationMs,
+
+    action: {
+      object: 'slate.action',
+
+      id: call.action.id,
+      key: call.action.key,
+      name: call.action.name
+    },
+
+    attachments: await slateInvocationAttachmentsPresenter(call.invocation),
+    createdAt: call.createdAt
+  };
+};
+
+export let slatePublicToolCallLogsPresenter = async (
+  call: SlatePublicToolCall & {
+    action: SlateAction;
+    invocation: InvocationWithStoredAttachments;
+    slate: Slate;
+    slateVersion: SlateVersion;
+  }
+) => {
+  return {
+    object: 'slate.public_tool_call',
+
+    id: call.id,
+    status: call.status,
+    slateId: call.slate.id,
+    slateVersionId: call.slateVersion.id,
+
+    error: call.errorCode
+      ? {
+          code: call.errorCode,
+          message: call.errorMessage ?? call.errorCode
+        }
+      : null,
+    durationMs: call.durationMs,
+
+    action: {
+      object: 'slate.action',
+
+      id: call.action.id,
+      key: call.action.key,
+      name: call.action.name
+    },
+
+    attachments: await slateInvocationAttachmentsPresenter(call.invocation),
+    invocation: await slateInvocationLitePresenter(call.invocation),
+
+    createdAt: call.createdAt
+  };
+};

--- a/src/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/slates/apps/hub/src/queues/discovery/discover.ts
@@ -328,6 +328,8 @@ let buildActionUpsertData = async (d: {
         'action.trigger': 'trigger' as const
       }[action.type],
 
+      isPublic: action.type === 'action.tool' ? action.isPublic === true : false,
+
       hash,
       identifier,
 

--- a/src/slates/apps/hub/src/services/index.ts
+++ b/src/slates/apps/hub/src/services/index.ts
@@ -16,6 +16,7 @@ export * from './slateOAuthCredentials';
 export * from './slateOAuthHandler';
 export * from './slateOAuthSetup';
 export * from './slateOAuthSetupEvent';
+export * from './slatePublicToolCall';
 export * from './slateSession';
 export * from './slateSessionToolCall';
 export * from './slateSpecification';

--- a/src/slates/apps/hub/src/services/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/services/slatePublicToolCall.ts
@@ -1,0 +1,230 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { SlatesParticipant } from '@slates/proto';
+import type { Tenant } from '../../prisma/generated/client';
+import { db } from '../db';
+import { getId } from '../id';
+import { ensureSlateInvocationAttachment } from '../lib/invocation/attachments';
+import { slateInvocationService } from './slateInvocation';
+
+let include = {
+  action: true,
+  invocation: {
+    include: {
+      slateInvocationAttachment: {
+        include: {
+          attachments: true
+        }
+      }
+    }
+  },
+  slate: true,
+  slateVersion: true
+};
+
+class slatePublicToolCallServiceImpl {
+  async createPublicToolCall(d: {
+    input: {
+      tenantId: string;
+      slateId: string;
+      slateVersionId?: string;
+      toolId: string;
+      enclaveId?: string;
+      egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
+      input: Record<string, any>;
+      participants: SlatesParticipant[];
+    };
+  }) {
+    let tenant = await db.tenant.findFirst({
+      where: { OR: [{ id: d.input.tenantId }, { identifier: d.input.tenantId }] }
+    });
+    if (!tenant) throw new ServiceError(notFoundError('tenant'));
+
+    let slate = await db.slate.findFirst({
+      where: { OR: [{ id: d.input.slateId }, { identifier: d.input.slateId }] }
+    });
+    if (!slate) throw new ServiceError(notFoundError('slate'));
+
+    if (!d.input.slateVersionId && !slate.currentVersionOid) {
+      throw new ServiceError(
+        badRequestError({ message: 'Provider does not have a current version set.' })
+      );
+    }
+
+    let version = await db.slateVersion.findFirst({
+      where: {
+        slateOid: slate.oid,
+        ...(d.input.slateVersionId
+          ? { OR: [{ id: d.input.slateVersionId }, { version: d.input.slateVersionId }] }
+          : { oid: slate.currentVersionOid! })
+      },
+      include: { specification: true }
+    });
+    if (!version) throw new ServiceError(notFoundError('slate.version'));
+    if (version.status !== 'active' || !version.activeDeploymentOid || !version.specification) {
+      throw new ServiceError(
+        badRequestError({ message: 'Provider version has not been deployed yet.' })
+      );
+    }
+
+    let action = await db.slateAction.findFirst({
+      where: {
+        type: 'tool',
+        slateOid: slate.oid,
+        slateSpecifications: { some: { specificationOid: version.specification.oid } },
+        OR: [{ id: d.input.toolId }, { key: d.input.toolId }, { identifier: d.input.toolId }]
+      }
+    });
+    if (!action) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'invalid_tool_action',
+          message: 'Tool action not found for this provider.'
+        })
+      );
+    }
+    if (!action.isPublic) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'not_a_public_tool',
+          message: 'This tool action is not a public tool.'
+        })
+      );
+    }
+
+    let startTime = Date.now();
+
+    let stack = await slateInvocationService.createInvocation({
+      tenant,
+      slateVersion: version,
+      participants: d.input.participants,
+      enclaveId: d.input.enclaveId,
+      egressPolicy: d.input.egressPolicy
+    });
+    let callRes = await slateInvocationService.invokeToolAction({
+      stack,
+      actionId: action.key,
+      input: d.input.input
+    });
+
+    let durationMs = Date.now() - startTime;
+
+    let call = await db.slatePublicToolCall.create({
+      data: {
+        ...getId('slatePublicToolCall'),
+
+        status: callRes.status === 'success' ? 'succeeded' : 'failed',
+        errorCode: callRes.status === 'error' ? callRes.error.code : null,
+        errorMessage: callRes.status === 'error' ? callRes.error.message : null,
+        durationMs,
+
+        tenantOid: tenant.oid,
+        actionOid: action.oid,
+        invocationOid: callRes.invocation.oid,
+        slateOid: slate.oid,
+        slateVersionOid: version.oid
+      }
+    });
+
+    if (callRes.status === 'error') {
+      return {
+        status: 'error' as const,
+        call,
+        invocationId: callRes.invocation.id,
+        error: callRes.error
+      };
+    }
+
+    let attachments = await Promise.all(
+      (callRes.data.attachments ?? []).map(attachment =>
+        ensureSlateInvocationAttachment({
+          content: attachment.content,
+          mimeType: attachment.mimeType,
+          invocation: callRes.invocation
+        })
+      )
+    );
+
+    return {
+      call,
+      invocationId: callRes.invocation.id,
+      status: 'success' as const,
+
+      output: callRes.data.output,
+      message: callRes.data.message,
+      attachments
+    };
+  }
+
+  async getPublicToolCallById(d: { tenant: Tenant; id: string }) {
+    let slatePublicToolCall = await db.slatePublicToolCall.findFirst({
+      where: {
+        tenantOid: d.tenant.oid,
+        id: d.id
+      },
+      include
+    });
+    if (!slatePublicToolCall) throw new ServiceError(notFoundError('slate.public_tool_call'));
+    return slatePublicToolCall;
+  }
+
+  async listPublicToolCalls(d: {
+    tenant: Tenant;
+    slateIds?: string[];
+    slateVersionIds?: string[];
+    toolIds?: string[];
+  }) {
+    let slates = d.slateIds
+      ? await db.slate.findMany({
+          where: { id: { in: d.slateIds } }
+        })
+      : undefined;
+    let slateVersions = d.slateVersionIds
+      ? await db.slateVersion.findMany({
+          where: { id: { in: d.slateVersionIds } }
+        })
+      : undefined;
+    let tools = d.toolIds
+      ? await db.slateAction.findMany({
+          where: { id: { in: d.toolIds } }
+        })
+      : undefined;
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.slatePublicToolCall.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+
+              AND: [
+                ...(tools ? [{ actionOid: { in: tools.map(t => t.oid) } }] : []),
+                ...(slateVersions
+                  ? [{ slateVersionOid: { in: slateVersions.map(sv => sv.oid) } }]
+                  : []),
+                ...(slates ? [{ slateOid: { in: slates.map(s => s.oid) } }] : [])
+              ]
+            },
+            include
+          })
+      )
+    );
+  }
+
+  async getManyPublicToolCallsByIds(d: { ids: string[]; tenant: Tenant }) {
+    return db.slatePublicToolCall.findMany({
+      where: {
+        tenantOid: d.tenant.oid,
+        id: { in: d.ids }
+      },
+      include
+    });
+  }
+}
+
+export let slatePublicToolCallService = Service.create(
+  'slatePublicToolCallService',
+  () => new slatePublicToolCallServiceImpl()
+).build();

--- a/src/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -2,13 +2,11 @@ import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import type { SlatesParticipant } from '@slates/proto';
-import { addDays, differenceInMinutes } from 'date-fns';
-import { PublicUrlPurpose } from 'object-storage-client';
-import type { SlateInvocation, Tenant } from '../../prisma/generated/client';
+import { differenceInMinutes } from 'date-fns';
+import type { Tenant } from '../../prisma/generated/client';
 import { db } from '../db';
 import { getId } from '../id';
-import { getStoredAttachmentsStorageKey } from '../lib/invocation/store';
-import { invocationsBucketRecord, storage } from '../storage';
+import { ensureSlateInvocationAttachment } from '../lib/invocation/attachments';
 import { slateErrorService } from './slateError';
 import { slateAuthHandlerService } from './slateInstanceAuthHandler';
 import { slateInvocationService } from './slateInvocation';
@@ -28,22 +26,6 @@ let include = {
   session: true,
   slateVersion: true
 };
-
-type SlateToolCallAttachment = {
-  content:
-    | {
-        type: 'url';
-        url: string;
-      }
-    | {
-        type: 'content';
-        encoding: 'base64' | 'utf-8';
-        content: string;
-      };
-  mimeType?: string;
-};
-
-let ATTACHMENT_EXPIRATION_DAYS = 7;
 
 let throwStoredConfigError = (d: { errorCode: string; errorMessage?: string | null }) => {
   throw new ServiceError(
@@ -252,7 +234,7 @@ class slateSessionToolCallServiceImpl {
 
     let attachments = await Promise.all(
       (callRes.data.attachments ?? []).map(attachment =>
-        this.ensureAttachment({
+        ensureSlateInvocationAttachment({
           content: attachment.content,
           mimeType: attachment.mimeType,
           invocation: callRes.invocation
@@ -268,75 +250,6 @@ class slateSessionToolCallServiceImpl {
       output: callRes.data.output,
       message: callRes.data.message,
       attachments
-    };
-  }
-
-  private async ensureAttachment(d: {
-    content: SlateToolCallAttachment['content'];
-    mimeType?: string | undefined;
-    invocation: SlateInvocation;
-  }) {
-    if (d.content.type === 'url') {
-      return {
-        type: 'url' as const,
-        url: d.content.url,
-        mimeType: d.mimeType
-      };
-    }
-
-    let contentBuffer = Buffer.from(d.content.content, d.content.encoding);
-    let digest = new Uint8Array(await crypto.subtle.digest('SHA-256', contentBuffer));
-    let digestString = Buffer.from(digest).toString('hex');
-    let storageKey = getStoredAttachmentsStorageKey(digestString);
-
-    let attachment = await db.slateAttachment.findFirst({
-      where: { digest }
-    });
-    if (!attachment) {
-      await storage.putObject(
-        invocationsBucketRecord.bucket,
-        storageKey,
-        contentBuffer,
-        d.mimeType ?? 'application/octet-stream'
-      );
-    }
-
-    let expiresAt = addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS);
-    let inner = {
-      digest,
-      expiresAt,
-      lastCreatedAt: new Date()
-    };
-
-    attachment = await db.slateAttachment.upsert({
-      where: { digest },
-      create: {
-        ...getId('slateAttachment'),
-        ...inner
-      },
-      update: inner
-    });
-
-    await db.slateInvocationAttachment.createMany({
-      data: {
-        ...getId('slateInvocationAttachment'),
-        invocationOid: d.invocation.oid,
-        attachmentsOid: attachment.oid
-      }
-    });
-
-    let url = await storage.getPublicURL(
-      invocationsBucketRecord.bucket,
-      storageKey,
-      ATTACHMENT_EXPIRATION_DAYS * 24 * 60 * 60,
-      PublicUrlPurpose.Retrieve
-    );
-
-    return {
-      type: 'url' as const,
-      url: url.url,
-      mimeType: d.mimeType,
-      urlExpiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS)
     };
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New execution path runs provider tools without session/auth, gated only by an `isPublic` flag. That is a meaningful change to invocation and data handling, though it is opt-in per tool.
> 
> **Overview**
> Adds **public tools**: tools marked `isPublic` can be invoked without a session, instance, or auth. Regular provider specs and listing docs now **exclude** those tools so they are not exposed as session-callable MCP tools.
> 
> Hub persists `SlatePublicToolCall` records, stores `isPublic` on `SlateAction` during discovery, and exposes internal RPC to call, list, get, and fetch logs. Subspace routes through a new `providerPublicToolCallService` into the slates backend `callPublicTool` implementation.
> 
> Attachment storage is extracted to a shared helper used by both session and public tool calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bcb4f651c7c3ff60c2e16c0cf665122b289f291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->