### PR TITLE
Enforce audit log retention

### DIFF
--- a/src/metorial/apis/core/src/controllers/dashboard/auditLogRetention.ts
+++ b/src/metorial/apis/core/src/controllers/dashboard/auditLogRetention.ts
@@ -1,0 +1,71 @@
+import { v } from '@lowerdeck/validation';
+import { auditLogRetentionService } from '@metorial/module-audit-log';
+import { organizationAuditLogRetentionPresenter } from '@metorial/presenters';
+import { Controller, Path } from '@metorial/rest';
+import { checkAccess } from '../../middleware/checkAccess';
+import { isDashboardGroup } from '../../middleware/isDashboard';
+import { organizationGroup } from '../../middleware/organizationGroup';
+
+export let dashboardAuditLogRetentionController = Controller.create(
+  {
+    name: 'Organization audit log retention',
+    description: 'Configure organization audit log retention'
+  },
+  {
+    get: organizationGroup
+      .use(isDashboardGroup())
+      .get(
+        Path(
+          '/dashboard/organizations/:organizationId/configure/audit-log-retention',
+          'dashboard.organizations.configure.audit_log_retention.get'
+        ),
+        {
+          name: 'Get audit log retention configuration',
+          description: 'Get the audit log retention period for an organization'
+        }
+      )
+      .use(checkAccess({ possibleScopes: ['organization:read'] }))
+      .output(organizationAuditLogRetentionPresenter)
+      .do(async ctx => {
+        let organization = await auditLogRetentionService.getAuditLogRetention({
+          organization: ctx.organization
+        });
+
+        return organizationAuditLogRetentionPresenter.present({ organization });
+      }),
+
+    update: organizationGroup
+      .use(isDashboardGroup())
+      .patch(
+        Path(
+          '/dashboard/organizations/:organizationId/configure/audit-log-retention',
+          'dashboard.organizations.configure.audit_log_retention.update'
+        ),
+        {
+          name: 'Update audit log retention configuration',
+          description: 'Update the audit log retention period for an organization'
+        }
+      )
+      .use(checkAccess({ possibleScopes: ['organization:write'] }))
+      .body(
+        'default',
+        v.object({
+          audit_log_retention_in_days: v.number({
+            modifiers: [v.positive(), v.integer(), v.minValue(1), v.maxValue(2_147_483_647)]
+          })
+        })
+      )
+      .output(organizationAuditLogRetentionPresenter)
+      .do(async ctx => {
+        let organization = await auditLogRetentionService.updateAuditLogRetention({
+          organization: ctx.organization,
+          auditScope: ctx.auditScope,
+          input: {
+            auditLogRetentionInDays: ctx.body.audit_log_retention_in_days
+          }
+        });
+
+        return organizationAuditLogRetentionPresenter.present({ organization });
+      })
+  }
+);

