### PR TITLE
Enforce zdr in slates

### DIFF
--- a/src/slates/apps/hub/prisma/schema/tenant.prisma
+++ b/src/slates/apps/hub/prisma/schema/tenant.prisma
@@ -10,7 +10,10 @@ model Tenant {
   functionBayTenantId         String?
   functionBayTenantIdentifier String?
 
-  logRetentionInDays Int @default(30)
+  logRetentionInDays       Int     @default(30)
+  storeContent             Boolean @default(true)
+  collectErrors            Boolean @default(true)
+  storeToolCallAttachments Boolean @default(true)
 
   createdAt DateTime @default(now())
 

--- a/src/slates/apps/hub/src/apis/internal/tenant.ts
+++ b/src/slates/apps/hub/src/apis/internal/tenant.ts
@@ -19,7 +19,10 @@ export let tenantController = app.controller({
       v.object({
         name: v.string(),
         identifier: v.string(),
-        logRetentionInDays: v.optional(v.number())
+        logRetentionInDays: v.optional(v.number()),
+        storeContent: v.optional(v.boolean()),
+        collectErrors: v.optional(v.boolean()),
+        storeToolCallAttachments: v.optional(v.boolean())
       })
     )
     .do(async ctx => {
@@ -27,7 +30,10 @@ export let tenantController = app.controller({
         input: {
           name: ctx.input.name,
           identifier: ctx.input.identifier,
-          logRetentionInDays: ctx.input.logRetentionInDays
+          logRetentionInDays: ctx.input.logRetentionInDays,
+          storeContent: ctx.input.storeContent,
+          collectErrors: ctx.input.collectErrors,
+          storeToolCallAttachments: ctx.input.storeToolCallAttachments
         }
       });
       return tenantPresenter(tenant);

--- a/src/slates/apps/hub/src/lib/invocation/stack.ts
+++ b/src/slates/apps/hub/src/lib/invocation/stack.ts
@@ -124,6 +124,7 @@ export class SlateInvocationStack {
 
     if (providerInvocation.type === 'error') {
       storeSlateInvocation({
+        tenant: this.#tenant,
         slateVersion: this.#slateVersion,
         participants: this.#participants,
         record: invocationRecord,
@@ -160,6 +161,7 @@ export class SlateInvocationStack {
     let resultMessages = providerInvocation.result.messages as SlatesResponse[];
 
     storeSlateInvocation({
+      tenant: this.#tenant,
       slateVersion: this.#slateVersion,
       participants: this.#participants,
       record: invocationRecord,

--- a/src/slates/apps/hub/src/lib/invocation/store.test.ts
+++ b/src/slates/apps/hub/src/lib/invocation/store.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  putObject: vi.fn(),
+  invocationUpdate: vi.fn()
+}));
+
+vi.mock('@lowerdeck/sentry', () => ({
+  getSentry: () => ({ captureException: vi.fn() })
+}));
+
+vi.mock('../../db', () => ({
+  db: { slateInvocation: { update: mocks.invocationUpdate } }
+}));
+
+vi.mock('../../storage', () => ({
+  storage: { putObject: mocks.putObject },
+  invocationsBucketRecord: { bucket: 'invocations', oid: 1 }
+}));
+
+import { storeSlateInvocation } from './store';
+
+let record = { oid: 10n, id: 'shiv_10' } as any;
+let slateVersion = { oid: 1n, id: 'shvr_1' } as any;
+
+let requestMessages = [
+  {
+    jsonrpc: '2.0' as const,
+    id: 'req1',
+    method: 'slates/action.tool.invoke' as const,
+    params: { actionId: 'me', input: { secret: 'user-input' } }
+  }
+] as any;
+
+let responseMessages = [
+  {
+    jsonrpc: '2.0' as const,
+    id: 'req1',
+    result: {
+      output: { email: 'mock.user@example.com' },
+      requestTraces: [
+        { startedAt: 'now', durationMs: 1, request: { method: 'GET', url: 'https://x/y' } }
+      ]
+    }
+  }
+] as any;
+
+let invocationResult = {
+  id: 'fbiv_1',
+  type: 'success',
+  status: 'succeeded' as const,
+  functionVersionId: 'fbvr_1',
+  billedTimeMs: 12,
+  computeTimeMs: 10,
+  logs: [{ timestamp: 1, message: 'INFO Completed tool "Me" (me)' }],
+  result: {}
+} as any;
+
+// Wait for the internal p-queue to drain the async store job.
+let flush = () => new Promise(resolve => setTimeout(resolve, 20));
+
+let storedPayload = () => JSON.parse(mocks.putObject.mock.calls[0]![2] as string);
+
+describe('storeSlateInvocation retention gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.putObject.mockResolvedValue(undefined);
+    mocks.invocationUpdate.mockResolvedValue(undefined);
+  });
+
+  it('stores the full payload for tenants that retain content', async () => {
+    storeSlateInvocation({
+      tenant: { storeContent: true } as any,
+      slateVersion,
+      participants: [],
+      record,
+      requestMessages,
+      responseMessages,
+      invocationResult
+    });
+    await flush();
+
+    let payload = storedPayload();
+    expect(payload.requests).toHaveLength(1);
+    expect(payload.responses).toHaveLength(1);
+    expect(payload.logs).toHaveLength(1);
+    expect(payload.requestTraces).toHaveLength(1);
+  });
+
+  it('persists no request, response, log or trace content when the tenant disables it', async () => {
+    storeSlateInvocation({
+      tenant: { storeContent: false } as any,
+      slateVersion,
+      participants: [],
+      record,
+      requestMessages,
+      responseMessages,
+      invocationResult
+    });
+    await flush();
+
+    let payload = storedPayload();
+    expect(payload.requests).toEqual([]);
+    expect(payload.responses).toEqual([]);
+    expect(payload.logs).toEqual([]);
+    expect(payload.requestTraces).toEqual([]);
+
+    // Nothing user-derived may survive anywhere in the serialized blob.
+    let serialized = mocks.putObject.mock.calls[0]![2] as string;
+    expect(serialized).not.toContain('mock.user@example.com');
+    expect(serialized).not.toContain('user-input');
+    expect(serialized).not.toContain('Completed tool');
+
+    // Operational metadata is still recorded so the invocation stays auditable.
+    expect(payload.provider).toMatchObject({ status: 'succeeded', billedTimeMs: 12 });
+    expect(mocks.invocationUpdate).toHaveBeenCalled();
+  });
+
+  it('drops the provider error payload when content is not retained', async () => {
+    storeSlateInvocation({
+      tenant: { storeContent: false } as any,
+      slateVersion,
+      participants: [],
+      record,
+      requestMessages,
+      responseMessages,
+      invocationResult: {
+        ...invocationResult,
+        type: 'error',
+        status: 'failed',
+        error: { message: 'boom mock.user@example.com' }
+      }
+    });
+    await flush();
+
+    let payload = storedPayload();
+    expect(payload.provider.error).toBeNull();
+    expect(mocks.putObject.mock.calls[0]![2]).not.toContain('mock.user@example.com');
+  });
+
+  it('retains content when no tenant is attached (platform-level invocations)', async () => {
+    storeSlateInvocation({
+      slateVersion,
+      participants: [],
+      record,
+      requestMessages,
+      responseMessages,
+      invocationResult
+    });
+    await flush();
+
+    expect(storedPayload().requests).toHaveLength(1);
+  });
+});

--- a/src/slates/apps/hub/src/lib/invocation/store.ts
+++ b/src/slates/apps/hub/src/lib/invocation/store.ts
@@ -49,6 +49,8 @@ export let storeSlateInvocation = (
 ) => {
   storeQueue
     .add(async () => {
+      let storeContent = d.tenant?.storeContent !== false;
+
       let idToMethodMap = new Map<string, SlatesRequest['method']>();
 
       let sanitizedRequests = d.requestMessages.map(m => {
@@ -113,11 +115,13 @@ export let storeSlateInvocation = (
           storageKey,
           JSON.stringify({
             id: d.record.id,
-            requests: sanitizedRequests as any,
-            responses: (sanitizedResponses ?? []) as any,
-            provider: { error: (d.invocationResult as any).error } as any,
+            requests: (storeContent ? sanitizedRequests : []) as any,
+            responses: (storeContent ? (sanitizedResponses ?? []) : []) as any,
+            provider: {
+              error: storeContent ? (d.invocationResult as any).error : null
+            } as any,
             logs: [],
-            requestTraces
+            requestTraces: storeContent ? requestTraces : []
           } satisfies StoredSlateInvocation)
         );
 
@@ -140,7 +144,8 @@ export let storeSlateInvocation = (
         functionVersionId: d.invocationResult.functionVersionId,
         billedTimeMs: d.invocationResult.billedTimeMs,
         computeTimeMs: d.invocationResult.computeTimeMs,
-        error: d.invocationResult.type === 'error' ? d.invocationResult.error : null
+        error:
+          storeContent && d.invocationResult.type === 'error' ? d.invocationResult.error : null
       };
 
       let storageKey = getStoredInvocationStorageKey(d.record);
@@ -149,11 +154,13 @@ export let storeSlateInvocation = (
         storageKey,
         JSON.stringify({
           id: d.record.id,
-          requests: sanitizedRequests as any,
-          responses: (sanitizedResponses ?? []) as any,
+          requests: (storeContent ? sanitizedRequests : []) as any,
+          responses: (storeContent ? (sanitizedResponses ?? []) : []) as any,
           provider,
-          logs: d.invocationResult.logs.map(log => [log.timestamp, log.message] as const),
-          requestTraces
+          logs: storeContent
+            ? d.invocationResult.logs.map(log => [log.timestamp, log.message] as const)
+            : [],
+          requestTraces: storeContent ? requestTraces : []
         } satisfies StoredSlateInvocation)
       );
 

--- a/src/slates/apps/hub/src/lib/invocation/types.ts
+++ b/src/slates/apps/hub/src/lib/invocation/types.ts
@@ -18,7 +18,12 @@ export interface SlateInvocationDeploymentTarget {
 export interface SlateInvocationBaseParams {
   tenant?: Pick<
     Tenant,
-    'oid' | 'identifier' | 'name' | 'functionBayTenantId' | 'functionBayTenantIdentifier'
+    | 'oid'
+    | 'identifier'
+    | 'name'
+    | 'functionBayTenantId'
+    | 'functionBayTenantIdentifier'
+    | 'storeContent'
   >;
   slateVersion: SlateVersion;
   deploymentTarget?: SlateInvocationDeploymentTarget;

--- a/src/slates/apps/hub/src/lib/validateJsonSchema.ts
+++ b/src/slates/apps/hub/src/lib/validateJsonSchema.ts
@@ -21,8 +21,9 @@ export let validateJsonSchema = ({
     valRes = z.fromJSONSchema(schema).safeParse(data);
   } catch (e) {
     console.error(e);
+
     Sentry.captureException(e, {
-      extra: { schema, data }
+      extra: { schema, entity }
     });
 
     return data;

--- a/src/slates/apps/hub/src/queues/instance/configChanged.ts
+++ b/src/slates/apps/hub/src/queues/instance/configChanged.ts
@@ -22,7 +22,7 @@ export let slateInstanceConfigChangedQueueProcessor = slateInstanceConfigChanged
       : null;
     let newConfig = await db.slateInstanceConfig.findUnique({
       where: { id: data.newConfigId },
-      include: { instance: true }
+      include: { instance: true, tenant: true }
     });
     let version = await db.slateVersion.findUnique({
       where: { id: data.versionId },
@@ -31,6 +31,7 @@ export let slateInstanceConfigChangedQueueProcessor = slateInstanceConfigChanged
     if (!newConfig || !version) throw new QueueRetryError();
 
     let stack = await slateInvocationService.createInvocation({
+      tenant: newConfig.tenant,
       slateVersion: version,
       participants: []
     });

--- a/src/slates/apps/hub/src/queues/instance/processAuth.ts
+++ b/src/slates/apps/hub/src/queues/instance/processAuth.ts
@@ -47,6 +47,7 @@ export let processAuthQueueProcessor = processAuthQueue.process(async data => {
     authConfig.authMethod.spec.capabilities.handleChangedInput?.enabled
   ) {
     let stack = await slateInvocationService.createInvocation({
+      tenant: authConfig.tenant,
       slateVersion: version,
       participants: []
     });
@@ -90,6 +91,7 @@ export let processAuthQueueProcessor = processAuthQueue.process(async data => {
 
   if (!decrypted.output) {
     let stack = await slateInvocationService.createInvocation({
+      tenant: authConfig.tenant,
       slateVersion: version,
       participants: []
     });

--- a/src/slates/apps/hub/src/queues/instance/updateProfile.ts
+++ b/src/slates/apps/hub/src/queues/instance/updateProfile.ts
@@ -47,6 +47,7 @@ export let updateProfileQueueProcessor = updateProfileQueue.process(async data =
   });
 
   let stack = await slateInvocationService.createInvocation({
+    tenant: authConfig.tenant,
     slateVersion: version,
     participants: []
   });

--- a/src/slates/apps/hub/src/services/slateError.ts
+++ b/src/slates/apps/hub/src/services/slateError.ts
@@ -96,7 +96,18 @@ let toBigIntOrNull = (v: string | null | undefined): bigint | null =>
   v != null ? BigInt(v) : null;
 
 class slateErrorServiceImpl {
+  private async shouldCollectErrors(tenantOid: bigint | string) {
+    let tenant = await db.tenant.findUnique({
+      where: { oid: BigInt(tenantOid) },
+      select: { collectErrors: true }
+    });
+
+    return tenant ? tenant.collectErrors : true;
+  }
+
   async recordSlateError(d: RecordSlateErrorInput) {
+    if (!(await this.shouldCollectErrors(d.tenantOid))) return;
+
     await recordSlateErrorQueue.add({
       type: d.type,
       errorCode: d.errorCode,
@@ -134,6 +145,8 @@ class slateErrorServiceImpl {
     triggerReceiverOid: string | null;
     triggerEventInputOid: string | null;
   }) {
+    if (!(await this.shouldCollectErrors(d.tenantOid))) return null;
+
     return db.slateError.create({
       data: {
         ...getId('slateError'),
@@ -158,10 +171,7 @@ class slateErrorServiceImpl {
     });
   }
 
-  async listSlateErrors(d: {
-    tenant?: Tenant;
-    types?: SlateErrorType[];
-  }) {
+  async listSlateErrors(d: { tenant?: Tenant; types?: SlateErrorType[] }) {
     return Paginator.create(({ prisma }) =>
       prisma(
         async opts =>

--- a/src/slates/apps/hub/src/services/slateInstanceAuthHandler.ts
+++ b/src/slates/apps/hub/src/services/slateInstanceAuthHandler.ts
@@ -6,8 +6,8 @@ import type { SlateInstance, Tenant } from '../../prisma/generated/client';
 import { db } from '../db';
 import { ID, snowflake } from '../id';
 import { extractExpiresAt } from '../lib/extractExpiresAt';
-import { slateErrorService } from './slateError';
 import { secretService } from './secret';
+import { slateErrorService } from './slateError';
 import { slateInvocationService } from './slateInvocation';
 
 let include = { secret: true, authMethod: true };
@@ -150,6 +150,7 @@ class slateAuthHandlerServiceImpl {
         });
 
         let stack = await slateInvocationService.createInvocation({
+          tenant: d.tenant,
           slateVersion: version,
           participants: []
         });

--- a/src/slates/apps/hub/src/services/slateOAuthHandler.ts
+++ b/src/slates/apps/hub/src/services/slateOAuthHandler.ts
@@ -62,6 +62,7 @@ class slateOAuthHandlerServiceImpl {
 
     let urlRes = await slateInvocationService.getOAuthUrl({
       stack: await slateInvocationService.createInvocation({
+        tenant: setup.tenant,
         participants: [],
         slateVersion: setup.slateVersion,
         enclaveId: setup.instanceConfiguration?.enclaveId,
@@ -235,6 +236,7 @@ class slateOAuthHandlerServiceImpl {
 
     let authRes = await slateInvocationService.getOAuthCallback({
       stack: await slateInvocationService.createInvocation({
+        tenant: setup.tenant,
         participants: [],
         slateVersion: setup.slateVersion,
         enclaveId: setup.instanceConfiguration?.enclaveId,

--- a/src/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -250,15 +250,17 @@ class slateSessionToolCallServiceImpl {
       };
     }
 
-    let attachments = await Promise.all(
-      (callRes.data.attachments ?? []).map(attachment =>
-        this.ensureAttachment({
-          content: attachment.content,
-          mimeType: attachment.mimeType,
-          invocation: callRes.invocation
-        })
-      )
-    );
+    let attachments = session.tenant.storeToolCallAttachments
+      ? await Promise.all(
+          (callRes.data.attachments ?? []).map(attachment =>
+            this.ensureAttachment({
+              content: attachment.content,
+              mimeType: attachment.mimeType,
+              invocation: callRes.invocation
+            })
+          )
+        )
+      : [];
 
     return {
       call,

--- a/src/slates/apps/hub/src/services/tenant.ts
+++ b/src/slates/apps/hub/src/services/tenant.ts
@@ -11,19 +11,28 @@ class tenantServiceImpl {
       name: string;
       identifier: string;
       logRetentionInDays?: number;
+      storeContent?: boolean;
+      collectErrors?: boolean;
+      storeToolCallAttachments?: boolean;
     };
   }) {
     return await db.tenant.upsert({
       where: { identifier: d.input.identifier },
       update: {
         name: d.input.name,
-        logRetentionInDays: d.input.logRetentionInDays
+        logRetentionInDays: d.input.logRetentionInDays,
+        storeContent: d.input.storeContent,
+        collectErrors: d.input.collectErrors,
+        storeToolCallAttachments: d.input.storeToolCallAttachments
       },
       create: {
         ...getId('tenant'),
         name: d.input.name,
         identifier: d.input.identifier,
-        logRetentionInDays: d.input.logRetentionInDays
+        logRetentionInDays: d.input.logRetentionInDays,
+        storeContent: d.input.storeContent ?? true,
+        collectErrors: d.input.collectErrors ?? true,
+        storeToolCallAttachments: d.input.storeToolCallAttachments ?? true
       },
       include
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes what sensitive invocation, error, and attachment data is persisted tenant-wide; misconfiguration or missing tenant context could affect auditability or accidentally retain PII.
> 
> **Overview**
> Adds per-tenant **data retention controls** (`storeContent`, `collectErrors`, `storeToolCallAttachments`, all defaulting to `true`) on the tenant model and internal tenant upsert API.
> 
> When **`storeContent` is false**, invocation persistence still writes metadata (provider status, billing, DB flags) but **omits** stored requests, responses, logs, traces, and provider error bodies so user-derived data does not land in object storage. The invocation stack and background jobs now pass **tenant** into `createInvocation` / `storeSlateInvocation` so this gate applies consistently.
> 
> **`collectErrors: false`** skips queuing and creating slate error records. **`storeToolCallAttachments: false`** skips persisting tool-call attachments while still returning tool output.
> 
> Also stops sending validated **`data`** to Sentry in `validateJsonSchema` failures (keeps `schema` and `entity`). New Vitest coverage exercises `storeSlateInvocation` retention behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028cc87477d907db544b1ffd0574da518450d712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->