### PR TITLE
Harden subspace connections

### DIFF
--- a/src/lowerdeck/packages/lock/README.md
+++ b/src/lowerdeck/packages/lock/README.md
@@ -54,6 +54,25 @@ await lock.usingLock(['user:123', 'account:456'], async () => {
 });
 ```
 
+Lock acquisition is bounded to 5 seconds by default. Override the acquisition budget without
+changing the lease duration when a caller has a different latency budget:
+
+```typescript
+await lock.usingLock('resource-key', performWork, {
+  acquisitionTimeoutMs: 2_000,
+  durationMs: 10_000
+});
+```
+
+Redis connections are pooled by URL. Long-running services may close the shared pool during
+graceful shutdown:
+
+```typescript
+import { closeLockPool } from '@lowerdeck/lock';
+
+await closeLockPool();
+```
+
 ## License
 
 This project is licensed under the Apache License 2.0.

--- a/src/lowerdeck/packages/lock/src/index.test.ts
+++ b/src/lowerdeck/packages/lock/src/index.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => {
+  let redisInstances: Array<{ quit: ReturnType<typeof vi.fn> }> = [];
+  let acquire = vi.fn();
+  let quit = vi.fn(async () => {});
+
+  return { redisInstances, acquire, quit };
+});
+
+vi.mock('ioredis', () => ({
+  Redis: class {
+    setnx = vi.fn();
+    expire = vi.fn();
+    set = vi.fn();
+    get = vi.fn();
+    quit = vi.fn(async () => {});
+
+    constructor() {
+      mocks.redisInstances.push(this);
+    }
+  }
+}));
+
+vi.mock('redlock', () => ({
+  default: class {
+    acquire = mocks.acquire;
+    quit = mocks.quit;
+  }
+}));
+
+import { closeLockPool, createLock } from './index';
+
+let createFakeLease = (durationMs: number) => {
+  let lease: any = {
+    expiration: Date.now() + durationMs,
+    extend: vi.fn(async (nextDurationMs: number) => {
+      lease.expiration = Date.now() + nextDurationMs;
+      return lease;
+    }),
+    release: vi.fn(async () => {})
+  };
+  return lease;
+};
+
+describe('lock pooling and acquisition', () => {
+  beforeEach(async () => {
+    await closeLockPool();
+    mocks.redisInstances.length = 0;
+    mocks.acquire.mockReset();
+    mocks.quit.mockClear();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await closeLockPool();
+  });
+
+  it('shares one Redis client between locks using the same URL', () => {
+    for (let i = 0; i < 500; i++) {
+      createLock({ name: `lock-${i}`, redisUrl: 'redis://localhost:6379/0' });
+    }
+
+    expect(mocks.redisInstances).toHaveLength(1);
+  });
+
+  it('keeps the Redis pool across module reloads', async () => {
+    for (let i = 0; i < 250; i++) {
+      createLock({ name: `before-reload-${i}`, redisUrl: 'redis://localhost:6379/0' });
+    }
+
+    vi.resetModules();
+    let reloadedLockModule = await vi.importActual<typeof import('./index')>('./index');
+    for (let i = 0; i < 250; i++) {
+      reloadedLockModule.createLock({
+        name: `after-reload-${i}`,
+        redisUrl: 'redis://localhost:6379/0'
+      });
+    }
+
+    expect(mocks.redisInstances).toHaveLength(1);
+  });
+
+  it('uses fresh acquisition attempts so waiting does not consume the lease', async () => {
+    vi.useFakeTimers();
+    mocks.acquire
+      .mockRejectedValueOnce(new Error('locked'))
+      .mockRejectedValueOnce(new Error('locked'))
+      .mockRejectedValueOnce(new Error('locked'))
+      .mockImplementationOnce(async (_keys, durationMs) => createFakeLease(durationMs));
+
+    let lock = createLock({ name: 'contended', redisUrl: 'redis://localhost:6379/0' });
+    let remainingLeaseMs = 0;
+    let resultPromise = lock.usingLock(
+      'resource',
+      async () => {
+        let lease = await mocks.acquire.mock.results.at(-1)!.value;
+        remainingLeaseMs = lease.expiration - Date.now();
+        return 'ok';
+      },
+      {
+        durationMs: 10_000,
+        acquisitionTimeoutMs: 5_000,
+        retryDelay: 1_000,
+        retryJitter: 0
+      }
+    );
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    await expect(resultPromise).resolves.toBe('ok');
+    expect(remainingLeaseMs).toBeGreaterThanOrEqual(9_900);
+    expect(mocks.acquire).toHaveBeenCalledTimes(4);
+    expect(mocks.acquire).toHaveBeenCalledWith(expect.any(Array), 10_000, {
+      retryCount: 0
+    });
+  });
+
+  it('bounds acquisition by acquisitionTimeoutMs', async () => {
+    vi.useFakeTimers();
+    mocks.acquire.mockRejectedValue(new Error('locked'));
+
+    let lock = createLock({ name: 'bounded', redisUrl: 'redis://localhost:6379/0' });
+    let resultPromise = lock.usingLock('resource', async () => 'never', {
+      acquisitionTimeoutMs: 2_500,
+      retryDelay: 1_000,
+      retryJitter: 0
+    });
+
+    let assertion = expect(resultPromise).rejects.toThrow('locked');
+    await vi.advanceTimersByTimeAsync(2_500);
+    await assertion;
+    expect(mocks.acquire).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lowerdeck/packages/lock/src/index.ts
+++ b/src/lowerdeck/packages/lock/src/index.ts
@@ -9,39 +9,66 @@ import SuperJSON from 'superjson';
 // @ts-ignore
 import Redlock_ from 'redlock';
 
+interface LockPoolEntry {
+  redis: Redis;
+  redlock: any;
+}
+
+interface LockPoolState {
+  entries: Map<string, LockPoolEntry>;
+}
+
+let LOCK_POOL_SYMBOL = Symbol.for('@lowerdeck/lock/pool/v1');
+let globalWithLockPool = globalThis as typeof globalThis & {
+  [LOCK_POOL_SYMBOL]?: LockPoolState;
+};
+
+let getLockPool = () => {
+  if (!globalWithLockPool[LOCK_POOL_SYMBOL]) {
+    globalWithLockPool[LOCK_POOL_SYMBOL] = { entries: new Map() };
+  }
+
+  return globalWithLockPool[LOCK_POOL_SYMBOL];
+};
+
+let getLockPoolEntry = (redisUrl: string): LockPoolEntry => {
+  let pool = getLockPool();
+  let existing = pool.entries.get(redisUrl);
+  if (existing) return existing;
+
+  let redis = new Redis(parseRedisUrl(redisUrl));
+  let redlock = new Redlock_([redis as any], {
+    driftFactor: 0.01,
+    retryCount: 0,
+    retryDelay: 200,
+    retryJitter: 200,
+    automaticExtensionThreshold: 500
+  } as any);
+
+  let entry = { redis, redlock };
+  pool.entries.set(redisUrl, entry);
+  return entry;
+};
+
+export let closeLockPool = async () => {
+  let pool = getLockPool();
+  let entries = Array.from(pool.entries.values());
+  pool.entries.clear();
+
+  await Promise.allSettled(entries.map(entry => entry.redlock.quit()));
+};
+
 export let createLock = ({ name, redisUrl }: { name: string; redisUrl: string }) => {
   let hash = crypto.createHash('sha256').update(name).digest();
   let nameHash = hash.readBigUInt64LE(0).toString(36);
-
-  let redis = new Redis(parseRedisUrl(redisUrl));
-
-  let redlock = new Redlock_([redis as any], {
-    // The expected clock drift; for more details see:
-    // http://redis.io/topics/distlock
-    driftFactor: 0.01, // multiplied by lock ttl to determine drift time
-
-    // The max number of times Redlock will attempt to lock a resource
-    // before erroring.
-    retryCount: 50,
-
-    // the time in ms between attempts
-    retryDelay: 200, // time in ms
-
-    // the max time in ms randomly added to retries
-    // to improve performance under high contention
-    // see https://www.awsarchitectureblog.com/2015/03/backoff.html
-    retryJitter: 200, // time in ms
-
-    // The minimum remaining time on a lock before an extension is automatically
-    // attempted with the `using` API.
-    automaticExtensionThreshold: 500
-  } as any);
+  let { redis, redlock } = getLockPoolEntry(redisUrl);
 
   let usingLock = async <T>(
     key: string | string[],
     fn: (controller: { passForNow: () => void }) => Promise<T>,
     options?: {
       durationMs?: number;
+      acquisitionTimeoutMs?: number;
       retryCount?: number;
       retryDelay?: number;
       retryJitter?: number;
@@ -49,34 +76,128 @@ export let createLock = ({ name, redisUrl }: { name: string; redisUrl: string })
   ): Promise<T> => {
     let keyArray = (Array.isArray(key) ? key : [key]).map(k => `l:${nameHash}:${k}`);
 
-    let runLock = async () => {
+    let runLock = async (): Promise<T> => {
       let passingForNow = false;
       let passForNow = () => {
         passingForNow = true;
       };
 
       let durationMs = options?.durationMs ?? 10_000;
-      let routine = () => fn({ passForNow });
-      let settings = options
-        ? {
-            ...(options.retryCount === undefined ? {} : { retryCount: options.retryCount }),
-            ...(options.retryDelay === undefined ? {} : { retryDelay: options.retryDelay }),
-            ...(options.retryJitter === undefined ? {} : { retryJitter: options.retryJitter })
+      let acquisitionTimeoutMs = options?.acquisitionTimeoutMs ?? 5_000;
+      let retryCount = options?.retryCount ?? 50;
+      let retryDelay = options?.retryDelay ?? 200;
+      let retryJitter = options?.retryJitter ?? 200;
+      let startedAt = Date.now();
+      let attempt = 0;
+      let lock: any;
+
+      if (durationMs <= 600) {
+        throw new Error('Lock duration must be greater than 600ms');
+      }
+      if (acquisitionTimeoutMs < 0) {
+        throw new Error('Lock acquisition timeout cannot be negative');
+      }
+
+      while (true) {
+        try {
+          // Each attempt starts a new lease clock. Redlock's internal retry loop
+          // starts the clock before waiting and can otherwise return an expired lock.
+          lock = await redlock.acquire(keyArray, durationMs, { retryCount: 0 });
+          break;
+        } catch (error) {
+          let elapsedMs = Date.now() - startedAt;
+          if (attempt >= retryCount || elapsedMs >= acquisitionTimeoutMs) {
+            console.warn(
+              `LOCK.acquire.failed name=${name} keyCount=${keyArray.length} attempts=${attempt + 1} elapsedMs=${elapsedMs}`
+            );
+            throw error;
           }
-        : undefined;
-      let result = options
-        ? await redlock.using(keyArray, durationMs, settings!, routine)
-        : await redlock.using(keyArray, durationMs, routine);
+
+          let jitter = Math.floor((Math.random() * 2 - 1) * retryJitter);
+          let retryInMs = Math.max(0, retryDelay + jitter);
+          if (retryInMs >= acquisitionTimeoutMs - elapsedMs) {
+            console.warn(
+              `LOCK.acquire.failed name=${name} keyCount=${keyArray.length} attempts=${attempt + 1} elapsedMs=${elapsedMs}`
+            );
+            throw error;
+          }
+
+          attempt++;
+          await delay(retryInMs);
+        }
+      }
+
+      let acquiredAfterMs = Date.now() - startedAt;
+      if (acquiredAfterMs >= 500) {
+        console.warn(
+          `LOCK.acquire.slow name=${name} keyCount=${keyArray.length} attempts=${attempt + 1} elapsedMs=${acquiredAfterMs}`
+        );
+      }
+
+      let extensionTimer: ReturnType<typeof setTimeout> | null = null;
+      let extensionPromise: Promise<void> | null = null;
+      let extensionStopped = false;
+
+      let queueExtension = () => {
+        if (extensionStopped) return;
+
+        let extensionInMs = Math.max(0, lock.expiration - Date.now() - 500);
+        extensionTimer = setTimeout(() => {
+          extensionTimer = null;
+          extensionPromise = (async () => {
+            while (!extensionStopped) {
+              try {
+                lock = await lock.extend(durationMs);
+                queueExtension();
+                return;
+              } catch (error) {
+                if (Date.now() < lock.expiration) {
+                  await delay(Math.min(50, Math.max(0, lock.expiration - Date.now())));
+                  continue;
+                }
+
+                console.error(
+                  `LOCK.extend.failed name=${name} keyCount=${keyArray.length} heldMs=${Date.now() - startedAt}`,
+                  error
+                );
+                return;
+              }
+            }
+          })();
+        }, extensionInMs);
+      };
+
+      queueExtension();
+
+      let result: T;
+      try {
+        result = await fn({ passForNow });
+      } finally {
+        extensionStopped = true;
+        if (extensionTimer) clearTimeout(extensionTimer);
+        let pendingExtension = extensionPromise as Promise<void> | null;
+        if (pendingExtension) await pendingExtension.catch(() => {});
+
+        try {
+          await lock.release();
+        } catch (error) {
+          console.error(
+            `LOCK.release.failed name=${name} keyCount=${keyArray.length} heldMs=${Date.now() - startedAt}`,
+            error
+          );
+          throw error;
+        }
+      }
 
       if (passingForNow) {
         await delay(100);
-        return runLock();
+        return await runLock();
       }
 
       return result;
     };
 
-    return runLock();
+    return await runLock();
   };
 
   let doOnce = async <T>(key: string, fn: () => Promise<T>): Promise<T | null> => {

--- a/src/metorial/apis/connection/package.json
+++ b/src/metorial/apis/connection/package.json
@@ -7,7 +7,6 @@
     "@metorial/config": "^1.0.0",
     "@metorial/context": "^1.0.0",
     "@metorial/db": "^1.0.0",
-    "@lowerdeck/delay": "workspace:2.0.0",
     "@lowerdeck/error": "workspace:2.0.0",
     "@lowerdeck/execution-context": "workspace:2.0.0",
     "@lowerdeck/hono": "workspace:2.0.0",

--- a/src/metorial/apis/connection/src/mcp.ts
+++ b/src/metorial/apis/connection/src/mcp.ts
@@ -1,4 +1,3 @@
-import { delay } from '@lowerdeck/delay';
 import type { Instance } from '@metorial/db';
 import { Fabric } from '@metorial/fabric';
 import {
@@ -10,6 +9,7 @@ import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import z from 'zod';
+import { createStreamableHttpPostResponse } from './streamableHttpResponse';
 
 let agentClientSchema = z.discriminatedUnion('type', [
   z.object({
@@ -65,22 +65,29 @@ let publicProxyUrl = (c: Context) => {
     : `http://${inputUrl.host}${inputUrl.pathname}${inputUrl.search}`;
 };
 
