### PR TITLE
Fix auth selection bug

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/product/lib/providerDocs.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/lib/providerDocs.tsx
@@ -42,19 +42,6 @@ let getDocs = (providerListing: unknown): ProviderListingDocs | null => {
   return docs as ProviderListingDocs;
 };
 
-let matchesAuthMethod = (
-  docMethod: AuthMethodDocTarget,
-  authMethod?: AuthMethodDocTarget | null
-) => {
-  if (!authMethod) return false;
-
-  if (docMethod.key && authMethod.key && docMethod.key === authMethod.key) return true;
-  if (docMethod.name && authMethod.name && docMethod.name === authMethod.name) return true;
-  if (docMethod.type && authMethod.type && docMethod.type === authMethod.type) return true;
-
-  return false;
-};
-
 let findAuthMethodDocs = (
   providerListing: unknown,
   authMethod?: AuthMethodDocTarget | null
@@ -62,11 +49,21 @@ let findAuthMethodDocs = (
   let docs = getDocs(providerListing);
   if (!docs || !authMethod) return [];
 
-  let authMethodEntry = (docs.authMethods ?? []).find(entry =>
-    matchesAuthMethod(entry, authMethod)
-  );
+  let authMethods = docs.authMethods ?? [];
+  let keyMatch = authMethod.key
+    ? authMethods.find(entry => entry.key === authMethod.key)
+    : undefined;
+  if (keyMatch) return keyMatch.docs ?? [];
 
-  return authMethodEntry?.docs ?? [];
+  let nameMatch = authMethod.name
+    ? authMethods.find(entry => entry.name === authMethod.name)
+    : undefined;
+  if (nameMatch) return nameMatch.docs ?? [];
+
+  let typeMatches = authMethod.type
+    ? authMethods.filter(entry => entry.type === authMethod.type)
+    : [];
+  return typeMatches.length === 1 ? (typeMatches[0].docs ?? []) : [];
 };
 
 let findAuthMethodDocByType = (

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/integrations/providerPanelFlow.tsx
@@ -421,8 +421,9 @@ let IntegrationProviderAuthSection = (p: {
                 {hasUnlistedSelectedAuthMethod ? (
                   <Callout color="gray">
                     This integration is using a previously selected auth method
-                    {p.selectedAuthMethod?.name ? ` (${p.selectedAuthMethod.name})` : ''}.
-                    Choose a new method only if you want to change it.
+                    {p.selectedAuthMethod?.name
+                      ? ` (${p.selectedAuthMethod.name})`
+                      : ''}. Choose a new method only if you want to change it.
                   </Callout>
                 ) : null}
                 {p.authMethodError}
@@ -768,8 +769,8 @@ let IntegrationProviderSetupStep = (p: {
   );
   let isSelectedAuthMethodLoading = Boolean(
     form.values.selectedAuthMethodId &&
-    !listedSelectedAuthMethod &&
-    currentAuthMethod.isLoading
+      !listedSelectedAuthMethod &&
+      currentAuthMethod.isLoading
   );
   // In update mode, keep the auth section available when an existing provider
   // references an older auth method that is no longer returned in the picker list.
@@ -1448,15 +1449,13 @@ let IntegrationInstanceProviderPanel = (p: {
   );
   let fixedAuthMethodId =
     inheritedAuthMethodId &&
-    (inheritedAuthMethods.data?.items ?? []).some(
-      method => method.id === inheritedAuthMethodId
-    )
+    (inheritedAuthMethods.data?.items ?? []).some(method => method.id === inheritedAuthMethodId)
       ? inheritedAuthMethodId
       : undefined;
   let isInheritedAuthMethodLoading = Boolean(
     inheritedAuthMethodId &&
-    visibility.provider.data?.currentVersion?.id &&
-    inheritedAuthMethods.isLoading
+      visibility.provider.data?.currentVersion?.id &&
+      inheritedAuthMethods.isLoading
   );
 
   let submitProviderSetup = async (values: IntegrationInstanceProviderFormValues) => {

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/integrations/providerPanelFlow.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/integrations/providerPanelFlow.tsx
@@ -421,9 +421,8 @@ let IntegrationProviderAuthSection = (p: {
                 {hasUnlistedSelectedAuthMethod ? (
                   <Callout color="gray">
                     This integration is using a previously selected auth method
-                    {p.selectedAuthMethod?.name
-                      ? ` (${p.selectedAuthMethod.name})`
-                      : ''}. Choose a new method only if you want to change it.
+                    {p.selectedAuthMethod?.name ? ` (${p.selectedAuthMethod.name})` : ''}.
+                    Choose a new method only if you want to change it.
                   </Callout>
                 ) : null}
                 {p.authMethodError}
@@ -505,6 +504,7 @@ let IntegrationProviderAuthSection = (p: {
                               instanceId: p.instanceId,
                               providerId: p.providerId,
                               deploymentId: p.providerDeploymentId,
+                              providerAuthMethodId: p.selectedAuthMethodId,
                               onCreate: credentials => {
                                 p.onSelectedAuthCredentialsIdChange(
                                   credentials.id,
@@ -768,8 +768,8 @@ let IntegrationProviderSetupStep = (p: {
   );
   let isSelectedAuthMethodLoading = Boolean(
     form.values.selectedAuthMethodId &&
-      !listedSelectedAuthMethod &&
-      currentAuthMethod.isLoading
+    !listedSelectedAuthMethod &&
+    currentAuthMethod.isLoading
   );
   // In update mode, keep the auth section available when an existing provider
   // references an older auth method that is no longer returned in the picker list.
@@ -1448,13 +1448,15 @@ let IntegrationInstanceProviderPanel = (p: {
   );
   let fixedAuthMethodId =
     inheritedAuthMethodId &&
-    (inheritedAuthMethods.data?.items ?? []).some(method => method.id === inheritedAuthMethodId)
+    (inheritedAuthMethods.data?.items ?? []).some(
+      method => method.id === inheritedAuthMethodId
+    )
       ? inheritedAuthMethodId
       : undefined;
   let isInheritedAuthMethodLoading = Boolean(
     inheritedAuthMethodId &&
-      visibility.provider.data?.currentVersion?.id &&
-      inheritedAuthMethods.isLoading
+    visibility.provider.data?.currentVersion?.id &&
+    inheritedAuthMethods.isLoading
   );
 
   let submitProviderSetup = async (values: IntegrationInstanceProviderFormValues) => {

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthCredentials/modal.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthCredentials/modal.tsx
@@ -1,11 +1,9 @@
-import {
-  DashboardInstanceProviderDeploymentsAuthCredentialsCreateOutput,
-  DashboardInstanceProvidersAuthMethodsListOutput
-} from '@metorial/dashboard-sdk';
+import { DashboardInstanceProviderDeploymentsAuthCredentialsCreateOutput } from '@metorial/dashboard-sdk';
 import { useForm } from '@metorial/data-hooks';
 import {
   useCreateProviderAuthCredentials,
   useProvider,
+  useProviderAuthMethod,
   useProviderAuthMethods,
   useProviderDeployment,
   useProviderListing
@@ -28,15 +26,15 @@ import {
   getAuthMethodOAuthScopesDoc,
   ProviderDocsLink
 } from '../../lib/providerDocs';
-import { ScopePickerField } from './scopePicker';
 import { ProviderContextCard } from '../providerContextCard';
-
-type AuthMethod = DashboardInstanceProvidersAuthMethodsListOutput['items'][number];
+import { resolveOAuthMethodState } from './oauthMethodSelection';
+import { ScopePickerField } from './scopePicker';
 
 export let ProviderAuthCredentialsForm = ({
   instanceId,
   providerId,
   deploymentId,
+  providerAuthMethodId,
   close,
   onBack,
   onCreate,
@@ -47,6 +45,7 @@ export let ProviderAuthCredentialsForm = ({
   instanceId: string;
   providerId: string;
   deploymentId?: string;
+  providerAuthMethodId?: string;
   close: () => void;
   onBack?: () => void;
   onCreate?: (
@@ -63,13 +62,19 @@ export let ProviderAuthCredentialsForm = ({
   let versionId = deployment.data?.lockedVersion?.id ?? provider.data?.currentVersion?.id;
   let authMethods = useProviderAuthMethods(
     instanceId,
-    versionId ? { providerVersionId: versionId } : null
+    !providerAuthMethodId && versionId ? { providerVersionId: versionId } : null
   );
-  let oauthMethod = useMemo(
-    () =>
-      (authMethods.data?.items ?? []).find((method: AuthMethod) => method.type === 'oauth'),
-    [authMethods.data?.items]
-  );
+  let selectedAuthMethod = useProviderAuthMethod(instanceId, providerAuthMethodId);
+  let oauthMethodState = resolveOAuthMethodState({
+    methods: authMethods.data?.items ?? [],
+    selectedAuthMethodId: providerAuthMethodId,
+    selectedAuthMethod: selectedAuthMethod.data,
+    selectedAuthMethodLoading: selectedAuthMethod.isLoading,
+    providerLoading: provider.isLoading,
+    deploymentLoading: Boolean(deploymentId) && deployment.isLoading,
+    authMethodsLoading: authMethods.isLoading
+  });
+  let oauthMethod = oauthMethodState.oauthMethod;
   let redirectUri = provider.data?.oauth?.callbackUrl;
   let providerName = deployment.data?.name ?? provider.data?.name ?? providerId;
   let oauthMethodName = oauthMethod?.name ?? 'OAuth';
@@ -123,7 +128,7 @@ export let ProviderAuthCredentialsForm = ({
     setSelectedScopes(null);
   }, [oauthMethod?.id]);
 
-  if (authCreation.isLoading) {
+  if (authCreation.isLoading || oauthMethodState.isLoading) {
     return (
       <>
         <Dialog.Title>Create Auth Credentials</Dialog.Title>
@@ -176,6 +181,54 @@ export let ProviderAuthCredentialsForm = ({
           )}
           <Button type="button" size="2" onClick={close}>
             {onBack ? 'Cancel' : 'Close'}
+          </Button>
+        </Dialog.Actions>
+      </>
+    );
+  }
+
+  if (oauthMethodState.isUnavailable) {
+    return (
+      <>
+        {!embedded && (
+          <>
+            <Dialog.Title>Create Auth Credentials</Dialog.Title>
+            <Dialog.Description>
+              Enter OAuth app credentials for {providerName}.
+            </Dialog.Description>
+            <Spacer size={15} />
+          </>
+        )}
+
+        {!effectiveHideProviderContext && (
+          <>
+            <ProviderContextCard
+              providerId={providerId}
+              providerName={provider.data?.name ?? providerName}
+              providerImageUrl={provider.data?.publisher.imageUrl}
+              deploymentName={deployment.data?.name}
+              deploymentDescription={deployment.data?.description}
+            />
+
+            <Spacer size={15} />
+          </>
+        )}
+
+        <Callout color="gray">
+          The selected OAuth method is unavailable. Go back and choose another OAuth method
+          before creating credentials.
+        </Callout>
+
+        <Spacer size={15} />
+
+        <Dialog.Actions>
+          {onBack && (
+            <Button type="button" size="2" variant="outline" onClick={onBack}>
+              Back
+            </Button>
+          )}
+          <Button type="button" size="2" onClick={close}>
+            Close
           </Button>
         </Dialog.Actions>
       </>
@@ -299,6 +352,7 @@ export let showProviderAuthCredentialsFormModal = (p: {
   instanceId: string;
   providerId: string;
   deploymentId?: string;
+  providerAuthMethodId?: string;
   onBack?: () => void;
   onCreate?: (
     credentials: DashboardInstanceProviderDeploymentsAuthCredentialsCreateOutput

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthCredentials/oauthMethodSelection.ts
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthCredentials/oauthMethodSelection.ts
@@ -20,7 +20,7 @@ export let resolveOAuthMethodState = <Method extends AuthMethod>({
   deploymentLoading: boolean;
   authMethodsLoading: boolean;
 }) => {
-  let hasSelectedAuthMethod = selectedAuthMethodId !== undefined;
+  let hasSelectedAuthMethod = Boolean(selectedAuthMethodId);
   let oauthMethod = hasSelectedAuthMethod
     ? selectedAuthMethod?.id === selectedAuthMethodId && selectedAuthMethod?.type === 'oauth'
       ? selectedAuthMethod
@@ -29,12 +29,10 @@ export let resolveOAuthMethodState = <Method extends AuthMethod>({
   let isLoading = hasSelectedAuthMethod
     ? selectedAuthMethodLoading
     : providerLoading || deploymentLoading || authMethodsLoading;
-  let canSubmit = !isLoading && oauthMethod !== undefined;
 
   return {
     oauthMethod,
     isLoading,
-    canSubmit,
     isUnavailable: !isLoading && oauthMethod === undefined
   };
 };

--- a/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthCredentials/oauthMethodSelection.ts
+++ b/src/metorial-frontend/apps/dashboard/src/product/scenes/providerAuthCredentials/oauthMethodSelection.ts
@@ -1,0 +1,40 @@
+type AuthMethod = {
+  id: string;
+  type: string;
+};
+
+export let resolveOAuthMethodState = <Method extends AuthMethod>({
+  methods,
+  selectedAuthMethodId,
+  selectedAuthMethod,
+  selectedAuthMethodLoading,
+  providerLoading,
+  deploymentLoading,
+  authMethodsLoading
+}: {
+  methods: readonly Method[];
+  selectedAuthMethodId?: string;
+  selectedAuthMethod?: Method | null;
+  selectedAuthMethodLoading: boolean;
+  providerLoading: boolean;
+  deploymentLoading: boolean;
+  authMethodsLoading: boolean;
+}) => {
+  let hasSelectedAuthMethod = selectedAuthMethodId !== undefined;
+  let oauthMethod = hasSelectedAuthMethod
+    ? selectedAuthMethod?.id === selectedAuthMethodId && selectedAuthMethod?.type === 'oauth'
+      ? selectedAuthMethod
+      : undefined
+    : methods.find(method => method.type === 'oauth');
+  let isLoading = hasSelectedAuthMethod
+    ? selectedAuthMethodLoading
+    : providerLoading || deploymentLoading || authMethodsLoading;
+  let canSubmit = !isLoading && oauthMethod !== undefined;
+
+  return {
+    oauthMethod,
+    isLoading,
+    canSubmit,
+    isUnavailable: !isLoading && oauthMethod === undefined
+  };
+};


### PR DESCRIPTION
Fix auth selection bug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UX and doc-resolution logic; no API or credential storage changes, with clearer failure when the selected OAuth method is invalid.
> 
> **Overview**
> Fixes auth selection issues when creating OAuth credentials and when resolving provider documentation for a specific auth method.
> 
> **Create credentials** now accepts an optional `providerAuthMethodId` from the integration provider flow. The modal loads that method via `useProviderAuthMethod` instead of picking the first OAuth entry from the version’s auth-method list. A new `resolveOAuthMethodState` helper centralizes loading/unavailable handling and shows a callout when the chosen method is missing or not OAuth.
> 
> **Provider docs lookup** in `findAuthMethodDocs` no longer treats key, name, and type as interchangeable matches. It resolves docs by **key**, then **name**, then **type** only when exactly one listing entry shares that type—avoiding wrong OAuth/scopes doc links when multiple methods could match loosely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3863d9b0660d714161c518880c3a4551a7506957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->