### PR TITLE
Add chat attachments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3677,7 +3677,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@metorial-subspace/adapter": "^1.0.0",
-        "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat",
+        "@slates/adapter-chat": "1.0.0-rc.5",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -3954,7 +3954,7 @@
         "@metorial-subspace/module-session": "^1.0.0",
         "@metorial-subspace/module-tenant": "^1.0.0",
         "@metorial/module-file": "^1.0.0",
-        "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat",
+        "@slates/adapter-chat": "1.0.0-rc.5",
         "date-fns": "^4.1.0",
       },
       "devDependencies": {
@@ -7275,11 +7275,11 @@
 
     "@slates/adapter": ["@slates/adapter@1.0.0-rc.3", "", { "dependencies": { "@slates/provider": "1.0.0-rc.18", "zod": "^4.2.1" } }, "sha512-9IEOaRuEslf2ge5rAe2FpMZUYmFZXYoD+JusS3/NqBGe2hilwgZv3PIxl7ArY0efhYbDnlW2HDjLrICaB41vqg=="],
 
+    "@slates/adapter-chat": ["@slates/adapter-chat@1.0.0-rc.5", "", { "dependencies": { "@slates/adapter": "1.0.0-rc.3", "@slates/provider": "1.0.0-rc.18", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "zod": "^4.2.1" } }, "sha512-Wmfh+RAz3TdfkyGt8R7ETqDQRil0HqRSO8EdLHVoB9tJetjHUWiUEqLrNIYOoWwwf7K/2PU8X/DWgsMHB98P+g=="],
+
     "@slates/proto": ["@slates/proto@1.0.0-rc.14", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-wEayhNEw1ZHXpPQ5bxT9PCI6rviDJoO85r2/twEswcd1Ck7Zcbe1uH8/mPg6PpogCp/ned3RP78rQ5rGxIOqJA=="],
 
     "@slates/provider": ["@slates/provider@1.0.0-rc.18", "", { "dependencies": { "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-rdzgQsBDOtTlLMRhrLk4mH31ircRT8yQhn9W1Je5dTeIaTMstwZWg/CFwWmmuhL9D2XS9STaN/WfxfZoxOZfWg=="],
-
-    "@slates/tsconfig": ["@slates/tsconfig@1.0.0-rc.1", "", { "dependencies": { "@types/node": "^22.15.3" } }, "sha512-a+uD1mbhykElEKKg5ZW6F5xqXuhX8F+l2G3BfwMJaL0XLFbrxnb3zvwlqjmA0sQoupdYXgkCOOiSJMGS5thn8A=="],
 
     "@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
 
@@ -10619,11 +10619,7 @@
 
     "@metorial-services/slates-registry-internal-client/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@metorial-subspace/adapter-chat/@slates/adapter-chat": ["@slates/adapter-chat@file:../../metorial/metorial/adapters/chat", { "dependencies": { "@slates/adapter": "1.0.0-rc.3", "@slates/provider": "1.0.0-rc.18", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "zod": "^4.2.1" }, "devDependencies": { "@slates/tsconfig": "1.0.0-rc.1", "@types/mdast": "^4.0.4", "typescript": "5.8.2", "vitest": "^3.1.2" } }],
-
     "@metorial-subspace/conduit/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
-
-    "@metorial-subspace/module-chat/@slates/adapter-chat": ["@slates/adapter-chat@file:../../metorial/metorial/adapters/chat", { "dependencies": { "@slates/adapter": "1.0.0-rc.3", "@slates/provider": "1.0.0-rc.18", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "zod": "^4.2.1" }, "devDependencies": { "@slates/tsconfig": "1.0.0-rc.1", "@types/mdast": "^4.0.4", "typescript": "5.8.2", "vitest": "^3.1.2" } }],
 
     "@metorial-subspace/module-session/p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -3351,6 +3351,7 @@
         "@metorial/list-utils": "^1.0.0",
         "@metorial/module-resource-actor": "^1.0.0",
         "@metorial/queue": "^1.0.0",
+        "ipaddr.js": "^2.3.0",
         "object-storage-client": "^0.2.5",
       },
       "devDependencies": {
@@ -3676,7 +3677,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@metorial-subspace/adapter": "^1.0.0",
-        "@slates/adapter-chat": "1.0.0-rc.4",
+        "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -3952,7 +3953,8 @@
         "@metorial-subspace/module-search": "^1.0.0",
         "@metorial-subspace/module-session": "^1.0.0",
         "@metorial-subspace/module-tenant": "^1.0.0",
-        "@slates/adapter-chat": "1.0.0-rc.4",
+        "@metorial/module-file": "^1.0.0",
+        "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat",
         "date-fns": "^4.1.0",
       },
       "devDependencies": {
@@ -5160,6 +5162,7 @@
         "@types/unzipper": "^0.10.11",
         "date-fns": "^4.1.0",
         "hono": "4.12.23",
+        "ipaddr.js": "^2.3.0",
         "jszip": "^3.10.1",
         "lodash": "4.17.21",
         "object-storage-client": "^0.2.5",
@@ -7272,11 +7275,11 @@
 
     "@slates/adapter": ["@slates/adapter@1.0.0-rc.3", "", { "dependencies": { "@slates/provider": "1.0.0-rc.18", "zod": "^4.2.1" } }, "sha512-9IEOaRuEslf2ge5rAe2FpMZUYmFZXYoD+JusS3/NqBGe2hilwgZv3PIxl7ArY0efhYbDnlW2HDjLrICaB41vqg=="],
 
-    "@slates/adapter-chat": ["@slates/adapter-chat@1.0.0-rc.4", "", { "dependencies": { "@slates/adapter": "1.0.0-rc.3", "@slates/provider": "1.0.0-rc.18", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "zod": "^4.2.1" } }, "sha512-yKbFJbX8fHBY/eqI9j2edQBONo8/QdPALzpi5U3mHbtsQ5NQsJgh8vgWJ07GZaa0tiLR7J1TAXQI2oJq7Asoog=="],
-
     "@slates/proto": ["@slates/proto@1.0.0-rc.14", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-wEayhNEw1ZHXpPQ5bxT9PCI6rviDJoO85r2/twEswcd1Ck7Zcbe1uH8/mPg6PpogCp/ned3RP78rQ5rGxIOqJA=="],
 
     "@slates/provider": ["@slates/provider@1.0.0-rc.18", "", { "dependencies": { "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-rdzgQsBDOtTlLMRhrLk4mH31ircRT8yQhn9W1Je5dTeIaTMstwZWg/CFwWmmuhL9D2XS9STaN/WfxfZoxOZfWg=="],
+
+    "@slates/tsconfig": ["@slates/tsconfig@1.0.0-rc.1", "", { "dependencies": { "@types/node": "^22.15.3" } }, "sha512-a+uD1mbhykElEKKg5ZW6F5xqXuhX8F+l2G3BfwMJaL0XLFbrxnb3zvwlqjmA0sQoupdYXgkCOOiSJMGS5thn8A=="],
 
     "@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
 
@@ -10616,7 +10619,11 @@
 
     "@metorial-services/slates-registry-internal-client/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "@metorial-subspace/adapter-chat/@slates/adapter-chat": ["@slates/adapter-chat@file:../../metorial/metorial/adapters/chat", { "dependencies": { "@slates/adapter": "1.0.0-rc.3", "@slates/provider": "1.0.0-rc.18", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "zod": "^4.2.1" }, "devDependencies": { "@slates/tsconfig": "1.0.0-rc.1", "@types/mdast": "^4.0.4", "typescript": "5.8.2", "vitest": "^3.1.2" } }],
+
     "@metorial-subspace/conduit/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "@metorial-subspace/module-chat/@slates/adapter-chat": ["@slates/adapter-chat@file:../../metorial/metorial/adapters/chat", { "dependencies": { "@slates/adapter": "1.0.0-rc.3", "@slates/provider": "1.0.0-rc.18", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "zod": "^4.2.1" }, "devDependencies": { "@slates/tsconfig": "1.0.0-rc.1", "@types/mdast": "^4.0.4", "typescript": "5.8.2", "vitest": "^3.1.2" } }],
 
     "@metorial-subspace/module-session/p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 

--- a/src/metorial/apis/core/src/controllers/instance/files/file.ts
+++ b/src/metorial/apis/core/src/controllers/instance/files/file.ts
@@ -16,7 +16,8 @@ let purposeSlugs = [
   'project_brand_image',
   'skill_image',
   'skill_export',
-  'generic'
+  'generic',
+  'chat_message_attachment'
 ] as const;
 
 export let fileGroup = instanceGroup.use(async ctx => {

--- a/src/metorial/apis/files/src/index.ts
+++ b/src/metorial/apis/files/src/index.ts
@@ -192,6 +192,7 @@ let getFileContentHandler = async (c: Context) => {
     fileId,
     key
   });
+
   let shouldDownload = new URL(c.req.url).searchParams.has('download');
   let fileName = file.fileName?.trim();
   let contentDisposition = fileName
@@ -205,7 +206,10 @@ let getFileContentHandler = async (c: Context) => {
           ? getDocumentContentType(metadata.contentType)
           : getServedContentType(metadata.contentType),
       'Cache-Control':
-        metadata.source === 'document' || metadata.source === 'database' || link.expiresAt
+        metadata.source === 'document' ||
+        metadata.source === 'database' ||
+        metadata.source === 'delegate' ||
+        link.expiresAt
           ? 'private, no-store'
           : 'public, max-age=31536000, immutable',
       'X-Content-Type-Options': 'nosniff',

--- a/src/metorial/db/prisma/schema/file/file.prisma
+++ b/src/metorial/db/prisma/schema/file/file.prisma
@@ -32,6 +32,13 @@ model File {
 
   isInternal Boolean @default(false)
 
+  delegatorOid BigInt?
+  delegator    FileContentDelegator? @relation(fields: [delegatorOid], references: [oid], onDelete: SetNull)
+  delegatorRef Json?
+
+  delegatedContentUrl          String?
+  delegatedContentUrlExpiresAt DateTime?
+
   fileName          String
   fileSize          Int
   fileType          String
@@ -79,6 +86,20 @@ model File {
 
   @@index([storeId, status])
   @@index([status, expiresAt, oid])
+  @@index([delegatedContentUrlExpiresAt])
+}
+
+model FileContentDelegator {
+  oid BigInt @id @default(autoincrement())
+  id  String @unique
+
+  key         String  @unique
+  description String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  files File[]
 }
 
 model FilePendingContent {

--- a/src/metorial/db/src/id.ts
+++ b/src/metorial/db/src/id.ts
@@ -60,6 +60,7 @@ export let ID = createIdGenerator({
   file: idType.sorted('fil'),
   fileLink: idType.sorted('flk'),
   fileRef: idType.sorted('frf'),
+  fileContentDelegator: idType.sorted('fcd'),
 
   secretType: idType.sorted('sty'),
   secret: idType.sorted('sec'),

--- a/src/metorial/products/storage/modules/file/package.json
+++ b/src/metorial/products/storage/modules/file/package.json
@@ -28,7 +28,8 @@
     "@metorial/list-utils": "^1.0.0",
     "object-storage-client": "^0.2.5",
     "@metorial/queue": "^1.0.0",
-    "@metorial/cron": "^1.0.0"
+    "@metorial/cron": "^1.0.0",
+    "ipaddr.js": "^2.3.0"
   },
   "module": "src/index.ts",
   "types": "src/index.ts",

--- a/src/metorial/products/storage/modules/file/src/definitions.ts
+++ b/src/metorial/products/storage/modules/file/src/definitions.ts
@@ -10,6 +10,8 @@ let ensureFilePurpose = async (d: {
     input: d
   });
 
+export let chatMessageAttachmentFilePurposeSlug = 'chat_message_attachment';
+
 export let purposes = {
   user_image: ensureFilePurpose({
     name: 'User Image',
@@ -49,6 +51,13 @@ export let purposes = {
   generic: ensureFilePurpose({
     name: 'Generic',
     slug: 'generic',
+    ownerType: 'instance',
+    canHaveLinks: true
+  }),
+
+  chat_message_attachment: ensureFilePurpose({
+    name: 'Chat Message Attachment',
+    slug: chatMessageAttachmentFilePurposeSlug,
     ownerType: 'instance',
     canHaveLinks: true
   })

--- a/src/metorial/products/storage/modules/file/src/lib/delegation.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/delegation.ts
@@ -1,0 +1,84 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { db, ID, type File, type FileContentDelegator } from '@metorial/db';
+
+export type FileContentDelegateResult =
+  | {
+      type: 'stream';
+      stream: ReadableStream | AsyncIterable<Uint8Array>;
+      contentLength?: number;
+      mimeType?: string;
+    }
+  | { type: 'url'; url: string; expiresAt?: Date };
+
+export interface FileContentDelegate {
+  key: string;
+  resolve(d: { file: File; ref: unknown }): Promise<FileContentDelegateResult>;
+}
+
+let registry = new Map<string, FileContentDelegate>();
+let delegatorRowCacheByOid = new Map<string, FileContentDelegator>();
+
+export let registerFileContentDelegate = async (delegate: FileContentDelegate) => {
+  registry.set(delegate.key, delegate);
+
+  let row = await db.fileContentDelegator.upsert({
+    where: { key: delegate.key },
+    create: { id: await ID.generateId('fileContentDelegator'), key: delegate.key },
+    update: {}
+  });
+  delegatorRowCacheByOid.set(row.oid.toString(), row);
+};
+
+let getDelegatorRowByOid = async (delegatorOid: bigint) => {
+  let cached = delegatorRowCacheByOid.get(delegatorOid.toString());
+  if (cached) return cached;
+
+  let row = await db.fileContentDelegator.findUnique({ where: { oid: delegatorOid } });
+  if (!row) {
+    throw new ServiceError(
+      badRequestError({ message: `File content delegator ${delegatorOid} no longer exists` })
+    );
+  }
+
+  delegatorRowCacheByOid.set(row.oid.toString(), row);
+  return row;
+};
+
+export let resolveDelegatedFileContent = async (
+  file: File
+): Promise<FileContentDelegateResult | null> => {
+  if (!file.delegatorOid) return null;
+
+  if (
+    file.delegatedContentUrl &&
+    file.delegatedContentUrlExpiresAt &&
+    file.delegatedContentUrlExpiresAt > new Date()
+  ) {
+    return {
+      type: 'url',
+      url: file.delegatedContentUrl,
+      expiresAt: file.delegatedContentUrlExpiresAt
+    };
+  }
+
+  let row = await getDelegatorRowByOid(file.delegatorOid);
+  let delegate = registry.get(row.key);
+  if (!delegate) {
+    throw new ServiceError(
+      badRequestError({
+        message: `No file content delegate registered for key "${row.key}" in this process`
+      })
+    );
+  }
+
+  let result = await delegate.resolve({ file, ref: file.delegatorRef });
+
+  if (result.type === 'url' && result.expiresAt) {
+    await db.file.update({
+      where: { oid: file.oid },
+      data: { delegatedContentUrl: result.url, delegatedContentUrlExpiresAt: result.expiresAt }
+    });
+  }
+
+  return result;
+};

--- a/src/metorial/products/storage/modules/file/src/lib/fileContent.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/fileContent.ts
@@ -1,6 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { documentService } from '@metorial/module-documents';
 import { fileDownloadService } from '../services/fileDownload';
+import { resolveDelegatedFileContent } from './delegation';
 import { getStoredFileContent } from './pendingFileContent';
 
 export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
@@ -14,6 +15,33 @@ export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
     );
   }
 
+  if (file.delegatorOid) {
+    let delegated = await resolveDelegatedFileContent(file);
+    if (delegated) {
+      return delegated.type === 'url'
+        ? {
+            file,
+            link,
+            content: null,
+            redirectUrl: delegated.url,
+            metadata: {
+              contentType: file.fileType,
+              source: 'delegate' as const
+            }
+          }
+        : {
+            file,
+            link,
+            content: delegated.stream,
+            redirectUrl: null,
+            metadata: {
+              contentType: delegated.mimeType ?? file.fileType,
+              source: 'delegate' as const
+            }
+          };
+    }
+  }
+
   let document = await documentService.getDocumentByFileId({
     fileId: file.id
   });
@@ -22,6 +50,7 @@ export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
       file,
       link,
       content: document.resolvedContent ?? document.content.content,
+      redirectUrl: null,
       metadata: {
         contentType: file.fileType,
         source: 'document' as const
@@ -35,6 +64,7 @@ export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
     file,
     link,
     content: stored.data,
+    redirectUrl: null,
     metadata: {
       contentType: stored.contentType ?? file.fileType,
       source: stored.source

--- a/src/metorial/products/storage/modules/file/src/lib/fileContent.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/fileContent.ts
@@ -3,6 +3,9 @@ import { documentService } from '@metorial/module-documents';
 import { fileDownloadService } from '../services/fileDownload';
 import { resolveDelegatedFileContent } from './delegation';
 import { getStoredFileContent } from './pendingFileContent';
+import { downloadDelegatedFileContent } from './ssrfDownload';
+
+let delegatedContentMaxDownloadBytes = 100 * 1024 * 1024;
 
 export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
   let { link, file } = await fileDownloadService.getFileByDownloadKey(d);
@@ -18,27 +21,32 @@ export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
   if (file.delegatorOid) {
     let delegated = await resolveDelegatedFileContent(file);
     if (delegated) {
-      return delegated.type === 'url'
-        ? {
-            file,
-            link,
-            content: null,
-            redirectUrl: delegated.url,
-            metadata: {
-              contentType: file.fileType,
-              source: 'delegate' as const
-            }
+      if (delegated.type === 'url') {
+        let downloaded = await downloadDelegatedFileContent({
+          url: delegated.url,
+          maxBytes: delegatedContentMaxDownloadBytes
+        });
+
+        return {
+          file,
+          link,
+          content: downloaded.stream,
+          metadata: {
+            contentType: downloaded.mimeType ?? file.fileType,
+            source: 'delegate' as const
           }
-        : {
-            file,
-            link,
-            content: delegated.stream,
-            redirectUrl: null,
-            metadata: {
-              contentType: delegated.mimeType ?? file.fileType,
-              source: 'delegate' as const
-            }
-          };
+        };
+      }
+
+      return {
+        file,
+        link,
+        content: delegated.stream,
+        metadata: {
+          contentType: delegated.mimeType ?? file.fileType,
+          source: 'delegate' as const
+        }
+      };
     }
   }
 
@@ -50,7 +58,6 @@ export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
       file,
       link,
       content: document.resolvedContent ?? document.content.content,
-      redirectUrl: null,
       metadata: {
         contentType: file.fileType,
         source: 'document' as const
@@ -64,7 +71,6 @@ export let getCargoFileContent = async (d: { fileId: string; key: string }) => {
     file,
     link,
     content: stored.data,
-    redirectUrl: null,
     metadata: {
       contentType: stored.contentType ?? file.fileType,
       source: stored.source

--- a/src/metorial/products/storage/modules/file/src/lib/index.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './access';
 export * from './instanceScope';
+export * from './delegation';
 export * from './fileContent';
 export * from './signedDownloadUrl';
 export * from './uploadFile';

--- a/src/metorial/products/storage/modules/file/src/lib/signedDownloadUrl.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/signedDownloadUrl.ts
@@ -1,3 +1,4 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Tokens } from '@lowerdeck/tokens';
 import { env } from '../env';
 import type { File } from '@metorial/db';
@@ -12,18 +13,20 @@ type SignedDownloadTokenData = {
   storeId: string;
 };
 
-let getExpirationDate = () => {
-  let date = new Date();
-  date.setDate(date.getDate() + 3);
-  return date;
-};
+let defaultExpirationMs = 3 * 24 * 60 * 60 * 1000;
+
+let getExpirationDate = (expiresInSeconds?: number) =>
+  new Date(Date.now() + (expiresInSeconds ? expiresInSeconds * 1000 : defaultExpirationMs));
 
 let regionSuffix = `_${env.service.METORIAL_REGION ?? 'ext'}`;
 
-export let createSignedFileDownloadKey = async (file: Pick<File, 'id' | 'storeId'>) => {
+export let createSignedFileDownloadKey = async (
+  file: Pick<File, 'id' | 'storeId'>,
+  opts?: { expiresInSeconds?: number }
+) => {
   let token = await signedDownloadTokens.sign({
     type: signedDownloadTokenType,
-    expiresAt: getExpirationDate(),
+    expiresAt: getExpirationDate(opts?.expiresInSeconds),
     data: {
       fileId: file.id,
       storeId: file.storeId
@@ -33,11 +36,30 @@ export let createSignedFileDownloadKey = async (file: Pick<File, 'id' | 'storeId
   return token + regionSuffix;
 };
 
-export let getSignedFileDownloadUrl = async (file: Pick<File, 'id' | 'storeId'>) => {
+export let getSignedFileDownloadUrl = async (
+  file: Pick<File, 'id' | 'storeId'>,
+  opts?: { expiresInSeconds?: number }
+) => {
   if (!env.service.DOWNLOAD_PUBLIC_URL) return undefined;
 
-  let key = await createSignedFileDownloadKey(file);
+  let key = await createSignedFileDownloadKey(file, opts);
   return `${env.service.DOWNLOAD_PUBLIC_URL.replace(/\/$/, '')}/files/${file.id}/${encodeURIComponent(key)}`;
+};
+
+export let getSignedFileDownloadUrlOrThrow = async (
+  file: Pick<File, 'id' | 'storeId'>,
+  opts?: { expiresInSeconds?: number }
+) => {
+  let url = await getSignedFileDownloadUrl(file, opts);
+  if (!url) {
+    throw new ServiceError(
+      badRequestError({
+        message: 'DOWNLOAD_PUBLIC_URL is not configured; cannot generate a signed file URL'
+      })
+    );
+  }
+
+  return url;
 };
 
 export let verifySignedFileDownloadKey = async (d: { fileId: string; key: string }) => {

--- a/src/metorial/products/storage/modules/file/src/lib/ssrfDownload.ts
+++ b/src/metorial/products/storage/modules/file/src/lib/ssrfDownload.ts
@@ -1,0 +1,155 @@
+import { badRequestError, internalServerError, ServiceError } from '@lowerdeck/error';
+import http from 'http';
+import https from 'https';
+import ipaddr from 'ipaddr.js';
+import { Readable, Transform } from 'stream';
+
+let checkIp = (ip: string) => {
+  if (!ipaddr.isValid(ip)) return true;
+
+  try {
+    return ipaddr.parse(ip).range() === 'unicast';
+  } catch {
+    return false;
+  }
+};
+
+let createSsrfGuardedAgent = (protocol: string) => {
+  let AgentCtor = protocol === 'https:' ? https.Agent : http.Agent;
+  let agent = new AgentCtor();
+  let originalCreateConnection = (agent as any).createConnection;
+
+  (agent as any).createConnection = function (options: any, callback: any) {
+    let address = options.host;
+    if (typeof address === 'string' && !checkIp(address)) {
+      throw new Error(`Connection to ${address} is blocked`);
+    }
+
+    let socket = originalCreateConnection.call(this, options, callback);
+    socket.on('lookup', (error: unknown, resolvedAddress: string) => {
+      if (error) return;
+      if (!checkIp(resolvedAddress)) {
+        socket.destroy(new Error(`Connection to ${resolvedAddress} is blocked`));
+      }
+    });
+
+    return socket;
+  };
+
+  return agent;
+};
+
+let validateUrl = (input: string) => {
+  let url = new URL(input);
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Unsupported protocol for delegated file content download');
+  }
+  if (url.username || url.password) {
+    throw new Error('Credentials in delegated file content URL are not allowed');
+  }
+
+  return url;
+};
+
+class DelegatedContentDownloadTooLargeError extends Error {
+  constructor(message = 'Delegated file content exceeds the maximum download size') {
+    super(message);
+  }
+}
+
+let requestOnce = (url: URL) =>
+  new Promise<http.IncomingMessage>((resolve, reject) => {
+    let client = url.protocol === 'https:' ? https : http;
+    let req = client.get(
+      url,
+      {
+        agent: createSsrfGuardedAgent(url.protocol),
+        headers: { 'User-Agent': 'Metorial-Files (https://metorial.com)' },
+        timeout: 15_000
+      },
+      resolve
+    );
+    req.on('error', reject);
+    req.on('timeout', () =>
+      req.destroy(new Error('Delegated file content download timed out'))
+    );
+  });
+
+let createSizeGuardTransform = (maxBytes: number) => {
+  let total = 0;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      total += chunk.length;
+      if (total > maxBytes) {
+        callback(new DelegatedContentDownloadTooLargeError());
+        return;
+      }
+      callback(null, chunk);
+    }
+  });
+};
+
+let downloadUrlToStreamOrThrow = async (d: {
+  url: string;
+  maxBytes: number;
+  maxRedirects?: number;
+}) => {
+  let currentUrl = validateUrl(d.url);
+  let maxRedirects = d.maxRedirects ?? 5;
+
+  for (let i = 0; i <= maxRedirects; i++) {
+    let res = await requestOnce(currentUrl);
+    let statusCode = res.statusCode ?? 0;
+
+    if (statusCode >= 300 && statusCode < 400 && res.headers.location) {
+      res.resume();
+      if (i === maxRedirects) {
+        throw new Error('Too many redirects while downloading delegated file content');
+      }
+      currentUrl = validateUrl(new URL(res.headers.location, currentUrl).toString());
+      continue;
+    }
+
+    if (statusCode < 200 || statusCode >= 300) {
+      res.resume();
+      throw new Error(`Delegated file content download failed with status ${statusCode}`);
+    }
+
+    let contentLength = Number(res.headers['content-length'] ?? 0);
+    if (contentLength > d.maxBytes) {
+      res.destroy();
+      throw new DelegatedContentDownloadTooLargeError();
+    }
+
+    let mimeType = res.headers['content-type'];
+    let sizeGuard = createSizeGuardTransform(d.maxBytes);
+
+    res.on('error', err => sizeGuard.destroy(err));
+    sizeGuard.on('error', () => res.destroy());
+    res.pipe(sizeGuard);
+
+    let stream = Readable.toWeb(sizeGuard) as unknown as ReadableStream;
+
+    return { stream, mimeType };
+  }
+
+  throw new Error('Unreachable');
+};
+
+export let downloadDelegatedFileContent = async (d: { url: string; maxBytes: number }) => {
+  try {
+    return await downloadUrlToStreamOrThrow(d);
+  } catch (error) {
+    if (error instanceof DelegatedContentDownloadTooLargeError) {
+      throw new ServiceError(badRequestError({ message: error.message }));
+    }
+
+    throw new ServiceError(
+      internalServerError({
+        message:
+          error instanceof Error ? error.message : 'Delegated file content download failed'
+      })
+    );
+  }
+};

--- a/src/metorial/products/storage/modules/file/src/queues/delegatedContentCacheCleanup.ts
+++ b/src/metorial/products/storage/modules/file/src/queues/delegatedContentCacheCleanup.ts
@@ -1,0 +1,22 @@
+import { createCron } from '@metorial/cron';
+import { db } from '@metorial/db';
+
+export let delegatedContentCacheCleanupCron = createCron(
+  {
+    name: 'cargo/file/delegatedContentCache/cleanup/cron',
+    cron: '*/15 * * * *'
+  },
+  async () => {
+    await db.file.updateMany({
+      where: {
+        delegatedContentUrlExpiresAt: {
+          lte: new Date()
+        }
+      },
+      data: {
+        delegatedContentUrl: null,
+        delegatedContentUrlExpiresAt: null
+      }
+    });
+  }
+);

--- a/src/metorial/products/storage/modules/file/src/queues/index.ts
+++ b/src/metorial/products/storage/modules/file/src/queues/index.ts
@@ -1,8 +1,10 @@
 import { combineQueueProcessors } from '@metorial/queue';
+import { delegatedContentCacheCleanupCron } from './delegatedContentCacheCleanup';
 import { fileCleanupProcessors } from './fileCleanup';
 import { fileContentFlushProcessors } from './fileContentFlush';
 import { fileExpirationProcessors } from './fileExpiration';
 
+export * from './delegatedContentCacheCleanup';
 export * from './fileCleanup';
 export * from './fileContentFlush';
 export * from './fileExpiration';
@@ -10,5 +12,6 @@ export * from './fileExpiration';
 export let fileQueueProcessor = combineQueueProcessors([
   fileCleanupProcessors,
   fileContentFlushProcessors,
-  fileExpirationProcessors
+  fileExpirationProcessors,
+  delegatedContentCacheCleanupCron
 ]);

--- a/src/metorial/products/storage/modules/file/src/services/file.ts
+++ b/src/metorial/products/storage/modules/file/src/services/file.ts
@@ -779,6 +779,40 @@ class FileServiceImpl {
     return file;
   }
 
+  async deleteDelegatedFile(d: { file: File }) {
+    await this.ensureFileActive(d.file);
+
+    if (!d.file.delegatorOid) {
+      throw new ServiceError(
+        badRequestError({
+          message: `File ${d.file.id} is not a delegated file`
+        })
+      );
+    }
+
+    let hasRefs = await fileReferenceService.hasReferencesForFile({
+      file: d.file
+    });
+
+    if (hasRefs) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Cannot delete file: it has active references'
+        })
+      );
+    }
+
+    return await db.file.update({
+      where: {
+        id: d.file.id
+      },
+      data: {
+        status: 'deleted'
+      },
+      include
+    });
+  }
+
   async listFiles(
     d: {
       project: Project;

--- a/src/metorial/products/storage/modules/file/src/services/file.ts
+++ b/src/metorial/products/storage/modules/file/src/services/file.ts
@@ -422,6 +422,68 @@ class FileServiceImpl {
     return result;
   }
 
+  async createDelegatedFile(
+    d: CargoOwnerScope & {
+      purpose: string;
+      delegatorKey: string;
+      delegatorRef: unknown;
+      input: {
+        id?: string;
+        name: string;
+        mimeType: string;
+        size: number;
+        title?: string;
+        expiresAt?: Date;
+      };
+    }
+  ): Promise<FileRecord> {
+    return await withTransaction(async db => {
+      let fileName = d.input.name?.trim();
+      if (!fileName) {
+        throw new ServiceError(
+          badRequestError({
+            message: 'File name is required'
+          })
+        );
+      }
+
+      let purpose = await filePurposeService.getFilePurposeById({
+        id: d.purpose
+      });
+
+      let delegator = await db.fileContentDelegator.findUnique({
+        where: { key: d.delegatorKey }
+      });
+      if (!delegator) {
+        throw new ServiceError(
+          badRequestError({
+            message: `Unknown file content delegator "${d.delegatorKey}"`
+          })
+        );
+      }
+
+      let createdFile = await db.file.create({
+        data: {
+          id: d.input.id ?? (await ID.generateId('file')),
+          ...cargoFileScope(d),
+          purposeOid: purpose.oid,
+          storeId: '',
+          fileName,
+          fileSize: d.input.size,
+          fileType: d.input.mimeType,
+          title: d.input.title,
+          expiresAt: d.input.expiresAt,
+          isReadOnly: true,
+          delegatorOid: delegator.oid,
+          delegatorRef: d.delegatorRef as Prisma.InputJsonValue
+        },
+        include
+      });
+
+      return await this.withEffectiveStoreId(createdFile);
+    });
+  }
+
   async getFileById(
     d: CargoOwnerScope & {
       fileId: string;

--- a/src/metorial/subspace/adapters/chat/package.json
+++ b/src/metorial/subspace/adapters/chat/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "@metorial-subspace/adapter": "^1.0.0",
-    "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat"
+    "@slates/adapter-chat": "1.0.0-rc.5"
   }
 }

--- a/src/metorial/subspace/adapters/chat/package.json
+++ b/src/metorial/subspace/adapters/chat/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "@metorial-subspace/adapter": "^1.0.0",
-    "@slates/adapter-chat": "1.0.0-rc.4"
+    "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat"
   }
 }

--- a/src/metorial/subspace/adapters/chat/src/index.ts
+++ b/src/metorial/subspace/adapters/chat/src/index.ts
@@ -2,6 +2,7 @@ import { AdapterClient, type AdapterClientParams } from '@metorial-subspace/adap
 import { ChatAdapter } from '@slates/adapter-chat';
 
 export type {
+  AttachmentRef,
   Author,
   AuthorRole,
   AuthorType,

--- a/src/metorial/subspace/db/prisma/schema/chat/channel.prisma
+++ b/src/metorial/subspace/db/prisma/schema/chat/channel.prisma
@@ -67,8 +67,9 @@ model ChatChannel {
   updatedAt         DateTime  @default(now()) @updatedAt
   lastInteractionAt DateTime?
 
-  threads  ChatThread[]
-  messages ChatMessage[]
+  threads      ChatThread[]
+  messages     ChatMessage[]
+  messageGroups ChatMessageGroup[]
 
   @@unique([chatOid, channelId])
 }

--- a/src/metorial/subspace/db/prisma/schema/chat/message.prisma
+++ b/src/metorial/subspace/db/prisma/schema/chat/message.prisma
@@ -34,4 +34,6 @@ model ChatMessage {
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @default(now()) @updatedAt
   lastInteractionAt DateTime?
+
+  @@unique([channelOid, messageId])
 }

--- a/src/metorial/subspace/db/prisma/schema/chat/message.prisma
+++ b/src/metorial/subspace/db/prisma/schema/chat/message.prisma
@@ -35,5 +35,34 @@ model ChatMessage {
   updatedAt         DateTime  @default(now()) @updatedAt
   lastInteractionAt DateTime?
 
+  attachments ChatMessageAttachment[]
+
+  groupOid BigInt?
+  group    ChatMessageGroup? @relation("GroupMessages", fields: [groupOid], references: [oid], onDelete: SetNull)
+
+  primaryOfGroup ChatMessageGroup? @relation("GroupPrimaryMessage")
+
+  isChildMessage Boolean @default(false)
+
   @@unique([channelOid, messageId])
+  @@index([channelOid, isChildMessage])
+}
+
+model ChatMessageGroup {
+  oid BigInt @id
+  id  String @unique
+
+  channelOid BigInt
+  channel    ChatChannel @relation(fields: [channelOid], references: [oid], onDelete: Cascade)
+
+  primaryMessageOid BigInt?      @unique
+  primaryMessage    ChatMessage? @relation("GroupPrimaryMessage", fields: [primaryMessageOid], references: [oid], onDelete: SetNull)
+
+  providerGroupKey String?
+
+  createdAt DateTime @default(now())
+
+  messages ChatMessage[] @relation("GroupMessages")
+
+  @@unique([channelOid, providerGroupKey])
 }

--- a/src/metorial/subspace/db/prisma/schema/chat/messageAttachment.prisma
+++ b/src/metorial/subspace/db/prisma/schema/chat/messageAttachment.prisma
@@ -8,8 +8,12 @@ model ChatMessageAttachment {
   fileId String
 
   // Only set for outbound attachments: the file the user originally uploaded via the
-  // file module before it was pushed to the provider. 
+  // file module before it was pushed to the provider.
   uploadedFileId String?
+
+  // The FileReference tying the uploaded file above to this attachment. Cleaned up
+  // (and the uploaded file deleted if left unreferenced) when the attachment is deleted.
+  uploadedFileReferenceId String?
 
   toolCallAttachmentOid BigInt?
   toolCallAttachment    ToolCallAttachment? @relation(fields: [toolCallAttachmentOid], references: [oid], onDelete: SetNull)

--- a/src/metorial/subspace/db/prisma/schema/chat/messageAttachment.prisma
+++ b/src/metorial/subspace/db/prisma/schema/chat/messageAttachment.prisma
@@ -1,0 +1,37 @@
+model ChatMessageAttachment {
+  oid BigInt @id
+  id  String @unique
+
+  messageOid BigInt
+  message    ChatMessage @relation(fields: [messageOid], references: [oid], onDelete: Cascade)
+
+  fileId String
+
+  // Only set for outbound attachments: the file the user originally uploaded via the
+  // file module before it was pushed to the provider. 
+  uploadedFileId String?
+
+  toolCallAttachmentOid BigInt?
+  toolCallAttachment    ToolCallAttachment? @relation(fields: [toolCallAttachmentOid], references: [oid], onDelete: SetNull)
+
+  type     String
+  name     String?
+  mimeType String?
+  size     Int?
+  width    Int?
+  height   Int?
+
+  attachmentId String?
+
+  clientReferenceId String?
+
+  providerFileReference Json?
+
+  raw Json?
+
+  position  Int      @default(0)
+  createdAt DateTime @default(now())
+
+  @@unique([messageOid, attachmentId])
+  @@index([messageOid])
+}

--- a/src/metorial/subspace/db/prisma/schema/session/message.prisma
+++ b/src/metorial/subspace/db/prisma/schema/session/message.prisma
@@ -188,6 +188,8 @@ model ToolCallAttachment {
 
   createdAt DateTime @default(now())
 
+  chatMessageAttachments ChatMessageAttachment[]
+
   @@index([createdAt])
   @@index([toolCallOid])
 }

--- a/src/metorial/subspace/db/src/id.ts
+++ b/src/metorial/subspace/db/src/id.ts
@@ -198,6 +198,8 @@ export let ID = createIdGenerator({
   chatThread: idType.sorted('cth'),
   chatAuthor: idType.sorted('cau'),
   chatMessage: idType.sorted('cms'),
+  chatMessageAttachment: idType.sorted('cma'),
+  chatMessageGroup: idType.sorted('cmg'),
 
   skillEntity: idType.sorted('ske'),
   skill: idType.sorted('skl'),

--- a/src/metorial/subspace/db/src/utils/toolCallAttachment.ts
+++ b/src/metorial/subspace/db/src/utils/toolCallAttachment.ts
@@ -17,11 +17,13 @@ export let getToolCallAttachmentPublicUrl = (urlKey: string) => {
 };
 
 export let presentToolCallAttachment = (attachment: {
+  id: string;
   urlKey: string;
   mimeType?: string | null;
   expiresAt?: Date | null;
 }) => ({
   type: 'url' as const,
+  id: attachment.id,
   url: getToolCallAttachmentPublicUrl(attachment.urlKey),
   mimeType: attachment.mimeType ?? undefined,
   urlExpiresAt: attachment.expiresAt ?? undefined

--- a/src/metorial/subspace/modules/chat/package.json
+++ b/src/metorial/subspace/modules/chat/package.json
@@ -27,7 +27,8 @@
     "@metorial-subspace/module-search": "^1.0.0",
     "@metorial-subspace/module-session": "^1.0.0",
     "@metorial-subspace/module-tenant": "^1.0.0",
-    "@slates/adapter-chat": "1.0.0-rc.4",
+    "@metorial/module-file": "^1.0.0",
+    "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat",
     "date-fns": "^4.1.0"
   },
   "devDependencies": {

--- a/src/metorial/subspace/modules/chat/package.json
+++ b/src/metorial/subspace/modules/chat/package.json
@@ -28,7 +28,7 @@
     "@metorial-subspace/module-session": "^1.0.0",
     "@metorial-subspace/module-tenant": "^1.0.0",
     "@metorial/module-file": "^1.0.0",
-    "@slates/adapter-chat": "file:../../../../../../../metorial/metorial/adapters/chat",
+    "@slates/adapter-chat": "1.0.0-rc.5",
     "date-fns": "^4.1.0"
   },
   "devDependencies": {

--- a/src/metorial/subspace/modules/chat/src/index.ts
+++ b/src/metorial/subspace/modules/chat/src/index.ts
@@ -4,8 +4,8 @@ import { db } from '@metorial-subspace/db';
 import './listener';
 import {
   chatMessageAttachmentDelegatorKey,
-  chatMessageAttachmentService
-} from './services/chatMessageAttachment';
+  chatMessageAttachmentInternalService
+} from './internal/chatMessageAttachment';
 
 void registerFileContentDelegate({
   key: chatMessageAttachmentDelegatorKey,
@@ -36,12 +36,13 @@ void registerFileContentDelegate({
       db.environment.findUniqueOrThrow({ where: { oid: ciip.environmentOid } })
     ]);
 
-    let refreshed = await chatMessageAttachmentService.ensureFreshChatMessageAttachment({
-      tenant,
-      environment,
-      chat,
-      attachment
-    });
+    let refreshed =
+      await chatMessageAttachmentInternalService.ensureFreshChatMessageAttachment({
+        tenant,
+        environment,
+        chat,
+        attachment
+      });
 
     if (!refreshed.toolCallAttachment) {
       throw new Error(`Chat message attachment ${chatMessageAttachmentId} has no content`);

--- a/src/metorial/subspace/modules/chat/src/index.ts
+++ b/src/metorial/subspace/modules/chat/src/index.ts
@@ -1,2 +1,56 @@
 export * from './services';
+import { registerFileContentDelegate } from '@metorial/module-file';
+import { db } from '@metorial-subspace/db';
 import './listener';
+import {
+  chatMessageAttachmentDelegatorKey,
+  chatMessageAttachmentService
+} from './services/chatMessageAttachment';
+
+void registerFileContentDelegate({
+  key: chatMessageAttachmentDelegatorKey,
+  resolve: async ({ ref }) => {
+    let { chatMessageAttachmentId } = ref as { chatMessageAttachmentId: string };
+
+    let attachment = await db.chatMessageAttachment.findUniqueOrThrow({
+      where: { id: chatMessageAttachmentId },
+      include: {
+        toolCallAttachment: true,
+        message: {
+          include: {
+            channel: {
+              include: {
+                chat: { include: { chatIntegrationInstanceProvider: true } }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    let chat = attachment.message.channel.chat;
+    let ciip = chat.chatIntegrationInstanceProvider;
+
+    let [tenant, environment] = await Promise.all([
+      db.tenant.findUniqueOrThrow({ where: { oid: ciip.tenantOid } }),
+      db.environment.findUniqueOrThrow({ where: { oid: ciip.environmentOid } })
+    ]);
+
+    let refreshed = await chatMessageAttachmentService.ensureFreshChatMessageAttachment({
+      tenant,
+      environment,
+      chat,
+      attachment
+    });
+
+    if (!refreshed.toolCallAttachment) {
+      throw new Error(`Chat message attachment ${chatMessageAttachmentId} has no content`);
+    }
+
+    return {
+      type: 'url',
+      url: refreshed.toolCallAttachment.url,
+      expiresAt: refreshed.toolCallAttachment.expiresAt ?? undefined
+    };
+  }
+});

--- a/src/metorial/subspace/modules/chat/src/internal/chatMessage.ts
+++ b/src/metorial/subspace/modules/chat/src/internal/chatMessage.ts
@@ -1,18 +1,22 @@
 import { canonicalize } from '@lowerdeck/canonicalize';
 import { Hash } from '@lowerdeck/hash';
 import { Service } from '@lowerdeck/service';
-import { type Message } from '@metorial-subspace/adapter-chat';
+import { type AttachmentRef, type Message } from '@metorial-subspace/adapter-chat';
 import {
   type Chat,
   type ChatChannel,
   type ChatMessage,
   type ChatThread,
+  type Environment,
   db,
   getId,
+  type Tenant,
   withTransaction
 } from '@metorial-subspace/db';
+import { enqueueChatMessageAttachmentSync } from '../queues/attachment/sync';
 import { isUniqueConstraintError } from '../lib/unique';
 import { chatAuthorServiceInternal } from './chatAuthor';
+import { chatMessageGroupServiceInternal } from './chatMessageGroup';
 
 export type ChatMessageWithRelations = ChatMessage & {
   chat: Chat;
@@ -40,7 +44,74 @@ class chatMessageServiceInternalImpl {
     return Hash.sha256(canonicalize(payload));
   }
 
+  private async discoverAndSyncAttachments(d: {
+    tenant: Tenant;
+    environment: Environment;
+    chat: Chat;
+    messages: Message[];
+    persistedByRemoteId: Map<string, ChatMessage>;
+  }) {
+    let candidates: Array<{ messageOid: bigint; messageId: string; attachment: AttachmentRef }> =
+      [];
+
+    for (let message of d.messages) {
+      let persisted = d.persistedByRemoteId.get(message.id);
+      let attachments = (message.body as { attachments?: AttachmentRef[] } | null)
+        ?.attachments;
+      if (!persisted || !attachments?.length) continue;
+
+      for (let attachment of attachments) {
+        candidates.push({ messageOid: persisted.oid, messageId: persisted.id, attachment });
+      }
+    }
+    if (candidates.length === 0) return;
+
+    let existing = await db.chatMessageAttachment.findMany({
+      where: {
+        messageOid: { in: candidates.map(c => c.messageOid) },
+        attachmentId: { in: candidates.map(c => c.attachment.id).filter((id): id is string => !!id) }
+      },
+      select: { messageOid: true, attachmentId: true }
+    });
+    let existingKeys = new Set(existing.map(row => `${row.messageOid}:${row.attachmentId}`));
+
+    for (let [index, candidate] of candidates.entries()) {
+      if (candidate.attachment.id && existingKeys.has(`${candidate.messageOid}:${candidate.attachment.id}`)) {
+        continue;
+      }
+
+      await enqueueChatMessageAttachmentSync({
+        tenantId: d.tenant.id,
+        environmentId: d.environment.id,
+        chatId: d.chat.id,
+        messageId: candidate.messageId,
+        attachment: candidate.attachment,
+        position: index
+      });
+    }
+  }
+
+  private async syncMessageGroups(d: {
+    channel: ChatChannel;
+    messages: Message[];
+    persistedByRemoteId: Map<string, ChatMessage>;
+  }) {
+    for (let message of d.messages) {
+      if (!message.groupId) continue;
+      let persisted = d.persistedByRemoteId.get(message.id);
+      if (!persisted) continue;
+
+      await chatMessageGroupServiceInternal.attachInboundMessageToGroup({
+        channel: d.channel,
+        message: persisted,
+        providerGroupKey: message.groupId
+      });
+    }
+  }
+
   async upsertChatMessages(d: {
+    tenant: Tenant;
+    environment: Environment;
     chat: Chat;
     channel: ChatChannel;
     messages: Message[];
@@ -132,12 +203,29 @@ class chatMessageServiceInternalImpl {
         { ifExists: true }
       );
 
+    let upserted: ChatMessageWithRelations[];
     try {
-      return await run();
+      upserted = await run();
     } catch (err) {
       if (!isUniqueConstraintError(err)) throw err;
-      return await run();
+      upserted = await run();
     }
+
+    let persistedByRemoteId = new Map(upserted.map(message => [message.messageId, message]));
+    await this.syncMessageGroups({
+      channel: d.channel,
+      messages: d.messages,
+      persistedByRemoteId
+    });
+    await this.discoverAndSyncAttachments({
+      tenant: d.tenant,
+      environment: d.environment,
+      chat: d.chat,
+      messages: d.messages,
+      persistedByRemoteId
+    });
+
+    return upserted;
   }
 }
 

--- a/src/metorial/subspace/modules/chat/src/internal/chatMessageAttachment.ts
+++ b/src/metorial/subspace/modules/chat/src/internal/chatMessageAttachment.ts
@@ -10,15 +10,24 @@ import {
   type Tenant,
   type ToolCallAttachment
 } from '@metorial-subspace/db';
-import type { File } from '@metorial/db';
-import { fileService } from '@metorial/module-file';
+import { db as coreDb, type File } from '@metorial/db';
+import {
+  chatMessageAttachmentFilePurposeSlug,
+  fileLinkService,
+  fileReferenceService,
+  fileService
+} from '@metorial/module-file';
 import { toDownloadInput } from '@slates/adapter-chat';
-import { chatAdapterService } from '../internal/chatAdapter';
 import { assertChatCapability } from '../lib/chatCapability';
 import { unwrapChatCall } from '../lib/chatError';
-import { type ChatWithProvider } from './chatChannel';
+import { type ChatWithProvider } from '../services/chatChannel';
+import { chatAdapterService } from './chatAdapter';
 
 export let chatMessageAttachmentDelegatorKey = 'subspace-chat-message-attachment';
+
+// entityType used for the FileReference tying an uploaded file to the attachment
+// that references it -- see createUploadedFileReference / cleanupAttachmentFiles below.
+export let chatMessageAttachmentFileReferenceEntityType = 'chat_message_attachment';
 
 export type DownloadChatMessageAttachmentParams = {
   chat: ChatWithProvider;
@@ -30,13 +39,19 @@ export type DownloadChatMessageAttachmentParams = {
 export type AttachUploadedChatMessageAttachmentParams = {
   message: ChatMessage;
   attachment: AttachmentRef;
-  uploadedFile: Pick<File, 'id'>;
+  uploadedFile: Pick<File, 'id' | 'oid'> & { purpose: { canHaveLinks: boolean } };
   position?: number;
 };
 
 export type ChatMessageAttachmentWithToolCallAttachment = ChatMessageAttachment & {
   toolCallAttachment: ToolCallAttachment | null;
 };
+
+export type HydratedChatMessageAttachment<T extends ChatMessageAttachment = ChatMessageAttachment> =
+  T & {
+    file: File | null;
+    uploadedFile: File | null;
+  };
 
 type DownloadFileResult = {
   attachment: AttachmentRef;
@@ -57,7 +72,7 @@ let attachmentDownloadFailedError = () =>
     })
   );
 
-class chatMessageAttachmentServiceImpl {
+class chatMessageAttachmentInternalServiceImpl {
   private attachmentPayload(ref: AttachmentRef) {
     return {
       type: ref.type,
@@ -83,11 +98,7 @@ class chatMessageAttachmentServiceImpl {
     return toolCallAttachment?.oid ?? null;
   }
 
-  private async createDelegatedFileForAttachment(d: {
-    environment: Environment;
-    chatMessageAttachmentId: string;
-    ref: AttachmentRef;
-  }) {
+  private requireStorageScope(d: { tenant: Tenant; environment: Environment }) {
     if (!d.environment.instanceOid) {
       throw new ServiceError(
         badRequestError({
@@ -95,10 +106,31 @@ class chatMessageAttachmentServiceImpl {
         })
       );
     }
+    if (!d.tenant.projectOid) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Chat tenant is not linked to a project; cannot store attachments.'
+        })
+      );
+    }
+
+    return {
+      project: { oid: d.tenant.projectOid },
+      instance: { oid: d.environment.instanceOid }
+    };
+  }
+
+  private async createDelegatedFileForAttachment(d: {
+    tenant: Tenant;
+    environment: Environment;
+    chatMessageAttachmentId: string;
+    ref: AttachmentRef;
+  }) {
+    let scope = this.requireStorageScope(d);
 
     let file = await fileService.createDelegatedFile({
-      instance: { oid: d.environment.instanceOid },
-      purpose: 'generic',
+      ...scope,
+      purpose: chatMessageAttachmentFilePurposeSlug,
       delegatorKey: chatMessageAttachmentDelegatorKey,
       delegatorRef: { chatMessageAttachmentId: d.chatMessageAttachmentId },
       input: {
@@ -109,6 +141,35 @@ class chatMessageAttachmentServiceImpl {
     });
 
     return file.id;
+  }
+
+  // Uploaded files pre-exist and may be shared elsewhere, so (unlike the delegated file
+  // above, which is created exclusively for this attachment) we reference-count them via
+  // a FileLink/FileReference pair instead of assuming exclusive ownership.
+  private async createUploadedFileReference(d: {
+    tenant: Tenant;
+    environment: Environment;
+    chatMessageAttachmentId: string;
+    uploadedFile: AttachUploadedChatMessageAttachmentParams['uploadedFile'];
+  }) {
+    let scope = this.requireStorageScope(d);
+
+    let link = await fileLinkService.createFileLink({
+      ...scope,
+      file: d.uploadedFile,
+      input: {}
+    });
+
+    let reference = await fileReferenceService.upsertFileReference({
+      ...scope,
+      fileLink: link,
+      input: {
+        entityType: chatMessageAttachmentFileReferenceEntityType,
+        entityId: d.chatMessageAttachmentId
+      }
+    });
+
+    return reference.id;
   }
 
   async downloadChatMessageAttachment(
@@ -135,6 +196,7 @@ class chatMessageAttachmentServiceImpl {
 
     let ids = getId('chatMessageAttachment');
     let fileId = await this.createDelegatedFileForAttachment({
+      tenant: d.tenant,
       environment: d.environment,
       chatMessageAttachmentId: ids.id,
       ref: result.attachment
@@ -153,13 +215,20 @@ class chatMessageAttachmentServiceImpl {
   }
 
   async attachUploadedFile(
-    d: { environment: Environment } & AttachUploadedChatMessageAttachmentParams
+    d: { tenant: Tenant; environment: Environment } & AttachUploadedChatMessageAttachmentParams
   ): Promise<ChatMessageAttachment> {
     let ids = getId('chatMessageAttachment');
     let fileId = await this.createDelegatedFileForAttachment({
+      tenant: d.tenant,
       environment: d.environment,
       chatMessageAttachmentId: ids.id,
       ref: d.attachment
+    });
+    let uploadedFileReferenceId = await this.createUploadedFileReference({
+      tenant: d.tenant,
+      environment: d.environment,
+      chatMessageAttachmentId: ids.id,
+      uploadedFile: d.uploadedFile
     });
 
     return db.chatMessageAttachment.create({
@@ -168,6 +237,7 @@ class chatMessageAttachmentServiceImpl {
         messageOid: d.message.oid,
         fileId,
         uploadedFileId: d.uploadedFile.id,
+        uploadedFileReferenceId,
         position: d.position ?? 0,
         ...this.attachmentPayload(d.attachment)
       }
@@ -215,9 +285,77 @@ class chatMessageAttachmentServiceImpl {
 
     return { ...updated, toolCallAttachment: freshToolCallAttachment };
   }
+
+  // Called after a chat message (and, via cascade, its ChatMessageAttachment rows) has
+  // been deleted. The delegated file is exclusively owned by this attachment, so it is
+  // always deleted outright. The uploaded file may be shared elsewhere, so only its
+  // reference is removed here -- the file itself is deleted only once unreferenced.
+  async cleanupAttachmentFiles(d: {
+    fileId: string;
+    uploadedFileId?: string | null;
+    uploadedFileReferenceId?: string | null;
+  }) {
+    if (d.uploadedFileReferenceId) {
+      await fileReferenceService.deleteFileReferenceByIdAndCleanup({
+        fileReferenceId: d.uploadedFileReferenceId
+      });
+    }
+
+    if (d.uploadedFileId) {
+      let uploadedFile = await coreDb.file.findFirst({
+        where: { id: d.uploadedFileId, status: 'active' }
+      });
+      if (uploadedFile && !uploadedFile.isReadOnly) {
+        let hasRefs = await fileReferenceService.hasReferencesForFile({ file: uploadedFile });
+        if (!hasRefs) await fileService.deleteFile({ file: uploadedFile });
+      }
+    }
+
+    let delegatedFile = await coreDb.file.findFirst({
+      where: { id: d.fileId, status: 'active' }
+    });
+    if (delegatedFile) {
+      await fileService.deleteDelegatedFile({ file: delegatedFile });
+    }
+  }
+
+  // Batches file lookups for all given attachments into a single query, so callers
+  // hydrating attachments for many messages at once only pay for one round trip.
+  async hydrateChatMessageAttachments<T extends ChatMessageAttachment>(
+    attachments: T[]
+  ): Promise<HydratedChatMessageAttachment<T>[]> {
+    if (!attachments.length) return [];
+
+    let fileIds = [
+      ...new Set(
+        attachments
+          .flatMap(attachment => [attachment.fileId, attachment.uploadedFileId])
+          .filter((id): id is string => !!id)
+      )
+    ];
+    let files = fileIds.length
+      ? await coreDb.file.findMany({ where: { id: { in: fileIds } } })
+      : [];
+    let fileById = new Map(files.map(file => [file.id, file]));
+
+    return attachments.map(attachment => ({
+      ...attachment,
+      file: fileById.get(attachment.fileId) ?? null,
+      uploadedFile: attachment.uploadedFileId
+        ? (fileById.get(attachment.uploadedFileId) ?? null)
+        : null
+    }));
+  }
+
+  async hydrateChatMessageAttachment<T extends ChatMessageAttachment>(
+    attachment: T
+  ): Promise<HydratedChatMessageAttachment<T>> {
+    let [hydrated] = await this.hydrateChatMessageAttachments([attachment]);
+    return hydrated!;
+  }
 }
 
-export let chatMessageAttachmentService = Service.create(
-  'chatMessageAttachmentService',
-  () => new chatMessageAttachmentServiceImpl()
+export let chatMessageAttachmentInternalService = Service.create(
+  'chatMessageAttachmentInternalService',
+  () => new chatMessageAttachmentInternalServiceImpl()
 ).build();

--- a/src/metorial/subspace/modules/chat/src/internal/chatMessageGroup.ts
+++ b/src/metorial/subspace/modules/chat/src/internal/chatMessageGroup.ts
@@ -1,0 +1,94 @@
+import { Service } from '@lowerdeck/service';
+import { type ChatPart } from '@metorial-subspace/adapter-chat';
+import { type ChatChannel, type ChatMessage, db, getId } from '@metorial-subspace/db';
+
+let messageHasTextContent = (message: Pick<ChatMessage, 'body'>) => {
+  let body = message.body as { parts?: ChatPart[] } | null;
+  if (!body?.parts?.length) return false;
+
+  return body.parts.some(part => {
+    if (part.type === 'markdown') return !!part.markdown?.trim();
+    if (part.type === 'text') return !!part.content?.trim();
+    return false;
+  });
+};
+
+class chatMessageGroupServiceInternalImpl {
+  async setGroupPrimary(d: { groupOid: bigint; primaryMessageOid: bigint }) {
+    await db.chatMessageGroup.update({
+      where: { oid: d.groupOid },
+      data: { primaryMessageOid: d.primaryMessageOid }
+    });
+    await db.chatMessage.update({
+      where: { oid: d.primaryMessageOid },
+      data: { isChildMessage: false }
+    });
+    await db.chatMessage.updateMany({
+      where: { groupOid: d.groupOid, oid: { not: d.primaryMessageOid } },
+      data: { isChildMessage: true }
+    });
+  }
+
+  async createGroupForMessages(d: { channel: ChatChannel; messages: ChatMessage[] }) {
+    if (d.messages.length < 2) return;
+
+    let group = await db.chatMessageGroup.create({
+      data: { ...getId('chatMessageGroup'), channelOid: d.channel.oid }
+    });
+
+    await db.chatMessage.updateMany({
+      where: { oid: { in: d.messages.map(message => message.oid) } },
+      data: { groupOid: group.oid }
+    });
+
+    let primary = d.messages.find(messageHasTextContent) ?? d.messages[0]!;
+    await this.setGroupPrimary({ groupOid: group.oid, primaryMessageOid: primary.oid });
+  }
+
+  async attachInboundMessageToGroup(d: {
+    channel: ChatChannel;
+    message: ChatMessage;
+    providerGroupKey: string;
+  }) {
+    if (d.message.groupOid) return;
+
+    let group = await db.chatMessageGroup.upsert({
+      where: {
+        channelOid_providerGroupKey: {
+          channelOid: d.channel.oid,
+          providerGroupKey: d.providerGroupKey
+        }
+      },
+      create: {
+        ...getId('chatMessageGroup'),
+        channelOid: d.channel.oid,
+        providerGroupKey: d.providerGroupKey
+      },
+      update: {}
+    });
+
+    await db.chatMessage.update({
+      where: { oid: d.message.oid },
+      data: { groupOid: group.oid }
+    });
+
+    if (!group.primaryMessageOid) {
+      await this.setGroupPrimary({ groupOid: group.oid, primaryMessageOid: d.message.oid });
+      return;
+    }
+
+    if (!messageHasTextContent(d.message)) return;
+
+    let currentPrimary = await db.chatMessage.findUnique({
+      where: { oid: group.primaryMessageOid }
+    });
+    if (!currentPrimary || !messageHasTextContent(currentPrimary)) {
+      await this.setGroupPrimary({ groupOid: group.oid, primaryMessageOid: d.message.oid });
+    }
+  }
+}
+
+export let chatMessageGroupServiceInternal = Service.create(
+  'chatMessageGroupServiceInternal',
+  () => new chatMessageGroupServiceInternalImpl()
+).build();

--- a/src/metorial/subspace/modules/chat/src/lib/chatLifecycle.ts
+++ b/src/metorial/subspace/modules/chat/src/lib/chatLifecycle.ts
@@ -1,4 +1,5 @@
 import { withTransaction } from '@metorial-subspace/db';
+import { enqueueChatMessageAttachmentCleanup } from '../queues/attachment/cleanup';
 
 export type ChatLifecycleWhere = {
   oid?: bigint | { in: bigint[] };
@@ -52,9 +53,22 @@ export let deleteChatsWhere = async (where: ChatLifecycleWhere) => {
 
       let chatOids = chats.map(chat => chat.oid);
 
-      await db.chatMessage.deleteMany({
-        where: { author: { chatOid: { in: chatOids } } }
+      let messages = await db.chatMessage.findMany({
+        where: { author: { chatOid: { in: chatOids } } },
+        select: { oid: true }
       });
+      let messageOids = messages.map(message => message.oid);
+      let attachments = messageOids.length
+        ? await db.chatMessageAttachment.findMany({
+            where: { messageOid: { in: messageOids } },
+            select: { fileId: true, uploadedFileId: true, uploadedFileReferenceId: true }
+          })
+        : [];
+
+      await db.chatMessage.deleteMany({
+        where: { oid: { in: messageOids } }
+      });
+      await enqueueChatMessageAttachmentCleanup(attachments);
       await db.chatThread.deleteMany({
         where: { chatOid: { in: chatOids } }
       });

--- a/src/metorial/subspace/modules/chat/src/lib/chatLock.ts
+++ b/src/metorial/subspace/modules/chat/src/lib/chatLock.ts
@@ -1,0 +1,10 @@
+import { createLock } from '@lowerdeck/lock';
+import { env } from '../env';
+
+let chatMessageLock = createLock({
+  name: 'sub/chat/message/lock',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let usingChatMessageLock = <T>(chatOid: bigint, fn: () => Promise<T>) =>
+  chatMessageLock.usingLock(chatOid.toString(), fn);

--- a/src/metorial/subspace/modules/chat/src/queues.ts
+++ b/src/metorial/subspace/modules/chat/src/queues.ts
@@ -1,5 +1,6 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
 import './listener';
+import { attachmentQueues } from './queues/attachment';
 import { deleteQueues } from './queues/delete';
 import { lifecycleQueues } from './queues/lifecycle';
 import { searchQueues } from './queues/search';
@@ -9,5 +10,6 @@ export let chatQueueProcessor = combineQueueProcessors([
   lifecycleQueues,
   searchQueues,
   deleteQueues,
-  syncQueues
+  syncQueues,
+  attachmentQueues
 ]);

--- a/src/metorial/subspace/modules/chat/src/queues/attachment/cleanup.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/attachment/cleanup.ts
@@ -1,0 +1,29 @@
+import { createQueue } from '@lowerdeck/queue';
+import { addAfterTransactionHook } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { chatMessageAttachmentInternalService } from '../../internal/chatMessageAttachment';
+
+export type ChatMessageAttachmentCleanupJob = {
+  fileId: string;
+  uploadedFileId?: string | null;
+  uploadedFileReferenceId?: string | null;
+};
+
+export let chatMessageAttachmentCleanupQueue = createQueue<ChatMessageAttachmentCleanupJob>({
+  name: 'sub/cht/attachment/cleanup',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatMessageAttachmentCleanup = (jobs: ChatMessageAttachmentCleanupJob[]) => {
+  if (!jobs.length) return;
+
+  return addAfterTransactionHook(async () => {
+    await chatMessageAttachmentCleanupQueue.addMany(jobs);
+  });
+};
+
+export let chatMessageAttachmentCleanupQueueProcessor = chatMessageAttachmentCleanupQueue.process(
+  async data => {
+    await chatMessageAttachmentInternalService.cleanupAttachmentFiles(data);
+  }
+);

--- a/src/metorial/subspace/modules/chat/src/queues/attachment/index.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/attachment/index.ts
@@ -1,0 +1,7 @@
+import { combineQueueProcessors } from '@lowerdeck/queue';
+import { chatMessageAttachmentSyncQueueProcessor } from './sync';
+
+export let attachmentQueues = combineQueueProcessors([chatMessageAttachmentSyncQueueProcessor]);
+
+export { enqueueChatMessageAttachmentSync } from './sync';
+export type { ChatMessageAttachmentSyncJob } from './sync';

--- a/src/metorial/subspace/modules/chat/src/queues/attachment/index.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/attachment/index.ts
@@ -1,7 +1,13 @@
 import { combineQueueProcessors } from '@lowerdeck/queue';
+import { chatMessageAttachmentCleanupQueueProcessor } from './cleanup';
 import { chatMessageAttachmentSyncQueueProcessor } from './sync';
 
-export let attachmentQueues = combineQueueProcessors([chatMessageAttachmentSyncQueueProcessor]);
+export let attachmentQueues = combineQueueProcessors([
+  chatMessageAttachmentSyncQueueProcessor,
+  chatMessageAttachmentCleanupQueueProcessor
+]);
 
+export { enqueueChatMessageAttachmentCleanup } from './cleanup';
+export type { ChatMessageAttachmentCleanupJob } from './cleanup';
 export { enqueueChatMessageAttachmentSync } from './sync';
 export type { ChatMessageAttachmentSyncJob } from './sync';

--- a/src/metorial/subspace/modules/chat/src/queues/attachment/sync.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/attachment/sync.ts
@@ -2,7 +2,7 @@ import { createQueue } from '@lowerdeck/queue';
 import { type AttachmentRef } from '@metorial-subspace/adapter-chat';
 import { addAfterTransactionHook, db } from '@metorial-subspace/db';
 import { env } from '../../env';
-import { chatMessageAttachmentService } from '../../services/chatMessageAttachment';
+import { chatMessageAttachmentInternalService } from '../../internal/chatMessageAttachment';
 import { isUniqueConstraintError } from '../../lib/unique';
 
 export type ChatMessageAttachmentSyncJob = {
@@ -40,7 +40,7 @@ export let chatMessageAttachmentSyncQueueProcessor = chatMessageAttachmentSyncQu
     if (!chat) return;
 
     try {
-      await chatMessageAttachmentService.downloadChatMessageAttachment({
+      await chatMessageAttachmentInternalService.downloadChatMessageAttachment({
         tenant,
         environment,
         chat,

--- a/src/metorial/subspace/modules/chat/src/queues/attachment/sync.ts
+++ b/src/metorial/subspace/modules/chat/src/queues/attachment/sync.ts
@@ -1,0 +1,56 @@
+import { createQueue } from '@lowerdeck/queue';
+import { type AttachmentRef } from '@metorial-subspace/adapter-chat';
+import { addAfterTransactionHook, db } from '@metorial-subspace/db';
+import { env } from '../../env';
+import { chatMessageAttachmentService } from '../../services/chatMessageAttachment';
+import { isUniqueConstraintError } from '../../lib/unique';
+
+export type ChatMessageAttachmentSyncJob = {
+  tenantId: string;
+  environmentId: string;
+  chatId: string;
+  messageId: string;
+  attachment: AttachmentRef;
+  position: number;
+};
+
+export let chatMessageAttachmentSyncQueue = createQueue<ChatMessageAttachmentSyncJob>({
+  name: 'sub/cht/attachment/sync',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let enqueueChatMessageAttachmentSync = (job: ChatMessageAttachmentSyncJob) =>
+  addAfterTransactionHook(async () => {
+    await chatMessageAttachmentSyncQueue.add(job);
+  });
+
+export let chatMessageAttachmentSyncQueueProcessor = chatMessageAttachmentSyncQueue.process(
+  async data => {
+    let [tenant, environment, message] = await Promise.all([
+      db.tenant.findUnique({ where: { id: data.tenantId } }),
+      db.environment.findUnique({ where: { id: data.environmentId } }),
+      db.chatMessage.findUnique({ where: { id: data.messageId } })
+    ]);
+    if (!tenant || !environment || !message) return;
+
+    let chat = await db.chat.findUnique({
+      where: { id: data.chatId },
+      include: { chatIntegrationInstanceProvider: true }
+    });
+    if (!chat) return;
+
+    try {
+      await chatMessageAttachmentService.downloadChatMessageAttachment({
+        tenant,
+        environment,
+        chat,
+        message,
+        attachment: data.attachment,
+        position: data.position
+      });
+    } catch (err) {
+      // Already materialized by a previous attempt at this job -- fine, not an error.
+      if (!isUniqueConstraintError(err)) throw err;
+    }
+  }
+);

--- a/src/metorial/subspace/modules/chat/src/services/chatChannel.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatChannel.ts
@@ -71,13 +71,25 @@ class chatChannelServiceImpl {
   ) {
     let search = d.search?.trim() || undefined;
 
+    let resolveWorkspaceId = (async () => {
+      if (!d.workspaceId) return d.workspaceId;
+
+      let localWorkspace = await db.chatWorkspace.findFirst({
+        where: {
+          chatIntegrationInstanceProviderOid: d.chat.chatIntegrationInstanceProviderOid,
+          OR: [{ id: d.workspaceId }, { workspaceId: d.workspaceId }]
+        }
+      });
+      return localWorkspace?.workspaceId ?? d.workspaceId;
+    })();
+
     return Paginator.create(({ externalCursor }) =>
       externalCursor(async page => {
         let listed = await d.client.call('metorial_chat$channel.list', {
           cursor: page.cursor,
           limit: page.limit,
           direction: page.direction,
-          workspaceId: d.workspaceId,
+          workspaceId: await resolveWorkspaceId,
           type: d.type,
           query: search
         });

--- a/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
@@ -304,8 +304,7 @@ class chatMessageServiceImpl {
           where: {
             channelOid: localChannel.oid,
             ...(threadOid !== undefined ? { threadOid } : {})
-          },
-          orderBy: { sentAt: 'asc' }
+          }
         });
 
         let threadOids = [

--- a/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
@@ -24,14 +24,22 @@ import {
   resolveMetorialFacing
 } from '@metorial-subspace/module-tenant';
 import { db as coreDb } from '@metorial/db';
-import { getSignedFileDownloadUrlOrThrow } from '@metorial/module-file';
+import {
+  chatMessageAttachmentFilePurposeSlug,
+  getSignedFileDownloadUrlOrThrow
+} from '@metorial/module-file';
 import { chatAdapterService } from '../internal/chatAdapter';
 import { chatChannelServiceInternal } from '../internal/chatChannel';
-import { chatMessageGroupServiceInternal } from '../internal/chatMessageGroup';
 import {
   chatMessageServiceInternal,
   type ChatMessageWithRelations
 } from '../internal/chatMessage';
+import {
+  type AttachUploadedChatMessageAttachmentParams,
+  chatMessageAttachmentInternalService,
+  type HydratedChatMessageAttachment
+} from '../internal/chatMessageAttachment';
+import { chatMessageGroupServiceInternal } from '../internal/chatMessageGroup';
 import { chatThreadServiceInternal } from '../internal/chatThread';
 import {
   assertChatCapability,
@@ -40,7 +48,7 @@ import {
 } from '../lib/chatCapability';
 import { unwrapChatCall } from '../lib/chatError';
 import { usingChatMessageLock } from '../lib/chatLock';
-import { chatMessageAttachmentService } from './chatMessageAttachment';
+import { enqueueChatMessageAttachmentCleanup } from '../queues/attachment/cleanup';
 import { type ChatWithProvider } from './chatChannel';
 
 export type ListChatMessagesParams = {
@@ -155,15 +163,18 @@ class chatMessageServiceImpl {
     });
 
     let search = d.search?.trim() || undefined;
+    let paginator: Paginator<ChatMessageWithRelations>;
     if (search) {
       assertMessageSearchCapability(client);
-      return this.listChatMessagesFromSearch({ ...d, search, client });
+      paginator = await this.listChatMessagesFromSearch({ ...d, search, client });
+    } else {
+      paginator = await withChatCapabilityFallback(client, 'message_read', {
+        provider: () => this.listChatMessagesFromProvider({ ...d, client }),
+        fallback: () => this.listChatMessagesFromDb(d)
+      });
     }
 
-    return withChatCapabilityFallback(client, 'message_read', {
-      provider: () => this.listChatMessagesFromProvider({ ...d, client }),
-      fallback: () => this.listChatMessagesFromDb(d)
-    });
+    return paginator.mapAll(messages => this.hydrateChatMessages(messages));
   }
 
   private async listChatMessagesFromProvider(
@@ -375,10 +386,12 @@ class chatMessageServiceImpl {
       chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
     });
 
-    return withChatCapabilityFallback(client, 'message_read', {
+    let message = await withChatCapabilityFallback(client, 'message_read', {
       provider: () => this.getChatMessageFromProvider({ ...d, client }),
       fallback: () => this.getChatMessageFromDb(d)
     });
+
+    return this.hydrateChatMessage(message);
   }
 
   private async getChatMessageFromProvider(
@@ -529,10 +542,17 @@ class chatMessageServiceImpl {
           message: 'Failed to send the message with the chat provider.'
         });
 
-        return this.persistMessageResult(d.tenant, d.environment, d.chat, localChannel, result);
+        let withRelations = await this.persistMessageResult(
+          d.tenant,
+          d.environment,
+          d.chat,
+          localChannel,
+          result
+        );
+        return this.hydrateChatMessage(withRelations);
       }
 
-      return this.sendChatMessageWithAttachments({
+      let sent = await this.sendChatMessageWithAttachments({
         tenant: d.tenant,
         environment: d.environment,
         chat: d.chat,
@@ -543,6 +563,7 @@ class chatMessageServiceImpl {
         threadId,
         reply
       });
+      return this.hydrateChatMessage(sent);
     });
   }
 
@@ -559,9 +580,12 @@ class chatMessageServiceImpl {
   }): Promise<ChatMessageWithRelations> {
     assertFileUploadCapability(d.client);
 
-    let uploadedFilesByReferenceId = new Map<string, { id: string }>();
+    let uploadedFilesByReferenceId = new Map<
+      string,
+      AttachUploadedChatMessageAttachmentParams['uploadedFile']
+    >();
     let pendingAttachmentRefs: AttachmentRef[] = [];
-    let pendingUploadedFiles: { id: string }[] = [];
+    let pendingUploadedFiles: AttachUploadedChatMessageAttachmentParams['uploadedFile'][] = [];
     let createdMessages: {
       chatMessage: ChatMessage;
       withRelations: ChatMessageWithRelations;
@@ -581,9 +605,17 @@ class chatMessageServiceImpl {
           id: attachmentInput.fileId,
           status: 'active',
           instanceOid: d.environment.instanceOid!
-        }
+        },
+        include: { purpose: true }
       });
       if (!file) throw new ServiceError(notFoundError('file', attachmentInput.fileId));
+      if (file.purpose.slug !== chatMessageAttachmentFilePurposeSlug) {
+        throw new ServiceError(
+          badRequestError({
+            message: `File ${file.id} cannot be used as a chat attachment; it must have the "${chatMessageAttachmentFilePurposeSlug}" purpose.`
+          })
+        );
+      }
 
       let fileUrl = await getSignedFileDownloadUrlOrThrow(file, { expiresInSeconds: 1800 });
 
@@ -611,7 +643,8 @@ class chatMessageServiceImpl {
           d.localChannel,
           { message: uploadResult.message }
         );
-        await chatMessageAttachmentService.attachUploadedFile({
+        await chatMessageAttachmentInternalService.attachUploadedFile({
+          tenant: d.tenant,
           environment: d.environment,
           message: withRelations,
           attachment: uploadResult.attachment,
@@ -655,7 +688,8 @@ class chatMessageServiceImpl {
           pendingUploadedFiles[index];
         if (!uploadedFile) continue;
 
-        await chatMessageAttachmentService.attachUploadedFile({
+        await chatMessageAttachmentInternalService.attachUploadedFile({
+          tenant: d.tenant,
           environment: d.environment,
           message: withRelations,
           attachment,
@@ -744,7 +778,14 @@ class chatMessageServiceImpl {
         message: 'Failed to edit the message with the chat provider.'
       });
 
-      return this.persistMessageResult(d.tenant, d.environment, d.chat, localChannel, result);
+      let withRelations = await this.persistMessageResult(
+        d.tenant,
+        d.environment,
+        d.chat,
+        localChannel,
+        result
+      );
+      return this.hydrateChatMessage(withRelations);
     });
   }
 
@@ -790,17 +831,29 @@ class chatMessageServiceImpl {
         : null;
       let messageId = localMessage?.messageId ?? d.messageId;
 
-      let deleted = await client.call('metorial_chat$message.delete', { channelId, messageId });
+      let deleted = await client.call('metorial_chat$message.delete', {
+        channelId,
+        messageId
+      });
       let result = unwrapChatCall(deleted, {
         code: 'chat_message_delete_failed',
         message: 'Failed to delete the message with the chat provider.'
       });
+
+      let attachments = localMessage
+        ? await db.chatMessageAttachment.findMany({
+            where: { messageOid: localMessage.oid },
+            select: { fileId: true, uploadedFileId: true, uploadedFileReferenceId: true }
+          })
+        : [];
 
       if (localChannel) {
         await db.chatMessage.deleteMany({
           where: { channelOid: localChannel.oid, messageId }
         });
       }
+
+      await enqueueChatMessageAttachmentCleanup(attachments);
 
       return result;
     });
@@ -905,6 +958,40 @@ class chatMessageServiceImpl {
     });
 
     return upserted!;
+  }
+
+  // Batches attachment hydration across all given messages into a single call, so
+  // listing N messages costs one attachment lookup instead of N.
+  private async hydrateChatMessages<T extends ChatMessageWithRelations>(
+    messages: T[]
+  ): Promise<(T & { attachments: HydratedChatMessageAttachment[] })[]> {
+    if (!messages.length) return [];
+
+    let attachments = await db.chatMessageAttachment.findMany({
+      where: { messageOid: { in: messages.map(message => message.oid) } },
+      orderBy: { position: 'asc' }
+    });
+    let hydratedAttachments =
+      await chatMessageAttachmentInternalService.hydrateChatMessageAttachments(attachments);
+
+    let attachmentsByMessageOid = new Map<bigint, HydratedChatMessageAttachment[]>();
+    for (let attachment of hydratedAttachments) {
+      let existing = attachmentsByMessageOid.get(attachment.messageOid);
+      if (existing) existing.push(attachment);
+      else attachmentsByMessageOid.set(attachment.messageOid, [attachment]);
+    }
+
+    return messages.map(message => ({
+      ...message,
+      attachments: attachmentsByMessageOid.get(message.oid) ?? []
+    }));
+  }
+
+  private async hydrateChatMessage<T extends ChatMessageWithRelations>(
+    message: T
+  ): Promise<T & { attachments: HydratedChatMessageAttachment[] }> {
+    let [hydrated] = await this.hydrateChatMessages([message]);
+    return hydrated!;
   }
 }
 

--- a/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
@@ -435,6 +435,25 @@ class chatMessageServiceImpl {
     if (d.ephemeral) assertMessageSendEphemeralCapability(client);
     else assertMessageSendCapability(client);
 
+    let localChannel = await db.chatChannel.findFirst({
+      where: {
+        chatOid: d.chat.oid,
+        OR: [{ id: d.channelId }, { channelId: d.channelId }]
+      }
+    });
+    let channelId = localChannel?.channelId ?? d.channelId;
+
+    let localThread =
+      d.threadId && localChannel
+        ? await db.chatThread.findFirst({
+            where: {
+              channelOid: localChannel.oid,
+              OR: [{ id: d.threadId }, { threadId: d.threadId }]
+            }
+          })
+        : null;
+    let threadId = localThread?.threadId ?? d.threadId;
+
     let reply: ReplyRef | undefined;
     if (d.reply) {
       assertMessageReplyCapability(client);
@@ -462,28 +481,21 @@ class chatMessageServiceImpl {
       ? await client.call('metorial_chat$message.sendEphemeral', {
           parts: d.body.parts,
           altText: d.body.altText,
-          channelId: d.channelId,
+          channelId,
           userId: d.ephemeral.targetUserId,
-          threadId: d.threadId
+          threadId
         })
       : await client.call('metorial_chat$message.send', {
           parts: d.body.parts,
           altText: d.body.altText,
-          channelId: d.channelId,
-          threadId: d.threadId,
+          channelId,
+          threadId,
           reply
         });
 
     let result = unwrapChatCall(sent, {
       code: 'chat_message_send_failed',
       message: 'Failed to send the message with the chat provider.'
-    });
-
-    let localChannel = await db.chatChannel.findFirst({
-      where: {
-        chatOid: d.chat.oid,
-        OR: [{ id: d.channelId }, { channelId: d.channelId }]
-      }
     });
 
     return this.persistMessageResult(d.chat, localChannel, result);

--- a/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatMessage.ts
@@ -1,7 +1,8 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import {
+  type AttachmentRef,
   type Channel,
   type ChatAdapterInstance,
   type ChatBody,
@@ -10,14 +11,23 @@ import {
   type ReplyRef,
   type Thread
 } from '@metorial-subspace/adapter-chat';
-import { type ChatChannel, db, type Environment, type Tenant } from '@metorial-subspace/db';
+import {
+  type ChatChannel,
+  type ChatMessage,
+  db,
+  type Environment,
+  type Tenant
+} from '@metorial-subspace/db';
 import {
   checkTenant,
   type MetorialFacing,
   resolveMetorialFacing
 } from '@metorial-subspace/module-tenant';
+import { db as coreDb } from '@metorial/db';
+import { getSignedFileDownloadUrlOrThrow } from '@metorial/module-file';
 import { chatAdapterService } from '../internal/chatAdapter';
 import { chatChannelServiceInternal } from '../internal/chatChannel';
+import { chatMessageGroupServiceInternal } from '../internal/chatMessageGroup';
 import {
   chatMessageServiceInternal,
   type ChatMessageWithRelations
@@ -29,6 +39,8 @@ import {
   withChatCapabilityFallback
 } from '../lib/chatCapability';
 import { unwrapChatCall } from '../lib/chatError';
+import { usingChatMessageLock } from '../lib/chatLock';
+import { chatMessageAttachmentService } from './chatMessageAttachment';
 import { type ChatWithProvider } from './chatChannel';
 
 export type ListChatMessagesParams = {
@@ -47,6 +59,7 @@ export type GetChatMessageParams = {
 export type SendChatMessageBody = {
   parts: ChatPart[];
   altText?: string;
+  attachments?: { fileId: string }[];
 };
 
 export type SendChatMessageParams = {
@@ -81,6 +94,11 @@ export type MarkChatMessageReadParams = {
 let assertMessageSendCapability = (client: ChatAdapterInstance) =>
   assertChatCapability(client, 'message_send', {
     message: 'This chat provider does not support sending messages.'
+  });
+
+let assertFileUploadCapability = (client: ChatAdapterInstance) =>
+  assertChatCapability(client, 'file_upload', {
+    message: 'This chat provider does not support uploading files.'
   });
 
 let assertMessageSendEphemeralCapability = (client: ChatAdapterInstance) =>
@@ -149,7 +167,9 @@ class chatMessageServiceImpl {
   }
 
   private async listChatMessagesFromProvider(
-    d: ListChatMessagesParams & { client: ChatAdapterInstance }
+    d: { tenant: Tenant; environment: Environment } & ListChatMessagesParams & {
+        client: ChatAdapterInstance;
+      }
   ) {
     let localChannel = await db.chatChannel.findFirst({
       where: {
@@ -203,6 +223,8 @@ class chatMessageServiceImpl {
         }
 
         let upserted = await chatMessageServiceInternal.upsertChatMessages({
+          tenant: d.tenant,
+          environment: d.environment,
           chat: d.chat,
           channel,
           messages: listing.messages
@@ -218,7 +240,10 @@ class chatMessageServiceImpl {
   }
 
   private async listChatMessagesFromSearch(
-    d: ListChatMessagesParams & { search: string; client: ChatAdapterInstance }
+    d: { tenant: Tenant; environment: Environment } & ListChatMessagesParams & {
+        search: string;
+        client: ChatAdapterInstance;
+      }
   ) {
     let localChannel = await db.chatChannel.findFirst({
       where: {
@@ -261,6 +286,8 @@ class chatMessageServiceImpl {
         }
 
         let upserted = await chatMessageServiceInternal.upsertChatMessages({
+          tenant: d.tenant,
+          environment: d.environment,
           chat: d.chat,
           channel,
           messages: listing.messages
@@ -355,7 +382,9 @@ class chatMessageServiceImpl {
   }
 
   private async getChatMessageFromProvider(
-    d: GetChatMessageParams & { client: ChatAdapterInstance }
+    d: { tenant: Tenant; environment: Environment } & GetChatMessageParams & {
+        client: ChatAdapterInstance;
+      }
   ) {
     let localChannel = await db.chatChannel.findFirst({
       where: {
@@ -381,7 +410,7 @@ class chatMessageServiceImpl {
       message: 'Failed to load the message from the chat provider.'
     });
 
-    return this.persistMessageResult(d.chat, localChannel, result);
+    return this.persistMessageResult(d.tenant, d.environment, d.chat, localChannel, result);
   }
 
   private async getChatMessageFromDb(d: GetChatMessageParams) {
@@ -424,81 +453,242 @@ class chatMessageServiceImpl {
   async sendChatMessageInternal(
     d: { tenant: Tenant; environment: Environment } & SendChatMessageParams
   ) {
-    checkTenant(d, d.chat.chatIntegrationInstanceProvider);
+    return usingChatMessageLock(d.chat.oid, async () => {
+      checkTenant(d, d.chat.chatIntegrationInstanceProvider);
 
-    let client = await chatAdapterService.getChatAdapterClientInternal({
-      tenant: d.tenant,
-      environment: d.environment,
-      chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
-    });
+      let client = await chatAdapterService.getChatAdapterClientInternal({
+        tenant: d.tenant,
+        environment: d.environment,
+        chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
+      });
 
-    if (d.ephemeral) assertMessageSendEphemeralCapability(client);
-    else assertMessageSendCapability(client);
+      if (d.ephemeral) assertMessageSendEphemeralCapability(client);
+      else assertMessageSendCapability(client);
 
-    let localChannel = await db.chatChannel.findFirst({
-      where: {
-        chatOid: d.chat.oid,
-        OR: [{ id: d.channelId }, { channelId: d.channelId }]
+      let localChannel = await db.chatChannel.findFirst({
+        where: {
+          chatOid: d.chat.oid,
+          OR: [{ id: d.channelId }, { channelId: d.channelId }]
+        }
+      });
+      let channelId = localChannel?.channelId ?? d.channelId;
+
+      let localThread =
+        d.threadId && localChannel
+          ? await db.chatThread.findFirst({
+              where: {
+                channelOid: localChannel.oid,
+                OR: [{ id: d.threadId }, { threadId: d.threadId }]
+              }
+            })
+          : null;
+      let threadId = localThread?.threadId ?? d.threadId;
+
+      let reply: ReplyRef | undefined;
+      if (d.reply) {
+        assertMessageReplyCapability(client);
+
+        let resolved = await this.getChatMessageInternal({
+          tenant: d.tenant,
+          environment: d.environment,
+          chat: d.chat,
+          channelId: d.channelId,
+          messageId: d.reply.messageId
+        });
+
+        reply = {
+          id: resolved.messageId,
+          reference: {
+            id: resolved.messageId,
+            channelId: resolved.channel.channelId,
+            threadId: resolved.thread?.threadId,
+            body: resolved.body as ChatBody
+          }
+        };
       }
-    });
-    let channelId = localChannel?.channelId ?? d.channelId;
 
-    let localThread =
-      d.threadId && localChannel
-        ? await db.chatThread.findFirst({
-            where: {
-              channelOid: localChannel.oid,
-              OR: [{ id: d.threadId }, { threadId: d.threadId }]
-            }
-          })
-        : null;
-    let threadId = localThread?.threadId ?? d.threadId;
+      if (d.ephemeral || !d.body.attachments?.length) {
+        let sent = d.ephemeral
+          ? await client.call('metorial_chat$message.sendEphemeral', {
+              parts: d.body.parts,
+              altText: d.body.altText,
+              channelId,
+              userId: d.ephemeral.targetUserId,
+              threadId
+            })
+          : await client.call('metorial_chat$message.send', {
+              parts: d.body.parts,
+              altText: d.body.altText,
+              channelId,
+              threadId,
+              reply
+            });
 
-    let reply: ReplyRef | undefined;
-    if (d.reply) {
-      assertMessageReplyCapability(client);
+        let result = unwrapChatCall(sent, {
+          code: 'chat_message_send_failed',
+          message: 'Failed to send the message with the chat provider.'
+        });
 
-      let resolved = await this.getChatMessageInternal({
+        return this.persistMessageResult(d.tenant, d.environment, d.chat, localChannel, result);
+      }
+
+      return this.sendChatMessageWithAttachments({
         tenant: d.tenant,
         environment: d.environment,
         chat: d.chat,
-        channelId: d.channelId,
-        messageId: d.reply.messageId
+        body: d.body,
+        client,
+        localChannel,
+        channelId,
+        threadId,
+        reply
       });
+    });
+  }
 
-      reply = {
-        id: resolved.messageId,
-        reference: {
-          id: resolved.messageId,
-          channelId: resolved.channel.channelId,
-          threadId: resolved.thread?.threadId,
-          body: resolved.body as ChatBody
-        }
-      };
+  private async sendChatMessageWithAttachments(d: {
+    tenant: Tenant;
+    environment: Environment;
+    chat: ChatWithProvider;
+    body: SendChatMessageBody;
+    client: ChatAdapterInstance;
+    localChannel: ChatChannel | null;
+    channelId: string;
+    threadId?: string;
+    reply?: ReplyRef;
+  }): Promise<ChatMessageWithRelations> {
+    assertFileUploadCapability(d.client);
+
+    let uploadedFilesByReferenceId = new Map<string, { id: string }>();
+    let pendingAttachmentRefs: AttachmentRef[] = [];
+    let pendingUploadedFiles: { id: string }[] = [];
+    let createdMessages: {
+      chatMessage: ChatMessage;
+      withRelations: ChatMessageWithRelations;
+    }[] = [];
+
+    if (d.body.attachments?.length && !d.environment.instanceOid) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Chat environment is not linked to an instance; cannot send attachments.'
+        })
+      );
     }
 
-    let sent = d.ephemeral
-      ? await client.call('metorial_chat$message.sendEphemeral', {
-          parts: d.body.parts,
-          altText: d.body.altText,
-          channelId,
-          userId: d.ephemeral.targetUserId,
-          threadId
-        })
-      : await client.call('metorial_chat$message.send', {
-          parts: d.body.parts,
-          altText: d.body.altText,
-          channelId,
-          threadId,
-          reply
+    for (let attachmentInput of d.body.attachments ?? []) {
+      let file = await coreDb.file.findFirst({
+        where: {
+          id: attachmentInput.fileId,
+          status: 'active',
+          instanceOid: d.environment.instanceOid!
+        }
+      });
+      if (!file) throw new ServiceError(notFoundError('file', attachmentInput.fileId));
+
+      let fileUrl = await getSignedFileDownloadUrlOrThrow(file, { expiresInSeconds: 1800 });
+
+      let uploaded = await d.client.call('metorial_chat$file.upload', {
+        channelId: d.channelId,
+        threadId: d.threadId,
+        filename: file.fileName,
+        mimeType: file.fileType,
+        fileUrl,
+        fileSize: file.fileSize,
+        clientReferenceId: file.id
+      });
+      let uploadResult = unwrapChatCall(uploaded, {
+        code: 'chat_attachment_upload_failed',
+        message: 'Failed to upload the attachment to the chat provider.'
+      });
+
+      uploadedFilesByReferenceId.set(file.id, file);
+
+      if (uploadResult.message) {
+        let withRelations = await this.persistMessageResult(
+          d.tenant,
+          d.environment,
+          d.chat,
+          d.localChannel,
+          { message: uploadResult.message }
+        );
+        await chatMessageAttachmentService.attachUploadedFile({
+          environment: d.environment,
+          message: withRelations,
+          attachment: uploadResult.attachment,
+          uploadedFile: file
         });
+        createdMessages.push({ chatMessage: withRelations, withRelations });
+      } else {
+        pendingAttachmentRefs.push(uploadResult.attachment);
+        pendingUploadedFiles.push(file);
+      }
+    }
 
-    let result = unwrapChatCall(sent, {
-      code: 'chat_message_send_failed',
-      message: 'Failed to send the message with the chat provider.'
-    });
+    if (d.body.parts.length > 0 || pendingAttachmentRefs.length > 0) {
+      let sent = await d.client.call('metorial_chat$message.send', {
+        parts: d.body.parts,
+        altText: d.body.altText,
+        channelId: d.channelId,
+        threadId: d.threadId,
+        reply: d.reply,
+        attachments: pendingAttachmentRefs
+      });
+      let result = unwrapChatCall(sent, {
+        code: 'chat_message_send_failed',
+        message: 'Failed to send the message with the chat provider.'
+      });
 
-    return this.persistMessageResult(d.chat, localChannel, result);
+      let withRelations = await this.persistMessageResult(
+        d.tenant,
+        d.environment,
+        d.chat,
+        d.localChannel,
+        result
+      );
+
+      let finalizedAttachments = ((result.message.body as ChatBody | null)?.attachments ??
+        []) as AttachmentRef[];
+      for (let [index, attachment] of finalizedAttachments.entries()) {
+        let uploadedFile =
+          (attachment.clientReferenceId &&
+            uploadedFilesByReferenceId.get(attachment.clientReferenceId)) ||
+          pendingUploadedFiles[index];
+        if (!uploadedFile) continue;
+
+        await chatMessageAttachmentService.attachUploadedFile({
+          environment: d.environment,
+          message: withRelations,
+          attachment,
+          uploadedFile,
+          position: index
+        });
+      }
+
+      createdMessages.push({ chatMessage: withRelations, withRelations });
+    }
+
+    if (createdMessages.length > 1) {
+      await chatMessageGroupServiceInternal.createGroupForMessages({
+        channel: createdMessages[0]!.withRelations.channel,
+        messages: createdMessages.map(m => m.chatMessage)
+      });
+    }
+
+    let primary =
+      createdMessages.find(m =>
+        (m.chatMessage.body as ChatBody | null)?.parts?.some(
+          part => part.type === 'text' || part.type === 'markdown'
+        )
+      ) ?? createdMessages[0];
+    if (!primary) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Sending this message did not produce any provider message.'
+        })
+      );
+    }
+
+    return primary.withRelations;
   }
 
   async editChatMessage(d: MetorialFacing<EditChatMessageParams>) {
@@ -514,46 +704,48 @@ class chatMessageServiceImpl {
   async editChatMessageInternal(
     d: { tenant: Tenant; environment: Environment } & EditChatMessageParams
   ) {
-    checkTenant(d, d.chat.chatIntegrationInstanceProvider);
+    return usingChatMessageLock(d.chat.oid, async () => {
+      checkTenant(d, d.chat.chatIntegrationInstanceProvider);
 
-    let client = await chatAdapterService.getChatAdapterClientInternal({
-      tenant: d.tenant,
-      environment: d.environment,
-      chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
+      let client = await chatAdapterService.getChatAdapterClientInternal({
+        tenant: d.tenant,
+        environment: d.environment,
+        chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
+      });
+
+      assertMessageEditCapability(client);
+
+      let localChannel = await db.chatChannel.findFirst({
+        where: {
+          chatOid: d.chat.oid,
+          OR: [{ id: d.channelId }, { channelId: d.channelId }]
+        }
+      });
+      let channelId = localChannel?.channelId ?? d.channelId;
+
+      let localMessage = localChannel
+        ? await db.chatMessage.findFirst({
+            where: {
+              channelOid: localChannel.oid,
+              OR: [{ id: d.messageId }, { messageId: d.messageId }]
+            }
+          })
+        : null;
+      let messageId = localMessage?.messageId ?? d.messageId;
+
+      let edited = await client.call('metorial_chat$message.edit', {
+        parts: d.body.parts,
+        altText: d.body.altText,
+        channelId,
+        messageId
+      });
+      let result = unwrapChatCall(edited, {
+        code: 'chat_message_edit_failed',
+        message: 'Failed to edit the message with the chat provider.'
+      });
+
+      return this.persistMessageResult(d.tenant, d.environment, d.chat, localChannel, result);
     });
-
-    assertMessageEditCapability(client);
-
-    let localChannel = await db.chatChannel.findFirst({
-      where: {
-        chatOid: d.chat.oid,
-        OR: [{ id: d.channelId }, { channelId: d.channelId }]
-      }
-    });
-    let channelId = localChannel?.channelId ?? d.channelId;
-
-    let localMessage = localChannel
-      ? await db.chatMessage.findFirst({
-          where: {
-            channelOid: localChannel.oid,
-            OR: [{ id: d.messageId }, { messageId: d.messageId }]
-          }
-        })
-      : null;
-    let messageId = localMessage?.messageId ?? d.messageId;
-
-    let edited = await client.call('metorial_chat$message.edit', {
-      parts: d.body.parts,
-      altText: d.body.altText,
-      channelId,
-      messageId
-    });
-    let result = unwrapChatCall(edited, {
-      code: 'chat_message_edit_failed',
-      message: 'Failed to edit the message with the chat provider.'
-    });
-
-    return this.persistMessageResult(d.chat, localChannel, result);
   }
 
   async deleteChatMessage(d: MetorialFacing<DeleteChatMessageParams>) {
@@ -569,47 +761,49 @@ class chatMessageServiceImpl {
   async deleteChatMessageInternal(
     d: { tenant: Tenant; environment: Environment } & DeleteChatMessageParams
   ) {
-    checkTenant(d, d.chat.chatIntegrationInstanceProvider);
+    return usingChatMessageLock(d.chat.oid, async () => {
+      checkTenant(d, d.chat.chatIntegrationInstanceProvider);
 
-    let client = await chatAdapterService.getChatAdapterClientInternal({
-      tenant: d.tenant,
-      environment: d.environment,
-      chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
-    });
-
-    assertMessageDeleteCapability(client);
-
-    let localChannel = await db.chatChannel.findFirst({
-      where: {
-        chatOid: d.chat.oid,
-        OR: [{ id: d.channelId }, { channelId: d.channelId }]
-      }
-    });
-    let channelId = localChannel?.channelId ?? d.channelId;
-
-    let localMessage = localChannel
-      ? await db.chatMessage.findFirst({
-          where: {
-            channelOid: localChannel.oid,
-            OR: [{ id: d.messageId }, { messageId: d.messageId }]
-          }
-        })
-      : null;
-    let messageId = localMessage?.messageId ?? d.messageId;
-
-    let deleted = await client.call('metorial_chat$message.delete', { channelId, messageId });
-    let result = unwrapChatCall(deleted, {
-      code: 'chat_message_delete_failed',
-      message: 'Failed to delete the message with the chat provider.'
-    });
-
-    if (localChannel) {
-      await db.chatMessage.deleteMany({
-        where: { channelOid: localChannel.oid, messageId }
+      let client = await chatAdapterService.getChatAdapterClientInternal({
+        tenant: d.tenant,
+        environment: d.environment,
+        chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
       });
-    }
 
-    return result;
+      assertMessageDeleteCapability(client);
+
+      let localChannel = await db.chatChannel.findFirst({
+        where: {
+          chatOid: d.chat.oid,
+          OR: [{ id: d.channelId }, { channelId: d.channelId }]
+        }
+      });
+      let channelId = localChannel?.channelId ?? d.channelId;
+
+      let localMessage = localChannel
+        ? await db.chatMessage.findFirst({
+            where: {
+              channelOid: localChannel.oid,
+              OR: [{ id: d.messageId }, { messageId: d.messageId }]
+            }
+          })
+        : null;
+      let messageId = localMessage?.messageId ?? d.messageId;
+
+      let deleted = await client.call('metorial_chat$message.delete', { channelId, messageId });
+      let result = unwrapChatCall(deleted, {
+        code: 'chat_message_delete_failed',
+        message: 'Failed to delete the message with the chat provider.'
+      });
+
+      if (localChannel) {
+        await db.chatMessage.deleteMany({
+          where: { channelOid: localChannel.oid, messageId }
+        });
+      }
+
+      return result;
+    });
   }
 
   async markChatMessageRead(d: MetorialFacing<MarkChatMessageReadParams>) {
@@ -677,6 +871,8 @@ class chatMessageServiceImpl {
   }
 
   private async persistMessageResult(
+    tenant: Tenant,
+    environment: Environment,
     chat: ChatWithProvider,
     localChannel: ChatChannel | null,
     result: { message: Message; channel?: Channel; thread?: Thread }
@@ -701,6 +897,8 @@ class chatMessageServiceImpl {
     }
 
     let [upserted] = await chatMessageServiceInternal.upsertChatMessages({
+      tenant,
+      environment,
       chat,
       channel,
       messages: [result.message]

--- a/src/metorial/subspace/modules/chat/src/services/chatMessageAttachment.ts
+++ b/src/metorial/subspace/modules/chat/src/services/chatMessageAttachment.ts
@@ -1,0 +1,223 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import { type AttachmentRef, type ChatAdapterInstance } from '@metorial-subspace/adapter-chat';
+import {
+  type ChatMessage,
+  type ChatMessageAttachment,
+  db,
+  type Environment,
+  getId,
+  type Tenant,
+  type ToolCallAttachment
+} from '@metorial-subspace/db';
+import type { File } from '@metorial/db';
+import { fileService } from '@metorial/module-file';
+import { toDownloadInput } from '@slates/adapter-chat';
+import { chatAdapterService } from '../internal/chatAdapter';
+import { assertChatCapability } from '../lib/chatCapability';
+import { unwrapChatCall } from '../lib/chatError';
+import { type ChatWithProvider } from './chatChannel';
+
+export let chatMessageAttachmentDelegatorKey = 'subspace-chat-message-attachment';
+
+export type DownloadChatMessageAttachmentParams = {
+  chat: ChatWithProvider;
+  message: ChatMessage;
+  attachment: AttachmentRef;
+  position?: number;
+};
+
+export type AttachUploadedChatMessageAttachmentParams = {
+  message: ChatMessage;
+  attachment: AttachmentRef;
+  uploadedFile: Pick<File, 'id'>;
+  position?: number;
+};
+
+export type ChatMessageAttachmentWithToolCallAttachment = ChatMessageAttachment & {
+  toolCallAttachment: ToolCallAttachment | null;
+};
+
+type DownloadFileResult = {
+  attachment: AttachmentRef;
+  raw?: unknown;
+  $attachments?: Array<{ id: string; type: 'url'; url: string; mimeType?: string }>;
+};
+
+let assertFileDownloadCapability = (client: ChatAdapterInstance) =>
+  assertChatCapability(client, 'file_download', {
+    message: 'This chat provider does not support downloading files.'
+  });
+
+let attachmentDownloadFailedError = () =>
+  new ServiceError(
+    badRequestError({
+      code: 'chat_attachment_download_failed',
+      message: 'The chat provider did not return downloadable attachment content.'
+    })
+  );
+
+class chatMessageAttachmentServiceImpl {
+  private attachmentPayload(ref: AttachmentRef) {
+    return {
+      type: ref.type,
+      name: ref.name,
+      mimeType: ref.mimeType,
+      size: ref.size,
+      width: ref.width,
+      height: ref.height,
+      attachmentId: ref.id,
+      clientReferenceId: ref.clientReferenceId ?? null,
+      providerFileReference: (ref.providerFileReference as any) ?? null,
+      raw: (ref.raw as any) ?? null
+    };
+  }
+
+  private async resolveToolCallAttachmentOid(result: DownloadFileResult) {
+    let presented = result.$attachments?.[0];
+    if (!presented) return null;
+
+    let toolCallAttachment = await db.toolCallAttachment.findUnique({
+      where: { id: presented.id }
+    });
+    return toolCallAttachment?.oid ?? null;
+  }
+
+  private async createDelegatedFileForAttachment(d: {
+    environment: Environment;
+    chatMessageAttachmentId: string;
+    ref: AttachmentRef;
+  }) {
+    if (!d.environment.instanceOid) {
+      throw new ServiceError(
+        badRequestError({
+          message: 'Chat environment is not linked to an instance; cannot store attachments.'
+        })
+      );
+    }
+
+    let file = await fileService.createDelegatedFile({
+      instance: { oid: d.environment.instanceOid },
+      purpose: 'generic',
+      delegatorKey: chatMessageAttachmentDelegatorKey,
+      delegatorRef: { chatMessageAttachmentId: d.chatMessageAttachmentId },
+      input: {
+        name: d.ref.name ?? 'attachment',
+        mimeType: d.ref.mimeType ?? 'application/octet-stream',
+        size: d.ref.size ?? 0
+      }
+    });
+
+    return file.id;
+  }
+
+  async downloadChatMessageAttachment(
+    d: { tenant: Tenant; environment: Environment } & DownloadChatMessageAttachmentParams
+  ): Promise<ChatMessageAttachment> {
+    let client = await chatAdapterService.getChatAdapterClientInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
+    });
+    assertFileDownloadCapability(client);
+
+    let downloaded = await client.call(
+      'metorial_chat$file.download',
+      toDownloadInput(d.attachment)
+    );
+    let result = unwrapChatCall(downloaded, {
+      code: 'chat_attachment_download_failed',
+      message: 'Failed to download the attachment from the chat provider.'
+    }) as DownloadFileResult;
+
+    let toolCallAttachmentOid = await this.resolveToolCallAttachmentOid(result);
+    if (!toolCallAttachmentOid) throw attachmentDownloadFailedError();
+
+    let ids = getId('chatMessageAttachment');
+    let fileId = await this.createDelegatedFileForAttachment({
+      environment: d.environment,
+      chatMessageAttachmentId: ids.id,
+      ref: result.attachment
+    });
+
+    return db.chatMessageAttachment.create({
+      data: {
+        ...ids,
+        messageOid: d.message.oid,
+        toolCallAttachmentOid,
+        fileId,
+        position: d.position ?? 0,
+        ...this.attachmentPayload(result.attachment)
+      }
+    });
+  }
+
+  async attachUploadedFile(
+    d: { environment: Environment } & AttachUploadedChatMessageAttachmentParams
+  ): Promise<ChatMessageAttachment> {
+    let ids = getId('chatMessageAttachment');
+    let fileId = await this.createDelegatedFileForAttachment({
+      environment: d.environment,
+      chatMessageAttachmentId: ids.id,
+      ref: d.attachment
+    });
+
+    return db.chatMessageAttachment.create({
+      data: {
+        ...ids,
+        messageOid: d.message.oid,
+        fileId,
+        uploadedFileId: d.uploadedFile.id,
+        position: d.position ?? 0,
+        ...this.attachmentPayload(d.attachment)
+      }
+    });
+  }
+
+  async ensureFreshChatMessageAttachment(d: {
+    tenant: Tenant;
+    environment: Environment;
+    chat: ChatWithProvider;
+    attachment: ChatMessageAttachmentWithToolCallAttachment;
+  }): Promise<ChatMessageAttachmentWithToolCallAttachment> {
+    let { toolCallAttachment } = d.attachment;
+    let isFresh =
+      !!toolCallAttachment &&
+      (!toolCallAttachment.expiresAt || toolCallAttachment.expiresAt > new Date());
+    if (isFresh) return d.attachment;
+
+    let client = await chatAdapterService.getChatAdapterClientInternal({
+      tenant: d.tenant,
+      environment: d.environment,
+      chatIntegrationInstanceProvider: d.chat.chatIntegrationInstanceProvider
+    });
+    assertFileDownloadCapability(client);
+
+    let downloaded = await client.call('metorial_chat$file.download', {
+      providerFileReference: d.attachment.providerFileReference
+    });
+    let result = unwrapChatCall(downloaded, {
+      code: 'chat_attachment_download_failed',
+      message: 'Failed to re-download the attachment from the chat provider.'
+    }) as DownloadFileResult;
+
+    let toolCallAttachmentOid = await this.resolveToolCallAttachmentOid(result);
+    if (!toolCallAttachmentOid) throw attachmentDownloadFailedError();
+
+    let freshToolCallAttachment = await db.toolCallAttachment.findUniqueOrThrow({
+      where: { oid: toolCallAttachmentOid }
+    });
+
+    let updated = await db.chatMessageAttachment.update({
+      where: { oid: d.attachment.oid },
+      data: { toolCallAttachmentOid }
+    });
+
+    return { ...updated, toolCallAttachment: freshToolCallAttachment };
+  }
+}
+
+export let chatMessageAttachmentService = Service.create(
+  'chatMessageAttachmentService',
+  () => new chatMessageAttachmentServiceImpl()
+).build();

--- a/src/metorial/subspace/modules/chat/src/services/index.ts
+++ b/src/metorial/subspace/modules/chat/src/services/index.ts
@@ -7,6 +7,7 @@ export * from './chatIntegrationInstance';
 export * from './chatIntegrationInstanceProvider';
 export * from './chatIntegrationProvider';
 export * from './chatMessage';
+export * from './chatMessageAttachment';
 export * from './chatReaction';
 export * from './chatThread';
 export * from './chatTyping';

--- a/src/metorial/subspace/modules/chat/src/services/index.ts
+++ b/src/metorial/subspace/modules/chat/src/services/index.ts
@@ -7,7 +7,6 @@ export * from './chatIntegrationInstance';
 export * from './chatIntegrationInstanceProvider';
 export * from './chatIntegrationProvider';
 export * from './chatMessage';
-export * from './chatMessageAttachment';
 export * from './chatReaction';
 export * from './chatThread';
 export * from './chatTyping';

--- a/src/metorial/subspace/modules/session/src/services/index.ts
+++ b/src/metorial/subspace/modules/session/src/services/index.ts
@@ -3,6 +3,7 @@ export * from './adminProviderTelemetryErrorGroup';
 export * from './ephemeralManagedSession';
 export * from './internalToolCall';
 export * from './providerInvocation';
+export * from './providerPublicToolCall';
 export * from './providerRun';
 export * from './providerRunLogs';
 export * from './providerRunUsageRecord';

--- a/src/metorial/subspace/modules/session/src/services/providerPublicToolCall.ts
+++ b/src/metorial/subspace/modules/session/src/services/providerPublicToolCall.ts
@@ -1,0 +1,82 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import type { Environment, Tenant } from '@metorial-subspace/db';
+import { providerService, providerVersionService } from '@metorial-subspace/module-catalog';
+import { type MetorialFacing, resolveMetorialFacing } from '@metorial-subspace/module-tenant';
+import { getBackend } from '@metorial-subspace/provider';
+
+export type CallProviderPublicToolParams = {
+  providerId: string;
+  providerVersionId?: string;
+
+  toolKey: string;
+  input: Record<string, any>;
+
+  caller?: {
+    id: string;
+    name: string;
+    description?: string;
+  };
+};
+
+class providerPublicToolCallServiceImpl {
+  async callPublicTool(d: MetorialFacing<CallProviderPublicToolParams>) {
+    let { instance, organizationActor, ...rest } = d;
+    let scope = await resolveMetorialFacing(d);
+
+    return this.callPublicToolInternal({
+      ...rest,
+      tenant: scope.tenant,
+      environment: scope.environment
+    });
+  }
+
+  async callPublicToolInternal(
+    d: { tenant: Tenant; environment: Environment } & CallProviderPublicToolParams
+  ) {
+    let provider = await providerService.getProviderByIdInternal({
+      providerId: d.providerId,
+      tenant: d.tenant,
+      environment: d.environment
+    });
+
+    let providerVariant = provider.defaultVariant;
+    if (!providerVariant) {
+      throw new ServiceError(notFoundError('provider.variant'));
+    }
+
+    let providerVersion = d.providerVersionId
+      ? await providerVersionService.getProviderVersionByIdInternal({
+          providerVersionId: d.providerVersionId,
+          tenant: d.tenant,
+          environment: d.environment
+        })
+      : providerVariant.currentVersion;
+
+    if (!providerVersion) {
+      throw new ServiceError(
+        badRequestError({ message: 'Provider does not have a current version set.' })
+      );
+    }
+    if (providerVersion.providerOid !== provider.oid) {
+      throw new ServiceError(notFoundError('provider.version', d.providerVersionId));
+    }
+
+    let backend = await getBackend({ entity: providerVersion });
+
+    return backend.providerRun.callPublicTool({
+      tenant: d.tenant,
+      provider,
+      providerVariant,
+      providerVersion,
+      toolKey: d.toolKey,
+      input: d.input,
+      caller: d.caller
+    });
+  }
+}
+
+export let providerPublicToolCallService = Service.create(
+  'providerPublicToolCallService',
+  () => new providerPublicToolCallServiceImpl()
+).build();

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/capabilities.ts
@@ -172,31 +172,33 @@ export class ProviderCapabilities extends IProviderCapabilities {
         capabilities: {},
         metadata: {}
       })),
-      tools: specRecord.tools.map(t => {
-        let tool = t as typeof t & { authMethods?: string[] | null };
+      tools: specRecord.tools
+        .filter(t => !t.isPublic)
+        .map(t => {
+          let tool = t as typeof t & { authMethods?: string[] | null };
 
-        return {
-          specId: t.id,
-          specUniqueIdentifier: t.identifier,
-          callableId: t.key,
-          key: t.key,
-          name: t.name,
-          description: t.description,
-          inputJsonSchema: t.inputSchema,
-          outputJsonSchema: t.outputSchema,
-          constraints: t.constraints ?? [],
-          instructions: t.instructions ?? [],
-          capabilities: {},
-          mcpToolType: {
-            type: 'tool.callable'
-          },
-          scopes: t.scopes ?? null,
-          authMethods: tool.authMethods ?? null,
-          tags: t.tags,
-          metadata: {},
-          adapterIdentifier: t.adapter?.slateIdentifier ?? null
-        };
-      })
+          return {
+            specId: t.id,
+            specUniqueIdentifier: t.identifier,
+            callableId: t.key,
+            key: t.key,
+            name: t.name,
+            description: t.description,
+            inputJsonSchema: t.inputSchema,
+            outputJsonSchema: t.outputSchema,
+            constraints: t.constraints ?? [],
+            instructions: t.instructions ?? [],
+            capabilities: {},
+            mcpToolType: {
+              type: 'tool.callable'
+            },
+            scopes: t.scopes ?? null,
+            authMethods: tool.authMethods ?? null,
+            tags: t.tags,
+            metadata: {},
+            adapterIdentifier: t.adapter?.slateIdentifier ?? null
+          };
+        })
     };
   }
 }

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
@@ -14,6 +14,8 @@ import type {
   ProviderRunLogsParam,
   ProviderRunLogsRes,
   ProviderRuntimeBehavior,
+  PublicToolInvocationParam,
+  PublicToolInvocationRes,
   ToolInvocationCreateParam,
   ToolInvocationCreateRes
 } from '@metorial-subspace/provider-utils';
@@ -115,6 +117,46 @@ export class ProviderRun extends IProviderRun {
       connectTimeoutMs: 30_000,
       requestTimeoutMs: 120_000,
       messageTtlExtensionMs: 1000 * 30
+    };
+  }
+
+  override async callPublicTool(data: PublicToolInvocationParam): Promise<PublicToolInvocationRes> {
+    if (!data.providerVersion.slateVersionOid) {
+      throw new Error('Provider version does not have a slate associated with it');
+    }
+
+    let tenant = await getTenantForSlates(data.tenant);
+
+    let slateVersion = await db.slateVersion.findUniqueOrThrow({
+      where: { oid: data.providerVersion.slateVersionOid },
+      include: { slate: true }
+    });
+
+    let res = await slates.slatePublicToolCall.call({
+      tenantId: tenant.id,
+      slateId: slateVersion.slate.id,
+      slateVersionId: slateVersion.id,
+      toolId: data.toolKey,
+      input: data.input,
+      participants: [
+        {
+          type: 'consumer',
+          id: data.caller?.id ?? 'subspace',
+          name: data.caller?.name ?? 'Subspace',
+          description: data.caller?.description
+        }
+      ]
+    });
+
+    if (res.status === 'error') {
+      return { status: 'error', error: res.error };
+    }
+
+    return {
+      status: 'success',
+      output: res.output,
+      message: res.message,
+      attachments: res.attachments
     };
   }
 }

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/run.ts
@@ -120,7 +120,9 @@ export class ProviderRun extends IProviderRun {
     };
   }
 
-  override async callPublicTool(data: PublicToolInvocationParam): Promise<PublicToolInvocationRes> {
+  override async callPublicTool(
+    data: PublicToolInvocationParam
+  ): Promise<PublicToolInvocationRes> {
     if (!data.providerVersion.slateVersionOid) {
       throw new Error('Provider version does not have a slate associated with it');
     }
@@ -145,7 +147,8 @@ export class ProviderRun extends IProviderRun {
           name: data.caller?.name ?? 'Subspace',
           description: data.caller?.description
         }
-      ]
+      ],
+      downloadUrlAttachments: true
     });
 
     if (res.status === 'error') {
@@ -237,7 +240,8 @@ export class ProviderRunConnection extends IProviderRunConnection {
           name: data.sender.name,
           description: (data.sender.payload as any).description
         }
-      ]
+      ],
+      downloadUrlAttachments: this.params.adapter?.identifier === 'chat'
     });
 
     let slateToolCall = await db.slateToolCall.create({

--- a/src/metorial/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/queues/sync/syncSlateVersion.ts
@@ -11,8 +11,8 @@ import {
   publisherInternalService
 } from '@metorial-subspace/module-provider-internal';
 import { normalizeJsonSchema } from '@metorial-subspace/provider-utils';
-import { backend } from '../../backend';
 import { canonicalizeAdapterCapabilities } from '../../adapterCapabilities';
+import { backend } from '../../backend';
 import { slates } from '../../client';
 import { env } from '../../env';
 
@@ -95,7 +95,7 @@ let buildProviderListingDocs = (spec: any): PrismaJson.ProviderListingDocs | und
     }))
     .filter((authMethod: any) => authMethod.docs.length > 0);
   let actions = [...(spec.tools ?? []), ...(spec.triggers ?? [])]
-    .filter((action: any) => !action.adapter)
+    .filter((action: any) => !action.adapter && !action.isPublic)
     .map((action: any) => ({
       key: action.key,
       name: action.name,

--- a/src/metorial/subspace/provider-backends/provider-utils/src/interfaces/providerRun.ts
+++ b/src/metorial/subspace/provider-backends/provider-utils/src/interfaces/providerRun.ts
@@ -33,6 +33,10 @@ export abstract class IProviderRun extends IProviderFunctionality {
   abstract getProviderRunLogs(data: ProviderRunLogsParam): Promise<ProviderRunLogsRes>;
 
   abstract getRuntimeBehavior(): ProviderRuntimeBehavior;
+
+  async callPublicTool(data: PublicToolInvocationParam): Promise<PublicToolInvocationRes> {
+    throw new Error(`Backend "${this.backend.type}" does not support calling public tools`);
+  }
 }
 
 export abstract class IProviderRunConnection {
@@ -172,4 +176,30 @@ export interface ProviderRunLog {
 
 export interface ProviderRunLogsRes {
   logs: ProviderRunLog[];
+}
+
+export interface PublicToolInvocationParam {
+  tenant: Tenant;
+  provider: Provider;
+  providerVariant: ProviderVariant;
+  providerVersion: ProviderVersion;
+
+  toolKey: string;
+  input: Record<string, any>;
+
+  caller?: {
+    id: string;
+    name: string;
+    description?: string;
+  };
+}
+
+export interface PublicToolInvocationRes {
+  status: 'success' | 'error';
+
+  output?: Record<string, any>;
+  message?: string;
+  attachments?: any[];
+
+  error?: ProviderInvocationError;
 }

--- a/src/metorial/subspace/provider-backends/provider-utils/src/types/specification.ts
+++ b/src/metorial/subspace/provider-backends/provider-utils/src/types/specification.ts
@@ -85,6 +85,7 @@ export interface SpecificationTool {
 
   scopes?: SpecificationActionScopes | null;
   authMethods?: string[] | null;
+  isPublic?: boolean;
 
   metadata: Record<string, any>;
 

--- a/src/slates/apps/hub/package.json
+++ b/src/slates/apps/hub/package.json
@@ -97,6 +97,7 @@
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",
     "hono": "4.12.23",
+    "ipaddr.js": "^2.3.0",
     "jszip": "^3.10.1",
     "lodash": "4.17.21",
     "object-storage-client": "^0.2.5",

--- a/src/slates/apps/hub/prisma/schema/attachment.prisma
+++ b/src/slates/apps/hub/prisma/schema/attachment.prisma
@@ -2,7 +2,18 @@ model SlateAttachment {
   oid BigInt @id
   id  String @unique
 
-  digest Bytes @unique
+  // Content-addressed dedup key. Null for URL-downloaded attachments, where we stream
+  // straight into storage without buffering the whole body to compute a digest.
+  digest Bytes? @unique
+
+  // Caller-supplied stable identifier for the underlying attachment (e.g. `slack:file:F123`),
+  // scoped to a tenant + slate so a repeated tool call referencing the same file reuses the
+  // stored copy instead of re-downloading/re-uploading it.
+  tenantOid      BigInt?
+  tenant         Tenant? @relation(fields: [tenantOid], references: [oid])
+  slateOid       BigInt?
+  slate          Slate?  @relation(fields: [slateOid], references: [oid])
+  attachmentHash String?
 
   createdAt     DateTime @default(now())
   expiresAt     DateTime
@@ -10,5 +21,6 @@ model SlateAttachment {
 
   slateInvocationAttachments SlateInvocationAttachment[]
 
+  @@unique([tenantOid, slateOid, attachmentHash])
   @@index([expiresAt])
 }

--- a/src/slates/apps/hub/prisma/schema/attachment.prisma
+++ b/src/slates/apps/hub/prisma/schema/attachment.prisma
@@ -15,6 +15,8 @@ model SlateAttachment {
   slate          Slate?  @relation(fields: [slateOid], references: [oid])
   attachmentHash String?
 
+  sourceUrl String?
+
   createdAt     DateTime @default(now())
   expiresAt     DateTime
   lastCreatedAt DateTime @default(now())

--- a/src/slates/apps/hub/prisma/schema/invocation.prisma
+++ b/src/slates/apps/hub/prisma/schema/invocation.prisma
@@ -26,6 +26,7 @@ model SlateInvocation {
   slateInstanceOAuthSetupEvents SlateInstanceOAuthSetupEvent[]
   slateAuthConfigEvents         SlateAuthConfigEvent[]
   slateSessionToolCalls         SlateSessionToolCall[]
+  slatePublicToolCalls          SlatePublicToolCall[]
   slateTriggerInvocations       SlateTriggerInvocation[]
   slateTriggerEvents            SlateTriggerEvent[]
   slateInvocationAttachment     SlateInvocationAttachment[]

--- a/src/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/slates/apps/hub/prisma/schema/slate.prisma
@@ -48,6 +48,7 @@ model Slate {
   changeNotifications       ChangeNotification[]
   slateErrors               SlateError[]
   slateAdapters             SlateAdapter[]
+  slateAttachments          SlateAttachment[]
 
   @@unique([registryOid, slateIdOnRegistry])
   @@unique([registryOid, slateFullIdentifierOnRegistry])

--- a/src/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/slates/apps/hub/prisma/schema/slate.prisma
@@ -41,6 +41,7 @@ model Slate {
   slateInstanceOAuthSetups  SlateInstanceOAuthSetup[]
   slateAuthConfigs          SlateAuthConfig[]
   slateSessions             SlateSession[]
+  slatePublicToolCalls      SlatePublicToolCall[]
   slateTriggerReceivers     SlateTriggerReceiver[]
   slateTriggerEvents        SlateTriggerEvent[]
   slateTriggerEventInputs   SlateTriggerEventInput[]
@@ -108,6 +109,7 @@ model SlateVersion {
   slateInstanceOAuthSetups   SlateInstanceOAuthSetup[]
   slateSessions              SlateSession[]
   slateSessionToolCalls      SlateSessionToolCall[]
+  slatePublicToolCalls       SlatePublicToolCall[]
   changeNotifications        ChangeNotification[]
   slateErrors                SlateError[]
   slateVersionAdapters       SlateVersionAdapter[]
@@ -219,6 +221,8 @@ model SlateAction {
   key  String
   name String
 
+  isPublic Boolean @default(false)
+
   /// [SlateAction]
   spec Json
 
@@ -235,6 +239,7 @@ model SlateAction {
 
   slateSpecifications          SlateSpecificationAction[]
   slateSessionToolCalls        SlateSessionToolCall[]
+  slatePublicToolCalls         SlatePublicToolCall[]
   slateTriggerReceiverTriggers SlateTriggerReceiverTrigger[]
   slateTriggerEvents           SlateTriggerEvent[]
   slateTriggerEventInputs      SlateTriggerEventInput[]

--- a/src/slates/apps/hub/prisma/schema/tenant.prisma
+++ b/src/slates/apps/hub/prisma/schema/tenant.prisma
@@ -23,6 +23,7 @@ model Tenant {
   slateInstanceConfigs        SlateInstanceConfig[]
   slateInstanceEvents         SlateInstanceEvent[]
   slateSessions               SlateSession[]
+  slatePublicToolCalls        SlatePublicToolCall[]
   slateTriggerDestinations    SlateTriggerDestination[]    @ignore
   slateTriggerReceivers       SlateTriggerReceiver[]
   slateErrors                 SlateError[]

--- a/src/slates/apps/hub/prisma/schema/tenant.prisma
+++ b/src/slates/apps/hub/prisma/schema/tenant.prisma
@@ -28,4 +28,5 @@ model Tenant {
   slateTriggerReceivers       SlateTriggerReceiver[]
   slateErrors                 SlateError[]
   slateInstanceConfigurations SlateInstanceConfiguration[]
+  slateAttachments            SlateAttachment[]
 }

--- a/src/slates/apps/hub/prisma/schema/tool.prisma
+++ b/src/slates/apps/hub/prisma/schema/tool.prisma
@@ -56,3 +56,37 @@ model SlateSessionToolCall {
 
   slateErrors SlateError[]
 }
+
+enum SlatePublicToolCallStatus {
+  succeeded
+  failed
+}
+
+model SlatePublicToolCall {
+  oid    BigInt                    @id
+  id     String                    @unique
+  status SlatePublicToolCallStatus
+
+  errorCode    String?
+  errorMessage String?
+  durationMs   Int?
+
+  tenantOid BigInt
+  tenant    Tenant @relation(fields: [tenantOid], references: [oid], onDelete: Cascade)
+
+  actionOid BigInt
+  action    SlateAction @relation(fields: [actionOid], references: [oid], onDelete: Cascade)
+
+  invocationOid BigInt
+  invocation    SlateInvocation @relation(fields: [invocationOid], references: [oid], onDelete: Cascade)
+
+  slateOid BigInt
+  slate    Slate @relation(fields: [slateOid], references: [oid], onDelete: Cascade)
+
+  slateVersionOid BigInt
+  slateVersion    SlateVersion @relation(fields: [slateVersionOid], references: [oid], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@index([tenantOid, createdAt])
+}

--- a/src/slates/apps/hub/src/apis/internal/index.ts
+++ b/src/slates/apps/hub/src/apis/internal/index.ts
@@ -18,6 +18,7 @@ import { slateInvocationController } from './slateInvocation';
 import { slateOAuthCredentialsController } from './slateOAuthCredentials';
 import { slateOAuthSetupController } from './slateOAuthSetup';
 import { slateOAuthSetupEventController } from './slateOAuthSetupEvent';
+import { slatePublicToolCallController } from './slatePublicToolCall';
 import { slateSessionController } from './slateSession';
 import { slateSessionToolCallController } from './slateSessionToolCall';
 import { slateSpecificationController } from './slateSpecification';
@@ -56,6 +57,7 @@ export let rootController = app.controller({
   slateAuthConfigEvent: slateAuthConfigEventController,
   slateSession: slateSessionController,
   slateSessionToolCall: slateSessionToolCallController,
+  slatePublicToolCall: slatePublicToolCallController,
 
   slateTriggerReceiver: slateTriggerReceiverController,
   slateTriggerEvent: slateTriggerEventController,

--- a/src/slates/apps/hub/src/apis/internal/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/apis/internal/slatePublicToolCall.ts
@@ -76,7 +76,8 @@ export let slatePublicToolCallController = app.controller({
             description: v.optional(v.string()),
             metadata: v.optional(v.record(v.any()))
           })
-        )
+        ),
+        downloadUrlAttachments: v.optional(v.boolean())
       })
     )
     .do(async ctx => {
@@ -89,7 +90,8 @@ export let slatePublicToolCallController = app.controller({
           enclaveId: ctx.input.enclaveId,
           egressPolicy: ctx.input.egressPolicy,
           input: ctx.input.input,
-          participants: ctx.input.participants
+          participants: ctx.input.participants,
+          downloadUrlAttachments: ctx.input.downloadUrlAttachments
         }
       });
 

--- a/src/slates/apps/hub/src/apis/internal/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/apis/internal/slatePublicToolCall.ts
@@ -1,0 +1,140 @@
+import { Paginator } from '@lowerdeck/pagination';
+import { v } from '@lowerdeck/validation';
+import {
+  slatePublicToolCallLogsPresenter,
+  slatePublicToolCallPresenter
+} from '../../presenters';
+import { slatePublicToolCallService } from '../../services';
+import { app } from './_app';
+import { tenantApp } from './tenant';
+
+export let slatePublicToolCallApp = tenantApp.use(async ctx => {
+  let slatePublicToolCallId = ctx.body.slatePublicToolCallId;
+  if (!slatePublicToolCallId) throw new Error('Slate Public Tool Call ID is required');
+
+  let slatePublicToolCall = await slatePublicToolCallService.getPublicToolCallById({
+    id: slatePublicToolCallId,
+    tenant: ctx.tenant
+  });
+
+  return { slatePublicToolCall };
+});
+
+export let slatePublicToolCallController = app.controller({
+  list: tenantApp
+    .handler()
+    .input(
+      Paginator.validate(
+        v.object({
+          tenantId: v.string(),
+          slateIds: v.optional(v.array(v.string()))
+        })
+      )
+    )
+    .do(async ctx => {
+      let paginator = await slatePublicToolCallService.listPublicToolCalls({
+        tenant: ctx.tenant,
+        slateIds: ctx.input.slateIds
+      });
+
+      let list = await paginator.run(ctx.input);
+
+      return await Paginator.presentLight(list, slatePublicToolCallPresenter);
+    }),
+
+  call: app
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slateId: v.string(),
+        slateVersionId: v.optional(v.string()),
+        toolId: v.string(),
+        enclaveId: v.optional(v.string()),
+        egressPolicy: v.optional(
+          v.object({
+            direction: v.literal('egress'),
+            entries: v.array(
+              v.object({
+                cidr: v.string(),
+                portRange: v.optional(
+                  v.object({
+                    from: v.number(),
+                    to: v.number()
+                  })
+                )
+              })
+            )
+          })
+        ),
+        input: v.record(v.any()),
+        participants: v.array(
+          v.object({
+            type: v.enumOf(['consumer', 'hub']),
+            id: v.string(),
+            name: v.string(),
+            description: v.optional(v.string()),
+            metadata: v.optional(v.record(v.any()))
+          })
+        )
+      })
+    )
+    .do(async ctx => {
+      let res = await slatePublicToolCallService.createPublicToolCall({
+        input: {
+          tenantId: ctx.input.tenantId,
+          slateId: ctx.input.slateId,
+          slateVersionId: ctx.input.slateVersionId,
+          toolId: ctx.input.toolId,
+          enclaveId: ctx.input.enclaveId,
+          egressPolicy: ctx.input.egressPolicy,
+          input: ctx.input.input,
+          participants: ctx.input.participants
+        }
+      });
+
+      return {
+        ...res,
+        call: undefined,
+        toolCallId: res.call.id,
+        invocationId: res.invocationId
+      };
+    }),
+
+  get: slatePublicToolCallApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slatePublicToolCallId: v.string()
+      })
+    )
+    .do(async ctx => await slatePublicToolCallPresenter(ctx.slatePublicToolCall)),
+
+  getLogs: slatePublicToolCallApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slatePublicToolCallId: v.string()
+      })
+    )
+    .do(async ctx => slatePublicToolCallLogsPresenter(ctx.slatePublicToolCall)),
+
+  getMany: tenantApp
+    .handler()
+    .input(
+      v.object({
+        tenantId: v.string(),
+        slatePublicToolCallIds: v.array(v.string())
+      })
+    )
+    .do(async ctx => {
+      let slatePublicToolCalls = await slatePublicToolCallService.getManyPublicToolCallsByIds({
+        ids: ctx.input.slatePublicToolCallIds,
+        tenant: ctx.tenant
+      });
+
+      return await Promise.all(slatePublicToolCalls.map(slatePublicToolCallPresenter));
+    })
+});

--- a/src/slates/apps/hub/src/apis/internal/slateSessionToolCall.ts
+++ b/src/slates/apps/hub/src/apis/internal/slateSessionToolCall.ts
@@ -77,7 +77,8 @@ export let slateSessionToolCallController = app.controller({
               description: v.optional(v.string()),
               metadata: v.optional(v.record(v.any()))
             })
-          )
+          ),
+          downloadUrlAttachments: v.optional(v.boolean())
         })
       )
     )
@@ -91,7 +92,8 @@ export let slateSessionToolCallController = app.controller({
           enclaveId: ctx.input.enclaveId,
           egressPolicy: ctx.input.egressPolicy,
           input: ctx.input.input,
-          participants: ctx.input.participants
+          participants: ctx.input.participants,
+          downloadUrlAttachments: ctx.input.downloadUrlAttachments
         }
       });
 

--- a/src/slates/apps/hub/src/id.ts
+++ b/src/slates/apps/hub/src/id.ts
@@ -41,6 +41,7 @@ export let ID = createIdGenerator({
 
   slateOAuthCredentials: idType.sorted('shoc'),
   slateToolCall: idType.sorted('shtc'),
+  slatePublicToolCall: idType.sorted('shptc'),
   slateSession: idType.sorted('shses'),
 
   slateTriggerReceiver: idType.sorted('shtr'),

--- a/src/slates/apps/hub/src/lib/invocation/attachments.ts
+++ b/src/slates/apps/hub/src/lib/invocation/attachments.ts
@@ -1,14 +1,11 @@
-import { getSentry } from '@lowerdeck/sentry';
 import { addDays } from 'date-fns';
 import { PublicUrlPurpose } from 'object-storage-client';
 import type { SlateAttachment, SlateInvocation } from '../../../prisma/generated/client';
 import { db } from '../../db';
 import { getId } from '../../id';
+import { slateAttachmentReplicateQueue } from '../../queues/attachment/replicate';
 import { invocationsBucketRecord, storage } from '../../storage';
-import { AttachmentDownloadTooLargeError, downloadUrlToStream } from '../network/ssrfDownload';
 import { getAttachmentStorageKey, getStoredAttachmentsStorageKey } from './store';
-
-let Sentry = getSentry();
 
 export type SlateToolCallAttachment = {
   content:
@@ -26,12 +23,19 @@ export type SlateToolCallAttachment = {
 };
 
 let ATTACHMENT_EXPIRATION_DAYS = 7;
-let ATTACHMENT_MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
 
 let presentStoredAttachment = async (d: {
   attachment: SlateAttachment;
   mimeType?: string;
 }) => {
+  if (d.attachment.sourceUrl) {
+    return {
+      type: 'url' as const,
+      url: d.attachment.sourceUrl,
+      mimeType: d.mimeType
+    };
+  }
+
   let storageKey = getAttachmentStorageKey(d.attachment);
   let url = await storage.getPublicURL(
     invocationsBucketRecord.bucket,
@@ -98,50 +102,28 @@ export let ensureSlateInvocationAttachment = async (d: {
       };
     }
 
-    try {
-      let { stream, mimeType } = await downloadUrlToStream({
-        url: d.content.url,
-        maxBytes: ATTACHMENT_MAX_DOWNLOAD_BYTES
-      });
-
-      let attachmentId = getId('slateAttachment');
-      let storageKey = getStoredAttachmentsStorageKey(attachmentId.id);
-
-      await storage.putObject(
-        invocationsBucketRecord.bucket,
-        storageKey,
-        stream,
-        d.mimeType ?? mimeType ?? 'application/octet-stream'
-      );
-
-      let attachment = await db.slateAttachment.create({
-        data: {
-          ...attachmentId,
-          digest: null,
-          tenantOid: d.tenantOid,
-          slateOid: d.slateOid,
-          attachmentHash: d.attachmentHash ?? null,
-          expiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS),
-          lastCreatedAt: new Date()
-        }
-      });
-
-      await linkInvocationToAttachment({ invocation: d.invocation, attachment });
-
-      return presentStoredAttachment({ attachment, mimeType: d.mimeType });
-    } catch (err) {
-      if (!(err instanceof AttachmentDownloadTooLargeError)) {
-        Sentry.captureException(err, {
-          extra: { invocationOid: d.invocation.oid, url: d.content.url }
-        });
+    let attachment = await db.slateAttachment.create({
+      data: {
+        ...getId('slateAttachment'),
+        digest: null,
+        tenantOid: d.tenantOid,
+        slateOid: d.slateOid,
+        attachmentHash: d.attachmentHash ?? null,
+        sourceUrl: d.content.url,
+        expiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS),
+        lastCreatedAt: new Date()
       }
+    });
 
-      return {
-        type: 'url' as const,
-        url: d.content.url,
-        mimeType: d.mimeType
-      };
-    }
+    await linkInvocationToAttachment({ invocation: d.invocation, attachment });
+
+    await slateAttachmentReplicateQueue.add({
+      attachmentId: attachment.id,
+      url: d.content.url,
+      mimeType: d.mimeType
+    });
+
+    return presentStoredAttachment({ attachment, mimeType: d.mimeType });
   }
 
   let contentBuffer = Buffer.from(d.content.content, d.content.encoding);

--- a/src/slates/apps/hub/src/lib/invocation/attachments.ts
+++ b/src/slates/apps/hub/src/lib/invocation/attachments.ts
@@ -1,10 +1,14 @@
+import { getSentry } from '@lowerdeck/sentry';
 import { addDays } from 'date-fns';
 import { PublicUrlPurpose } from 'object-storage-client';
-import type { SlateInvocation } from '../../../prisma/generated/client';
+import type { SlateAttachment, SlateInvocation } from '../../../prisma/generated/client';
 import { db } from '../../db';
 import { getId } from '../../id';
 import { invocationsBucketRecord, storage } from '../../storage';
-import { getStoredAttachmentsStorageKey } from './store';
+import { AttachmentDownloadTooLargeError, downloadUrlToStream } from '../network/ssrfDownload';
+import { getAttachmentStorageKey, getStoredAttachmentsStorageKey } from './store';
+
+let Sentry = getSentry();
 
 export type SlateToolCallAttachment = {
   content:
@@ -18,21 +22,126 @@ export type SlateToolCallAttachment = {
         content: string;
       };
   mimeType?: string;
+  attachmentHash?: string;
 };
 
 let ATTACHMENT_EXPIRATION_DAYS = 7;
+let ATTACHMENT_MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
+
+let presentStoredAttachment = async (d: {
+  attachment: SlateAttachment;
+  mimeType?: string;
+}) => {
+  let storageKey = getAttachmentStorageKey(d.attachment);
+  let url = await storage.getPublicURL(
+    invocationsBucketRecord.bucket,
+    storageKey,
+    ATTACHMENT_EXPIRATION_DAYS * 24 * 60 * 60,
+    PublicUrlPurpose.Retrieve
+  );
+
+  return {
+    type: 'url' as const,
+    url: url.url,
+    mimeType: d.mimeType,
+    urlExpiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS)
+  };
+};
+
+let linkInvocationToAttachment = (d: {
+  invocation: SlateInvocation;
+  attachment: SlateAttachment;
+}) =>
+  db.slateInvocationAttachment.createMany({
+    data: {
+      ...getId('slateInvocationAttachment'),
+      invocationOid: d.invocation.oid,
+      attachmentsOid: d.attachment.oid
+    }
+  });
 
 export let ensureSlateInvocationAttachment = async (d: {
   content: SlateToolCallAttachment['content'];
   mimeType?: string | undefined;
+  attachmentHash?: string | undefined;
   invocation: SlateInvocation;
+  tenantOid: bigint;
+  slateOid: bigint;
+  downloadUrlAttachments?: boolean;
 }) => {
+  if (d.attachmentHash) {
+    let existing = await db.slateAttachment.findFirst({
+      where: { tenantOid: d.tenantOid, slateOid: d.slateOid, attachmentHash: d.attachmentHash }
+    });
+
+    if (existing) {
+      let refreshed = await db.slateAttachment.update({
+        where: { oid: existing.oid },
+        data: {
+          expiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS),
+          lastCreatedAt: new Date()
+        }
+      });
+
+      await linkInvocationToAttachment({ invocation: d.invocation, attachment: refreshed });
+
+      return presentStoredAttachment({ attachment: refreshed, mimeType: d.mimeType });
+    }
+  }
+
   if (d.content.type === 'url') {
-    return {
-      type: 'url' as const,
-      url: d.content.url,
-      mimeType: d.mimeType
-    };
+    if (!d.downloadUrlAttachments) {
+      return {
+        type: 'url' as const,
+        url: d.content.url,
+        mimeType: d.mimeType
+      };
+    }
+
+    try {
+      let { stream, mimeType } = await downloadUrlToStream({
+        url: d.content.url,
+        maxBytes: ATTACHMENT_MAX_DOWNLOAD_BYTES
+      });
+
+      let attachmentId = getId('slateAttachment');
+      let storageKey = getStoredAttachmentsStorageKey(attachmentId.id);
+
+      await storage.putObject(
+        invocationsBucketRecord.bucket,
+        storageKey,
+        stream,
+        d.mimeType ?? mimeType ?? 'application/octet-stream'
+      );
+
+      let attachment = await db.slateAttachment.create({
+        data: {
+          ...attachmentId,
+          digest: null,
+          tenantOid: d.tenantOid,
+          slateOid: d.slateOid,
+          attachmentHash: d.attachmentHash ?? null,
+          expiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS),
+          lastCreatedAt: new Date()
+        }
+      });
+
+      await linkInvocationToAttachment({ invocation: d.invocation, attachment });
+
+      return presentStoredAttachment({ attachment, mimeType: d.mimeType });
+    } catch (err) {
+      if (!(err instanceof AttachmentDownloadTooLargeError)) {
+        Sentry.captureException(err, {
+          extra: { invocationOid: d.invocation.oid, url: d.content.url }
+        });
+      }
+
+      return {
+        type: 'url' as const,
+        url: d.content.url,
+        mimeType: d.mimeType
+      };
+    }
   }
 
   let contentBuffer = Buffer.from(d.content.content, d.content.encoding);
@@ -52,10 +161,8 @@ export let ensureSlateInvocationAttachment = async (d: {
     );
   }
 
-  let expiresAt = addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS);
-  let inner = {
-    digest,
-    expiresAt,
+  let refresh = {
+    expiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS),
     lastCreatedAt: new Date()
   };
 
@@ -63,30 +170,16 @@ export let ensureSlateInvocationAttachment = async (d: {
     where: { digest },
     create: {
       ...getId('slateAttachment'),
-      ...inner
+      digest,
+      tenantOid: d.tenantOid,
+      slateOid: d.slateOid,
+      attachmentHash: d.attachmentHash ?? null,
+      ...refresh
     },
-    update: inner
+    update: refresh
   });
 
-  await db.slateInvocationAttachment.createMany({
-    data: {
-      ...getId('slateInvocationAttachment'),
-      invocationOid: d.invocation.oid,
-      attachmentsOid: attachment.oid
-    }
-  });
+  await linkInvocationToAttachment({ invocation: d.invocation, attachment });
 
-  let url = await storage.getPublicURL(
-    invocationsBucketRecord.bucket,
-    storageKey,
-    ATTACHMENT_EXPIRATION_DAYS * 24 * 60 * 60,
-    PublicUrlPurpose.Retrieve
-  );
-
-  return {
-    type: 'url' as const,
-    url: url.url,
-    mimeType: d.mimeType,
-    urlExpiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS)
-  };
+  return presentStoredAttachment({ attachment, mimeType: d.mimeType });
 };

--- a/src/slates/apps/hub/src/lib/invocation/attachments.ts
+++ b/src/slates/apps/hub/src/lib/invocation/attachments.ts
@@ -1,0 +1,92 @@
+import { addDays } from 'date-fns';
+import { PublicUrlPurpose } from 'object-storage-client';
+import type { SlateInvocation } from '../../../prisma/generated/client';
+import { db } from '../../db';
+import { getId } from '../../id';
+import { invocationsBucketRecord, storage } from '../../storage';
+import { getStoredAttachmentsStorageKey } from './store';
+
+export type SlateToolCallAttachment = {
+  content:
+    | {
+        type: 'url';
+        url: string;
+      }
+    | {
+        type: 'content';
+        encoding: 'base64' | 'utf-8';
+        content: string;
+      };
+  mimeType?: string;
+};
+
+let ATTACHMENT_EXPIRATION_DAYS = 7;
+
+export let ensureSlateInvocationAttachment = async (d: {
+  content: SlateToolCallAttachment['content'];
+  mimeType?: string | undefined;
+  invocation: SlateInvocation;
+}) => {
+  if (d.content.type === 'url') {
+    return {
+      type: 'url' as const,
+      url: d.content.url,
+      mimeType: d.mimeType
+    };
+  }
+
+  let contentBuffer = Buffer.from(d.content.content, d.content.encoding);
+  let digest = new Uint8Array(await crypto.subtle.digest('SHA-256', contentBuffer));
+  let digestString = Buffer.from(digest).toString('hex');
+  let storageKey = getStoredAttachmentsStorageKey(digestString);
+
+  let attachment = await db.slateAttachment.findFirst({
+    where: { digest }
+  });
+  if (!attachment) {
+    await storage.putObject(
+      invocationsBucketRecord.bucket,
+      storageKey,
+      contentBuffer,
+      d.mimeType ?? 'application/octet-stream'
+    );
+  }
+
+  let expiresAt = addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS);
+  let inner = {
+    digest,
+    expiresAt,
+    lastCreatedAt: new Date()
+  };
+
+  attachment = await db.slateAttachment.upsert({
+    where: { digest },
+    create: {
+      ...getId('slateAttachment'),
+      ...inner
+    },
+    update: inner
+  });
+
+  await db.slateInvocationAttachment.createMany({
+    data: {
+      ...getId('slateInvocationAttachment'),
+      invocationOid: d.invocation.oid,
+      attachmentsOid: attachment.oid
+    }
+  });
+
+  let url = await storage.getPublicURL(
+    invocationsBucketRecord.bucket,
+    storageKey,
+    ATTACHMENT_EXPIRATION_DAYS * 24 * 60 * 60,
+    PublicUrlPurpose.Retrieve
+  );
+
+  return {
+    type: 'url' as const,
+    url: url.url,
+    mimeType: d.mimeType,
+    urlExpiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS)
+  };
+};

--- a/src/slates/apps/hub/src/lib/invocation/store.ts
+++ b/src/slates/apps/hub/src/lib/invocation/store.ts
@@ -185,3 +185,11 @@ export let getStoredInvocationStorageKey = (invocation: SlateInvocation) => {
 export let getStoredAttachmentsStorageKey = (digest: string) => {
   return `attachments/${digest}`;
 };
+
+export let getAttachmentStorageKey = (attachment: {
+  id: string;
+  digest: Uint8Array | null;
+}) =>
+  attachment.digest
+    ? getStoredAttachmentsStorageKey(Buffer.from(attachment.digest).toString('hex'))
+    : getStoredAttachmentsStorageKey(attachment.id);

--- a/src/slates/apps/hub/src/lib/network/ssrfDownload.ts
+++ b/src/slates/apps/hub/src/lib/network/ssrfDownload.ts
@@ -1,0 +1,135 @@
+import http from 'http';
+import https from 'https';
+import ipaddr from 'ipaddr.js';
+import { Readable, Transform } from 'stream';
+
+let checkIp = (ip: string) => {
+  if (!ipaddr.isValid(ip)) return true;
+
+  try {
+    return ipaddr.parse(ip).range() === 'unicast';
+  } catch {
+    return false;
+  }
+};
+
+let createSsrfGuardedAgent = (protocol: string) => {
+  let AgentCtor = protocol === 'https:' ? https.Agent : http.Agent;
+  let agent = new AgentCtor();
+  let originalCreateConnection = (agent as any).createConnection;
+
+  (agent as any).createConnection = function (options: any, callback: any) {
+    let address = options.host;
+    if (typeof address === 'string' && !checkIp(address)) {
+      throw new Error(`Connection to ${address} is blocked`);
+    }
+
+    let socket = originalCreateConnection.call(this, options, callback);
+    socket.on('lookup', (error: unknown, resolvedAddress: string) => {
+      if (error) return;
+      if (!checkIp(resolvedAddress)) {
+        socket.destroy(new Error(`Connection to ${resolvedAddress} is blocked`));
+      }
+    });
+
+    return socket;
+  };
+
+  return agent;
+};
+
+let validateUrl = (input: string) => {
+  let url = new URL(input);
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Unsupported protocol for attachment download');
+  }
+  if (url.username || url.password) {
+    throw new Error('Credentials in attachment URL are not allowed');
+  }
+
+  return url;
+};
+
+export class AttachmentDownloadTooLargeError extends Error {
+  constructor(message = 'Attachment exceeds the maximum download size') {
+    super(message);
+  }
+}
+
+let requestOnce = (url: URL) =>
+  new Promise<http.IncomingMessage>((resolve, reject) => {
+    let client = url.protocol === 'https:' ? https : http;
+    let req = client.get(
+      url,
+      {
+        agent: createSsrfGuardedAgent(url.protocol),
+        headers: { 'User-Agent': 'Metorial-Slates-Hub (https://metorial.com)' },
+        timeout: 15_000
+      },
+      resolve
+    );
+    req.on('error', reject);
+    req.on('timeout', () => req.destroy(new Error('Attachment download timed out')));
+  });
+
+let createSizeGuardTransform = (maxBytes: number) => {
+  let total = 0;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      total += chunk.length;
+      if (total > maxBytes) {
+        callback(new AttachmentDownloadTooLargeError());
+        return;
+      }
+      callback(null, chunk);
+    }
+  });
+};
+
+export let downloadUrlToStream = async (d: {
+  url: string;
+  maxBytes: number;
+  maxRedirects?: number;
+}) => {
+  let currentUrl = validateUrl(d.url);
+  let maxRedirects = d.maxRedirects ?? 5;
+
+  for (let i = 0; i <= maxRedirects; i++) {
+    let res = await requestOnce(currentUrl);
+    let statusCode = res.statusCode ?? 0;
+
+    if (statusCode >= 300 && statusCode < 400 && res.headers.location) {
+      res.resume();
+      if (i === maxRedirects) {
+        throw new Error('Too many redirects while downloading attachment');
+      }
+      currentUrl = validateUrl(new URL(res.headers.location, currentUrl).toString());
+      continue;
+    }
+
+    if (statusCode < 200 || statusCode >= 300) {
+      res.resume();
+      throw new Error(`Attachment download failed with status ${statusCode}`);
+    }
+
+    let contentLength = Number(res.headers['content-length'] ?? 0);
+    if (contentLength > d.maxBytes) {
+      res.destroy();
+      throw new AttachmentDownloadTooLargeError();
+    }
+
+    let mimeType = res.headers['content-type'];
+    let sizeGuard = createSizeGuardTransform(d.maxBytes);
+
+    res.on('error', err => sizeGuard.destroy(err));
+    sizeGuard.on('error', () => res.destroy());
+    res.pipe(sizeGuard);
+
+    let stream = Readable.toWeb(sizeGuard) as unknown as ReadableStream;
+
+    return { stream, mimeType };
+  }
+
+  throw new Error('Unreachable');
+};

--- a/src/slates/apps/hub/src/presenters/index.ts
+++ b/src/slates/apps/hub/src/presenters/index.ts
@@ -19,6 +19,7 @@ export * from './slateOAuthCredentials';
 export * from './slateOAuthSetup';
 export * from './slateOAuthSetupEvent';
 export * from './slateOAuthSetupLogs';
+export * from './slatePublicToolCall';
 export * from './slateSession';
 export * from './slateSessionToolCall';
 export * from './slateSpecification';

--- a/src/slates/apps/hub/src/presenters/slateAction.ts
+++ b/src/slates/apps/hub/src/presenters/slateAction.ts
@@ -20,6 +20,7 @@ export let slateActionPresenter = (
     name: method.name,
     key: method.key,
     type: method.type,
+    isPublic: method.isPublic,
 
     capabilities: method.spec.capabilities,
     invocation: method.spec.type === 'action.trigger' ? method.spec.invocation : undefined,

--- a/src/slates/apps/hub/src/presenters/slateAttachment.ts
+++ b/src/slates/apps/hub/src/presenters/slateAttachment.ts
@@ -31,6 +31,13 @@ let getStoredAttachments = async (invocation: InvocationWithStoredAttachments) =
 };
 
 export let slateStoredAttachmentPresenter = async (attachment: SlateAttachment) => {
+  if (attachment.sourceUrl) {
+    return {
+      type: 'url' as const,
+      url: attachment.sourceUrl
+    };
+  }
+
   let storageKey = getAttachmentStorageKey(attachment);
   let url = await storage.getPublicURL(
     invocationsBucketRecord.bucket,

--- a/src/slates/apps/hub/src/presenters/slateAttachment.ts
+++ b/src/slates/apps/hub/src/presenters/slateAttachment.ts
@@ -1,7 +1,7 @@
 import { addDays } from 'date-fns';
 import type { SlateAttachment, SlateInvocation } from '../../prisma/generated/client';
 import { db } from '../db';
-import { getStoredAttachmentsStorageKey } from '../lib/invocation/store';
+import { getAttachmentStorageKey } from '../lib/invocation/store';
 import { invocationsBucketRecord, storage } from '../storage';
 
 let ATTACHMENT_PUBLIC_URL_EXPIRATION_DAYS = 7;
@@ -31,9 +31,7 @@ let getStoredAttachments = async (invocation: InvocationWithStoredAttachments) =
 };
 
 export let slateStoredAttachmentPresenter = async (attachment: SlateAttachment) => {
-  let storageKey = getStoredAttachmentsStorageKey(
-    Buffer.from(attachment.digest).toString('hex')
-  );
+  let storageKey = getAttachmentStorageKey(attachment);
   let url = await storage.getPublicURL(
     invocationsBucketRecord.bucket,
     storageKey,

--- a/src/slates/apps/hub/src/presenters/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/presenters/slatePublicToolCall.ts
@@ -1,0 +1,92 @@
+import type { SlateAction } from '../../prisma/generated/browser';
+import type {
+  Slate,
+  SlateAttachment,
+  SlateInvocation,
+  SlatePublicToolCall,
+  SlateVersion
+} from '../../prisma/generated/client';
+import { slateInvocationAttachmentsPresenter } from './slateAttachment';
+import { slateInvocationLitePresenter } from './slateInvocation';
+
+type InvocationWithStoredAttachments = SlateInvocation & {
+  slateInvocationAttachment?: Array<{
+    attachments: SlateAttachment;
+  }>;
+};
+
+export let slatePublicToolCallPresenter = async (
+  call: SlatePublicToolCall & {
+    action: SlateAction;
+    invocation: InvocationWithStoredAttachments;
+    slate: Slate;
+    slateVersion: SlateVersion;
+  }
+) => {
+  return {
+    object: 'slate.public_tool_call',
+
+    id: call.id,
+    status: call.status,
+    slateId: call.slate.id,
+    slateVersionId: call.slateVersion.id,
+
+    error: call.errorCode
+      ? {
+          code: call.errorCode,
+          message: call.errorMessage ?? call.errorCode
+        }
+      : null,
+    durationMs: call.durationMs,
+
+    action: {
+      object: 'slate.action',
+
+      id: call.action.id,
+      key: call.action.key,
+      name: call.action.name
+    },
+
+    attachments: await slateInvocationAttachmentsPresenter(call.invocation),
+    createdAt: call.createdAt
+  };
+};
+
+export let slatePublicToolCallLogsPresenter = async (
+  call: SlatePublicToolCall & {
+    action: SlateAction;
+    invocation: InvocationWithStoredAttachments;
+    slate: Slate;
+    slateVersion: SlateVersion;
+  }
+) => {
+  return {
+    object: 'slate.public_tool_call',
+
+    id: call.id,
+    status: call.status,
+    slateId: call.slate.id,
+    slateVersionId: call.slateVersion.id,
+
+    error: call.errorCode
+      ? {
+          code: call.errorCode,
+          message: call.errorMessage ?? call.errorCode
+        }
+      : null,
+    durationMs: call.durationMs,
+
+    action: {
+      object: 'slate.action',
+
+      id: call.action.id,
+      key: call.action.key,
+      name: call.action.name
+    },
+
+    attachments: await slateInvocationAttachmentsPresenter(call.invocation),
+    invocation: await slateInvocationLitePresenter(call.invocation),
+
+    createdAt: call.createdAt
+  };
+};

--- a/src/slates/apps/hub/src/queues/attachment/cleanup.ts
+++ b/src/slates/apps/hub/src/queues/attachment/cleanup.ts
@@ -2,7 +2,7 @@ import { createCron } from '@lowerdeck/cron';
 import { createQueue } from '@lowerdeck/queue';
 import { db } from '../../db';
 import { env } from '../../env';
-import { getStoredAttachmentsStorageKey } from '../../lib/invocation/store';
+import { getAttachmentStorageKey } from '../../lib/invocation/store';
 import { invocationsBucketRecord, storage } from '../../storage';
 import { RETENTION_BATCH_SIZE, retentionStorageCleanupWorkerOpts } from '../retention/_config';
 
@@ -45,7 +45,7 @@ export let slateAttachmentCleanupManyQueueProcessor = slateAttachmentCleanupMany
     await slateAttachmentCleanupSingleQueue.addMany(
       attachments.map(attachment => ({
         attachmentId: attachment.id,
-        digest: Buffer.from(attachment.digest).toString('hex')
+        digest: attachment.digest ? Buffer.from(attachment.digest).toString('hex') : null
       }))
     );
 
@@ -57,7 +57,7 @@ export let slateAttachmentCleanupManyQueueProcessor = slateAttachmentCleanupMany
 
 export let slateAttachmentCleanupSingleQueue = createQueue<{
   attachmentId: string;
-  digest: string;
+  digest: string | null;
 }>({
   name: 'shub/att/cleanup/single',
   redisUrl: env.service.REDIS_URL,
@@ -97,18 +97,23 @@ export let slateAttachmentCleanupSingleQueueProcessor =
       }
     }
 
-    let isDigestStillTracked = await db.slateAttachment.findFirst({
-      where: {
-        digest: Buffer.from(data.digest, 'hex')
-      },
-      select: {
-        oid: true
-      }
-    });
-    if (isDigestStillTracked) return;
+    if (data.digest) {
+      let isDigestStillTracked = await db.slateAttachment.findFirst({
+        where: {
+          digest: Buffer.from(data.digest, 'hex')
+        },
+        select: {
+          oid: true
+        }
+      });
+      if (isDigestStillTracked) return;
+    }
 
     await storage.deleteObject(
       invocationsBucketRecord.bucket,
-      getStoredAttachmentsStorageKey(data.digest)
+      getAttachmentStorageKey({
+        id: data.attachmentId,
+        digest: data.digest ? Buffer.from(data.digest, 'hex') : null
+      })
     );
   });

--- a/src/slates/apps/hub/src/queues/attachment/index.ts
+++ b/src/slates/apps/hub/src/queues/attachment/index.ts
@@ -4,9 +4,11 @@ import {
   slateAttachmentCleanupManyQueueProcessor,
   slateAttachmentCleanupSingleQueueProcessor
 } from './cleanup';
+import { slateAttachmentReplicateQueueProcessor } from './replicate';
 
 export let attachmentQueues = combineQueueProcessors([
   slateAttachmentCleanupCron,
   slateAttachmentCleanupManyQueueProcessor,
-  slateAttachmentCleanupSingleQueueProcessor
+  slateAttachmentCleanupSingleQueueProcessor,
+  slateAttachmentReplicateQueueProcessor
 ]);

--- a/src/slates/apps/hub/src/queues/attachment/replicate.ts
+++ b/src/slates/apps/hub/src/queues/attachment/replicate.ts
@@ -1,0 +1,57 @@
+import { createQueue } from '@lowerdeck/queue';
+import { getSentry } from '@lowerdeck/sentry';
+import { db } from '../../db';
+import { env } from '../../env';
+import { getAttachmentStorageKey } from '../../lib/invocation/store';
+import {
+  AttachmentDownloadTooLargeError,
+  downloadUrlToStream
+} from '../../lib/network/ssrfDownload';
+import { invocationsBucketRecord, storage } from '../../storage';
+
+let Sentry = getSentry();
+
+let ATTACHMENT_MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
+
+export let slateAttachmentReplicateQueue = createQueue<{
+  attachmentId: string;
+  url: string;
+  mimeType?: string;
+}>({
+  name: 'shub/att/replicate',
+  redisUrl: env.service.REDIS_URL
+});
+
+export let slateAttachmentReplicateQueueProcessor = slateAttachmentReplicateQueue.process(
+  async data => {
+    let attachment = await db.slateAttachment.findUnique({ where: { id: data.attachmentId } });
+    if (!attachment || !attachment.sourceUrl) return;
+
+    try {
+      let { stream, mimeType } = await downloadUrlToStream({
+        url: data.url,
+        maxBytes: ATTACHMENT_MAX_DOWNLOAD_BYTES
+      });
+
+      await storage.putObject(
+        invocationsBucketRecord.bucket,
+        getAttachmentStorageKey(attachment),
+        stream,
+        data.mimeType ?? mimeType ?? 'application/octet-stream'
+      );
+
+      await db.slateAttachment.update({
+        where: { oid: attachment.oid },
+        data: { sourceUrl: null }
+      });
+    } catch (err) {
+      if (err instanceof AttachmentDownloadTooLargeError) return;
+
+      Sentry.captureException(err, {
+        extra: { attachmentId: data.attachmentId, url: data.url }
+      });
+
+      throw err;
+    }
+  }
+);

--- a/src/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/slates/apps/hub/src/queues/discovery/discover.ts
@@ -328,6 +328,8 @@ let buildActionUpsertData = async (d: {
         'action.trigger': 'trigger' as const
       }[action.type],
 
+      isPublic: action.type === 'action.tool' ? action.isPublic === true : false,
+
       hash,
       identifier,
 

--- a/src/slates/apps/hub/src/services/index.ts
+++ b/src/slates/apps/hub/src/services/index.ts
@@ -16,6 +16,7 @@ export * from './slateOAuthCredentials';
 export * from './slateOAuthHandler';
 export * from './slateOAuthSetup';
 export * from './slateOAuthSetupEvent';
+export * from './slatePublicToolCall';
 export * from './slateSession';
 export * from './slateSessionToolCall';
 export * from './slateSpecification';

--- a/src/slates/apps/hub/src/services/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/services/slatePublicToolCall.ts
@@ -34,6 +34,7 @@ class slatePublicToolCallServiceImpl {
       egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
       input: Record<string, any>;
       participants: SlatesParticipant[];
+      downloadUrlAttachments?: boolean;
     };
   }) {
     let tenant = await db.tenant.findFirst({
@@ -62,7 +63,11 @@ class slatePublicToolCallServiceImpl {
       include: { specification: true }
     });
     if (!version) throw new ServiceError(notFoundError('slate.version'));
-    if (version.status !== 'active' || !version.activeDeploymentOid || !version.specification) {
+    if (
+      version.status !== 'active' ||
+      !version.activeDeploymentOid ||
+      !version.specification
+    ) {
       throw new ServiceError(
         badRequestError({ message: 'Provider version has not been deployed yet.' })
       );
@@ -141,7 +146,11 @@ class slatePublicToolCallServiceImpl {
         ensureSlateInvocationAttachment({
           content: attachment.content,
           mimeType: attachment.mimeType,
-          invocation: callRes.invocation
+          attachmentHash: (attachment as { attachmentHash?: string }).attachmentHash,
+          invocation: callRes.invocation,
+          tenantOid: tenant.oid,
+          slateOid: slate.oid,
+          downloadUrlAttachments: d.input.downloadUrlAttachments
         })
       )
     );

--- a/src/slates/apps/hub/src/services/slatePublicToolCall.ts
+++ b/src/slates/apps/hub/src/services/slatePublicToolCall.ts
@@ -1,0 +1,230 @@
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { Paginator } from '@lowerdeck/pagination';
+import { Service } from '@lowerdeck/service';
+import type { SlatesParticipant } from '@slates/proto';
+import type { Tenant } from '../../prisma/generated/client';
+import { db } from '../db';
+import { getId } from '../id';
+import { ensureSlateInvocationAttachment } from '../lib/invocation/attachments';
+import { slateInvocationService } from './slateInvocation';
+
+let include = {
+  action: true,
+  invocation: {
+    include: {
+      slateInvocationAttachment: {
+        include: {
+          attachments: true
+        }
+      }
+    }
+  },
+  slate: true,
+  slateVersion: true
+};
+
+class slatePublicToolCallServiceImpl {
+  async createPublicToolCall(d: {
+    input: {
+      tenantId: string;
+      slateId: string;
+      slateVersionId?: string;
+      toolId: string;
+      enclaveId?: string;
+      egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
+      input: Record<string, any>;
+      participants: SlatesParticipant[];
+    };
+  }) {
+    let tenant = await db.tenant.findFirst({
+      where: { OR: [{ id: d.input.tenantId }, { identifier: d.input.tenantId }] }
+    });
+    if (!tenant) throw new ServiceError(notFoundError('tenant'));
+
+    let slate = await db.slate.findFirst({
+      where: { OR: [{ id: d.input.slateId }, { identifier: d.input.slateId }] }
+    });
+    if (!slate) throw new ServiceError(notFoundError('slate'));
+
+    if (!d.input.slateVersionId && !slate.currentVersionOid) {
+      throw new ServiceError(
+        badRequestError({ message: 'Provider does not have a current version set.' })
+      );
+    }
+
+    let version = await db.slateVersion.findFirst({
+      where: {
+        slateOid: slate.oid,
+        ...(d.input.slateVersionId
+          ? { OR: [{ id: d.input.slateVersionId }, { version: d.input.slateVersionId }] }
+          : { oid: slate.currentVersionOid! })
+      },
+      include: { specification: true }
+    });
+    if (!version) throw new ServiceError(notFoundError('slate.version'));
+    if (version.status !== 'active' || !version.activeDeploymentOid || !version.specification) {
+      throw new ServiceError(
+        badRequestError({ message: 'Provider version has not been deployed yet.' })
+      );
+    }
+
+    let action = await db.slateAction.findFirst({
+      where: {
+        type: 'tool',
+        slateOid: slate.oid,
+        slateSpecifications: { some: { specificationOid: version.specification.oid } },
+        OR: [{ id: d.input.toolId }, { key: d.input.toolId }, { identifier: d.input.toolId }]
+      }
+    });
+    if (!action) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'invalid_tool_action',
+          message: 'Tool action not found for this provider.'
+        })
+      );
+    }
+    if (!action.isPublic) {
+      throw new ServiceError(
+        badRequestError({
+          code: 'not_a_public_tool',
+          message: 'This tool action is not a public tool.'
+        })
+      );
+    }
+
+    let startTime = Date.now();
+
+    let stack = await slateInvocationService.createInvocation({
+      tenant,
+      slateVersion: version,
+      participants: d.input.participants,
+      enclaveId: d.input.enclaveId,
+      egressPolicy: d.input.egressPolicy
+    });
+    let callRes = await slateInvocationService.invokeToolAction({
+      stack,
+      actionId: action.key,
+      input: d.input.input
+    });
+
+    let durationMs = Date.now() - startTime;
+
+    let call = await db.slatePublicToolCall.create({
+      data: {
+        ...getId('slatePublicToolCall'),
+
+        status: callRes.status === 'success' ? 'succeeded' : 'failed',
+        errorCode: callRes.status === 'error' ? callRes.error.code : null,
+        errorMessage: callRes.status === 'error' ? callRes.error.message : null,
+        durationMs,
+
+        tenantOid: tenant.oid,
+        actionOid: action.oid,
+        invocationOid: callRes.invocation.oid,
+        slateOid: slate.oid,
+        slateVersionOid: version.oid
+      }
+    });
+
+    if (callRes.status === 'error') {
+      return {
+        status: 'error' as const,
+        call,
+        invocationId: callRes.invocation.id,
+        error: callRes.error
+      };
+    }
+
+    let attachments = await Promise.all(
+      (callRes.data.attachments ?? []).map(attachment =>
+        ensureSlateInvocationAttachment({
+          content: attachment.content,
+          mimeType: attachment.mimeType,
+          invocation: callRes.invocation
+        })
+      )
+    );
+
+    return {
+      call,
+      invocationId: callRes.invocation.id,
+      status: 'success' as const,
+
+      output: callRes.data.output,
+      message: callRes.data.message,
+      attachments
+    };
+  }
+
+  async getPublicToolCallById(d: { tenant: Tenant; id: string }) {
+    let slatePublicToolCall = await db.slatePublicToolCall.findFirst({
+      where: {
+        tenantOid: d.tenant.oid,
+        id: d.id
+      },
+      include
+    });
+    if (!slatePublicToolCall) throw new ServiceError(notFoundError('slate.public_tool_call'));
+    return slatePublicToolCall;
+  }
+
+  async listPublicToolCalls(d: {
+    tenant: Tenant;
+    slateIds?: string[];
+    slateVersionIds?: string[];
+    toolIds?: string[];
+  }) {
+    let slates = d.slateIds
+      ? await db.slate.findMany({
+          where: { id: { in: d.slateIds } }
+        })
+      : undefined;
+    let slateVersions = d.slateVersionIds
+      ? await db.slateVersion.findMany({
+          where: { id: { in: d.slateVersionIds } }
+        })
+      : undefined;
+    let tools = d.toolIds
+      ? await db.slateAction.findMany({
+          where: { id: { in: d.toolIds } }
+        })
+      : undefined;
+
+    return Paginator.create(({ prisma }) =>
+      prisma(
+        async opts =>
+          await db.slatePublicToolCall.findMany({
+            ...opts,
+            where: {
+              tenantOid: d.tenant.oid,
+
+              AND: [
+                ...(tools ? [{ actionOid: { in: tools.map(t => t.oid) } }] : []),
+                ...(slateVersions
+                  ? [{ slateVersionOid: { in: slateVersions.map(sv => sv.oid) } }]
+                  : []),
+                ...(slates ? [{ slateOid: { in: slates.map(s => s.oid) } }] : [])
+              ]
+            },
+            include
+          })
+      )
+    );
+  }
+
+  async getManyPublicToolCallsByIds(d: { ids: string[]; tenant: Tenant }) {
+    return db.slatePublicToolCall.findMany({
+      where: {
+        tenantOid: d.tenant.oid,
+        id: { in: d.ids }
+      },
+      include
+    });
+  }
+}
+
+export let slatePublicToolCallService = Service.create(
+  'slatePublicToolCallService',
+  () => new slatePublicToolCallServiceImpl()
+).build();

--- a/src/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -2,13 +2,11 @@ import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import type { SlatesParticipant } from '@slates/proto';
-import { addDays, differenceInMinutes } from 'date-fns';
-import { PublicUrlPurpose } from 'object-storage-client';
-import type { SlateInvocation, Tenant } from '../../prisma/generated/client';
+import { differenceInMinutes } from 'date-fns';
+import type { Tenant } from '../../prisma/generated/client';
 import { db } from '../db';
 import { getId } from '../id';
-import { getStoredAttachmentsStorageKey } from '../lib/invocation/store';
-import { invocationsBucketRecord, storage } from '../storage';
+import { ensureSlateInvocationAttachment } from '../lib/invocation/attachments';
 import { slateErrorService } from './slateError';
 import { slateAuthHandlerService } from './slateInstanceAuthHandler';
 import { slateInvocationService } from './slateInvocation';
@@ -28,22 +26,6 @@ let include = {
   session: true,
   slateVersion: true
 };
-
-type SlateToolCallAttachment = {
-  content:
-    | {
-        type: 'url';
-        url: string;
-      }
-    | {
-        type: 'content';
-        encoding: 'base64' | 'utf-8';
-        content: string;
-      };
-  mimeType?: string;
-};
-
-let ATTACHMENT_EXPIRATION_DAYS = 7;
 
 let throwStoredConfigError = (d: { errorCode: string; errorMessage?: string | null }) => {
   throw new ServiceError(
@@ -252,7 +234,7 @@ class slateSessionToolCallServiceImpl {
 
     let attachments = await Promise.all(
       (callRes.data.attachments ?? []).map(attachment =>
-        this.ensureAttachment({
+        ensureSlateInvocationAttachment({
           content: attachment.content,
           mimeType: attachment.mimeType,
           invocation: callRes.invocation
@@ -268,75 +250,6 @@ class slateSessionToolCallServiceImpl {
       output: callRes.data.output,
       message: callRes.data.message,
       attachments
-    };
-  }
-
-  private async ensureAttachment(d: {
-    content: SlateToolCallAttachment['content'];
-    mimeType?: string | undefined;
-    invocation: SlateInvocation;
-  }) {
-    if (d.content.type === 'url') {
-      return {
-        type: 'url' as const,
-        url: d.content.url,
-        mimeType: d.mimeType
-      };
-    }
-
-    let contentBuffer = Buffer.from(d.content.content, d.content.encoding);
-    let digest = new Uint8Array(await crypto.subtle.digest('SHA-256', contentBuffer));
-    let digestString = Buffer.from(digest).toString('hex');
-    let storageKey = getStoredAttachmentsStorageKey(digestString);
-
-    let attachment = await db.slateAttachment.findFirst({
-      where: { digest }
-    });
-    if (!attachment) {
-      await storage.putObject(
-        invocationsBucketRecord.bucket,
-        storageKey,
-        contentBuffer,
-        d.mimeType ?? 'application/octet-stream'
-      );
-    }
-
-    let expiresAt = addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS);
-    let inner = {
-      digest,
-      expiresAt,
-      lastCreatedAt: new Date()
-    };
-
-    attachment = await db.slateAttachment.upsert({
-      where: { digest },
-      create: {
-        ...getId('slateAttachment'),
-        ...inner
-      },
-      update: inner
-    });
-
-    await db.slateInvocationAttachment.createMany({
-      data: {
-        ...getId('slateInvocationAttachment'),
-        invocationOid: d.invocation.oid,
-        attachmentsOid: attachment.oid
-      }
-    });
-
-    let url = await storage.getPublicURL(
-      invocationsBucketRecord.bucket,
-      storageKey,
-      ATTACHMENT_EXPIRATION_DAYS * 24 * 60 * 60,
-      PublicUrlPurpose.Retrieve
-    );
-
-    return {
-      type: 'url' as const,
-      url: url.url,
-      mimeType: d.mimeType,
-      urlExpiresAt: addDays(new Date(), ATTACHMENT_EXPIRATION_DAYS)
     };
   }
 

--- a/src/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -48,6 +48,7 @@ class slateSessionToolCallServiceImpl {
       egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
       input: Record<string, any>;
       participants: SlatesParticipant[];
+      downloadUrlAttachments?: boolean;
     };
   }) {
     let session = await db.slateSession.findFirst({
@@ -237,7 +238,11 @@ class slateSessionToolCallServiceImpl {
         ensureSlateInvocationAttachment({
           content: attachment.content,
           mimeType: attachment.mimeType,
-          invocation: callRes.invocation
+          attachmentHash: (attachment as { attachmentHash?: string }).attachmentHash,
+          invocation: callRes.invocation,
+          tenantOid: session.tenantOid,
+          slateOid: session.slateOid,
+          downloadUrlAttachments: d.input.downloadUrlAttachments
         })
       )
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches file serving, outbound HTTP downloads (SSRF-sensitive), and a new unauthenticated-style public tool invocation path. Attachment lifecycle and cache/TTL handling also affect how user content is stored and exposed.
> 
> **Overview**
> Adds **chat message attachments** end-to-end: inbound files from providers are synced into `ChatMessageAttachment` rows, outbound sends can attach instance files (`chat_message_attachment` purpose), and related messages can be grouped when a provider splits text and files.
> 
> Introduces **delegated files** so attachment content is resolved on demand (refresh from the chat provider, then SSRF-guarded fetch) instead of always storing bytes in cargo. Signed download URLs can use a shorter TTL; delegated URL cache is cleaned on a cron.
> 
> On the slates side, **public tools** can be invoked without a session (`isPublic` tools are excluded from normal MCP tool lists). Attachment storage now supports URL replication with hash-based reuse, and chat tool calls can request downloaded URL attachments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89ba45704a5a85e72630770b9624a0077aeb02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->