### PR TITLE
Fix oauth callback urls

### DIFF
--- a/src/metorial/apis/core/src/controllers/consumer/provider.ts
+++ b/src/metorial/apis/core/src/controllers/consumer/provider.ts
@@ -1,6 +1,7 @@
 import { badRequestError, preconditionFailedError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
+import { db } from '@metorial-subspace/db';
 import { consumerAccessRequestService } from '@metorial/module-consumer-access';
 import {
   consumerProfileService,
@@ -320,9 +321,12 @@ export let consumerProviderController = Controller.create(
             order: ctx.query.order
           }
         });
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
 
         return Paginator.present(list, consumerProvider =>
-          consumerProviderPresenter.present({ consumerProvider })
+          consumerProviderPresenter.present({ consumerProvider, tenant })
         );
       }),
 
@@ -335,8 +339,13 @@ export let consumerProviderController = Controller.create(
       .use(hasFlags(['paid-portals', 'portals-access']))
       .output(consumerProviderPresenter)
       .do(async ctx => {
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
+
         return consumerProviderPresenter.present({
-          consumerProvider: ctx.consumerProvider
+          consumerProvider: ctx.consumerProvider,
+          tenant
         });
       }),
 

--- a/src/metorial/apis/core/src/controllers/instance/custom-provider/customProvider.ts
+++ b/src/metorial/apis/core/src/controllers/instance/custom-provider/customProvider.ts
@@ -2,6 +2,7 @@ import { badRequestError, paymentRequiredError, ServiceError } from '@lowerdeck/
 import { Paginator } from '@lowerdeck/pagination';
 import { v, ValidationTypeValue } from '@lowerdeck/validation';
 import { flagService } from '@metorial/module-flags';
+import { db } from '@metorial-subspace/db';
 import { customProviderService } from '@metorial-subspace/module-custom-provider';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../../lib/dateFilter';
@@ -243,10 +244,14 @@ export let customProviderController = Controller.create(
         });
 
         let list = await paginator.run(ctx.query);
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
 
         return Paginator.present(list, customProvider =>
           subspaceCustomProviderPresenter.present({
-            customProvider
+            customProvider,
+            tenant
           })
         );
       }),
@@ -260,8 +265,13 @@ export let customProviderController = Controller.create(
       .use(hasFlags(['custom-providers-enabled', 'paid-custom-providers']))
       .output(subspaceCustomProviderPresenter)
       .do(async ctx => {
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
+
         return subspaceCustomProviderPresenter.present({
-          customProvider: ctx.customProvider
+          customProvider: ctx.customProvider,
+          tenant
         });
       }),
 
@@ -327,9 +337,13 @@ export let customProviderController = Controller.create(
             config: ctx.body.config
           }
         });
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
 
         return subspaceCustomProviderPresenter.present({
-          customProvider
+          customProvider,
+          tenant
         });
       }),
 
@@ -365,9 +379,13 @@ export let customProviderController = Controller.create(
             readme: ctx.body.readme
           }
         });
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
 
         return subspaceCustomProviderPresenter.present({
-          customProvider
+          customProvider,
+          tenant
         });
       }),
 
@@ -390,9 +408,13 @@ export let customProviderController = Controller.create(
           organizationActor: ctx.actor!,
           customProvider: ctx.customProvider
         });
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
 
         return subspaceCustomProviderPresenter.present({
-          customProvider
+          customProvider,
+          tenant
         });
       })
   }

--- a/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
+++ b/src/metorial/apis/core/src/controllers/instance/provider/provider.ts
@@ -1,6 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
+import { db } from '@metorial-subspace/db';
 import { providerService } from '@metorial-subspace/module-catalog';
 import { providerPresenter } from '@metorial/presenters';
 import { Controller } from '@metorial/rest';
@@ -136,8 +137,13 @@ export let providerController = Controller.create(
         });
 
         let list = await paginator.run(ctx.query);
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
 
-        return Paginator.present(list, provider => providerPresenter.present({ provider }));
+        return Paginator.present(list, provider =>
+          providerPresenter.present({ provider, tenant })
+        );
       }),
 
     get: providerGroup
@@ -148,7 +154,11 @@ export let providerController = Controller.create(
       .use(checkAccess({ possibleScopes: ['instance.provider:read'] }))
       .output(providerPresenter)
       .do(async ctx => {
-        return providerPresenter.present({ provider: ctx.provider });
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
+
+        return providerPresenter.present({ provider: ctx.provider, tenant });
       })
   }
 );

--- a/src/metorial/apis/core/src/controllers/instance/provider/providerListing.ts
+++ b/src/metorial/apis/core/src/controllers/instance/provider/providerListing.ts
@@ -1,6 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Paginator } from '@lowerdeck/pagination';
 import { v } from '@lowerdeck/validation';
+import { db } from '@metorial-subspace/db';
 import { providerListingService } from '@metorial-subspace/module-catalog';
 import { Controller } from '@metorial/rest';
 import { dateFilterValidator } from '../../../lib/dateFilter';
@@ -180,10 +181,14 @@ export let providerListingController = Controller.create(
         });
 
         let list = await paginator.run(ctx.query);
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
 
         return Paginator.present(list, providerListing =>
           providerListingPresenter.present({
-            providerListing
+            providerListing,
+            tenant
           })
         );
       }),