--- a/src/metorial/db/prisma/schema/organization/organization.prisma
+++ b/src/metorial/db/prisma/schema/organization/organization.prisma
@@ -23,6 +23,8 @@ model Organization {
 
   enforceTeamAccess Boolean @default(false)
 
+  auditLogRetentionInDays Int?
+
   ignoreAndDoNotUse_canCreateGlobalOauthApps Boolean @default(false) @map("canCreateGlobalOauthApps")
 
   slug          String   @unique

--- a/src/metorial/presenters/src/implementation/organization/auditLogRetention.ts
+++ b/src/metorial/presenters/src/implementation/organization/auditLogRetention.ts
@@ -1,0 +1,22 @@
+import { v } from '@lowerdeck/validation';
+import { Presenter } from '@metorial/presenter';
+import { organizationAuditLogRetentionType } from '../../types';
+
+export let v1OrganizationAuditLogRetentionPresenter = Presenter.create(
+  organizationAuditLogRetentionType
+)
+  .presenter(async ({ organization }) => ({
+    object: 'organization.audit_log_retention_configuration' as const,
+    organization_id: organization.id,
+    audit_log_retention_in_days: organization.auditLogRetentionInDays,
+    updated_at: organization.updatedAt
+  }))
+  .schema(
+    v.object({
+      object: v.literal('organization.audit_log_retention_configuration'),
+      organization_id: v.string(),
+      audit_log_retention_in_days: v.nullable(v.number()),
+      updated_at: v.date()
+    })
+  )
+  .build();

--- a/src/metorial/products/auditing/modules/audit-log/package.json
+++ b/src/metorial/products/auditing/modules/audit-log/package.json
@@ -13,7 +13,11 @@
     "@lowerdeck/pagination": "workspace:2.0.0",
     "@lowerdeck/service": "workspace:2.0.0",
     "@metorial/audit-models": "workspace:*",
-    "@metorial/db": "^1.0.0"
+    "@metorial/audit-scope": "workspace:*",
+    "@metorial/db": "^1.0.0",
+    "@metorial/fabric": "^1.0.0",
+    "@metorial/queue": "^1.0.0",
+    "@metorial/cron": "^1.0.0"
   },
   "devDependencies": {
     "@metorial/tsconfig": "^1.0.0",

--- a/src/metorial/products/auditing/modules/audit-log/src/index.ts
+++ b/src/metorial/products/auditing/modules/audit-log/src/index.ts
@@ -1,1 +1,7 @@
+import { combineQueueProcessors } from '@metorial/queue';
+import { auditLogCleanupQueueProcessor } from './queues';
+
+export * from './queues';
 export * from './services';
+
+export let auditLogQueueProcessor = combineQueueProcessors([auditLogCleanupQueueProcessor]);

--- a/src/metorial/products/auditing/modules/audit-log/src/queues/cleanup.test.ts
+++ b/src/metorial/products/auditing/modules/audit-log/src/queues/cleanup.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@metorial/audit-models', () => ({
+  deleteAuditEventsBefore: vi.fn()
+}));
+
+vi.mock('@metorial/cron', () => ({
+  createCron: vi.fn((_config, handler) => ({ handler }))
+}));
+
+vi.mock('@metorial/db', () => {
+  let db = {
+    organization: { findMany: vi.fn(), findUnique: vi.fn() },
+    auditLog: { deleteMany: vi.fn() },
+    event: { deleteMany: vi.fn() }
+  };
+  return {
+    db,
+    withTransaction: vi.fn(async callback => callback(db))
+  };
+});
+
+vi.mock('@metorial/queue', () => ({
+  createQueue: vi.fn(config => ({
+    name: config.name,
+    add: vi.fn(),
+    addMany: vi.fn(),
+    process: vi.fn(handler => ({ handler }))
+  })),
+  combineQueueProcessors: vi.fn(processors => processors),
+  QueueRetryError: class QueueRetryError extends Error {}
+}));
+
+import { deleteAuditEventsBefore } from '@metorial/audit-models';
+import { db } from '@metorial/db';
+import {
+  cleanupAuditLogOrganizationsQueue,
+  cleanupAuditLogOrganizationsQueueProcessor,
+  cleanupOrganizationAuditLogsQueue,
+  cleanupOrganizationAuditLogsQueueProcessor
+} from './cleanup';
+
+describe('audit log cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T00:00:00.000Z'));
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('fans out only initialized organizations', async () => {
+    vi.mocked(db.organization.findMany).mockResolvedValue([
+      { id: 'org-1' },
+      { id: 'org-2' }
+    ] as any);
+
+    await (cleanupAuditLogOrganizationsQueueProcessor as any).handler({});
+
+    expect(db.organization.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ auditLogRetentionInDays: { not: null } })
+      })
+    );
+    expect(cleanupOrganizationAuditLogsQueue.addMany).toHaveBeenCalledWith([
+      { organizationId: 'org-1' },
+      { organizationId: 'org-2' }
+    ]);
+    expect(cleanupAuditLogOrganizationsQueue.add).toHaveBeenCalledWith({
+      cursor: 'org-2'
+    });
+  });
+
+  it('deletes expired Postgres indexes and Mongo payloads for one organization', async () => {
+    vi.mocked(db.organization.findUnique).mockResolvedValue({
+      oid: 10n,
+      auditLogRetentionInDays: 30
+    } as any);
+
+    await (cleanupOrganizationAuditLogsQueueProcessor as any).handler({
+      organizationId: 'org-1'
+    });
+
+    let recordedAt = new Date('2026-07-29T00:00:00.000Z');
+    let where = { organizationOid: 10n, recordedAt: { lt: recordedAt } };
+    expect(db.auditLog.deleteMany).toHaveBeenCalledWith({ where });
+    expect(db.event.deleteMany).toHaveBeenCalledWith({ where });
+    expect(deleteAuditEventsBefore).toHaveBeenCalledWith({
+      organizationOid: 10n,
+      recordedAt
+    });
+  });
+
+  it('skips organizations awaiting reconciliation', async () => {
+    vi.mocked(db.organization.findUnique).mockResolvedValue({
+      oid: 10n,
+      auditLogRetentionInDays: null
+    } as any);
+
+    await (cleanupOrganizationAuditLogsQueueProcessor as any).handler({
+      organizationId: 'org-1'
+    });
+
+    expect(db.auditLog.deleteMany).not.toHaveBeenCalled();
+    expect(deleteAuditEventsBefore).not.toHaveBeenCalled();
+  });
+});

