### PR TITLE
Harden initial portal creation

### DIFF
--- a/src/metorial/products/core/modules/organization/src/queues/instancePortalSetup.ts
+++ b/src/metorial/products/core/modules/organization/src/queues/instancePortalSetup.ts
@@ -3,16 +3,21 @@ import { db } from '@metorial/db';
 import { portalService } from '@metorial/module-portal';
 import { createQueue, QueueRetryError } from '@metorial/queue';
 
-export let instancePortalSetupQueue = createQueue<{ instance: string; context: Context }>({
+export let instancePortalSetupQueue = createQueue<{ instanceId: string; context: Context }>({
   name: 'org/instancePortalSetup'
 });
 
 export let instancePortalSetupQueueProcessor = instancePortalSetupQueue.process(async data => {
   let instance = await db.instance.findUnique({
-    where: { id: data.instance },
+    where: { id: data.instanceId },
     include: { organization: true, project: true }
   });
   if (!instance) throw new QueueRetryError();
+
+  let existingPortal = await db.portal.findFirst({
+    where: { instanceOid: instance.oid }
+  });
+  if (existingPortal) return;
 
   await portalService.createPortal({
     organization: instance.organization,

--- a/src/metorial/products/core/modules/organization/src/services/instance.ts
+++ b/src/metorial/products/core/modules/organization/src/services/instance.ts
@@ -345,7 +345,10 @@ class InstanceService {
       });
 
       await addAfterTransactionHook(() =>
-        instancePortalSetupQueue.add({ instance: instance.id, context: d.auditScope.context })
+        instancePortalSetupQueue.add(
+          { instanceId: instance.id, context: d.auditScope.context },
+          { delay: 45_000 }
+        )
       );
 
       await Fabric.fire('organization.project.instance.created:after', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches instance-create side effects and the queue payload shape; in-flight jobs using `instance` would fail, and default portals now appear 45s later.
> 
> **Overview**
> Makes default portal creation after instance setup **idempotent** and **delayed**, so it does not race with other setup work or create a second portal.
> 
> `instancePortalSetupQueue` now skips `createPortal` if a portal already exists for the instance. Enqueue is delayed by **45 seconds**, and the payload field is renamed from `instance` to `instanceId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b6facfed937d5ee0b0545d6d98f08b8ff5d5ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->