### PR TITLE
Harden zdr for attachments

### DIFF
--- a/src/metorial/subspace/modules/connection/src/shared/completeMessage.test.ts
+++ b/src/metorial/subspace/modules/connection/src/shared/completeMessage.test.ts
@@ -289,4 +289,104 @@ describe('completeMessage', () => {
     expect(mocks.db.sessionEvent.createMany).not.toHaveBeenCalled();
     expect(mocks.finalizeMessageQueue.add).not.toHaveBeenCalled();
   });
+
+  it('rehosts attachments and persists a ToolCallAttachment when storeToolCallAttachments is enabled', async () => {
+    let rawAttachment = { url: 'https://provider.example/raw-file', mimeType: 'image/png', expiresAt: null };
+    mocks.getRawToolCallAttachmentsFromOutput.mockReturnValueOnce([rawAttachment]);
+
+    let currentMessage = {
+      id: 'msg_attach_on',
+      oid: 4n,
+      session: { oid: 41n, dataRetentionLevel: 'full', storeToolCallAttachments: true, collectErrors: true },
+      connection: { oid: 42n },
+      toolCall: { oid: 43n }
+    };
+    let completedMessage = {
+      id: 'msg_attach_on',
+      oid: 4n,
+      status: 'succeeded',
+      toolCall: { oid: 43n, attachments: [] }
+    };
+    let tx = {
+      sessionMessage: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findFirstOrThrow: vi.fn().mockResolvedValue(completedMessage)
+      },
+      toolCall: {
+        updateMany: vi.fn()
+      },
+      toolCallAttachment: {
+        createMany: vi.fn()
+      }
+    };
+
+    mocks.db.sessionMessage.findFirstOrThrow.mockResolvedValue(currentMessage);
+    mocks.db.$transaction.mockImplementation(async cb => await cb(tx));
+
+    await completeMessage(
+      { messageId: 'msg_attach_on' },
+      {
+        status: 'succeeded',
+        responderParticipant: { oid: 99n } as any,
+        output: { type: 'tool.result', data: {} } as any
+      }
+    );
+
+    expect(mocks.replaceToolCallAttachmentsInOutput).toHaveBeenCalledWith(
+      { type: 'tool.result', data: {} },
+      [expect.objectContaining({ url: rawAttachment.url, toolCallOid: 43n })]
+    );
+    expect(tx.toolCallAttachment.createMany).toHaveBeenCalledWith({
+      data: [expect.objectContaining({ url: rawAttachment.url, toolCallOid: 43n })]
+    });
+  });
+
+  it('strips $attachments and skips persisting a ToolCallAttachment when storeToolCallAttachments is disabled', async () => {
+    let rawAttachment = { url: 'https://provider.example/raw-file', mimeType: 'image/png', expiresAt: null };
+    mocks.getRawToolCallAttachmentsFromOutput.mockReturnValueOnce([rawAttachment]);
+
+    let currentMessage = {
+      id: 'msg_attach_off',
+      oid: 5n,
+      session: { oid: 51n, dataRetentionLevel: 'full', storeToolCallAttachments: false, collectErrors: true },
+      connection: { oid: 52n },
+      toolCall: { oid: 53n }
+    };
+    let completedMessage = {
+      id: 'msg_attach_off',
+      oid: 5n,
+      status: 'succeeded',
+      toolCall: { oid: 53n, attachments: [] }
+    };
+    let tx = {
+      sessionMessage: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findFirstOrThrow: vi.fn().mockResolvedValue(completedMessage)
+      },
+      toolCall: {
+        updateMany: vi.fn()
+      },
+      toolCallAttachment: {
+        createMany: vi.fn()
+      }
+    };
+
+    mocks.db.sessionMessage.findFirstOrThrow.mockResolvedValue(currentMessage);
+    mocks.db.$transaction.mockImplementation(async cb => await cb(tx));
+
+    await completeMessage(
+      { messageId: 'msg_attach_off' },
+      {
+        status: 'succeeded',
+        responderParticipant: { oid: 99n } as any,
+        output: { type: 'tool.result', data: {} } as any
+      }
+    );
+
+    expect(mocks.replaceToolCallAttachmentsInOutput).toHaveBeenCalledWith(
+      { type: 'tool.result', data: {} },
+      []
+    );
+    expect(tx.toolCallAttachment.createMany).not.toHaveBeenCalled();
+  });
 });

--- a/src/metorial/subspace/modules/connection/src/shared/completeMessage.ts
+++ b/src/metorial/subspace/modules/connection/src/shared/completeMessage.ts
@@ -56,25 +56,24 @@ export let completeMessage = async (
 
   let currentToolCall = currentMessage.toolCall;
 
-  let toolCallAttachments =
-    currentToolCall &&
-    data.output?.type === 'tool.result' &&
-    retention.storeToolCallAttachments
+  let rawToolCallAttachments =
+    currentToolCall && data.output?.type === 'tool.result'
       ? getRawToolCallAttachmentsFromOutput(data.output)
       : [];
 
-  let toolCallAttachmentRecords = currentToolCall
-    ? toolCallAttachments.map(attachment => ({
-        ...getId('toolCallAttachment'),
-        urlKey: generateCustomId('tca_link_', 50),
-        url: attachment.url,
-        mimeType: attachment.mimeType,
-        expiresAt: attachment.expiresAt,
-        toolCallOid: currentToolCall.oid
-      }))
-    : [];
+  let toolCallAttachmentRecords =
+    currentToolCall && retention.storeToolCallAttachments
+      ? rawToolCallAttachments.map(attachment => ({
+          ...getId('toolCallAttachment'),
+          urlKey: generateCustomId('tca_link_', 50),
+          url: attachment.url,
+          mimeType: attachment.mimeType,
+          expiresAt: attachment.expiresAt,
+          toolCallOid: currentToolCall.oid
+        }))
+      : [];
 
-  if (toolCallAttachmentRecords.length && data.output?.type === 'tool.result') {
+  if (rawToolCallAttachments.length && data.output?.type === 'tool.result') {
     data.output = replaceToolCallAttachmentsInOutput(
       data.output,
       toolCallAttachmentRecords.map(presentToolCallAttachment)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes message completion and what gets written into tool-result output under retention settings, which affects data handling for sessions with attachments disabled.
> 
> **Overview**
> **Hardens zero-data-retention behavior for tool-call attachments** in `completeMessage` by separating *reading* attachments from the provider output from *persisting* them.
> 
> Raw attachments are now extracted for every successful `tool.result` when the message has a tool call, but `ToolCallAttachment` rows are only built when `storeToolCallAttachments` is on. **`replaceToolCallAttachmentsInOutput` always runs when raw attachments exist**: with rehosted records when storage is enabled, or with an **empty list** when it is disabled so provider `$attachments` are not left on the output without being stored.
> 
> Two unit tests cover the enabled path (replace + `createMany`) and the disabled path (replace with `[]`, no `createMany`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3074559418e9abe11c84c5ad371a81648651ae26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->