--- a/src/metorial/products/auditing/modules/audit-log/src/queues/cleanup.ts
+++ b/src/metorial/products/auditing/modules/audit-log/src/queues/cleanup.ts
@@ -1,0 +1,81 @@
+import { deleteAuditEventsBefore } from '@metorial/audit-models';
+import { createCron } from '@metorial/cron';
+import { db, withTransaction } from '@metorial/db';
+import { combineQueueProcessors, createQueue, QueueRetryError } from '@metorial/queue';
+
+export let AUDIT_LOG_CLEANUP_BATCH_SIZE = 100;
+
+export let cleanupAuditLogsCron = createCron(
+  {
+    name: 'audit/log/cleanup/cron',
+    cron: '0 4 * * *'
+  },
+  async () => {
+    await cleanupAuditLogOrganizationsQueue.add({}, { id: 'audit-log-cleanup-organizations' });
+  }
+);
+
+export let cleanupAuditLogOrganizationsQueue = createQueue<{ cursor?: string }>({
+  name: 'audit/log/cleanup/organizations'
+});
+
+export let cleanupAuditLogOrganizationsQueueProcessor =
+  cleanupAuditLogOrganizationsQueue.process(async data => {
+    let organizations = await db.organization.findMany({
+      where: {
+        status: 'active',
+        auditLogRetentionInDays: { not: null },
+        id: data.cursor ? { gt: data.cursor } : undefined
+      },
+      orderBy: { id: 'asc' },
+      take: AUDIT_LOG_CLEANUP_BATCH_SIZE,
+      select: { id: true }
+    });
+    if (organizations.length === 0) return;
+
+    await cleanupOrganizationAuditLogsQueue.addMany(
+      organizations.map(organization => ({ organizationId: organization.id }))
+    );
+
+    let lastOrganization = organizations.at(-1);
+    if (lastOrganization) {
+      await cleanupAuditLogOrganizationsQueue.add({ cursor: lastOrganization.id });
+    }
+  });
+
+export let cleanupOrganizationAuditLogsQueue = createQueue<{ organizationId: string }>({
+  name: 'audit/log/cleanup/organization',
+  workerOpts: { concurrency: 5 }
+});
+
+export let cleanupOrganizationAuditLogsQueueProcessor =
+  cleanupOrganizationAuditLogsQueue.process(async data => {
+    let organization = await db.organization.findUnique({
+      where: { id: data.organizationId },
+      select: { oid: true, auditLogRetentionInDays: true }
+    });
+    if (!organization) throw new QueueRetryError();
+    if (organization.auditLogRetentionInDays == null) return;
+
+    let cutoffMs = Date.now() - organization.auditLogRetentionInDays * 24 * 60 * 60 * 1000;
+    if (!Number.isFinite(cutoffMs) || cutoffMs <= 0) return;
+
+    let recordedAt = new Date(cutoffMs);
+
+    await withTransaction(async tx => {
+      await tx.auditLog.deleteMany({
+        where: { organizationOid: organization.oid, recordedAt: { lt: recordedAt } }
+      });
+      await tx.event.deleteMany({
+        where: { organizationOid: organization.oid, recordedAt: { lt: recordedAt } }
+      });
+    });
+
+    await deleteAuditEventsBefore({ organizationOid: organization.oid, recordedAt });
+  });
+
+export let auditLogCleanupQueueProcessor = combineQueueProcessors([
+  cleanupAuditLogsCron,
+  cleanupAuditLogOrganizationsQueueProcessor,
+  cleanupOrganizationAuditLogsQueueProcessor
+]);

