### PR TITLE
Add native horizon auth

### DIFF
--- a/src/ares/service/frontend/admin/src/pages/apps/page.tsx
+++ b/src/ares/service/frontend/admin/src/pages/apps/page.tsx
@@ -120,11 +120,12 @@ export let AppsPage = () => {
       </div>
 
       <Table
-        headers={['Client ID', 'Slug', 'Users', 'Tenants', 'Created At', '']}
+        headers={['Client ID', 'Slug', 'Mode', 'Users', 'Tenants', 'Created At', '']}
         data={apps.data.items.map((app: any) => ({
           data: [
             app.clientId,
             app.slug ?? '-',
+            app.mode === 'horizon' ? 'Horizon' : 'Standard',
             app.counts.users,
             app.counts.tenants,
             new Date(app.createdAt).toLocaleDateString('de-at'),

--- a/src/ares/service/frontend/auth/src/scenes/auth.tsx
+++ b/src/ares/service/frontend/auth/src/scenes/auth.tsx
@@ -1,22 +1,13 @@
-import { Error } from '@metorial-io/ui';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { AuthLayout } from '../components/layout';
 import { authState } from '../state/auth';
 import { AuthHomeScene } from './authHome';
 import { AuthIntentScene } from './authIntent';
 
 export let AuthScene = ({ type }: { type: 'login' | 'signup' | 'switch' }) => {
   let [searchParams] = useSearchParams();
-  let clientId = searchParams.get('client_id');
 
-  if (!clientId) {
-    return (
-      <AuthLayout>
-        <Error>Missing required parameter: client_id</Error>
-      </AuthLayout>
-    );
-  }
+  let clientId = searchParams.get('client_id');
 
   let auth = authState.use({ clientId });
 

--- a/src/ares/service/frontend/auth/src/scenes/authHome.tsx
+++ b/src/ares/service/frontend/auth/src/scenes/authHome.tsx
@@ -66,7 +66,7 @@ export let AuthHomeScene = ({
 
   setAuthIntent
 }: {
-  clientId: string;
+  clientId: string | null;
   email: string | undefined;
   type: 'login' | 'signup' | 'switch';
   nextUrl: string;
@@ -76,6 +76,15 @@ export let AuthHomeScene = ({
   setAuthIntent?: (d: { authIntentId: string; authIntentClientSecret: string }) => void;
 }) => {
   let auth = authState.use({ clientId });
+
+  let resolvedClientId = clientId ?? undefined;
+
+  let crossLinkQuery = (target: string) => {
+    let params = new URLSearchParams();
+    if (clientId) params.set('client_id', clientId);
+    params.set('nextUrl', nextUrl);
+    return `${target}?${params.toString()}`;
+  };
   let startAuthentication = useMutation(auth.mutators.start);
   let selectUserAuthentication = useUserSelect();
 
@@ -122,7 +131,7 @@ export let AuthHomeScene = ({
 
       let [res] = await startAuthentication.mutate({
         type: 'email',
-        clientId,
+        clientId: resolvedClientId,
         email: values.email,
         redirectUrl: nextUrl,
         captchaToken: nextCaptchaToken
@@ -154,7 +163,7 @@ export let AuthHomeScene = ({
     }
 
     selectUserAuthentication
-      .mutate({ clientId, email: debouncedEmail })
+      .mutate({ clientId: resolvedClientId, email: debouncedEmail })
       .then(([selection]) => {
         if (request === userSelectionRequest.current && selection) {
           setUserSelection(selection);
@@ -182,7 +191,7 @@ export let AuthHomeScene = ({
     startAuthentication
       .mutate({
         type: 'session',
-        clientId,
+        clientId: resolvedClientId,
         userOrSessionId: sessionOrUserIdToLogInWith,
         redirectUrl: nextUrl
       })
@@ -245,8 +254,7 @@ export let AuthHomeScene = ({
   let userSelectionSupportsSso =
     userSelection?.options.some(option => option.type === 'sso') ?? false;
   let activeUserSelection =
-    userSelectionMatchesEmail ||
-    (resemblesEmail(normalizedEmail) && userSelectionSupportsSso)
+    userSelectionMatchesEmail || (resemblesEmail(normalizedEmail) && userSelectionSupportsSso)
       ? userSelection
       : null;
   let options = activeUserSelection?.options ?? auth.data?.options ?? [];
@@ -266,7 +274,8 @@ export let AuthHomeScene = ({
     setLoadingSource(`sso_${option.connectionId}`);
     startAuthentication.mutate({
       type: 'sso',
-      clientId: connectionSelection?.clientId ?? activeUserSelection?.clientId ?? clientId,
+      clientId:
+        connectionSelection?.clientId ?? activeUserSelection?.clientId ?? resolvedClientId,
       ssoTenantId: option.tenantId,
       ssoConnectionId: option.connectionId,
       email: connectionSelection?.email ?? form.values.email,
@@ -346,7 +355,7 @@ export let AuthHomeScene = ({
               <Text color="gray600" weight="medium" size="1">
                 {type == 'login' ? (
                   <Link
-                    to={`/signup?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}
+                    to={crossLinkQuery('/signup')}
                     style={{ color: 'inherit' }}
                     aria-disabled={startAuthentication.isLoading || form.isSubmitting}
                   >
@@ -355,7 +364,7 @@ export let AuthHomeScene = ({
                   </Link>
                 ) : (
                   <Link
-                    to={`/login?client_id=${encodeURIComponent(clientId)}&nextUrl=${encodeURIComponent(nextUrl)}`}
+                    to={crossLinkQuery('/login')}
                     style={{ color: 'inherit' }}
                     aria-disabled={startAuthentication.isLoading || form.isSubmitting}
                   >
@@ -404,7 +413,7 @@ export let AuthHomeScene = ({
                   setLoadingSource(providerType);
                   startAuthentication.mutate({
                     type: 'oauth',
-                    clientId,
+                    clientId: resolvedClientId,
                     provider: providerType,
                     redirectUrl: nextUrl
                   });

--- a/src/ares/service/frontend/auth/src/state/auth.ts
+++ b/src/ares/service/frontend/auth/src/state/auth.ts
@@ -67,12 +67,12 @@ let handleStartResponse = async (
 
 export let authState = createLoader({
   name: 'auth',
-  hash: ai => `auth:${ai.clientId}`,
-  fetch: (d: { clientId: string }) => {
+  hash: ai => `auth:${ai.clientId ?? '@default'}`,
+  fetch: (d: { clientId: string | null }) => {
     if (typeof window === 'undefined')
       throw new Error('Cannot fetch authIntent on the server');
 
-    return authClient.authentication.boot({ clientId: d.clientId });
+    return authClient.authentication.boot({ clientId: d.clientId ?? undefined });
   },
   mutators: {
     start: async (data: AuthStartInput) => {

--- a/src/ares/service/prisma/schema/app/app.prisma
+++ b/src/ares/service/prisma/schema/app/app.prisma
@@ -1,9 +1,16 @@
+enum AppMode {
+  standard
+  horizon
+}
+
 model App {
   oid BigInt @id
   id  String @unique
 
   clientId String  @unique
   slug     String? @unique
+
+  mode AppMode @default(standard)
 
   hasTerms Boolean @default(true)
 
@@ -41,7 +48,7 @@ model SyncListener {
   oid BigInt @id
   id  String @unique
 
-  identifier String @unique
+  identifier  String   @unique
   callbackUrl String
   secret      String
   eventTypes  String[] @default(["user.changed"])

--- a/src/ares/service/src/apis/admin/presenters/app.ts
+++ b/src/ares/service/src/apis/admin/presenters/app.ts
@@ -12,6 +12,7 @@ export let appPresenter = (
   clientId: app.clientId,
   slug: app.slug,
 
+  mode: app.mode,
   hasTerms: app.hasTerms,
   isSessionless: app.isSessionless,
   disableEmailAuth: app.disableEmailAuth,

--- a/src/ares/service/src/apis/auth/controllers/auth.ts
+++ b/src/ares/service/src/apis/auth/controllers/auth.ts
@@ -2,12 +2,12 @@ import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { v } from '@lowerdeck/validation';
 import { env } from '../../../env';
 import { getAccountSsoClientId } from '../../../lib/accountPolicy';
+import { resolveAppRedirectUrl } from '../../../lib/appRedirect';
 import { tickets } from '../../../lib/tickets';
-import { validateRedirectUrl } from '../../../lib/validateRedirectUrl';
 import { authService } from '../../../services/auth';
 import { deviceService } from '../../../services/device';
 import { publicApp } from '../_app';
-import { resolveClient } from '../lib/resolveApp';
+import { resolveClientOrDefault } from '../lib/resolveApp';
 import { deviceApp } from '../middleware/device';
 import { authAttemptPresenter, authIntentPresenter, deviceUserPresenter } from '../presenters';
 
@@ -16,11 +16,11 @@ export let authenticationController = publicApp.controller({
     .handler()
     .input(
       v.object({
-        clientId: v.string()
+        clientId: v.optional(v.string())
       })
     )
     .do(async ({ device, input }) => {
-      let { app, account } = await resolveClient(input.clientId);
+      let { app, account } = await resolveClientOrDefault(input.clientId);
 
       let users = await deviceService.getLoggedInAndLoggedOutUsersForDevice({
         device,
@@ -34,7 +34,7 @@ export let authenticationController = publicApp.controller({
         options,
         client: {
           type: account ? ('account' as const) : ('app' as const),
-          clientId: input.clientId,
+          clientId: account?.clientId ?? app.clientId,
           account: account
             ? {
                 id: account.id,
@@ -63,12 +63,12 @@ export let authenticationController = publicApp.controller({
     .handler()
     .input(
       v.object({
-        clientId: v.string(),
+        clientId: v.optional(v.string()),
         email: v.string({ modifiers: [v.maxLength(320)] })
       })
     )
     .do(async ({ input }) => {
-      let { app, account: clientAccount } = await resolveClient(input.clientId);
+      let { app, account: clientAccount } = await resolveClientOrDefault(input.clientId);
       let { options, account } = await authService.getUserAuthOptions({
         app,
         account: clientAccount,
@@ -78,7 +78,10 @@ export let authenticationController = publicApp.controller({
       return {
         email: input.email.trim().toLowerCase(),
         options,
-        clientId: getAccountSsoClientId(input.clientId, account?.clientId),
+        clientId: getAccountSsoClientId(
+          clientAccount?.clientId ?? app.clientId,
+          account?.clientId
+        ),
         account: account
           ? {
               id: account.id,
@@ -97,20 +100,20 @@ export let authenticationController = publicApp.controller({
       v.union([
         v.object({
           type: v.literal('email'),
-          clientId: v.string(),
+          clientId: v.optional(v.string()),
           email: v.string(),
           redirectUrl: v.string(),
           captchaToken: v.optional(v.string())
         }),
         v.object({
           type: v.literal('oauth'),
-          clientId: v.string(),
+          clientId: v.optional(v.string()),
           provider: v.enumOf(['google', 'github']),
           redirectUrl: v.string()
         }),
         v.object({
           type: v.literal('sso'),
-          clientId: v.string(),
+          clientId: v.optional(v.string()),
           ssoTenantId: v.string(),
           ssoConnectionId: v.optional(v.string()),
           email: v.optional(v.string()),
@@ -118,16 +121,20 @@ export let authenticationController = publicApp.controller({
         }),
         v.object({
           type: v.literal('session'),
-          clientId: v.string(),
+          clientId: v.optional(v.string()),
           userOrSessionId: v.string(),
           redirectUrl: v.string()
         })
       ])
     )
     .do(async ({ context, device, input }) => {
-      let { app, account } = await resolveClient(input.clientId);
+      let { app, account } = await resolveClientOrDefault(input.clientId);
+      let clientId = account?.clientId ?? app.clientId;
 
-      validateRedirectUrl(input.redirectUrl, app.redirectDomains);
+      let redirectUrl = resolveAppRedirectUrl({
+        app,
+        redirectUrl: input.redirectUrl
+      });
 
       if (input.type == 'email' || input.type == 'session') {
         let email = input.type == 'email' ? input.email : undefined;
@@ -157,7 +164,7 @@ export let authenticationController = publicApp.controller({
           },
           device,
           email,
-          redirectUrl: input.redirectUrl,
+          redirectUrl,
           captchaToken: input.type == 'email' ? input.captchaToken : undefined,
           app,
           account
@@ -168,18 +175,18 @@ export let authenticationController = publicApp.controller({
             type: 'hook' as const,
             url: `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso/${await tickets.encode({
               type: 'sso',
-              appClientId: getAccountSsoClientId(input.clientId, res.account?.clientId),
+              appClientId: getAccountSsoClientId(clientId, res.account?.clientId),
               deviceId: device.id,
               ssoTenantId: res.ssoTenant.id,
               ssoConnectionId: res.ssoConnection.id,
-              redirectUrl: input.redirectUrl,
+              redirectUrl,
               email: res.email
             })}`
           };
         } else if (res.type == 'selection') {
           return {
             type: 'selection' as const,
-            clientId: res.account?.clientId ?? input.clientId,
+            clientId: res.account?.clientId ?? clientId,
             email: res.email,
             account: res.account
               ? {
@@ -215,10 +222,10 @@ export let authenticationController = publicApp.controller({
           type: 'hook' as const,
           url: `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/oauth/${await tickets.encode({
             type: 'oauth',
-            appClientId: input.clientId,
+            appClientId: clientId,
             provider: input.provider,
             deviceId: device.id,
-            redirectUrl: input.redirectUrl
+            redirectUrl
           })}`
         };
       }
@@ -235,12 +242,12 @@ export let authenticationController = publicApp.controller({
           type: 'hook' as const,
           url: `${env.service.ARES_AUTH_URL}/metorial-ares/hooks/sso/${await tickets.encode({
             type: 'sso',
-            appClientId: input.clientId,
+            appClientId: clientId,
             deviceId: device.id,
             ssoTenantId: input.ssoTenantId,
             ssoConnectionId: connection?.id,
             email: input.email,
-            redirectUrl: input.redirectUrl
+            redirectUrl
           })}`
         };
       }

--- a/src/ares/service/src/apis/auth/lib/resolveApp.ts
+++ b/src/ares/service/src/apis/auth/lib/resolveApp.ts
@@ -1,4 +1,4 @@
-import { notFoundError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { db } from '../../../db';
 
 export let resolveClient = async (clientId: string) => {
@@ -24,4 +24,22 @@ export let resolveClient = async (clientId: string) => {
 
 export let resolveApp = async (clientId: string) => {
   return (await resolveClient(clientId)).app;
+};
+
+export let getHorizonApp = () =>
+  db.app.findFirst({ where: { mode: 'horizon' }, orderBy: { oid: 'desc' } });
+
+export let resolveClientOrDefault = async (clientId?: string | null) => {
+  if (clientId) return resolveClient(clientId);
+
+  let app = await getHorizonApp();
+  if (!app) {
+    throw new ServiceError(
+      badRequestError({
+        message: 'client_id is required: no default app is configured'
+      })
+    );
+  }
+
+  return { app, account: null };
 };

--- a/src/ares/service/src/apis/internal/controllers/app.ts
+++ b/src/ares/service/src/apis/internal/controllers/app.ts
@@ -34,7 +34,8 @@ export let appController = internalApp.controller({
         slug: v.optional(v.string()),
         redirectDomains: v.optional(v.array(v.string())),
         isSessionless: v.optional(v.boolean()),
-        disableEmailAuth: v.optional(v.boolean())
+        disableEmailAuth: v.optional(v.boolean()),
+        mode: v.optional(v.enumOf(['standard', 'horizon']))
       })
     )
     .do(async ({ input }) => {
@@ -50,7 +51,8 @@ export let appController = internalApp.controller({
         slug: v.string(),
         redirectDomains: v.optional(v.array(v.string())),
         isSessionless: v.optional(v.boolean()),
-        disableEmailAuth: v.optional(v.boolean())
+        disableEmailAuth: v.optional(v.boolean()),
+        mode: v.optional(v.enumOf(['standard', 'horizon']))
       })
     )
     .do(async ({ input }) => {
@@ -64,9 +66,11 @@ export let appController = internalApp.controller({
       v.object({
         id: v.string(),
         slug: v.optional(v.string()),
+        defaultRedirectUrl: v.optional(v.string()),
         redirectDomains: v.optional(v.array(v.string())),
         isSessionless: v.optional(v.boolean()),
-        disableEmailAuth: v.optional(v.boolean())
+        disableEmailAuth: v.optional(v.boolean()),
+        mode: v.optional(v.enumOf(['standard', 'horizon']))
       })
     )
     .do(async ({ input }) => {
@@ -75,9 +79,11 @@ export let appController = internalApp.controller({
         app,
         input: {
           slug: input.slug,
+          defaultRedirectUrl: input.defaultRedirectUrl,
           redirectDomains: input.redirectDomains,
           isSessionless: input.isSessionless,
-          disableEmailAuth: input.disableEmailAuth
+          disableEmailAuth: input.disableEmailAuth,
+          mode: input.mode
         }
       });
       return appPresenter(updated);

--- a/src/ares/service/src/apis/internal/controllers/oauth.ts
+++ b/src/ares/service/src/apis/internal/controllers/oauth.ts
@@ -34,7 +34,8 @@ export let oauthController = internalApp.controller({
 
       return {
         user: await userPresenter(res.user),
-        session: await sessionPresenter(res.session)
+        session: await sessionPresenter(res.session),
+        redirectUrl: res.authAttempt.redirectUrl
       };
     })
 });

--- a/src/ares/service/src/apis/internal/presenters/app.ts
+++ b/src/ares/service/src/apis/internal/presenters/app.ts
@@ -12,6 +12,7 @@ export let appPresenter = (
   clientId: app.clientId,
   slug: app.slug,
 
+  mode: app.mode,
   hasTerms: app.hasTerms,
   isSessionless: app.isSessionless,
   disableEmailAuth: app.disableEmailAuth,

--- a/src/ares/service/src/lib/appRedirect.test.ts
+++ b/src/ares/service/src/lib/appRedirect.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAppRedirectUrl, wrapHorizonRedirectUrl } from './appRedirect';
+
+let WRAPPER = 'https://horizon-sso.metorial.com/idp-callback';
+
+let horizonApp = {
+  mode: 'horizon' as const,
+  defaultRedirectUrl: WRAPPER,
+  redirectDomains: ['metorial.com', '*.metorial.com']
+};
+
+let standardApp = {
+  mode: 'standard' as const,
+  defaultRedirectUrl: 'https://app.metorial.com/callback',
+  redirectDomains: ['metorial.com', '*.metorial.com']
+};
+
+describe('resolveAppRedirectUrl', () => {
+  it('leaves a standard app untouched', () => {
+    expect(
+      resolveAppRedirectUrl({
+        app: standardApp,
+        redirectUrl: 'https://customer.metorial.com/test'
+      })
+    ).toBe('https://customer.metorial.com/test');
+  });
+
+  it('wraps a horizon redirect in the IdP-initiated endpoint', () => {
+    let resolved = resolveAppRedirectUrl({
+      app: horizonApp,
+      redirectUrl: 'https://customer.metorial.com/test'
+    });
+
+    let url = new URL(resolved);
+    expect(url.origin + url.pathname).toBe(WRAPPER);
+    expect(url.searchParams.get('redirect_url')).toBe('https://customer.metorial.com/test');
+  });
+
+  it('does not wrap the wrapper itself', () => {
+    expect(resolveAppRedirectUrl({ app: horizonApp, redirectUrl: WRAPPER })).toBe(WRAPPER);
+  });
+
+  it('does not wrap an already wrapped URL twice', () => {
+    let once = resolveAppRedirectUrl({
+      app: horizonApp,
+      redirectUrl: 'https://customer.metorial.com/test'
+    });
+
+    expect(resolveAppRedirectUrl({ app: horizonApp, redirectUrl: once })).toBe(once);
+  });
+
+  it('leaves the legacy per-attempt callback alone', () => {
+    let legacy =
+      'https://horizon-sso.metorial.com/callback/aat_0mte3?clientSecret=metorial_hrzn_aat_sec_x';
+
+    expect(resolveAppRedirectUrl({ app: horizonApp, redirectUrl: legacy })).toBe(legacy);
+  });
+
+  it('rejects a redirect outside the allowed domains before wrapping', () => {
+    expect(() =>
+      resolveAppRedirectUrl({ app: horizonApp, redirectUrl: 'https://evil.example/test' })
+    ).toThrow();
+  });
+
+  it('refuses to wrap for a horizon app with no allowed domains', () => {
+    expect(() =>
+      resolveAppRedirectUrl({
+        app: { ...horizonApp, redirectDomains: [] },
+        redirectUrl: 'https://evil.example/test'
+      })
+    ).toThrow();
+  });
+});
+
+describe('wrapHorizonRedirectUrl', () => {
+  it('preserves query params already on the wrapper', () => {
+    let resolved = wrapHorizonRedirectUrl({
+      defaultRedirectUrl: `${WRAPPER}?source=horizon`,
+      redirectUrl: 'https://customer.metorial.com/test'
+    });
+
+    let url = new URL(resolved);
+    expect(url.searchParams.get('source')).toBe('horizon');
+    expect(url.searchParams.get('redirect_url')).toBe('https://customer.metorial.com/test');
+  });
+
+  it('rejects an invalid redirect URL', () => {
+    expect(() =>
+      wrapHorizonRedirectUrl({ defaultRedirectUrl: WRAPPER, redirectUrl: 'not-a-url' })
+    ).toThrow();
+  });
+});

--- a/src/ares/service/src/lib/appRedirect.ts
+++ b/src/ares/service/src/lib/appRedirect.ts
@@ -1,0 +1,52 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { validateRedirectUrl } from './validateRedirectUrl';
+
+interface RedirectApp {
+  mode: 'standard' | 'horizon';
+  defaultRedirectUrl: string;
+  redirectDomains: string[];
+}
+
+export let wrapHorizonRedirectUrl = (d: {
+  defaultRedirectUrl: string;
+  redirectUrl: string;
+}) => {
+  let wrapper: URL;
+  try {
+    wrapper = new URL(d.defaultRedirectUrl);
+  } catch {
+    throw new ServiceError(
+      badRequestError({ message: 'Horizon app has an invalid default redirect URL' })
+    );
+  }
+
+  let target: URL;
+  try {
+    target = new URL(d.redirectUrl);
+  } catch {
+    throw new ServiceError(badRequestError({ message: 'Invalid redirect URL' }));
+  }
+
+  if (target.origin === wrapper.origin) return d.redirectUrl;
+
+  wrapper.searchParams.set('redirect_url', d.redirectUrl);
+
+  return wrapper.toString();
+};
+
+export let resolveAppRedirectUrl = (d: { app: RedirectApp; redirectUrl: string }) => {
+  validateRedirectUrl(d.redirectUrl, d.app.redirectDomains);
+
+  if (d.app.mode !== 'horizon') return d.redirectUrl;
+
+  if (d.app.redirectDomains.length === 0) {
+    throw new ServiceError(
+      badRequestError({ message: 'Horizon app must declare allowed redirect domains' })
+    );
+  }
+
+  return wrapHorizonRedirectUrl({
+    defaultRedirectUrl: d.app.defaultRedirectUrl,
+    redirectUrl: d.redirectUrl
+  });
+};

--- a/src/ares/service/src/services/admin.ts
+++ b/src/ares/service/src/services/admin.ts
@@ -1,14 +1,10 @@
-import {
-  notFoundError,
-  ServiceError,
-  unauthorizedError
-} from '@lowerdeck/error';
+import { notFoundError, ServiceError, unauthorizedError } from '@lowerdeck/error';
 import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
 import { addHours } from 'date-fns';
-import type { Admin, App } from '../../prisma/generated/client';
-import { db, withTransaction } from '../db';
+import type { Admin, App, AppMode } from '../../prisma/generated/client';
+import { db, type TransactionDB, withTransaction } from '../db';
 import { getId, ID } from '../id';
 import type { Context } from '../lib/context';
 import { normalizeRedirectDomains } from '../lib/redirectDomains';
@@ -73,10 +69,7 @@ class AdminServiceImpl {
             ...opts,
             where: d?.search
               ? {
-                  OR: [
-                    { email: { contains: d.search } },
-                    { name: { contains: d.search } }
-                  ]
+                  OR: [{ email: { contains: d.search } }, { name: { contains: d.search } }]
                 }
               : undefined
           })
@@ -96,12 +89,20 @@ class AdminServiceImpl {
     return session.admin;
   }
 
+  private async transferHorizonMode(db: TransactionDB, keepAppOid: bigint) {
+    await db.app.updateMany({
+      where: { mode: 'horizon', oid: { not: keepAppOid } },
+      data: { mode: 'standard' }
+    });
+  }
+
   async createApp(d: {
     defaultRedirectUrl: string;
     slug?: string;
     redirectDomains?: string[];
     isSessionless?: boolean;
     disableEmailAuth?: boolean;
+    mode?: AppMode;
   }) {
     let redirectDomains =
       d.redirectDomains !== undefined ? normalizeRedirectDomains(d.redirectDomains) : [];
@@ -115,9 +116,12 @@ class AdminServiceImpl {
           isSessionless: d.isSessionless ?? false,
           disableEmailAuth: d.disableEmailAuth ?? false,
           defaultRedirectUrl: d.defaultRedirectUrl,
+          mode: d.mode ?? 'standard',
           redirectDomains
         }
       });
+
+      if (d.mode === 'horizon') await this.transferHorizonMode(db, app.oid);
 
       let tenant = await db.tenant.create({
         data: {
@@ -144,6 +148,7 @@ class AdminServiceImpl {
     redirectDomains?: string[];
     isSessionless?: boolean;
     disableEmailAuth?: boolean;
+    mode?: AppMode;
   }) {
     let existingApp = await db.app.findUnique({
       where: { slug: d.slug },
@@ -158,7 +163,8 @@ class AdminServiceImpl {
         slug: d.slug,
         redirectDomains: d.redirectDomains,
         isSessionless: d.isSessionless,
-        disableEmailAuth: d.disableEmailAuth
+        disableEmailAuth: d.disableEmailAuth,
+        mode: d.mode
       });
     } catch (e: any) {
       if (e.code !== 'P2002') {
@@ -178,10 +184,16 @@ class AdminServiceImpl {
     return await this.updateApp({
       app: existingApp,
       input: {
+        // An upsert re-states the app's whole registration, so the redirect URL has to move
+        // with it. A horizon app derives it from PASSPORT_AUTH_URL, and leaving it pinned to
+        // whatever the app was first created with would strand every existing deployment on
+        // a stale wrapper endpoint.
+        defaultRedirectUrl: d.defaultRedirectUrl,
         redirectDomains: d.redirectDomains,
         slug: d.slug,
         isSessionless: d.isSessionless,
-        disableEmailAuth: d.disableEmailAuth
+        disableEmailAuth: d.disableEmailAuth,
+        mode: d.mode
       }
     });
   }
@@ -190,9 +202,11 @@ class AdminServiceImpl {
     app: App;
     input: {
       slug?: string;
+      defaultRedirectUrl?: string;
       redirectDomains?: string[];
       isSessionless?: boolean;
       disableEmailAuth?: boolean;
+      mode?: AppMode;
     };
   }) {
     let redirectDomains =
@@ -200,20 +214,28 @@ class AdminServiceImpl {
         ? normalizeRedirectDomains(d.input.redirectDomains)
         : undefined;
 
-    return await db.app.update({
-      where: { oid: d.app.oid },
-      data: {
-        slug: d.input.slug !== undefined ? d.input.slug || null : undefined,
-        isSessionless:
-          d.input.isSessionless !== undefined ? d.input.isSessionless : undefined,
-        disableEmailAuth:
-          d.input.disableEmailAuth !== undefined ? d.input.disableEmailAuth : undefined,
-        redirectDomains
-      },
-      include: {
-        defaultTenant: true,
-        _count: { select: { users: true, tenants: true } }
-      }
+    return withTransaction(async db => {
+      let app = await db.app.update({
+        where: { oid: d.app.oid },
+        data: {
+          slug: d.input.slug !== undefined ? d.input.slug || null : undefined,
+          defaultRedirectUrl: d.input.defaultRedirectUrl,
+          isSessionless:
+            d.input.isSessionless !== undefined ? d.input.isSessionless : undefined,
+          disableEmailAuth:
+            d.input.disableEmailAuth !== undefined ? d.input.disableEmailAuth : undefined,
+          mode: d.input.mode,
+          redirectDomains
+        },
+        include: {
+          defaultTenant: true,
+          _count: { select: { users: true, tenants: true } }
+        }
+      });
+
+      if (d.input.mode === 'horizon') await this.transferHorizonMode(db, app.oid);
+
+      return app;
     });
   }
 
@@ -225,10 +247,7 @@ class AdminServiceImpl {
             ...opts,
             where: d?.search
               ? {
-                  OR: [
-                    { clientId: { contains: d.search } },
-                    { slug: { contains: d.search } }
-                  ]
+                  OR: [{ clientId: { contains: d.search } }, { slug: { contains: d.search } }]
                 }
               : undefined,
             include: {

--- a/src/ares/service/src/services/auth.ts
+++ b/src/ares/service/src/services/auth.ts
@@ -1315,7 +1315,8 @@ class AuthServiceImpl {
 
     return {
       user,
-      session
+      session,
+      authAttempt
     };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes authentication client resolution, redirect handling, and optional client_id across boot/start/oauth paths—security-sensitive redirect wrapping and default-app selection need careful rollout and migration.
> 
> **Overview**
> Introduces **Horizon** as a distinct app mode (`standard` | `horizon`) on `App`, surfaced in admin APIs and the apps list, with only one horizon app allowed at a time via `transferHorizonMode` on create/update.
> 
> **Native Horizon login** no longer requires `client_id` on the auth UI or public auth endpoints: missing `client_id` resolves to the configured horizon app (`resolveClientOrDefault`). Horizon apps rewrite post-login redirects through `resolveAppRedirectUrl` (wrapper `defaultRedirectUrl` + `redirect_url` query) after domain validation; standard apps behave as before.
> 
> The auth frontend drops the hard error when `client_id` is absent, threads optional `clientId` through boot/start flows, and uses `crossLinkQuery` for login/signup links. OAuth code exchange now returns **`redirectUrl`** from the auth attempt alongside user/session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd4a28a29940cff692661f625278569713d12a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->