@@ -196,8 +201,13 @@ export let providerListingController = Controller.create(
       .use(checkAccess({ possibleScopes: ['instance.provider.listing:read'] }))
       .output(providerListingPresenter)
       .do(async ctx => {
+        let tenant = await db.tenant.findFirstOrThrow({
+          where: { projectOid: ctx.project.oid }
+        });
+
         return providerListingPresenter.present({
-          providerListing: ctx.providerListing
+          providerListing: ctx.providerListing,
+          tenant
         });
       })
   }

--- a/src/metorial/presenters/src/implementation/consumer/consumerProvider.ts
+++ b/src/metorial/presenters/src/implementation/consumer/consumerProvider.ts
@@ -13,7 +13,7 @@ let presentToolFilter = (toolFilter: unknown) =>
   toolFilter ? toolFilterPresenter(toolFilter as PrismaJson.ToolFilter) : null;
 
 export let v1ConsumerProviderPresenter = Presenter.create(consumerProviderType)
-  .presenter(async ({ consumerProvider }, opts) => {
+  .presenter(async ({ consumerProvider, tenant }, opts) => {
     let base = {
       object: 'consumer.provider' as const,
       id: consumerProvider.listing.id,
@@ -51,7 +51,8 @@ export let v1ConsumerProviderPresenter = Presenter.create(consumerProviderType)
       provider: await v1ProviderPresenter
         .present(
           {
-            provider: consumerProvider.provider
+            provider: consumerProvider.provider,
+            tenant
           },
           opts
         )

--- a/src/metorial/presenters/src/implementation/provider/provider/provider.ts
+++ b/src/metorial/presenters/src/implementation/provider/provider/provider.ts
@@ -37,11 +37,9 @@ export let v1ProviderPresenter = Presenter.create(providerType)
         provider.type.attributes.auth.oauth.status === 'enabled'
           ? {
               status: 'enabled' as 'enabled' | 'disabled',
-              callback_url: tenant
-                ? ((await getOAuthCallbackUrl(provider.type, provider, tenant)) as
-                    | string
-                    | null)
-                : null,
+              callback_url: (await getOAuthCallbackUrl(provider.type, provider, tenant)) as
+                | string
+                | null,
               auto_registration: {
                 status:
                   provider.type.attributes.auth.oauth.oauthAutoRegistration?.status ==

--- a/src/metorial/presenters/src/types.ts
+++ b/src/metorial/presenters/src/types.ts
@@ -2305,6 +2305,7 @@ export let consumerSessionType = PresentableType.create<{
 
 export let consumerProviderType = PresentableType.create<{
   consumerProvider: ConsumerProviderCatalogEntry;
+  tenant: SubspacePrisma.TenantGetPayload<{}>;
 }>()('consumer.provider');
 
 export let consumerActivityAgentType = PresentableType.create<ConsumerActivityAgent>()(
@@ -2550,7 +2551,7 @@ export let providerVersionType = PresentableType.create<{
 
 export let providerType = PresentableType.create<{
   provider: RawProvider | NonNullable<RawCustomProvider['provider']>;
-  tenant?: SubspacePrisma.TenantGetPayload<{}>;
+  tenant: SubspacePrisma.TenantGetPayload<{}>;
 }>()('provider');
 
 export let identityType = PresentableType.create<{
@@ -2597,7 +2598,7 @@ export let providerListingGroupType = PresentableType.create<{
 
 export let providerListingType = PresentableType.create<{
   providerListing: RawProviderListing;
-  tenant?: SubspacePrisma.TenantGetPayload<{}>;
+  tenant: SubspacePrisma.TenantGetPayload<{}>;
 }>()('providerListing');
 
 export let providerToolType = PresentableType.create<{ tool: RawProviderTool }>()('tool');
@@ -3171,7 +3172,7 @@ export let authConfigSchemaType = PresentableType.create<{
 
 export let customProviderType = PresentableType.create<{
   customProvider: RawCustomProvider;
-  tenant?: SubspacePrisma.TenantGetPayload<{}>;
+  tenant: SubspacePrisma.TenantGetPayload<{}>;
 }>()('customProvider');
 
 export let customProviderVersionType = PresentableType.create<{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth callback URL exposure across multiple read/write provider APIs and adds a DB lookup per response; missing tenant rows will now fail requests that previously returned null callback URLs.
> 
> **Overview**
> **Ensures provider API responses include correct OAuth `callback_url` values** by loading the project tenant in controllers and passing it into presenters, instead of leaving tenant optional and often unset.
> 
> Instance and consumer endpoints for **providers**, **provider listings**, **custom providers**, and **consumer providers** now call `db.tenant.findFirstOrThrow` for `ctx.project.oid` before `present`. Presenter input types treat **`tenant` as required** for `provider`, `providerListing`, `customProvider`, and `consumerProvider`. Nested presentation (e.g. consumer provider → provider) forwards the same tenant.
> 
> In **`v1ProviderPresenter`**, OAuth `callback_url` is always computed via `getOAuthCallbackUrl(..., tenant)` when OAuth is enabled—the previous branch that returned `null` when tenant was missing is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577523cf866c0f4141b6402b7605fcdca0a16d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->