### PR TITLE
Improve skill file uploads

### DIFF
--- a/src/metorial-frontend/scenes/skills/src/components/filePreviewLightbox.tsx
+++ b/src/metorial-frontend/scenes/skills/src/components/filePreviewLightbox.tsx
@@ -332,7 +332,7 @@ let TriggerButton = styled.button`
   all: unset;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   align-self: stretch;
   min-width: 0;
   flex: 1;

--- a/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
+++ b/src/metorial-frontend/scenes/skills/src/components/fileTree.tsx
@@ -52,7 +52,7 @@ let TreeItemStack = styled.div`
 let TreeRowButton = styled.button`
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   width: 100%;
   min-width: 0;
   flex: 1;
@@ -95,7 +95,7 @@ let TreeRowButton = styled.button`
 let TreeRowLink = styled(Link)`
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   align-self: stretch;
   min-width: 0;
   flex: 1;
@@ -124,7 +124,7 @@ let TreeRowLink = styled(Link)`
 let TreeRowShell = styled.div<{ $active?: boolean; $dropTarget?: boolean }>`
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   width: 100%;
   height: 32px;
   min-height: 32px;
@@ -205,7 +205,7 @@ let ChevronSpacer = styled.div`
 let TreeLabel = styled.div`
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   min-width: 0;
   flex: 1;
 `;

--- a/src/metorial-frontend/scenes/skills/src/scenes/skillStoreFileViewer.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillStoreFileViewer.tsx
@@ -31,6 +31,7 @@ type OptimisticStoreItem = {
   kind: 'file' | 'document' | 'directory';
   fileSize?: number;
   uploadProgress?: number;
+  isComplete?: boolean;
 };
 
 let buildTree = (items: StoreItem[], optimisticItems: OptimisticStoreItem[]) => {
@@ -260,11 +261,27 @@ export let SkillStoreFileTree = (p: {
     setOptimisticItems(current => current.filter(item => item.id != id));
   };
 
+  let markOptimisticItemComplete = (id: string) => {
+    setOptimisticItems(current =>
+      current.map(item => (item.id == id ? { ...item, isComplete: true } : item))
+    );
+  };
+
   let updateOptimisticProgress = (id: string, uploadProgress: number) => {
     setOptimisticItems(current =>
       current.map(item => (item.id == id ? { ...item, uploadProgress } : item))
     );
   };
+
+  useEffect(() => {
+    if (!storeItems.data) return;
+
+    let realItemPaths = new Set(storeItems.data.map(item => item.path));
+    setOptimisticItems(current => {
+      let next = current.filter(item => !item.isComplete || !realItemPaths.has(item.path));
+      return next.length == current.length ? current : next;
+    });
+  }, [optimisticItems, storeItems.data]);
 
   let createStoreItem = async (
     parentPath: string,
@@ -276,6 +293,7 @@ export let SkillStoreFileTree = (p: {
     let path = joinStorePath(parentPath, name);
     if (kind == 'directory') {
       let optimisticId = addOptimisticItem({ path, kind: 'directory' });
+      let completed = false;
 
       try {
         await modifyStoreItems.mutate({
@@ -289,9 +307,11 @@ export let SkillStoreFileTree = (p: {
           ]
         });
 
+        completed = true;
+        markOptimisticItemComplete(optimisticId);
         await storeItems.refetch();
       } finally {
-        removeOptimisticItem(optimisticId);
+        if (!completed) removeOptimisticItem(optimisticId);
       }
 
       return;
@@ -302,6 +322,7 @@ export let SkillStoreFileTree = (p: {
       path,
       kind: shouldCreateDocument ? 'document' : 'file'
     });
+    let completed = false;
 
     try {
       if (shouldCreateDocument) {
@@ -341,9 +362,11 @@ export let SkillStoreFileTree = (p: {
         });
       }
 
+      completed = true;
+      markOptimisticItemComplete(optimisticId);
       await storeItems.refetch();
     } finally {
-      removeOptimisticItem(optimisticId);
+      if (!completed) removeOptimisticItem(optimisticId);
     }
   };
 
@@ -362,6 +385,7 @@ export let SkillStoreFileTree = (p: {
             uploadProgress: 0
           })
     });
+    let completed = false;
 
     try {
       if (shouldCreateDocument) {
@@ -404,9 +428,11 @@ export let SkillStoreFileTree = (p: {
         });
       }
 
+      completed = true;
+      markOptimisticItemComplete(optimisticId);
       if (refetch) await storeItems.refetch();
     } finally {
-      removeOptimisticItem(optimisticId);
+      if (!completed) removeOptimisticItem(optimisticId);
     }
   };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only optimistic UI timing and minor spacing; no auth, API, or data-model changes.
> 
> **Overview**
> **Upload/create flows** in the skill store file viewer no longer drop optimistic tree rows as soon as the API call finishes. Successful directory creation, file/document creation, and uploads call `markOptimisticItemComplete` instead of always `removeOptimisticItem` in `finally`; failed operations still remove the placeholder.
> 
> A `useEffect` clears completed optimistic entries once the refetched store list includes the same path, avoiding a gap where the pending row vanishes before the real item appears.
> 
> **UI polish:** file tree rows and the file preview trigger use a consistent **7px** flex `gap` (was 8px in the tree, 6px on the lightbox trigger).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72a9fba30334af2a79801c3ef39d62e58f5672d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->