### PR TITLE
Enforce zdr in shuttle

### DIFF
--- a/src/shuttle/service/prisma/schema/tenant.prisma
+++ b/src/shuttle/service/prisma/schema/tenant.prisma
@@ -8,7 +8,9 @@ model Tenant {
   functionBayTenantId String?
   nebulaTenantId      String?
 
-  logRetentionInDays Int @default(30)
+  logRetentionInDays Int     @default(30)
+  storeContent       Boolean @default(true)
+  collectErrors      Boolean @default(true)
 
   createdAt DateTime @default(now())
 

--- a/src/shuttle/service/src/apis/controllers/tenant.ts
+++ b/src/shuttle/service/src/apis/controllers/tenant.ts
@@ -27,7 +27,9 @@ export let tenantController = app.controller({
       v.object({
         name: v.string(),
         identifier: v.string(),
-        logRetentionInDays: v.optional(v.number())
+        logRetentionInDays: v.optional(v.number()),
+        storeContent: v.optional(v.boolean()),
+        collectErrors: v.optional(v.boolean())
       })
     )
     .do(async ctx => {
@@ -35,7 +37,9 @@ export let tenantController = app.controller({
         input: {
           name: ctx.input.name,
           identifier: ctx.input.identifier,
-          logRetentionInDays: ctx.input.logRetentionInDays
+          logRetentionInDays: ctx.input.logRetentionInDays,
+          storeContent: ctx.input.storeContent,
+          collectErrors: ctx.input.collectErrors
         }
       });
       return tenantPresenter(tenant);

--- a/src/shuttle/service/src/lib/redactJsonShape.ts
+++ b/src/shuttle/service/src/lib/redactJsonShape.ts
@@ -1,0 +1,22 @@
+export let redactJsonShape = (value: unknown): unknown => {
+  if (value === null) return 'Redacted[null]';
+  if (Array.isArray(value)) return value.map(redactJsonShape);
+
+  switch (typeof value) {
+    case 'object': {
+      let out: Record<string, unknown> = {};
+      for (let [key, nested] of Object.entries(value as Record<string, unknown>)) {
+        out[key] = redactJsonShape(nested);
+      }
+      return out;
+    }
+    case 'string':
+      return 'Redacted[string]';
+    case 'number':
+      return 'Redacted[number]';
+    case 'boolean':
+      return 'Redacted[boolean]';
+    default:
+      return 'Redacted[unknown]';
+  }
+};

--- a/src/shuttle/service/src/lib/redactSensitiveKeys.ts
+++ b/src/shuttle/service/src/lib/redactSensitiveKeys.ts
@@ -1,0 +1,29 @@
+let SENSITIVE_KEYS = new Set([
+  'accessToken',
+  'access_token',
+  'refreshToken',
+  'refresh_token',
+  'idToken',
+  'id_token',
+  'clientSecret',
+  'client_secret',
+  'code',
+  'state',
+  'authorization',
+  'password',
+  'secret'
+]);
+
+export let redactSensitiveKeys = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(redactSensitiveKeys);
+
+  if (value && typeof value === 'object') {
+    let out: Record<string, unknown> = {};
+    for (let [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = SENSITIVE_KEYS.has(key) ? '[REDACTED]' : redactSensitiveKeys(nested);
+    }
+    return out;
+  }
+
+  return value;
+};

--- a/src/shuttle/service/src/mcp/function/connection.ts
+++ b/src/shuttle/service/src/mcp/function/connection.ts
@@ -50,7 +50,7 @@ export class FunctionConnection implements McpConnectionBackendAdapter {
       throw new Error('Server version is missing function server OID');
     }
 
-    this.logger = new ConnectionLogger(this.connection);
+    this.logger = new ConnectionLogger(this.connection, tenant);
     this.messenger = new ConnectionMessenger();
     this.manager = new ConnectionManager(this.connection);
 

--- a/src/shuttle/service/src/mcp/holopod/connection.ts
+++ b/src/shuttle/service/src/mcp/holopod/connection.ts
@@ -85,7 +85,7 @@ export class HolopodConnection implements McpConnectionBackendAdapter {
     this.#grpcClient = createSessionClient();
     this.#stream = this.#grpcClient.run();
 
-    this.logger = new ConnectionLogger(this.connection);
+    this.logger = new ConnectionLogger(this.connection, tenant);
     this.messenger = new ConnectionMessenger();
     this.manager = new ConnectionManager(this.connection);
 

--- a/src/shuttle/service/src/mcp/remote/sse.ts
+++ b/src/shuttle/service/src/mcp/remote/sse.ts
@@ -54,7 +54,7 @@ export class SSERemoteConnection implements McpConnectionBackendAdapter {
       throw new Error('Server version missing remote connection info');
     }
 
-    this.logger = new ConnectionLogger(this.connection);
+    this.logger = new ConnectionLogger(this.connection, tenant);
     this.messenger = new ConnectionMessenger();
     this.manager = new ConnectionManager(this.connection);
 

--- a/src/shuttle/service/src/mcp/remote/streamableHttp.ts
+++ b/src/shuttle/service/src/mcp/remote/streamableHttp.ts
@@ -49,7 +49,7 @@ export class StreamableHttpRemoteConnection implements McpConnectionBackendAdapt
       throw new Error('Server version missing remote connection info');
     }
 
-    this.logger = new ConnectionLogger(this.connection);
+    this.logger = new ConnectionLogger(this.connection, tenant);
     this.messenger = new ConnectionMessenger();
     this.manager = new ConnectionManager(this.connection);
 

--- a/src/shuttle/service/src/mcp/utils/logger.ts
+++ b/src/shuttle/service/src/mcp/utils/logger.ts
@@ -1,6 +1,9 @@
-import type { ServerConnection } from '../../../prisma/generated/client';
+import type { ServerConnection, Tenant } from '../../../prisma/generated/client';
 import { db, outputTypeReverseMapper } from '../../db';
 import { snowflake } from '../../id';
+
+let isErrorOutputType = (type: PrismaJson.OutputType) =>
+  type === 'debug.error' || type === 'debug.warning';
 
 export class ConnectionLogger {
   #buffer: {
@@ -10,7 +13,10 @@ export class ConnectionLogger {
   }[] = [];
   #flushTo: NodeJS.Timeout | null = null;
 
-  constructor(private readonly connection: ServerConnection) {}
+  constructor(
+    private readonly connection: ServerConnection,
+    private readonly tenant: Tenant
+  ) {}
 
   log(type: PrismaJson.OutputType, lines: string[] | string, ts?: number | string | Date) {
     let lastInBuffer = this.#buffer[this.#buffer.length - 1];
@@ -41,10 +47,15 @@ export class ConnectionLogger {
     let buffer = this.#buffer;
     this.#buffer = [];
 
+    let storable = buffer.filter(b =>
+      isErrorOutputType(b.type) ? this.tenant.collectErrors : this.tenant.storeContent
+    );
+    if (storable.length === 0) return;
+
     await db.serverConnectionLogsTemp.createMany({
       data: {
         oid: snowflake.nextId(),
-        logLines: buffer.map(b => [
+        logLines: storable.map(b => [
           b.timestamp,
           outputTypeReverseMapper.get(b.type) ?? 0,
           b.lines

--- a/src/shuttle/service/src/queues/retention/cleanup.ts
+++ b/src/shuttle/service/src/queues/retention/cleanup.ts
@@ -151,6 +151,44 @@ let cleanupDeploymentSteps = async (d: { tenantOid: bigint; cutoffDate: Date }) 
   });
 };
 
+let cleanupServerAuthConfigEvents = async (d: { tenantOid: bigint; cutoffDate: Date }) => {
+  await processBatch<{ oid: bigint }>({
+    findMany: () =>
+      db.serverAuthConfigEvent.findMany({
+        where: {
+          serverAuthConfig: { tenantOid: d.tenantOid },
+          createdAt: { lt: d.cutoffDate }
+        },
+        orderBy: { createdAt: 'asc' },
+        take: RETENTION_BATCH_SIZE,
+        select: { oid: true }
+      }),
+    deleteMany: records =>
+      db.serverAuthConfigEvent.deleteMany({
+        where: { oid: { in: records.map(record => record.oid) } }
+      })
+  });
+};
+
+let cleanupServerOAuthSetupEvents = async (d: { tenantOid: bigint; cutoffDate: Date }) => {
+  await processBatch<{ oid: bigint }>({
+    findMany: () =>
+      db.serverOAuthSetupEvent.findMany({
+        where: {
+          serverOAuthSetup: { tenantOid: d.tenantOid },
+          createdAt: { lt: d.cutoffDate }
+        },
+        orderBy: { createdAt: 'asc' },
+        take: RETENTION_BATCH_SIZE,
+        select: { oid: true }
+      }),
+    deleteMany: records =>
+      db.serverOAuthSetupEvent.deleteMany({
+        where: { oid: { in: records.map(record => record.oid) } }
+      })
+  });
+};
+
 let cleanupDeployments = async (d: { tenantOid: bigint; cutoffDate: Date }) => {
   await processBatch<{
     oid: bigint;
@@ -247,6 +285,14 @@ export let shuttleTenantRetentionCleanupQueueProcessor =
       cutoffDate
     });
     await cleanupServerDiscoveries({
+      tenantOid: tenant.oid,
+      cutoffDate
+    });
+    await cleanupServerAuthConfigEvents({
+      tenantOid: tenant.oid,
+      cutoffDate
+    });
+    await cleanupServerOAuthSetupEvents({
       tenantOid: tenant.oid,
       cutoffDate
     });

--- a/src/shuttle/service/src/services/functionServerInvocation.ts
+++ b/src/shuttle/service/src/services/functionServerInvocation.ts
@@ -135,7 +135,7 @@ class functionServerInvocationServiceImpl {
         connectionOid: d.connection?.oid ?? null,
         functionServerOid: d.functionServer.oid,
         tenantOid: d.tenant.oid,
-        logs: d.logs?.length ? d.logs : undefined
+        logs: d.tenant.storeContent && d.logs?.length ? d.logs : undefined
       },
       include
     });

--- a/src/shuttle/service/src/services/oauth/delegated/authorization.ts
+++ b/src/shuttle/service/src/services/oauth/delegated/authorization.ts
@@ -15,8 +15,8 @@ import { oauthCallbackUrl } from '../../../config';
 import { db } from '../../../db';
 import { getId } from '../../../id';
 import { callFunction } from '../../../lib/function/call';
-import { oauthErrorDescriptions } from '../../../lib/oauth/oauthErrors';
 import { normalizeAuthorizationUrl } from '../../../lib/oauth/normalizeAuthorizationUrl';
+import { oauthErrorDescriptions } from '../../../lib/oauth/oauthErrors';
 import { functionServerInvocationService } from '../../functionServerInvocation';
 import { secretService } from '../../secret';
 import { serverEventService } from '../serverEvent';
@@ -233,7 +233,7 @@ class delegatedOauthAuthorizationServiceImpl {
 
           let serverOAuthSetup = await db.serverOAuthSetup.findFirst({
             where: { delegatedOAuthConnectionSetupOid: res.oid },
-            select: { oid: true }
+            select: { oid: true, tenantOid: true }
           });
           if (serverOAuthSetup) {
             await serverEventService.recordServerOAuthSetupEvent({

--- a/src/shuttle/service/src/services/oauth/remote/authorization.ts
+++ b/src/shuttle/service/src/services/oauth/remote/authorization.ts
@@ -210,7 +210,7 @@ class remoteOauthAuthorizationServiceImpl {
 
           let serverOAuthSetup = await db.serverOAuthSetup.findFirst({
             where: { remoteOAuthConnectionSetupOid: res.oid },
-            select: { oid: true }
+            select: { oid: true, tenantOid: true }
           });
           if (serverOAuthSetup) {
             await serverEventService.recordServerOAuthSetupEvent({

--- a/src/shuttle/service/src/services/oauth/serverEvent.ts
+++ b/src/shuttle/service/src/services/oauth/serverEvent.ts
@@ -1,27 +1,53 @@
 import { Service } from '@lowerdeck/service';
-import type {
-  ServerAuthConfig,
-  ServerOAuthSetup
-} from '../../../prisma/generated/client';
+import type { ServerAuthConfig, ServerOAuthSetup } from '../../../prisma/generated/client';
 import { db } from '../../db';
 import { getId } from '../../id';
+import { redactJsonShape } from '../../lib/redactJsonShape';
+import { redactSensitiveKeys } from '../../lib/redactSensitiveKeys';
+
+let getTenantRetention = async (tenantOid: bigint) => {
+  let tenant = await db.tenant.findUnique({
+    where: { oid: tenantOid },
+    select: { collectErrors: true, storeContent: true }
+  });
+
+  return {
+    collectErrors: tenant?.collectErrors ?? true,
+    storeContent: tenant?.storeContent ?? true
+  };
+};
+
+let buildPayload = (
+  payload: Record<string, unknown> | null | undefined,
+  retention: { collectErrors: boolean; storeContent: boolean }
+) => {
+  if (!payload) return undefined;
+  if (!retention.collectErrors) return undefined;
+
+  let safePayload = redactSensitiveKeys(payload) as Record<string, unknown>;
+  return retention.storeContent
+    ? safePayload
+    : (redactJsonShape(safePayload) as Record<string, unknown>);
+};
 
 class serverEventServiceImpl {
   async recordServerOAuthSetupEvent(d: {
-    serverOAuthSetup: Pick<ServerOAuthSetup, 'oid'>;
+    serverOAuthSetup: Pick<ServerOAuthSetup, 'oid' | 'tenantOid'>;
     type: string;
     message?: string | null;
     payload?: Record<string, unknown> | null;
     functionInvocationId?: string | null;
     serverConnectionId?: string | null;
   }) {
+    let retention = await getTenantRetention(d.serverOAuthSetup.tenantOid);
+
     return await db.serverOAuthSetupEvent.create({
       data: {
         ...getId('serverOAuthSetupEvent'),
         serverOAuthSetupOid: d.serverOAuthSetup.oid,
         type: d.type,
         message: d.message ?? null,
-        payload: d.payload ?? undefined,
+        payload: buildPayload(d.payload, retention),
         functionInvocationId: d.functionInvocationId ?? null,
         serverConnectionId: d.serverConnectionId ?? null
       }
@@ -29,20 +55,22 @@ class serverEventServiceImpl {
   }
 
   async recordServerAuthConfigEvent(d: {
-    serverAuthConfig: Pick<ServerAuthConfig, 'oid'>;
+    serverAuthConfig: Pick<ServerAuthConfig, 'oid' | 'tenantOid'>;
     type: string;
     message?: string | null;
     payload?: Record<string, unknown> | null;
     functionInvocationId?: string | null;
     serverConnectionId?: string | null;
   }) {
+    let retention = await getTenantRetention(d.serverAuthConfig.tenantOid);
+
     return await db.serverAuthConfigEvent.create({
       data: {
         ...getId('serverAuthConfigEvent'),
         serverAuthConfigOid: d.serverAuthConfig.oid,
         type: d.type,
         message: d.message ?? null,
-        payload: d.payload ?? undefined,
+        payload: buildPayload(d.payload, retention),
         functionInvocationId: d.functionInvocationId ?? null,
         serverConnectionId: d.serverConnectionId ?? null
       }

--- a/src/shuttle/service/src/services/tenant.ts
+++ b/src/shuttle/service/src/services/tenant.ts
@@ -11,20 +11,26 @@ class tenantServiceImpl {
       name: string;
       identifier: string;
       logRetentionInDays?: number;
+      storeContent?: boolean;
+      collectErrors?: boolean;
     };
   }) {
     return await db.tenant.upsert({
       where: { identifier: d.input.identifier },
       update: {
         name: d.input.name,
-        logRetentionInDays: d.input.logRetentionInDays
+        logRetentionInDays: d.input.logRetentionInDays,
+        storeContent: d.input.storeContent,
+        collectErrors: d.input.collectErrors
       },
       create: {
         oid: snowflake.nextId(),
         id: await ID.generateId('tenant'),
         name: d.input.name,
         identifier: d.input.identifier,
-        logRetentionInDays: d.input.logRetentionInDays
+        logRetentionInDays: d.input.logRetentionInDays,
+        storeContent: d.input.storeContent ?? true,
+        collectErrors: d.input.collectErrors ?? true
       }
     });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes what diagnostic and OAuth event data is stored at runtime based on tenant flags; misconfiguration could drop logs/events customers expect, though defaults preserve current behavior.
> 
> **Overview**
> Adds per-tenant **zero-data-retention-style** controls via `storeContent` and `collectErrors` on `Tenant`, configurable through tenant upsert alongside existing `logRetentionInDays`.
> 
> **Persistence gating:** MCP `ConnectionLogger` only writes buffered connection logs when the line type matches tenant policy (errors/warnings honor `collectErrors`; other output honors `storeContent`). Function server invocations skip persisting invocation logs when `storeContent` is false.
> 
> **OAuth / auth events:** New `redactSensitiveKeys` and `redactJsonShape` helpers shape event payloads before storage—sensitive key names are stripped, and when `storeContent` is off, values are replaced with type placeholders while keeping structure. Event recording skips payloads entirely when `collectErrors` is false. OAuth callback failure paths now load `tenantOid` for retention lookup.
> 
> **Retention:** Daily cleanup also purges old `serverAuthConfigEvent` and `serverOAuthSetupEvent` rows by tenant cutoff, consistent with other retained data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c43a262b5cdbcd86df5aa829c47969c18b4b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->