-let applyConnectionHeaders = (
-  c: Context,
+let setConnectionHeaders = (
+  headers: Headers,
   connection: {
     session: { id: string };
     connection?: { id: string; token: string } | null;
   }
 ) => {
+  headers.set('Metorial-Session-Id', connection.session.id);
+  if (connection.connection) {
+    headers.set('Mcp-Session-Id', connection.connection.token);
+    headers.set('Metorial-Connection-Id', connection.connection.id);
+    headers.set('Metorial-Connection-Token', connection.connection.token);
+  }
+};
+
+let applyConnectionHeaders = (
+  c: Context,
+  connection: Parameters<typeof setConnectionHeaders>[1]
+) => {
   // Mutate the live response headers in place. `c.header()` after streamSSE
   // returns recreates the Response from `.body`, which steals the stream and
   // closes the SSE connection with Content-Length: 0.
-  c.res.headers.set('Metorial-Session-Id', connection.session.id);
-  if (connection.connection) {
-    c.res.headers.set('Mcp-Session-Id', connection.connection.token);
-    c.res.headers.set('Metorial-Connection-Id', connection.connection.id);
-    c.res.headers.set('Metorial-Connection-Token', connection.connection.token);
-  }
+  setConnectionHeaders(c.res.headers, connection);
 };
 
 export let handleMcpRequest = async (
@@ -151,18 +158,13 @@ export let handleMcpRequest = async (
   await Fabric.fire('provider.session_message.created:before', { instance: d.instance });
 
   let finish = async (response: Response, connection: McpConnection) => {
-    applyConnectionHeaders(c, connection);
-    let headers = new Headers(response.headers);
-    for (let [key, value] of c.res.headers) headers.set(key, value);
-    let finalResponse = new Response(response.body, {
-      status: response.status,
-      headers
-    });
+    for (let [key, value] of c.res.headers) response.headers.set(key, value);
+    setConnectionHeaders(response.headers, connection);
     await d.onSubspaceSessionResolved?.({
       subspaceSessionId: connection.session.id,
-      response: finalResponse
+      response
     });
-    return finalResponse;
+    return response;
   };
 
   if (transport === 'sse') {
@@ -241,22 +243,12 @@ export let handleMcpRequest = async (
       }
     });
 
-    if (!response && progress.length === 0) {
-      return finish(new Response(null, { status: 202 }), connection);
-    }
-
     return finish(
-      await sseResponse([
-        ...progress,
-        response?.mcp ?? {
-          jsonrpc: '2.0',
-          id: 'id' in message ? message.id : undefined,
-          error: {
-            code: -32603,
-            message: 'No response produced for MCP request'
-          }
-        }
-      ]),
+      createStreamableHttpPostResponse({
+        request: message,
+        response: response?.mcp,
+        progress
+      }),
       connection
     );
   }
@@ -276,12 +268,4 @@ let readMessage = async (c: Context): Promise<JSONRPCMessage | Response> => {
   } catch {
     return c.text('Invalid JSON body', 400);
   }
-};
-
-let sseResponse = async (messages: JSONRPCMessage[]) => {
-  let body = messages.map(message => `data: ${JSON.stringify(message)}\n\n`).join('');
-  await delay(100);
-  return new Response(body, {
-    headers: { 'Content-Type': 'text/event-stream' }
-  });
 };

