### PR TITLE
Add skill plugin import

### DIFF
--- a/src/metorial-frontend/scenes/skills/src/scenes/skillImport.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillImport.tsx
@@ -1,10 +1,23 @@
+import { renderWithLoader, useForm } from '@metorial/data-hooks';
+import { Paths } from '@metorial/frontend-config';
+import { parsePublicScmRepositoryUrl } from '@metorial/scene-scm';
 import type {
   CreateSkillImportInput,
-  DashboardInstanceSkillsImportsGetOutput
+  DashboardInstanceSkillsImportsGetOutput,
+  Skill
 } from '@metorial/state';
-import { renderWithLoader } from '@metorial/data-hooks';
-import { parsePublicScmRepositoryUrl } from '@metorial/scene-scm';
-import { useCreateSkillImport, useSkillImport, useUploadFile } from '@metorial/state';
+import {
+  useCreateSkillImport,
+  useCreateSkillMarketplacePlugin,
+  useCreateSkillPlugin,
+  useCreateSkillPluginSkill,
+  useCurrentInstance,
+  useCurrentOrganization,
+  useCurrentProject,
+  useSkillImport,
+  useSkillMarketplaces,
+  useUploadFile
+} from '@metorial/state';
 import {
   Attributes,
   Badge,
@@ -12,15 +25,17 @@ import {
   Callout,
   Dialog,
   Input,
+  Menu,
   Panel,
   Spacer,
   Text,
   showModal,
   toast
 } from '@metorial/ui';
-import { Table } from '@metorial/ui-product';
+import { SideBox, Table } from '@metorial/ui-product';
+import PQueue from 'p-queue';
 import { FormEvent, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 type SkillImport = DashboardInstanceSkillsImportsGetOutput;
@@ -30,6 +45,12 @@ type SkillImportSource = CreateSkillImportInput['source'];
 let SkillLink = styled(Link)`
   font-weight: 600;
   text-decoration: none;
+`;
+
+let FormStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 `;
 
 let statusColor = (status: SkillImportStatus): 'blue' | 'red' | 'orange' | 'gray' =>
@@ -62,71 +83,243 @@ let getSkillImportSourceAttribute = (source: SkillImport['source']) =>
           (source.type == 'public' ? source.repositoryUrl : source.repositoryId)
       };
 
+let getNewPluginSkillInput = (skill: Skill) => ({
+  skillId: skill.id,
+  clientName: skill.clientName ?? skill.name,
+  clientDescription: skill.clientDescription ?? skill.description ?? undefined,
+  clientMetadata: skill.clientMetadata ?? undefined,
+  license: skill.license ?? undefined,
+  compatibility: skill.compatibility ?? undefined
+});
+
+let CreatePluginFromImportForm = (p: {
+  instanceId: string;
+  skillMarketplaceId: string;
+  skills: Skill[];
+  close: () => void;
+  onCreated: (pluginId: string) => void;
+}) => {
+  let createPlugin = useCreateSkillPlugin();
+  let addMarketplacePlugin = useCreateSkillMarketplacePlugin();
+  let addPluginSkill = useCreateSkillPluginSkill();
+
+  let form = useForm({
+    initialValues: { name: '', description: '' },
+    onSubmit: async values => {
+      let [plugin] = await createPlugin.mutate({
+        instanceId: p.instanceId,
+        name: values.name.trim(),
+        description: values.description.trim() || undefined
+      });
+      if (!plugin) return;
+
+      let [added] = await addMarketplacePlugin.mutate({
+        instanceId: p.instanceId,
+        skillMarketplaceId: p.skillMarketplaceId,
+        skillPluginId: plugin.id
+      });
+      if (!added) return;
+
+      let queue = new PQueue({ concurrency: 10 });
+      await queue.addAll(
+        p.skills.map(
+          skill => () =>
+            addPluginSkill.mutate({
+              instanceId: p.instanceId,
+              skillPluginId: plugin.id,
+              ...getNewPluginSkillInput(skill)
+            })
+        )
+      );
+
+      p.onCreated(plugin.id);
+      p.close();
+    },
+    schema: yup =>
+      yup.object({
+        name: yup.string().trim().required('Name is required'),
+        description: yup.string()
+      })
+  });
+
+  let loading =
+    createPlugin.isLoading || addMarketplacePlugin.isLoading || addPluginSkill.isLoading;
+
+  return (
+    <form onSubmit={form.handleSubmit}>
+      <FormStack>
+        <Input label="Name" required {...form.getFieldProps('name')} />
+        <form.RenderError field="name" />
+        <Input
+          label="Description"
+          as="textarea"
+          minRows={3}
+          {...form.getFieldProps('description')}
+        />
+        <form.RenderError field="description" />
+        <Dialog.Actions>
+          <Button type="button" variant="soft" onClick={p.close}>
+            Cancel
+          </Button>
+          <Button type="submit" loading={loading}>
+            Create Plugin
+          </Button>
+        </Dialog.Actions>
+        <createPlugin.RenderError />
+        <addMarketplacePlugin.RenderError />
+        <addPluginSkill.RenderError />
+      </FormStack>
+    </form>
+  );
+};
+
+let showCreatePluginFromImportModal = (
+  p: Omit<Parameters<typeof CreatePluginFromImportForm>[0], 'close'> & {
+    marketplaceName: string;
+  }
+) =>
+  showModal(({ dialogProps, close }) => (
+    <Dialog.Wrapper {...dialogProps} width={550}>
+      <Dialog.Title>Add to {p.marketplaceName}</Dialog.Title>
+      <Dialog.Description>
+        Create a plugin for the imported {p.skills.length === 1 ? 'skill' : 'skills'} and add
+        it to this marketplace.
+      </Dialog.Description>
+      <CreatePluginFromImportForm {...p} close={close} />
+    </Dialog.Wrapper>
+  ));
+
 let SkillImportDetails = (p: {
   instanceId: string;
   skillImportId: string;
   getSkillPath: (skillId: string) => string;
 }) => {
   let skillImport = useSkillImport(p.instanceId, p.skillImportId);
+  let marketplaces = useSkillMarketplaces(p.instanceId);
+  let organization = useCurrentOrganization();
+  let project = useCurrentProject();
+  let instance = useCurrentInstance();
+  let navigate = useNavigate();
 
-  return renderWithLoader({ skillImport })(({ skillImport }) => (
-    <>
-      <Attributes
-        itemWidth="300px"
-        attributes={[
-          {
-            label: 'Status',
-            content: <SkillImportStatusBadge status={skillImport.data.status} />
-          },
-          getSkillImportSourceAttribute(skillImport.data.source)
-        ]}
-      />
+  return renderWithLoader({ skillImport })(({ skillImport }) => {
+    let marketplaceItems = marketplaces.data?.items ?? [];
 
-      <Spacer height={20} />
+    let openCreatePluginModal = (skillMarketplaceId: string) => {
+      if (!instance.data) return;
 
-      {(skillImport.data.items.length > 0 || !skillImport.data.error) && (
-        <Table
-          headers={['Skill', 'Path', 'Status']}
-          data={skillImport.data.items
-            .sort((a, b) => a.path.localeCompare(b.path))
-            .map(item => ({
-              data: [
-                item.skill && item.status == 'completed' ? (
-                  <SkillLink to={p.getSkillPath(item.skill.id)}>{item.skill.name}</SkillLink>
-                ) : item.skill ? (
-                  <Text size="2" color="gray600">
-                    {item.skill.name}
-                  </Text>
-                ) : item.error ? (
-                  <Text size="2" color="red500">
-                    {item.error}
-                  </Text>
-                ) : (
-                  <Text size="2" color="gray600">
-                    Waiting for skill…
-                  </Text>
-                ),
-                item.path,
-                <SkillImportStatusBadge status={item.status} />
-              ]
-            }))}
-        />
-      )}
+      let marketplace = marketplaceItems.find(item => item.id === skillMarketplaceId);
+      if (!marketplace) return;
 
-      {!skillImport.data.items.length && !skillImport.data.error && (
-        <Text size="2" color="gray600" align="center" style={{ marginTop: 16 }}>
-          The source is being scanned for skills.
-        </Text>
-      )}
+      let skills = skillImport.data.items
+        .map(item => item.skill)
+        .filter((skill): skill is Skill => !!skill);
 
-      {skillImport.data.error && (
-        <>
-          <Spacer height={10} />
-          <Callout color="red">{skillImport.data.error}</Callout>
-        </>
-      )}
-    </>
-  ));
+      showCreatePluginFromImportModal({
+        instanceId: p.instanceId,
+        skillMarketplaceId,
+        marketplaceName: marketplace.name,
+        skills,
+        onCreated: () =>
+          navigate(
+            Paths.instance.skillMarketplace(
+              organization.data,
+              project.data,
+              instance.data,
+              skillMarketplaceId
+            )
+          )
+      });
+    };
+
+    return (
+      <>
+        {!!(marketplaceItems.length && skillImport.data.status === 'completed') ? (
+          <>
+            <SideBox
+              title="Add to Marketplace"
+              description={`Create a plugin for the uploaded ${skillImport.data.items.length === 1 ? 'skill' : 'skills'}.`}
+            >
+              {marketplaceItems.length === 1 ? (
+                <Button
+                  size="2"
+                  onClick={() => openCreatePluginModal(marketplaceItems[0]!.id)}
+                >
+                  Add to {marketplaceItems[0]!.name}
+                </Button>
+              ) : (
+                <Menu
+                  title="Choose a marketplace"
+                  items={marketplaceItems.map(marketplace => ({
+                    id: marketplace.id,
+                    label: marketplace.name,
+                    description: marketplace.description ?? undefined
+                  }))}
+                  onItemClick={openCreatePluginModal}
+                >
+                  <Button size="2">Add to Marketplace</Button>
+                </Menu>
+              )}
+            </SideBox>
+          </>
+        ) : (
+          <Attributes
+            itemWidth="300px"
+            attributes={[
+              {
+                label: 'Status',
+                content: <SkillImportStatusBadge status={skillImport.data.status} />
+              },
+              getSkillImportSourceAttribute(skillImport.data.source)
+            ]}
+          />
+        )}
+
+        <Spacer height={20} />
+
+        {(skillImport.data.items.length > 0 || !skillImport.data.error) && (
+          <Table
+            headers={['Skill', 'Path', 'Status']}
+            data={skillImport.data.items
+              .sort((a, b) => a.path.localeCompare(b.path))
+              .map(item => ({
+                data: [
+                  item.skill && item.status == 'completed' ? (
+                    <SkillLink to={p.getSkillPath(item.skill.id)}>{item.skill.name}</SkillLink>
+                  ) : item.skill ? (
+                    <Text size="2" color="gray600">
+                      {item.skill.name}
+                    </Text>
+                  ) : item.error ? (
+                    <Text size="2" color="red500">
+                      {item.error}
+                    </Text>
+                  ) : (
+                    <Text size="2" color="gray600">
+                      Waiting for skill…
+                    </Text>
+                  ),
+                  item.path,
+                  <SkillImportStatusBadge status={item.status} />
+                ]
+              }))}
+          />
+        )}
+
+        {!skillImport.data.items.length && !skillImport.data.error && (
+          <Text size="2" color="gray600" align="center" style={{ marginTop: 16 }}>
+            The source is being scanned for skills.
+          </Text>
+        )}
+
+        {skillImport.data.error && (
+          <>
+            <Spacer height={10} />
+            <Callout color="red">{skillImport.data.error}</Callout>
+          </>
+        )}
+      </>
+    );
+  });
 };
 
 export let showSkillImportStatusPanel = (p: {
@@ -226,7 +419,6 @@ export let useSkillImportActions = (p: {
   let uploadWithToast = (run: () => Promise<void>) => {
     toast.promise(run, {
       loading: 'Uploading skill...',
-      success: 'Skill uploaded',
       error: error => error?.data?.message ?? error?.message ?? 'Failed to upload skill'
     });
   };
@@ -246,9 +438,8 @@ export let useSkillImportActions = (p: {
       let files = Array.from(input.files ?? []);
       if (!files.length) return;
 
-      let { createSkillImportZipFromDirectory, validateSkillImportDirectory } = await import(
-        './skillImportZip'
-      );
+      let { createSkillImportZipFromDirectory, validateSkillImportDirectory } =
+        await import('./skillImportZip');
 
       let validationError = validateSkillImportDirectory(files);
       if (validationError) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only workflow on top of existing skill import and marketplace APIs; main risk is partial failure across the multi-step create flow, not security or data-model changes.
> 
> **Overview**
> After a skill import **finishes successfully**, the import status UI now prompts users to **add the imported skills to a marketplace** by creating a skill plugin, instead of only showing status/source attributes at the top when marketplaces exist.
> 
> Users get an **Add to Marketplace** action (direct button for one marketplace, or a menu when there are several). That opens a modal to name/describe the plugin; submit runs create plugin → attach to marketplace → attach each imported skill (batched with `PQueue`, concurrency 10), then navigates to the chosen marketplace.
> 
> Upload toasts no longer show a generic **success** message on completion (loading and error handling are unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a946896746351cbd727ce15c920725225b1c53d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->