--- a/src/metorial/products/auditing/modules/audit-log/src/queues/index.ts
+++ b/src/metorial/products/auditing/modules/audit-log/src/queues/index.ts
@@ -1,0 +1,1 @@
+export * from './cleanup';

--- a/src/metorial/products/auditing/modules/audit-log/src/services/auditLogRetention.test.ts
+++ b/src/metorial/products/auditing/modules/audit-log/src/services/auditLogRetention.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { fire, updateOrganization } = vi.hoisted(() => ({
+  fire: vi.fn(),
+  updateOrganization: vi.fn()
+}));
+
+vi.mock('@metorial/db', () => ({
+  withTransaction: vi.fn(async callback =>
+    callback({ organization: { update: updateOrganization } })
+  )
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: { fire }
+}));
+
+import { auditLogRetentionService } from './auditLogRetention';
+
+let organization = {
+  oid: 1n,
+  id: 'org-1',
+  status: 'active',
+  auditLogRetentionInDays: 90
+} as any;
+
+describe('auditLogRetentionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateOrganization.mockResolvedValue({
+      ...organization,
+      auditLogRetentionInDays: 30
+    });
+  });
+
+  it('returns the active organization configuration', async () => {
+    await expect(
+      auditLogRetentionService.getAuditLogRetention({ organization })
+    ).resolves.toBe(organization);
+  });
+
+  it('fires Fabric hooks around the transactional update', async () => {
+    let auditScope = {} as any;
+
+    let result = await auditLogRetentionService.updateAuditLogRetention({
+      organization,
+      auditScope,
+      input: { auditLogRetentionInDays: 30 }
+    });
+
+    expect(fire).toHaveBeenNthCalledWith(
+      1,
+      'organization.audit_log_retention.updated:before',
+      { organization, auditScope, input: { auditLogRetentionInDays: 30 } }
+    );
+    expect(updateOrganization).toHaveBeenCalledWith({
+      where: { oid: 1n },
+      data: { auditLogRetentionInDays: 30 }
+    });
+    expect(fire).toHaveBeenNthCalledWith(
+      2,
+      'organization.audit_log_retention.updated:after',
+      expect.objectContaining({
+        previousOrganization: organization,
+        organization: result,
+        auditScope
+      })
+    );
+  });
+
+  it('does not write when the before hook rejects', async () => {
+    fire.mockRejectedValueOnce(new Error('plan limit'));
+
+    await expect(
+      auditLogRetentionService.updateAuditLogRetention({
+        organization,
+        auditScope: {} as any,
+        input: { auditLogRetentionInDays: 120 }
+      })
+    ).rejects.toThrow('plan limit');
+
+    expect(updateOrganization).not.toHaveBeenCalled();
+  });
+});

