### PR TITLE
OAuth 1.0 handling

### DIFF
--- a/src/slates/apps/hub/src/apis/public/index.ts
+++ b/src/slates/apps/hub/src/apis/public/index.ts
@@ -103,7 +103,7 @@ export let hubApp = createHono()
 
     deleteCookie(c, SETUP_COOKIE_NAME, cookieOpts);
 
-    let code = c.req.query('code');
+    let code = c.req.query('code') ?? c.req.query('oauth_verifier');
     let state = c.req.query('state');
     let error = c.req.query('error');
     let errorDescription = c.req.query('error_description');


### PR DESCRIPTION
OAuth 1.0 handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line query parsing change on the public OAuth callback with no auth or data-model changes.
> 
> **Overview**
> The hub OAuth callback at `/slates-hub/callback` now treats **`oauth_verifier`** as the authorization credential when **`code`** is absent, so OAuth 1.0 providers that return a verifier instead of an authorization code can complete the same flow via `completeOAuthFlow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6ece8b29bd89fde165375320b7416826c9f61c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->