### PR TITLE
Pass raw callbacks params

### DIFF
--- a/src/slates/apps/hub/src/apis/public/index.ts
+++ b/src/slates/apps/hub/src/apis/public/index.ts
@@ -106,6 +106,7 @@ export let hubApp = createHono()
     let state = c.req.query('state');
     let error = c.req.query('error');
     let errorDescription = c.req.query('error_description');
+    let callbackParams = Object.fromEntries(new URL(c.req.url).searchParams.entries());
 
     if (error || !code) {
       let res = await slateOAuthHandlerService.reportError({
@@ -124,7 +125,8 @@ export let hubApp = createHono()
       input: {
         code,
         lastOAuthSetupCookieId: setupCookie,
-        state: state || undefined
+        state: state || undefined,
+        callbackParams
       }
     });
 

--- a/src/slates/apps/hub/src/apis/public/index.ts
+++ b/src/slates/apps/hub/src/apis/public/index.ts
@@ -1,6 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { createHono } from '@lowerdeck/hono';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
+import { omit } from 'lodash';
 import { env } from '../../env';
 import { createSanitizedWebhookResponse } from '../../lib/triggerWebhookSync';
 import { slateOAuthHandlerService } from '../../services/slateOAuthHandler';
@@ -106,7 +107,7 @@ export let hubApp = createHono()
     let state = c.req.query('state');
     let error = c.req.query('error');
     let errorDescription = c.req.query('error_description');
-    let callbackParams = Object.fromEntries(new URL(c.req.url).searchParams.entries());
+    let callbackParams = omit(Object.fromEntries(new URL(c.req.url).searchParams), 'state');
 
     if (error || !code) {
       let res = await slateOAuthHandlerService.reportError({

--- a/src/slates/apps/hub/src/services/slateInvocation.ts
+++ b/src/slates/apps/hub/src/services/slateInvocation.ts
@@ -135,6 +135,7 @@ class slateInvocationServiceImpl {
     state: string;
     redirectUri: string;
     input: Record<string, any>;
+    callbackParams: Record<string, string>;
     callbackState: Record<string, any> | undefined;
     clientId: string;
     clientSecret: string;
@@ -146,6 +147,7 @@ class slateInvocationServiceImpl {
       state: d.state,
       redirectUri: d.redirectUri,
       input: d.input,
+      callbackParams: d.callbackParams,
       callbackState: d.callbackState,
       clientId: d.clientId,
       clientSecret: d.clientSecret,

--- a/src/slates/apps/hub/src/services/slateOAuthHandler.ts
+++ b/src/slates/apps/hub/src/services/slateOAuthHandler.ts
@@ -181,7 +181,12 @@ class slateOAuthHandlerServiceImpl {
   }
 
   async completeOAuthFlow(d: {
-    input: { code: string; state?: string; lastOAuthSetupCookieId: string };
+    input: {
+      code: string;
+      state?: string;
+      lastOAuthSetupCookieId: string;
+      callbackParams: Record<string, string>;
+    };
   }) {
     let setups = await db.slateInstanceOAuthSetup.findMany({
       where: {
@@ -243,6 +248,7 @@ class slateOAuthHandlerServiceImpl {
       authenticationMethodId: setup.authMethod.key,
       redirectUri: setup.callbackUrlOverride ?? callbackUrl,
       input: oauthSecret.input,
+      callbackParams: d.input.callbackParams,
       callbackState: oauthSecret.callbackState,
       clientId: credentialsSecrets.clientId,
       clientSecret: credentialsSecrets.clientSecret,


### PR DESCRIPTION
Pass raw callbacks params

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OAuth completion path by adding forwarded callback data; behavior is additive but touches authentication flow wiring.
> 
> **Overview**
> OAuth callback handling now forwards **all query parameters** from the provider redirect (except `state`) into the slate authorization callback, not just `code` and the explicit error fields.
> 
> The public `/slates-hub/callback` route builds `callbackParams` from the request URL search params (with `state` stripped via `omit`) and passes them into `completeOAuthFlow`. That value is threaded through `slateOAuthHandler` into `slateInvocation.getOAuthCallback` and the `slates/auth.authorization_callback.handle` stack invoke so slate auth implementations can use provider-specific callback parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf278f491bf9f366b4da87f75ba59d2e0a21f375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->