--- a/src/metorial/products/auditing/modules/audit-log/src/services/auditLogRetention.ts
+++ b/src/metorial/products/auditing/modules/audit-log/src/services/auditLogRetention.ts
@@ -1,0 +1,52 @@
+import { forbiddenError, ServiceError } from '@lowerdeck/error';
+import { Service } from '@lowerdeck/service';
+import type { AuditScope } from '@metorial/audit-scope';
+import { Organization, withTransaction } from '@metorial/db';
+import { Fabric } from '@metorial/fabric';
+
+class AuditLogRetentionService {
+  private ensureOrganizationActive(organization: Organization) {
+    if (organization.status !== 'active') {
+      throw new ServiceError(
+        forbiddenError({ message: 'Cannot perform this action on a deleted organization' })
+      );
+    }
+  }
+
+  async getAuditLogRetention(d: { organization: Organization }) {
+    this.ensureOrganizationActive(d.organization);
+
+    return d.organization;
+  }
+
+  async updateAuditLogRetention(d: {
+    organization: Organization;
+    auditScope: AuditScope;
+    input: { auditLogRetentionInDays: number };
+  }) {
+    this.ensureOrganizationActive(d.organization);
+
+    return await withTransaction(async db => {
+      await Fabric.fire('organization.audit_log_retention.updated:before', d);
+
+      let organization = await db.organization.update({
+        where: { oid: d.organization.oid },
+        data: { auditLogRetentionInDays: d.input.auditLogRetentionInDays }
+      });
+
+      await Fabric.fire('organization.audit_log_retention.updated:after', {
+        organization,
+        previousOrganization: d.organization,
+        auditScope: d.auditScope,
+        input: d.input
+      });
+
+      return organization;
+    });
+  }
+}
+
+export let auditLogRetentionService = Service.create(
+  'auditLogRetentionService',
+  () => new AuditLogRetentionService()
+).build();

--- a/src/metorial/products/auditing/modules/audit-log/src/services/index.ts
+++ b/src/metorial/products/auditing/modules/audit-log/src/services/index.ts
@@ -1,1 +1,2 @@
 export * from './auditLog';
+export * from './auditLogRetention';

--- a/src/metorial/products/auditing/packages/audit-listeners/src/auditLogRetention.ts
+++ b/src/metorial/products/auditing/packages/audit-listeners/src/auditLogRetention.ts
@@ -1,0 +1,20 @@
+import { Fabric, type FabricEvents } from '@metorial/fabric';
+import { auditTrackerService } from '@metorial/module-audit-tracker';
+import { recordAuditEventAfterCommit } from './record';
+
+export let recordAuditLogRetentionUpdated = async (
+  event: FabricEvents['organization.audit_log_retention.updated:after']
+) => {
+  await recordAuditEventAfterCommit(async recordedAt => {
+    await auditTrackerService.recordEvent(event.auditScope, 'audit_log_retention', 'update', {
+      payload: { organization: event.organization },
+      previousPayload: { organization: event.previousOrganization },
+      recordedAt
+    });
+  });
+};
+
+Fabric.listen(
+  'organization.audit_log_retention.updated:after',
+  recordAuditLogRetentionUpdated
+);

--- a/src/metorial/products/auditing/packages/audit-listeners/src/index.ts
+++ b/src/metorial/products/auditing/packages/audit-listeners/src/index.ts
@@ -12,3 +12,4 @@ export * from './apiKey';
 export * from './oauth';
 export * from './serviceAccount';
 export * from './auditLogStream';
+export * from './auditLogRetention';

--- a/src/metorial/products/auditing/packages/audit-listeners/src/projectSettings.ts
+++ b/src/metorial/products/auditing/packages/audit-listeners/src/projectSettings.ts
@@ -138,6 +138,33 @@ export let recordProjectBrandUpdated = async (
   });
 };
 
