### PR TITLE
Add advanced data retention billing item

### DIFF
--- a/src/metorial/products/core/modules/flags/src/definitions.ts
+++ b/src/metorial/products/core/modules/flags/src/definitions.ts
@@ -24,6 +24,7 @@ export type Flags = {
   'paid-advanced-roles': boolean;
   'paid-audit-logs': boolean;
   'paid-audit-log-streams': boolean;
+  'paid-project-reduced-data-retention': boolean;
   'paid-magic-mcp-groups': boolean;
   'paid-sso-tenants': boolean;
   'paid-portals': boolean;
@@ -57,6 +58,7 @@ export let defaultFlags: Flags = {
   'paid-advanced-roles': true,
   'paid-audit-logs': true,
   'paid-audit-log-streams': true,
+  'paid-project-reduced-data-retention': true,
   'paid-magic-mcp-groups': true,
   'paid-sso-tenants': true,
   'paid-portals': true,

--- a/src/metorial/products/core/modules/organization/src/services/index.ts
+++ b/src/metorial/products/core/modules/organization/src/services/index.ts
@@ -19,6 +19,7 @@ export * from './organizationMember';
 export * from './project';
 export * from './projectAuthConfigConfiguration';
 export * from './projectBrand';
+export * from './projectDataRetentionConfiguration';
 export * from './projectIntegrationNamingConfiguration';
 export * from './projectRetention';
 export * from './projectSkillSyncConfiguration';

--- a/src/metorial/products/core/modules/organization/src/services/projectDataRetentionConfiguration.ts
+++ b/src/metorial/products/core/modules/organization/src/services/projectDataRetentionConfiguration.ts
@@ -1,0 +1,104 @@
+import { forbiddenError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import type { AuditScope } from '@metorial/audit-scope';
+import { Organization, Project } from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+import type { SessionDataRetentionLevel } from '@metorial-subspace/db';
+import { subspaceScopeService, tenantService } from '@metorial-subspace/module-tenant';
+
+class ProjectDataRetentionConfigurationService {
+  private async ensureProjectActive(project: Project) {
+    if (project.status !== 'active') {
+      throw new ServiceError(
+        forbiddenError({
+          message: 'Cannot perform this action on a deleted project'
+        })
+      );
+    }
+  }
+
+  private async getSubspaceTenantForProject(project: Project) {
+    let { tenant } = await subspaceScopeService.ensureForProject(project);
+    return tenant;
+  }
+
+  async getProjectDataRetentionConfiguration(d: { project: Project }) {
+    await this.ensureProjectActive(d.project);
+
+    let tenant = await this.getSubspaceTenantForProject(d.project);
+
+    return {
+      dataRetentionLevel: tenant.dataRetentionLevel,
+      storeToolCallAttachments: tenant.storeToolCallAttachments,
+      collectErrors: tenant.collectErrors
+    };
+  }
+
+  async updateProjectDataRetentionConfiguration(d: {
+    project: Project;
+    organization: Organization;
+    auditScope: AuditScope;
+    input: {
+      dataRetentionLevel?: SessionDataRetentionLevel;
+      storeToolCallAttachments?: boolean;
+      collectErrors?: boolean;
+    };
+  }) {
+    await this.ensureProjectActive(d.project);
+
+    await Fabric.fire('organization.project.data_retention_configuration.updated:before', d);
+
+    let tenant = await this.getSubspaceTenantForProject(d.project);
+
+    let dataRetentionLevel = d.input.dataRetentionLevel ?? tenant.dataRetentionLevel;
+    let isFull = dataRetentionLevel === 'full';
+
+    let storeToolCallAttachments =
+      dataRetentionLevel === 'none'
+        ? false
+        : (d.input.storeToolCallAttachments ?? tenant.storeToolCallAttachments);
+
+    let collectErrors = isFull ? true : (d.input.collectErrors ?? tenant.collectErrors);
+
+    let updatedTenant = await tenantService.upsertTenant({
+      input: {
+        name: tenant.name,
+        identifier: tenant.identifier,
+        resourceTenantId: tenant.resourceTenantId!,
+        resourceTenantIdentifier: tenant.resourceTenantIdentifier!,
+        environments: [],
+        dataRetentionLevel,
+        storeToolCallAttachments,
+        collectErrors
+      }
+    });
+
+    await Fabric.fire('organization.project.data_retention_configuration.updated:after', {
+      organization: d.organization,
+      input: d.input,
+      project: d.project,
+      configuration: {
+        dataRetentionLevel: updatedTenant.dataRetentionLevel,
+        storeToolCallAttachments: updatedTenant.storeToolCallAttachments,
+        collectErrors: updatedTenant.collectErrors
+      },
+      previousConfiguration: {
+        dataRetentionLevel: tenant.dataRetentionLevel,
+        storeToolCallAttachments: tenant.storeToolCallAttachments,
+        collectErrors: tenant.collectErrors
+      },
+      auditScope: d.auditScope
+    });
+
+    return {
+      dataRetentionLevel: updatedTenant.dataRetentionLevel,
+      storeToolCallAttachments: updatedTenant.storeToolCallAttachments,
+      collectErrors: updatedTenant.collectErrors
+    };
+  }
+}
+
+export let projectDataRetentionConfigurationService = Service.create(
+  'projectDataRetentionConfigurationService',
+  () => new ProjectDataRetentionConfigurationService()
+).build();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how session/tool-call data is retained per project via tenant upserts; misconfiguration or missing entitlement checks elsewhere could affect privacy and stored telemetry.
> 
> **Overview**
> Introduces a **`paid-project-reduced-data-retention`** feature flag (typed and defaulted like other paid entitlements) to gate advanced/reduced session data retention as a billable capability.
> 
> Adds **`projectDataRetentionConfigurationService`**, which reads and updates per-project session retention settings on the linked subspace tenant: `dataRetentionLevel`, `storeToolCallAttachments`, and `collectErrors`. Updates normalize inputs (e.g. no attachment storage when retention is `none`, error collection forced on for `full`), persist via `tenantService.upsertTenant`, and emit Fabric before/after events for auditing. The service is exported from the organization module’s service barrel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af072de8e688bb0813c7163df66b064f27478928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->