--- a/src/metorial/apis/connection/src/streamableHttpResponse.ts
+++ b/src/metorial/apis/connection/src/streamableHttpResponse.ts
@@ -1,0 +1,33 @@
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+let sseResponse = (messages: JSONRPCMessage[]) => {
+  let body = messages.map(message => `data: ${JSON.stringify(message)}\n\n`).join('');
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/event-stream' }
+  });
+};
+
+export let createStreamableHttpPostResponse = (d: {
+  request: JSONRPCMessage;
+  response?: JSONRPCMessage | null;
+  progress: JSONRPCMessage[];
+}) => {
+  if (!d.response && d.progress.length === 0) {
+    return new Response(null, { status: 202 });
+  }
+
+  let responseMessage = d.response ?? {
+    jsonrpc: '2.0' as const,
+    id: 'id' in d.request ? d.request.id : undefined,
+    error: {
+      code: -32603,
+      message: 'No response produced for MCP request'
+    }
+  };
+
+  if (d.progress.length === 0) {
+    return Response.json(responseMessage);
+  }
+
+  return sseResponse([...d.progress, responseMessage]);
+};

--- a/src/metorial/apis/connection/test/mcp.test.ts
+++ b/src/metorial/apis/connection/test/mcp.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-let { create } = vi.hoisted(() => ({ create: vi.fn() }));
+let { create, handleSubspaceMcpRequest } = vi.hoisted(() => ({
+  create: vi.fn(),
+  handleSubspaceMcpRequest: vi.fn()
+}));
 
 vi.mock('@metorial/fabric', () => ({
   Fabric: { fire: vi.fn() }
@@ -18,7 +21,7 @@ vi.mock('@metorial-subspace/module-tenant', () => ({
 
 vi.mock('@metorial-subspace/module-connection', () => ({
   McpConnection: { create },
-  handleMcpRequest: vi.fn()
+  handleMcpRequest: handleSubspaceMcpRequest
 }));
 
 import { handleMcpRequest } from '../src/mcp';
@@ -29,7 +32,18 @@ let neverEndingIterator = async function* () {
 
 let readSseWithCurl = async (url: string) => {
   let proc = Bun.spawn(
-    ['curl', '-sS', '-N', '-D', '-', '--max-time', '1', url, '-H', 'Accept: text/event-stream'],
+    [
+      'curl',
+      '-sS',
+      '-N',
+      '-D',
+      '-',
+      '--max-time',
+      '1',
+      url,
+      '-H',
+      'Accept: text/event-stream'
+    ],
     { stdout: 'pipe', stderr: 'pipe' }
   );
   let stdout = await new Response(proc.stdout).text();
@@ -37,12 +51,15 @@ let readSseWithCurl = async (url: string) => {
   return stdout;
 };
 
-describe.skipIf(typeof Bun === 'undefined')('handleMcpRequest SSE', () => {
+describe('handleMcpRequest', () => {
   beforeEach(() => {
     create.mockReset();
+    handleSubspaceMcpRequest.mockReset();
   });
 
-  it('writes the endpoint event and keeps the stream open', async () => {
+  it.skipIf(typeof Bun === 'undefined')(
+    'writes the endpoint event and keeps the stream open',
+    async () => {
     let connection = {
       session: { id: 'ses_1' },
       connection: null as { id: string; token: string } | null,
@@ -85,5 +102,57 @@ describe.skipIf(typeof Bun === 'undefined')('handleMcpRequest SSE', () => {
     } finally {
       server.stop(true);
     }
+    }
+  );
+
+  it('returns completed POST requests as finite JSON responses', async () => {
+    let connection = {
+      session: { id: 'ses_1' },
+      connection: { id: 'scon_1', token: 'tok_1' }
+    };
+    handleSubspaceMcpRequest.mockResolvedValue({
+      connection,
+      response: {
+        mcp: {
+          jsonrpc: '2.0',
+          id: 0,
+          result: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            serverInfo: { name: 'Metorial', version: '1.0.0' }
+          }
+        }
+      }
+    });
+
+    let app = new Hono().post('/connect/mcp/:sessionId', c =>
+      handleMcpRequest(c, {
+        instance: { id: 'ins_1' } as any,
+        sessionId: 'ses_1'
+      })
+    );
+
+    let response = await app.request('/connect/mcp/ses_1', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 0,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0.0' }
+        }
+      })
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('mcp-session-id')).toBe('tok_1');
+    expect(await response.json()).toMatchObject({ jsonrpc: '2.0', id: 0 });
   });
 });

--- a/src/metorial/apis/connection/test/streamableHttpResponse.test.ts
+++ b/src/metorial/apis/connection/test/streamableHttpResponse.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { createStreamableHttpPostResponse } from '../src/streamableHttpResponse';
+
+let request = {
+  jsonrpc: '2.0' as const,
+  id: 0,
+  method: 'initialize',
+  params: {}
+};
+
+let response = {
+  jsonrpc: '2.0' as const,
+  id: 0,
+  result: { protocolVersion: '2025-11-25' }
+};
+
+describe('createStreamableHttpPostResponse', () => {
+  it('returns a finite JSON response when no progress was emitted', async () => {
+    let result = createStreamableHttpPostResponse({ request, response, progress: [] });
+
+    expect(result.status).toBe(200);
+    expect(result.headers.get('content-type')).toContain('application/json');
+    expect(await result.json()).toEqual(response);
+  });
+
+  it('uses SSE when progress events need to precede the result', async () => {
+    let progress = {
+      jsonrpc: '2.0' as const,
+      method: 'notifications/progress',
+      params: { progressToken: 'test', progress: 1 }
+    };
+    let result = createStreamableHttpPostResponse({ request, response, progress: [progress] });
+
+    expect(result.headers.get('content-type')).toContain('text/event-stream');
+    expect(await result.text()).toBe(
+      `data: ${JSON.stringify(progress)}\n\ndata: ${JSON.stringify(response)}\n\n`
+    );
+  });
+
+  it('returns 202 for notifications with no response', () => {
+    let notification = {
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized'
+    };
+    let result = createStreamableHttpPostResponse({
+      request: notification,
+      response: null,
+      progress: []
+    });
+
+    expect(result.status).toBe(202);
+  });
+});

--- a/src/metorial/subspace/apps/worker/package.json
+++ b/src/metorial/subspace/apps/worker/package.json
@@ -19,6 +19,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@lowerdeck/lock": "workspace:2.0.0",
     "@lowerdeck/queue": "workspace:2.0.0",
     "@metorial/service-init": "^1.0.0",
     "@metorial-subspace/module-auth": "^1.0.0",

--- a/src/metorial/subspace/apps/worker/src/connection.ts
+++ b/src/metorial/subspace/apps/worker/src/connection.ts
@@ -1,15 +1,79 @@
+import { closeLockPool } from '@lowerdeck/lock';
 import { startReceiver } from '@metorial-subspace/module-connection';
 
 let receiver = startReceiver();
+let isDevelopment = process.env.METORIAL_ENV === 'development';
+
+let startReceiverWithRetry = async () => {
+  let retryDelayMs = 250;
+
+  while (true) {
+    try {
+      await receiver.started;
+      return;
+    } catch (error) {
+      console.error(`CONDUIT.worker.receiver_start_retry retryInMs=${retryDelayMs}`, error);
+      await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+      retryDelayMs = Math.min(retryDelayMs * 2, 5_000);
+      receiver = startReceiver();
+    }
+  }
+};
+
+if (isDevelopment) {
+  await startReceiverWithRetry();
+} else {
+  // In deployed environments a failed boot must exit so the platform can
+  // replace the worker instead of keeping an unregistered process alive.
+  await receiver.started;
+}
 
 let DRAIN_TIMEOUT_MS = 25000;
 let DRAIN_POLL_MS = 250;
+let DEV_SUPERVISION_INTERVAL_MS = 5_000;
 
 let shuttingDown = false;
+let recoveringReceiver = false;
+let receiverSupervisor: Timer | null = null;
+
+if (isDevelopment) {
+  receiverSupervisor = setInterval(() => {
+    if (shuttingDown || recoveringReceiver) return;
+
+    void (async () => {
+      let registered = await receiver.isRegistered().catch(() => false);
+      if (receiver.isHealthy() && receiver.isReady() && registered) return;
+
+      recoveringReceiver = true;
+      console.warn(
+        `CONDUIT.worker.receiver_recover receiverId=${receiver.getReceiverId()} ready=${receiver.isReady()} healthy=${receiver.isHealthy()} registered=${registered}`
+      );
+
+      try {
+        await receiver.stop();
+      } catch (error) {
+        console.error('CONDUIT.worker.receiver_recover.stop_failed', error);
+      }
+
+      receiver = startReceiver();
+      await startReceiverWithRetry();
+      recoveringReceiver = false;
+      console.log(`CONDUIT.worker.receiver_recovered receiverId=${receiver.getReceiverId()}`);
+    })().catch(error => {
+      recoveringReceiver = false;
+      console.error('CONDUIT.worker.receiver_recover.failed', error);
+    });
+  }, DEV_SUPERVISION_INTERVAL_MS);
+}
 
 let gracefulShutdown = async (signal: string) => {
   if (shuttingDown) return;
   shuttingDown = true;
+
+  if (receiverSupervisor) {
+    clearInterval(receiverSupervisor);
+    receiverSupervisor = null;
+  }
 
   console.log(`CONDUIT.worker.shutdown signal=${signal} draining in-flight messages`);
 
@@ -24,7 +88,11 @@ let gracefulShutdown = async (signal: string) => {
     let remaining = receiver.getStats().inFlight;
     console.log(`CONDUIT.worker.shutdown.draining_done remainingInFlight=${remaining}`);
 
-    await receiver.stop();
+    try {
+      await receiver.stop();
+    } finally {
+      await closeLockPool();
+    }
   } catch (err) {
     console.error('CONDUIT.worker.shutdown.error', err);
   } finally {

--- a/src/metorial/subspace/modules/connection/src/mcp/request.ts
+++ b/src/metorial/subspace/modules/connection/src/mcp/request.ts
@@ -14,9 +14,10 @@ export let handleMcpRequest = async (
   }
 ) => {
   let { message, waitForResponse, onProgress, ...connectionInput } = d;
+  let method = 'method' in message ? message.method : undefined;
+
   let connection = await McpConnection.create(connectionInput);
 
-  let method = 'method' in message ? message.method : undefined;
   let response =
     onProgress && isLongRunningMcpMethod(method)
       ? await connection.handleMessageWithProgress(

--- a/src/metorial/subspace/modules/connection/src/sender/manager.ts
+++ b/src/metorial/subspace/modules/connection/src/sender/manager.ts
@@ -111,6 +111,8 @@ let connectionTokenLock = createLock({
   redisUrl: env.service.REDIS_URL
 });
 
+let providerInstanceResolutionPromises = new Map<string, Promise<any>>();
+
 let sender = conduit.createSender({
   defaultTimeout: 10_000,
   maxRetries: 2
@@ -469,7 +471,7 @@ export class SenderManager {
       }
     }
 
-    return new SenderManager(
+    let manager = new SenderManager(
       session,
       connection,
       session.tenant,
@@ -478,6 +480,7 @@ export class SenderManager {
       d.agentClient,
       d.connectionPrivateMetadata
     );
+    return manager;
   }
 
   #upsertAgentClientPromise: ReturnType<typeof this.upsertAgentClientIfNeeded> | null = null;
@@ -555,190 +558,256 @@ export class SenderManager {
     return connection.participant;
   }
 
-  private async ensureProviderInstance(provider: SessionProvider) {
-    return instanceLock.usingLock(provider.id, async () => {
-      let currentInstance = await db.sessionProviderInstance.findFirst({
-        where: {
-          sessionProviderOid: provider.oid,
-          expiresAt: { gt: new Date() }
-        },
-        include: { pairVersion: true }
-      });
-      if (currentInstance) {
-        let ageInMinutes = Math.abs(
-          differenceInMinutes(new Date(), currentInstance.createdAt)
-        );
-        if (ageInMinutes <= SESSION_PROVIDER_INSTANCE_MAX_AGE_MINUTES) {
-          return {
-            status: 'ok' as const,
-            instance: await db.sessionProviderInstance.update({
-              where: { oid: currentInstance.oid },
-              data: {
-                expiresAt: addMinutes(
-                  new Date(),
-                  SESSION_PROVIDER_INSTANCE_EXPIRATION_INCREMENT
-                )
-              },
-              include: { pairVersion: true }
-            })
-          };
-        }
+  private async findReusableProviderInstance(provider: SessionProvider) {
+    let currentInstance = await db.sessionProviderInstance.findFirst({
+      where: {
+        sessionProviderOid: provider.oid,
+        expiresAt: { gt: new Date() }
+      },
+      include: { pairVersion: true }
+    });
+    if (!currentInstance) return null;
 
-        await db.sessionProviderInstance.updateMany({
-          where: { oid: currentInstance.oid },
-          data: { expiresAt: new Date() }
-        });
+    let ageInMinutes = Math.abs(differenceInMinutes(new Date(), currentInstance.createdAt));
+    if (ageInMinutes > SESSION_PROVIDER_INSTANCE_MAX_AGE_MINUTES) return null;
+
+    return await db.sessionProviderInstance.update({
+      where: { oid: currentInstance.oid },
+      data: {
+        expiresAt: addMinutes(new Date(), SESSION_PROVIDER_INSTANCE_EXPIRATION_INCREMENT)
+      },
+      include: { pairVersion: true }
+    });
+  }
+
+  private async resolveProviderInstance(provider: SessionProvider) {
+    let reusableInstance = await this.findReusableProviderInstance(provider);
+    if (reusableInstance) {
+      return { status: 'ok' as const, instance: reusableInstance };
+    }
+
+    let fullProvider = await db.sessionProvider.findFirstOrThrow({
+      where: { oid: provider.oid },
+      include: {
+        environment: true,
+        deployment: { include: { currentVersion: true } },
+        config: { include: { currentVersion: true } },
+        authConfig: { include: { currentVersion: true } },
+        provider: { include: { defaultVariant: { include: { currentVersion: true } } } }
       }
+    });
 
-      let fullProvider = await db.sessionProvider.findFirstOrThrow({
+    let dependencyIsDeleted =
+      isRecordDeleted(fullProvider.deployment) ||
+      isRecordDeleted(fullProvider.config) ||
+      isRecordDeleted(fullProvider.authConfig);
+    if (dependencyIsDeleted) {
+      await db.sessionProvider.updateMany({
         where: { oid: provider.oid },
-        include: {
-          environment: true,
-          deployment: { include: { currentVersion: true } },
-          config: { include: { currentVersion: true } },
-          authConfig: { include: { currentVersion: true } },
-          provider: { include: { defaultVariant: { include: { currentVersion: true } } } }
+        data: { status: 'archived' }
+      });
+      return null;
+    }
+
+    let version = await providerDeploymentInternalService.getCurrentVersion({
+      environment: fullProvider.environment,
+      deployment: fullProvider.deployment,
+      provider: fullProvider.provider
+    });
+    if (!version?.specificationOid) {
+      let discoveryError = {
+        type: 'connection_error' as const,
+        error: {
+          code: version ? 'specification_unavailable' : 'version_unavailable',
+          message: version
+            ? 'The provider version has no discovered specification yet'
+            : 'The provider has no usable version'
         }
+      };
+
+      await createError({
+        session: this.session,
+        connection: this.connection,
+
+        type: 'provider_discovery_failed',
+        output: { type: 'error', data: discoveryError.error }
       });
 
-      let dependencyIsDeleted =
-        isRecordDeleted(fullProvider.deployment) ||
-        isRecordDeleted(fullProvider.config) ||
-        isRecordDeleted(fullProvider.authConfig);
-      if (dependencyIsDeleted) {
-        await db.sessionProvider.updateMany({
-          where: { oid: provider.oid },
-          data: { status: 'archived' }
-        });
-        return null;
-      }
-
-      let version = await providerDeploymentInternalService.getCurrentVersion({
-        environment: fullProvider.environment,
-        deployment: fullProvider.deployment,
-        provider: fullProvider.provider
-      });
-      if (!version?.specificationOid) {
-        let discoveryError = {
-          type: 'connection_error' as const,
-          error: {
-            code: version ? 'specification_unavailable' : 'version_unavailable',
-            message: version
-              ? 'The provider version has no discovered specification yet'
-              : 'The provider has no usable version'
-          }
-        };
-
-        await createError({
-          session: this.session,
-          connection: this.connection,
-
-          type: 'provider_discovery_failed',
-          output: { type: 'error', data: discoveryError.error }
-        });
-
-        let detail = buildConnectionFailedDetail({ provider: fullProvider, discoveryError });
-
-        return {
-          status: 'discovery_failed' as const,
-          discoveryError,
-          detail,
-          mcpError: { code: -32603, message: detail.shortMessage }
-        };
-      }
-
-      let pair = await providerDeploymentConfigPairInternalService.useDeploymentConfigPair({
-        deployment: fullProvider.deployment,
-        authConfig: fullProvider.authConfig,
-        config: fullProvider.config,
-        version
-      });
-
-      let rec = pair.version.latestDiscoveryRecord;
-
-      if (rec) {
-        for (let warning of rec.warnings) {
-          await createWarning({
-            session: this.session,
-            connection: this.connection,
-            warning: {
-              code: warning.code,
-              message: warning.message,
-              payload: warning.data
-            }
-          });
-        }
-      }
-
-      if (
-        pair.version.specificationDiscoveryStatus == 'failed' &&
-        !pair.version.specificationOid
-      ) {
-        await createError({
-          session: this.session,
-          connection: this.connection,
-
-          type: 'provider_discovery_failed',
-          output: rec?.error
-            ? {
-                type: 'error',
-                data:
-                  rec.error.type == 'timeout_error'
-                    ? {
-                        code: 'discovery_timeout',
-                        message:
-                          rec.error.message ?? 'Provider specification discovery timed out'
-                      }
-                    : {
-                        code: rec.error.error.code,
-                        message:
-                          rec.error.error.message ??
-                          `Unable to discover provider capabilities: ${rec.error.error.code}`
-                      }
-              }
-            : {
-                type: 'error',
-                data: {
-                  code: 'discovery_failed',
-                  message: 'Failed to discover provider specification'
-                }
-              }
-        });
-
-        let detail = buildConnectionFailedDetail({
-          provider: fullProvider,
-          discoveryError: rec?.error
-        });
-
-        return {
-          status: 'discovery_failed' as const,
-          discoveryError: rec?.error ?? null,
-          detail,
-          mcpError:
-            rec?.error?.type == 'mcp_error'
-              ? { ...rec.error.error, message: detail.shortMessage }
-              : {
-                  code: -32603,
-                  message: detail.shortMessage
-                }
-        };
-      }
+      let detail = buildConnectionFailedDetail({ provider: fullProvider, discoveryError });
 
       return {
-        status: 'ok' as const,
-        instance: await db.sessionProviderInstance.create({
-          data: {
-            ...getId('sessionProviderInstance'),
-            sessionProviderOid: provider.oid,
-            sessionOid: provider.sessionOid,
-            pairOid: pair.pair.oid,
-            pairVersionOid: pair.version.oid,
-            expiresAt: addMinutes(new Date(), SESSION_PROVIDER_INSTANCE_EXPIRATION_INCREMENT)
-          },
-          include: { pairVersion: true }
-        })
+        status: 'discovery_failed' as const,
+        discoveryError,
+        detail,
+        mcpError: { code: -32603, message: detail.shortMessage }
       };
+    }
+
+    let pair = await providerDeploymentConfigPairInternalService.useDeploymentConfigPair({
+      deployment: fullProvider.deployment,
+      authConfig: fullProvider.authConfig,
+      config: fullProvider.config,
+      version
     });
+
+    let rec = pair.version.latestDiscoveryRecord;
+
+    if (rec) {
+      for (let warning of rec.warnings) {
+        await createWarning({
+          session: this.session,
+          connection: this.connection,
+          warning: {
+            code: warning.code,
+            message: warning.message,
+            payload: warning.data
+          }
+        });
+      }
+    }
+
+    if (
+      pair.version.specificationDiscoveryStatus == 'failed' &&
+      !pair.version.specificationOid
+    ) {
+      await createError({
+        session: this.session,
+        connection: this.connection,
+
+        type: 'provider_discovery_failed',
+        output: rec?.error
+          ? {
+              type: 'error',
+              data:
+                rec.error.type == 'timeout_error'
+                  ? {
+                      code: 'discovery_timeout',
+                      message:
+                        rec.error.message ?? 'Provider specification discovery timed out'
+                    }
+                  : {
+                      code: rec.error.error.code,
+                      message:
+                        rec.error.error.message ??
+                        `Unable to discover provider capabilities: ${rec.error.error.code}`
+                    }
+            }
+          : {
+              type: 'error',
+              data: {
+                code: 'discovery_failed',
+                message: 'Failed to discover provider specification'
+              }
+            }
+      });
+
+      let detail = buildConnectionFailedDetail({
+        provider: fullProvider,
+        discoveryError: rec?.error
+      });
+
+      return {
+        status: 'discovery_failed' as const,
+        discoveryError: rec?.error ?? null,
+        detail,
+        mcpError:
+          rec?.error?.type == 'mcp_error'
+            ? { ...rec.error.error, message: detail.shortMessage }
+            : {
+                code: -32603,
+                message: detail.shortMessage
+              }
+      };
+    }
+
+    try {
+      return await instanceLock.usingLock(
+        provider.id,
+        async () => {
+          return await withTransaction(async tdb => {
+            let currentInstance = await tdb.sessionProviderInstance.findFirst({
+              where: {
+                sessionProviderOid: provider.oid,
+                expiresAt: { gt: new Date() }
+              },
+              include: { pairVersion: true }
+            });
+
+            if (currentInstance) {
+              let ageInMinutes = Math.abs(
+                differenceInMinutes(new Date(), currentInstance.createdAt)
+              );
+              if (ageInMinutes <= SESSION_PROVIDER_INSTANCE_MAX_AGE_MINUTES) {
+                return {
+                  status: 'ok' as const,
+                  instance: await tdb.sessionProviderInstance.update({
+                    where: { oid: currentInstance.oid },
+                    data: {
+                      expiresAt: addMinutes(
+                        new Date(),
+                        SESSION_PROVIDER_INSTANCE_EXPIRATION_INCREMENT
+                      )
+                    },
+                    include: { pairVersion: true }
+                  })
+                };
+              }
+            }
+
+            await tdb.sessionProviderInstance.updateMany({
+              where: {
+                sessionProviderOid: provider.oid,
+                expiresAt: { gt: new Date() }
+              },
+              data: { expiresAt: new Date() }
+            });
+
+            return {
+              status: 'ok' as const,
+              instance: await tdb.sessionProviderInstance.create({
+                data: {
+                  ...getId('sessionProviderInstance'),
+                  sessionProviderOid: provider.oid,
+                  sessionOid: provider.sessionOid,
+                  pairOid: pair.pair.oid,
+                  pairVersionOid: pair.version.oid,
+                  expiresAt: addMinutes(
+                    new Date(),
+                    SESSION_PROVIDER_INSTANCE_EXPIRATION_INCREMENT
+                  )
+                },
+                include: { pairVersion: true }
+              })
+            };
+          });
+        },
+        { acquisitionTimeoutMs: 5_000 }
+      );
+    } catch (error) {
+      // A contender may have committed immediately before our acquisition budget
+      // elapsed. Prefer its valid instance over surfacing lock contention.
+      let winnerInstance = await this.findReusableProviderInstance(provider);
+      if (winnerInstance) return { status: 'ok' as const, instance: winnerInstance };
+      throw error;
+    }
+  }
+
+  private async ensureProviderInstance(provider: SessionProvider) {
+    let existing = providerInstanceResolutionPromises.get(provider.id);
+    if (existing) {
+      return (await existing) as Awaited<ReturnType<typeof this.resolveProviderInstance>>;
+    }
+
+    let promise = this.resolveProviderInstance(provider);
+    providerInstanceResolutionPromises.set(provider.id, promise);
+
+    try {
+      return await promise;
+    } finally {
+      if (providerInstanceResolutionPromises.get(provider.id) === promise) {
+        providerInstanceResolutionPromises.delete(provider.id);
+      }
+    }
   }
 
   #connectionSpecificationPromises = new Map<
@@ -878,7 +947,7 @@ export class SenderManager {
             tool => checkToolScopesSatisfied(tool, grantedScopes).allowed
           );
 
-    return {
+    let result = {
       status: 'ok' as const,
       tools: scopeFilteredTools.map(t => ({
         ...t,
@@ -887,6 +956,7 @@ export class SenderManager {
         sessionProviderInstance: res.instance
       }))
     };
+    return result;
   }
 
   async listProviders() {

--- a/src/metorial/subspace/packages/conduit/src/core/conduitReceiver.ts
+++ b/src/metorial/subspace/packages/conduit/src/core/conduitReceiver.ts
@@ -67,7 +67,8 @@ export class ConduitReceiver {
       maxProcessingMs: 300000,
       maxInFlight: 2000,
       handlerConcurrency: 256,
-      maxOrphanedHandlers: config.config?.maxOrphanedHandlers ?? config.config?.handlerConcurrency ?? 256,
+      maxOrphanedHandlers:
+        config.config?.maxOrphanedHandlers ?? config.config?.handlerConcurrency ?? 256,
       ...config.config
     };
 
@@ -362,6 +363,11 @@ export class ConduitReceiver {
 
   isReady(): boolean {
     return this.receiver.isReady();
+  }
+
+  async isRegistered(): Promise<boolean> {
+    let activeReceivers = await this.coordination.getActiveReceivers();
+    return activeReceivers.includes(this.receiver.getReceiverId());
   }
 
   getStats() {

--- a/src/metorial/subspace/packages/conduit/src/core/receiver.ts
+++ b/src/metorial/subspace/packages/conduit/src/core/receiver.ts
@@ -100,28 +100,45 @@ export class Receiver {
       `CONDUIT.receiver.start receiverId=${this.receiverId} conduitId=${this.conduitId}`
     );
 
-    // Subscribe to messages FIRST. We must be listening before we advertise
-    // ourselves as an active receiver, otherwise a freshly-started worker would
-    // be in the active pool (and pingable / assignable) while not yet draining.
-    await this.subscribe();
-    this.ready = true;
+    let registered = false;
+    try {
+      // Subscribe to messages FIRST. We must be listening before we advertise
+      // ourselves as an active receiver, otherwise a freshly-started worker would
+      // be in the active pool (and pingable / assignable) while not yet draining.
+      await this.subscribe();
+      this.ready = true;
 
-    // Now register the receiver (only after we are actually listening).
-    await this.coordination.registerReceiver(this.receiverId, this.config.heartbeatTtl);
-    console.log(
-      `CONDUIT.receiver.start.registered receiverId=${this.receiverId} heartbeatTtl=${this.config.heartbeatTtl}`
-    );
+      // Now register the receiver (only after we are actually listening).
+      await this.coordination.registerReceiver(this.receiverId, this.config.heartbeatTtl);
+      registered = true;
+      console.log(
+        `CONDUIT.receiver.start.registered receiverId=${this.receiverId} heartbeatTtl=${this.config.heartbeatTtl}`
+      );
 
-    // Start heartbeat
-    this.startHeartbeat();
+      this.startHeartbeat();
+      this.ownershipManager.start();
+      this.startTimeoutChecker();
 
-    // Start ownership renewal
-    this.ownershipManager.start();
+      console.log(`CONDUIT.receiver.start.done receiverId=${this.receiverId}`);
+    } catch (error) {
+      // Leave the object in a genuinely stopped state so a supervisor can retry.
+      this.ready = false;
+      this.running = false;
+      this.stopHeartbeat();
+      this.stopTimeoutChecker();
+      this.ownershipManager.stop();
 
-    // Start shared timeout/health check interval
-    this.startTimeoutChecker();
+      if (this.subscriptionId) {
+        await this.transport.unsubscribe(this.subscriptionId).catch(() => {});
+        this.subscriptionId = null;
+      }
+      if (registered) {
+        await this.coordination.unregisterReceiver(this.receiverId).catch(() => {});
+      }
 
-    console.log(`CONDUIT.receiver.start.done receiverId=${this.receiverId}`);
+      console.error(`CONDUIT.receiver.start.failed receiverId=${this.receiverId}`, error);
+      throw error;
+    }
   }
 
   async stop(): Promise<void> {

--- a/src/metorial/subspace/packages/conduit/src/core/sender.ts
+++ b/src/metorial/subspace/packages/conduit/src/core/sender.ts
@@ -6,14 +6,13 @@ import type { SenderConfig } from '../types/config';
 import type { ConduitMessage, TimeoutExtension } from '../types/message';
 import { isTimeoutExtension } from '../types/message';
 import type { ConduitResponse } from '../types/response';
-import { ConduitSendError } from '../types/response';
+import { ConduitReceiverUnavailableError, ConduitSendError } from '../types/response';
 import type {
   TopicListener,
   TopicResponseBroadcast,
   TopicSubscription
 } from '../types/topicListener';
 import { CONDUIT_HEALTH_TOPIC } from './health';
-import { RetryManager } from './retryManager';
 
 let Sentry = getSentry();
 
@@ -29,7 +28,6 @@ interface InFlightMessage {
 
 export class Sender {
   private senderId: string;
-  private retryManager: RetryManager;
   private messageCounter = 0;
   private inFlightMessages: Map<string, InFlightMessage> = new Map();
   private topicSubscriptions: Map<string, string> = new Map(); // topic -> subscriptionId
@@ -45,12 +43,6 @@ export class Sender {
   ) {
     this.conduitId = conduitId;
     this.senderId = `sender-${crypto.randomUUID()}`;
-    this.retryManager = new RetryManager(
-      config.maxRetries,
-      config.retryBackoffMs,
-      config.retryBackoffMultiplier
-    );
-
     // Start cleanup interval for failed unsubscribes
     this.cleanupInterval = setInterval(() => {
       this.retryFailedUnsubscribes().catch(err => {
@@ -72,24 +64,84 @@ export class Sender {
 
     let actualTimeout = timeout ?? this.config.defaultTimeout;
     let messageId = this.generateMessageId();
+    let startedAt = Date.now();
+    let deadline = startedAt + actualTimeout;
+    let retryAttempt = 0;
+    let receiverWaitAttempt = 0;
+    let lastError: Error | null = null;
 
-    return this.retryManager.withRetry(
-      async attemptNumber => {
-        let message: ConduitMessage = {
+    while (true) {
+      let remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        if (lastError instanceof ConduitReceiverUnavailableError) {
+          throw new ConduitReceiverUnavailableError(
+            messageId,
+            topic,
+            retryAttempt + receiverWaitAttempt,
+            Date.now() - startedAt,
+            lastError.activeReceiverCount
+          );
+        }
+
+        throw new ConduitSendError(
+          `Send deadline exceeded for topic ${topic} after ${Date.now() - startedAt}ms`,
           messageId,
           topic,
-          payload,
-          replySubject: '', // Will be set by transport
-          timeout: actualTimeout,
-          sentAt: Date.now(),
-          retryCount: attemptNumber
-        };
+          retryAttempt + receiverWaitAttempt,
+          lastError ?? undefined,
+          false
+        );
+      }
 
-        return await this.sendMessage(message, actualTimeout);
-      },
-      `Send message ${messageId} to topic ${topic}`,
-      error => !(error instanceof ConduitSendError) || error.retryable
-    );
+      let attemptNumber = retryAttempt + receiverWaitAttempt;
+      let attemptsRemaining = Math.max(1, this.config.maxRetries - retryAttempt + 1);
+      let attemptTimeoutMs = Math.max(1, Math.floor(remainingMs / attemptsRemaining));
+      let message: ConduitMessage = {
+        messageId,
+        topic,
+        payload,
+        replySubject: '',
+        timeout: attemptTimeoutMs,
+        sentAt: Date.now(),
+        retryCount: attemptNumber
+      };
+
+      try {
+        let response = await this.sendMessage(message, attemptTimeoutMs, startedAt);
+        return response;
+      } catch (err) {
+        let error = err instanceof Error ? err : new Error(String(err));
+        lastError = error;
+
+        if (error.message === 'Sender closed') throw error;
+
+        if (error instanceof ConduitReceiverUnavailableError) {
+          let backoffMs = Math.min(100 * 2 ** receiverWaitAttempt, 1_000);
+          let waitMs = Math.min(backoffMs, Math.max(0, deadline - Date.now()));
+          if (waitMs <= 0) continue;
+
+          receiverWaitAttempt++;
+          await new Promise(resolve => setTimeout(resolve, waitMs));
+          continue;
+        }
+
+        let retryable = !(error instanceof ConduitSendError) || error.retryable;
+        if (!retryable || retryAttempt >= this.config.maxRetries) {
+          throw new Error(
+            `Send message ${messageId} to topic ${topic} failed after ${retryAttempt + 1} attempts: ${error.message}`
+          );
+        }
+
+        let backoffMs =
+          this.config.retryBackoffMs * this.config.retryBackoffMultiplier ** retryAttempt;
+        let waitMs = Math.min(backoffMs, Math.max(0, deadline - Date.now()));
+        console.warn(
+          `Send message ${messageId} to topic ${topic} failed (attempt ${retryAttempt + 1}/${this.config.maxRetries + 1}), retrying in ${waitMs}ms: ${error.message}`
+        );
+        retryAttempt++;
+        if (waitMs > 0) await new Promise(resolve => setTimeout(resolve, waitMs));
+      }
+    }
   }
 
   async pingReceiver(receiverId: string, timeoutMs?: number): Promise<ConduitResponse> {
@@ -293,16 +345,19 @@ export class Sender {
 
   private async sendMessage(
     message: ConduitMessage,
-    timeout: number
+    timeout: number,
+    sendStartedAt: number
   ): Promise<ConduitResponse> {
     // Resolve topic owner
     let receiverId = await this.resolveOwner(message.topic);
     if (!receiverId) {
-      throw new ConduitSendError(
-        `No receiver available for topic ${message.topic}`,
+      let activeReceivers = await this.coordination.getActiveReceivers();
+      throw new ConduitReceiverUnavailableError(
         message.messageId,
         message.topic,
-        message.retryCount
+        message.retryCount,
+        Date.now() - sendStartedAt,
+        activeReceivers.length
       );
     }
 

--- a/src/metorial/subspace/packages/conduit/src/index.ts
+++ b/src/metorial/subspace/packages/conduit/src/index.ts
@@ -50,7 +50,11 @@ export type {
 export { DEFAULT_CONFIG, mergeConfig } from './types/config';
 export { isTimeoutExtension } from './types/message';
 export type { ConduitMessage, TimeoutExtension } from './types/message';
-export { ConduitProcessError, ConduitSendError } from './types/response';
+export {
+  ConduitProcessError,
+  ConduitReceiverUnavailableError,
+  ConduitSendError
+} from './types/response';
 export type { ConduitResponse } from './types/response';
 export type {
   TopicListener,

--- a/src/metorial/subspace/packages/conduit/src/types/response.ts
+++ b/src/metorial/subspace/packages/conduit/src/types/response.ts
@@ -35,6 +35,24 @@ export class ConduitSendError extends Error {
   }
 }
 
+export class ConduitReceiverUnavailableError extends ConduitSendError {
+  constructor(
+    messageId: string,
+    topic: string,
+    retryCount: number,
+    public readonly elapsedMs: number,
+    public readonly activeReceiverCount: number
+  ) {
+    super(
+      `Receiver unavailable for topic ${topic} after ${elapsedMs}ms (activeReceivers=${activeReceiverCount})`,
+      messageId,
+      topic,
+      retryCount
+    );
+    this.name = 'ConduitReceiverUnavailableError';
+  }
+}
+
 export class ConduitProcessError extends Error {
   public readonly messageId: string;
   public readonly topic: string;

--- a/src/metorial/subspace/packages/conduit/tests/integration/advancedScenarios.test.ts
+++ b/src/metorial/subspace/packages/conduit/tests/integration/advancedScenarios.test.ts
@@ -306,7 +306,7 @@ describe('Advanced Scenarios Integration', () => {
       await receiver1.start();
 
       const sender = conduit.createSender({
-        defaultTimeout: 200,
+        defaultTimeout: 1_000,
         maxRetries: 3,
         retryBackoffMs: 100
       });
@@ -378,7 +378,7 @@ describe('Advanced Scenarios Integration', () => {
     test('should handle cascading receiver failures', async () => {
       const conduit = createConduit();
       const sender = conduit.createSender({
-        defaultTimeout: 200,
+        defaultTimeout: 1_500,
         maxRetries: 5,
         retryBackoffMs: 50
       });
@@ -528,7 +528,7 @@ describe('Advanced Scenarios Integration', () => {
     test('should handle network-like errors with retries', async () => {
       const conduit = createConduit();
       const sender = conduit.createSender({
-        defaultTimeout: 200,
+        defaultTimeout: 1_000,
         maxRetries: 3,
         retryBackoffMs: 50
       });

--- a/src/metorial/subspace/packages/conduit/tests/integration/receiverCrash.test.ts
+++ b/src/metorial/subspace/packages/conduit/tests/integration/receiverCrash.test.ts
@@ -77,8 +77,8 @@ describe('Receiver Crash Integration', () => {
       expect.unreachable('Should have thrown');
     } catch (err: unknown) {
       expect(err).toBeDefined();
-      // Should fail after retries
-      expect((err as Error).message).toContain('failed after');
+      expect((err as Error).message).toContain('Receiver unavailable');
+      expect((err as Error).message).toContain('activeReceivers=0');
     }
 
     await sender.close();
@@ -196,7 +196,9 @@ describe('Receiver Crash Integration', () => {
       receiver: 'healthy',
       payload: { data: 'test' }
     });
-    expect(await conduit.coordination.getTopicOwner('stale-topic')).toBe(receiver.getReceiverId());
+    expect(await conduit.coordination.getTopicOwner('stale-topic')).toBe(
+      receiver.getReceiverId()
+    );
 
     await receiver.stop();
     await sender.close();

--- a/src/metorial/subspace/packages/conduit/tests/integration/retryFlow.test.ts
+++ b/src/metorial/subspace/packages/conduit/tests/integration/retryFlow.test.ts
@@ -12,7 +12,8 @@ describe('Retry Flow Integration', () => {
       expect.unreachable('Should have thrown');
     } catch (err: unknown) {
       expect(err).toBeDefined();
-      expect((err as Error).message).toContain('No receiver available');
+      expect((err as Error).message).toContain('Receiver unavailable');
+      expect((err as Error).message).toContain('activeReceivers=0');
     }
 
     await sender.close();
@@ -22,7 +23,7 @@ describe('Retry Flow Integration', () => {
   test('should retry and succeed when receiver becomes available', async () => {
     const conduit = createConduit();
     const sender = conduit.createSender({
-      defaultTimeout: 200,
+      defaultTimeout: 500,
       maxRetries: 3,
       retryBackoffMs: 100
     });

--- a/src/metorial/subspace/packages/conduit/tests/unit/receiverStartup.test.ts
+++ b/src/metorial/subspace/packages/conduit/tests/unit/receiverStartup.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from 'vitest';
+import { MemoryCoordination, MemoryTransport, Receiver } from '../../src';
+import { DEFAULT_CONFIG } from '../../src/types/config';
+
+describe('Receiver startup', () => {
+  test('rolls back a failed subscription so startup can be retried', async () => {
+    let coordination = new MemoryCoordination();
+    let transport = new MemoryTransport();
+    let originalSubscribe = transport.subscribe.bind(transport);
+    let subscribe = vi.spyOn(transport, 'subscribe');
+
+    subscribe.mockRejectedValueOnce(new Error('temporary subscription failure'));
+    subscribe.mockImplementation((...args) => originalSubscribe(...args));
+
+    let receiver = new Receiver(
+      coordination,
+      transport,
+      DEFAULT_CONFIG.receiver,
+      async () => ({ ok: true })
+    );
+
+    await expect(receiver.start()).rejects.toThrow('temporary subscription failure');
+    expect(receiver.isRunning()).toBe(false);
+    expect(receiver.isReady()).toBe(false);
+
+    await expect(receiver.start()).resolves.toBeUndefined();
+    expect(receiver.isRunning()).toBe(true);
+    expect(receiver.isReady()).toBe(true);
+
+    await receiver.stop();
+    await coordination.close();
+    await transport.close();
+  });
+
+  test('rolls back a failed registration so startup can be retried', async () => {
+    let coordination = new MemoryCoordination();
+    let transport = new MemoryTransport();
+    let originalRegister = coordination.registerReceiver.bind(coordination);
+    let register = vi.spyOn(coordination, 'registerReceiver');
+
+    register.mockRejectedValueOnce(new Error('temporary registration failure'));
+    register.mockImplementation((...args) => originalRegister(...args));
+
+    let receiver = new Receiver(
+      coordination,
+      transport,
+      DEFAULT_CONFIG.receiver,
+      async () => ({ ok: true })
+    );
+
+    await expect(receiver.start()).rejects.toThrow('temporary registration failure');
+    expect(receiver.isRunning()).toBe(false);
+    expect(receiver.isReady()).toBe(false);
+
+    await expect(receiver.start()).resolves.toBeUndefined();
+    expect(receiver.isRunning()).toBe(true);
+    expect(receiver.isReady()).toBe(true);
+
+    await receiver.stop();
+    await coordination.close();
+    await transport.close();
+  });
+});

--- a/src/metorial/subspace/provider-backends/provider-slates/src/impl/providerInvocation.ts
+++ b/src/metorial/subspace/provider-backends/provider-slates/src/impl/providerInvocation.ts
@@ -112,6 +112,10 @@ export class ProviderInvocation extends IProviderInvocation {
           slateSessionToolCallId: localToolCall.id
         });
 
+        let hasToolIdentity = localToolCall.sessionMessages.every(
+          message => message.retentionLevel !== 'none'
+        );
+
         mergeInvocation(invocationMap, {
           id: getSlateProviderInvocationId(remote.invocation.id),
           source: 'slates',
@@ -122,7 +126,7 @@ export class ProviderInvocation extends IProviderInvocation {
           authConfigEventIds: [],
           providerOAuthSetupIds: [],
           toolCallId: remote.id,
-          action: remote.action,
+          action: hasToolIdentity ? remote.action : null,
           requests: remote.invocation.requests ?? [],
           responses: remote.invocation.responses ?? [],
           requestTraces: remote.invocation.requestTraces ?? [],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches Redis locking semantics, conduit send/retry behavior, and MCP HTTP response shapes on the connection path—areas that affect correctness under contention and client compatibility.
> 
> **Overview**
> Hardens subspace connection reliability end-to-end: distributed locks, worker/conduit messaging, MCP HTTP responses, and provider instance creation under contention.
> 
> **`@lowerdeck/lock`** pools Redis/Redlock clients per URL (survives hot reloads), adds configurable **`acquisitionTimeoutMs`** (default 5s) with per-attempt acquires so wait time does not eat the lease, manual extend/release instead of `redlock.using`, and **`closeLockPool()`** for shutdown. Vitest coverage for pooling and acquisition bounds.
> 
> **MCP connection API** routes streamable HTTP POSTs through **`createStreamableHttpPostResponse`**: finite **`application/json`** when there is no progress, SSE when progress precedes the result, and **202** for notification-only requests. Connection headers are applied on the returned `Response` without recreating the body (avoids breaking SSE).
> 
> **Subspace worker** retries receiver startup in development, periodically restarts receivers that are unhealthy or not registered in coordination, and closes the lock pool on graceful shutdown.
> 
> **Provider instance resolution** dedupes in-flight work per provider, reuses instances outside the lock, and only takes the Redis lock inside a DB transaction to create instances; on lock timeout it prefers a peer’s committed instance over failing.
> 
> **Conduit** rolls back failed receiver subscribe/register so startup can retry; senders use a single send deadline with distinct handling for **`ConduitReceiverUnavailableError`** (backoff until a receiver exists). Slates invocations omit tool **`action`** when session messages have no tool identity retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eab1a23584a772ee360f809979848e1dc78975e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->