+export let recordProjectDataRetentionUpdated = async (
+  event: FabricEvents['organization.project.data_retention_configuration.updated:after']
+) => {
+  await recordAuditEventAfterCommit(async recordedAt => {
+    await auditTrackerService.recordEvent(
+      event.auditScope,
+      'project_data_retention_configuration',
+      'update',
+      {
+        payload: {
+          project: event.project,
+          dataRetentionLevel: event.configuration.dataRetentionLevel,
+          storeToolCallAttachments: event.configuration.storeToolCallAttachments,
+          collectErrors: event.configuration.collectErrors
+        },
+        previousPayload: {
+          project: event.project,
+          dataRetentionLevel: event.previousConfiguration.dataRetentionLevel,
+          storeToolCallAttachments: event.previousConfiguration.storeToolCallAttachments,
+          collectErrors: event.previousConfiguration.collectErrors
+        },
+        recordedAt
+      }
+    );
+  });
+};
+
 Fabric.listen('organization.project.retention.updated:after', recordProjectRetentionUpdated);
 Fabric.listen(
   'organization.project.skill_sync_configuration.updated:after',
@@ -154,5 +181,9 @@ Fabric.listen(
 Fabric.listen(
   'organization.project.tool_calling_configuration.updated:after',
   recordProjectToolCallingUpdated
+);
+Fabric.listen(
+  'organization.project.data_retention_configuration.updated:after',
+  recordProjectDataRetentionUpdated
 );
 Fabric.listen('organization.project.brand.updated:after', recordProjectBrandUpdated);

--- a/src/metorial/products/auditing/packages/audit-models/src/index.ts
+++ b/src/metorial/products/auditing/packages/audit-models/src/index.ts
@@ -2,6 +2,7 @@ export { dbConnect, isAuditDbEnabled } from './connection';
 export {
   AuditEventModel,
   AuditEventSchema,
+  deleteAuditEventsBefore,
   getAuditEventsByIds,
   ingestAuditEvent,
   type AuditEvent,

--- a/src/metorial/products/auditing/packages/audit-models/src/models/auditEvent.ts
+++ b/src/metorial/products/auditing/packages/audit-models/src/models/auditEvent.ts
@@ -135,3 +135,17 @@ export let getAuditEventsByIds = async (eventIds: string[]): Promise<AuditEvent[
     .lean()
     .exec();
 };
+
+export let deleteAuditEventsBefore = async (d: {
+  organizationOid: bigint | string | number;
+  recordedAt: Date;
+}) => {
+  if (!isAuditDbEnabled()) return;
+
+  await dbConnect();
+
+  await AuditEventModel.deleteMany({
+    organizationOid: toOidString(d.organizationOid),
+    recordedAt: { $lt: d.recordedAt }
+  }).exec();
+};

--- a/src/metorial/products/auditing/packages/audit-schema/src/resources/organization/auditLogRetention.ts
+++ b/src/metorial/products/auditing/packages/audit-schema/src/resources/organization/auditLogRetention.ts
@@ -1,0 +1,15 @@
+import { v } from '@lowerdeck/validation';
+import { Organization } from '@metorial/db';
+import { organizationAuditLogRetentionPresenter } from '@metorial/presenters';
+import { resource } from '../../_lib/resource';
+
+export let auditLogRetentionResource = resource({
+  name: 'audit_log_retention',
+  payload: v.typedAny<{
+    organization: Organization;
+  }>('audit_log_retention'),
+  presenter: organizationAuditLogRetentionPresenter,
+  actions: {
+    update: true
+  }
+});

--- a/src/metorial/products/auditing/packages/audit-schema/src/resources/organization/index.ts
+++ b/src/metorial/products/auditing/packages/audit-schema/src/resources/organization/index.ts
@@ -10,12 +10,14 @@ import { organizationMemberResource } from './member';
 import {
   projectAuthConfigConfigurationResource,
   projectBrandResource,
+  projectDataRetentionConfigurationResource,
   projectIntegrationNamingConfigurationResource,
   projectRetentionResource,
   projectSkillSyncConfigurationResource,
   projectToolCallingConfigurationResource
 } from './projectSettings';
 import { auditLogStreamResource } from './auditLogStream';
+import { auditLogRetentionResource } from './auditLogRetention';
 import { teamMemberResource, teamResource } from './team';
 
 export let organizationResources = resourceSet({
@@ -23,6 +25,7 @@ export let organizationResources = resourceSet({
   organization_member: organizationMemberResource,
   organization_invite: organizationInviteResource,
   audit_log_stream: auditLogStreamResource,
+  audit_log_retention: auditLogRetentionResource,
   team: teamResource,
   team_member: teamMemberResource,
   access_role: accessRoleResource,
@@ -33,5 +36,6 @@ export let organizationResources = resourceSet({
   project_auth_config_configuration: projectAuthConfigConfigurationResource,
   project_integration_naming_configuration: projectIntegrationNamingConfigurationResource,
   project_skill_sync_configuration: projectSkillSyncConfigurationResource,
-  project_tool_calling_configuration: projectToolCallingConfigurationResource
+  project_tool_calling_configuration: projectToolCallingConfigurationResource,
+  project_data_retention_configuration: projectDataRetentionConfigurationResource
 });

--- a/src/metorial/products/auditing/packages/audit-schema/src/resources/organization/projectSettings.ts
+++ b/src/metorial/products/auditing/packages/audit-schema/src/resources/organization/projectSettings.ts
@@ -4,6 +4,7 @@ import type { ProjectBrandOverride } from '@metorial/module-organization';
 import {
   projectAuthConfigConfigurationPresenter,
   projectBrandPresenter,
+  projectDataRetentionConfigurationPresenter,
   projectIntegrationNamingConfigurationPresenter,
   projectRetentionPresenter,
   projectSkillSyncConfigurationPresenter,
@@ -79,6 +80,20 @@ export let projectToolCallingConfigurationResource = resource({
     messageProcessingTimeoutMs: number;
   }>('project_tool_calling_configuration'),
   presenter: projectToolCallingConfigurationPresenter,
+  actions: {
+    update: true
+  }
+});
+
+export let projectDataRetentionConfigurationResource = resource({
+  name: 'project_data_retention_configuration',
+  payload: v.typedAny<{
+    project: Project;
+    dataRetentionLevel: 'full' | 'intent_only' | 'none';
+    storeToolCallAttachments: boolean;
+    collectErrors: boolean;
+  }>('project_data_retention_configuration'),
+  presenter: projectDataRetentionConfigurationPresenter,
   actions: {
     update: true
   }

--- a/src/metorial/services/api/package.json
+++ b/src/metorial/services/api/package.json
@@ -30,6 +30,7 @@
     "@metorial/logging": "1.0.0",
     "@metorial/module-access": "1.0.0",
     "@metorial/module-audit-log-stream": "1.0.0",
+    "@metorial/module-audit-log": "1.0.0",
     "@metorial/module-audit-tracker": "1.0.0",
     "@metorial/module-email": "1.0.0",
     "@metorial/module-consumer-access": "1.0.0",

--- a/src/metorial/services/api/src/worker.ts
+++ b/src/metorial/services/api/src/worker.ts
@@ -7,6 +7,7 @@ import { fileQueueProcessor as cargoFileQueueProcessor } from '@metorial/module-
 import { storeQueueProcessor as cargoStoreQueueProcessor } from '@metorial/module-store';
 import { accessQueueProcessor } from '@metorial/module-access';
 import { auditLogStreamQueueProcessor } from '@metorial/module-audit-log-stream';
+import { auditLogQueueProcessor } from '@metorial/module-audit-log';
 import { auditTrackerQueueProcessor } from '@metorial/module-audit-tracker';
 import { communityQueueProcessor } from '@metorial/module-community';
 import { consumerAccessQueueProcessor } from '@metorial/module-consumer-access';
@@ -32,6 +33,7 @@ import { multiRegionQueueProcessor } from '@metorial/multi-region';
 
 export let worker = runQueueProcessors([
   auditTrackerQueueProcessor,
+  auditLogQueueProcessor,
   auditLogStreamQueueProcessor,
   productAssistantQueueProcessor,
   userQueueProcessor,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Scheduled jobs permanently delete audit data across Postgres and Mongo; misconfiguration or bugs could cause compliance loss or over-deletion.
> 
> **Overview**
> Adds **per-organization audit log retention**: organizations can store `audit_log_retention_in_days`, and dashboard **GET/PATCH** routes expose and update that setting via `auditLogRetentionService` (scoped reads/writes, validated day count).
> 
> Retention changes emit Fabric hooks, are recorded as audit events (`audit_log_retention`), and register in the audit schema. A **daily cleanup pipeline** (cron → batched org fan-out → per-org workers) deletes records older than the configured window from Postgres `auditLog`/`event` indexes and from Mongo audit payloads via new `deleteAuditEventsBefore`. The API worker loads `auditLogQueueProcessor` so cleanup runs in production.
> 
> Also wires audit tracking for **project data retention configuration** updates (schema resource + Fabric listener), separate from org-level audit log retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a06d0a8a7216d568db90c970c48a0d42b80344c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->