### PR TITLE
Update otel sampling

### DIFF
--- a/src/lowerdeck/packages/telemetry/README.md
+++ b/src/lowerdeck/packages/telemetry/README.md
@@ -77,6 +77,17 @@ Example:
 export OTEL_ALLOW_ROOT_SPANS=true
 ```
 
+### `OTEL_TRACES_SAMPLER_ARG`
+- Type: number between `0` and `1`
+- Default: `0.1`
+- What it does: sets the proportion of new root traces to export. Parent trace sampling decisions are preserved so a sampled request remains sampled across services.
+
+Example:
+
+```bash
+export OTEL_TRACES_SAMPLER_ARG=0.05
+```
+
 ### `OTEL_SERVICE_NAME`
 - Type: string
 - Default: value passed to `initTelemetry({ serviceName })`

--- a/src/lowerdeck/packages/telemetry/src/index.ts
+++ b/src/lowerdeck/packages/telemetry/src/index.ts
@@ -18,7 +18,8 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
   AlwaysOffSampler,
   BatchSpanProcessor,
-  ParentBasedSampler
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler
 } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
@@ -56,6 +57,16 @@ let parseHeaders = (headers: string | undefined): Record<string, string> | undef
 
 let parseResourceAttributes = (attrs: string | undefined): Record<string, string> =>
   parseKeyValuePairs(attrs);
+
+let getTraceSampleRate = () => {
+  let configuredRate = Number(process.env.OTEL_TRACES_SAMPLER_ARG);
+
+  if (Number.isFinite(configuredRate) && configuredRate >= 0 && configuredRate <= 1) {
+    return configuredRate;
+  }
+
+  return 0.1;
+};
 
 export {
   context as otelContext,
@@ -115,6 +126,7 @@ export let initTelemetry = (opts: { serviceName: string; allowRootSpans?: boolea
   let extraResourceAttributes = parseResourceAttributes(process.env.OTEL_RESOURCE_ATTRIBUTES);
   let allowRootSpans =
     opts.allowRootSpans === true || process.env.OTEL_ALLOW_ROOT_SPANS === 'true';
+  let traceSampleRate = getTraceSampleRate();
 
   let provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
@@ -123,11 +135,11 @@ export let initTelemetry = (opts: { serviceName: string; allowRootSpans?: boolea
         process.env.METORIAL_ENV ?? process.env.NODE_ENV ?? 'development',
       ...extraResourceAttributes
     }),
-    sampler: allowRootSpans
-      ? undefined
-      : new ParentBasedSampler({
-          root: new AlwaysOffSampler()
-        }),
+    sampler: new ParentBasedSampler({
+      root: allowRootSpans
+        ? new TraceIdRatioBasedSampler(traceSampleRate)
+        : new AlwaysOffSampler()
+    }),
     spanProcessors: [
       new BatchSpanProcessor(
         new OTLPTraceExporter({
@@ -157,6 +169,6 @@ export let initTelemetry = (opts: { serviceName: string; allowRootSpans?: boolea
   initialized = true;
 
   console.log(
-    `[otel] initialized for ${serviceName} -> ${endpoint} (allowRootSpans=${allowRootSpans})`
+    `[otel] initialized for ${serviceName} -> ${endpoint} (allowRootSpans=${allowRootSpans}, traceSampleRate=${traceSampleRate})`
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Telemetry sampling changes affect observability volume and cross-service trace consistency; dashboard client additions are generated bindings with limited runtime impact unless callers start using new retention settings.
> 
> **Overview**
> **OpenTelemetry** root trace export is no longer all-or-nothing when root spans are allowed: `@lowerdeck/telemetry` always uses a `ParentBasedSampler`, with the root sampler set to `TraceIdRatioBasedSampler` when `OTEL_ALLOW_ROOT_SPANS` / `allowRootSpans` is on (otherwise `AlwaysOffSampler`). The sample ratio comes from **`OTEL_TRACES_SAMPLER_ARG`** (default **0.1**), documented in the package README and logged at init.
> 
> The **metorial-dashboard** generated client and SDK also pick up new configure APIs: **organization audit log retention** (`organizations.configureAuditLogRetention` — GET/PATCH `audit_log_retention_in_days`) and **project integration message data retention** (`projects.configureDataRetention` — level, tool-call attachments, error collection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eca7d3a8e6df38dcf7f479c45be840c12a05bcf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->