### PR TITLE
Fix global router pollution

### DIFF
--- a/src/metorial/apis/connection/src/oauth/skeleton.ts
+++ b/src/metorial/apis/connection/src/oauth/skeleton.ts
@@ -1,6 +1,5 @@
 import { Context } from '@lowerdeck/hono';
 import { createConnectionHono } from '../hono';
-import { assertOutpostConnectionAccess, getOutpostAuth } from '../outpost';
 
 export type PortalOAuthRouteInput = {
   portalId: string;
@@ -40,6 +39,7 @@ export let buildOAuthClientConfig = (base: string) => ({
 type OAuthRouteHandlers<TInput, TRoute> = {
   resolveRoute: (route: TInput, c: Context) => Promise<TRoute>;
   resolveConnectRoute?: (route: TInput, c: Context) => Promise<TRoute>;
+  authorizeRoute?: (c: Context, route: TRoute) => Promise<void>;
   metadata: (d: { route: TRoute }, c: Context) => Promise<Response>;
   portal: (d: { route: TRoute }, c: Context) => Promise<Response>;
   protectedResource: (d: { route: TRoute }, c: Context) => Promise<Response>;
@@ -128,25 +128,12 @@ let createOAuthRouteServers = <TInput, TRoute>(d: {
     return await d.handlers.resolveRoute(input, c);
   };
 
-  // Every connection route resolves to an instance. An outpost-proxied request must be granted
-  // `mcp_connection_proxy` for that specific project and instance -- direct requests are
-  // untouched, see `assertOutpostConnectionAccess`.
   let resolveAuthorizedRoute = async (
     c: Context,
     resolver: (c: Context) => Promise<TRoute>
   ) => {
     let route = await resolver(c);
-    let scope = route as TRoute & { projectOid?: bigint; instanceOid?: bigint };
-    let outpostAuth = getOutpostAuth(c);
-    if (outpostAuth && (scope.projectOid === undefined || scope.instanceOid === undefined)) {
-      throw new Error('Outpost-authenticated OAuth route did not resolve an instance scope');
-    }
-    if (scope.projectOid !== undefined && scope.instanceOid !== undefined) {
-      await assertOutpostConnectionAccess(c, {
-        projectOid: scope.projectOid,
-        instanceOid: scope.instanceOid
-      });
-    }
+    if (d.handlers.authorizeRoute) await d.handlers.authorizeRoute(c, route);
     return route;
   };
 

--- a/src/metorial/apis/connection/src/outpost.ts
+++ b/src/metorial/apis/connection/src/outpost.ts
@@ -147,3 +147,19 @@ export let assertOutpostConnectionAccess = async (
     );
   }
 };
+
+export let assertOutpostOAuthRouteAccess = async (
+  c: Context,
+  route: { projectOid?: bigint; instanceOid?: bigint }
+) => {
+  let outpostAuth = getOutpostAuth(c);
+  if (outpostAuth && (route.projectOid === undefined || route.instanceOid === undefined)) {
+    throw new Error('Outpost-authenticated OAuth route did not resolve an instance scope');
+  }
+  if (route.projectOid !== undefined && route.instanceOid !== undefined) {
+    await assertOutpostConnectionAccess(c, {
+      projectOid: route.projectOid,
+      instanceOid: route.instanceOid
+    });
+  }
+};

--- a/src/metorial/apis/connection/src/portal.ts
+++ b/src/metorial/apis/connection/src/portal.ts
@@ -21,7 +21,12 @@ import {
   createPortalOAuthServers
 } from './oauth/skeleton';
 import { getClientCredentials, getString, parseOAuthBody } from './oauth/utils';
-import { getOutpostAuth, resolveOutpostOrigin, useConnectionRequestContext } from './outpost';
+import {
+  assertOutpostOAuthRouteAccess,
+  getOutpostAuth,
+  resolveOutpostOrigin,
+  useConnectionRequestContext
+} from './outpost';
 
 export { createPluginOAuthServers, createPortalOAuthServers } from './oauth/skeleton';
 
@@ -133,6 +138,7 @@ export let createPortalHandler = (d: {
         originOverride: resolveOutpostOrigin(getOutpostAuth(c))
       });
     },
+    authorizeRoute: assertOutpostOAuthRouteAccess,
 
     metadata: async ({ route }, c) => {
       return c.json(buildOAuthClientConfig(route.base));
@@ -322,6 +328,7 @@ export let createPluginHandler = (d: {
         originOverride: resolveOutpostOrigin(getOutpostAuth(c))
       });
     },
+    authorizeRoute: assertOutpostOAuthRouteAccess,
 
     metadata: async ({ route }, c) => {
       return c.json(buildOAuthClientConfig(route.base));

--- a/src/metorial/apis/connection/test/oauthSkeleton.test.ts
+++ b/src/metorial/apis/connection/test/oauthSkeleton.test.ts
@@ -12,7 +12,7 @@ vi.mock('@metorial/module-outpost', () => ({
 }));
 
 import { createPortalOAuthServers } from '../src/oauth/skeleton';
-import { setOutpostAuth } from '../src/outpost';
+import { assertOutpostOAuthRouteAccess, setOutpostAuth } from '../src/outpost';
 
 let fakeAuth = () =>
   ({
@@ -34,6 +34,7 @@ let buildServers = () =>
       projectOid: 42n,
       instanceOid: 84n
     }),
+    authorizeRoute: assertOutpostOAuthRouteAccess,
     metadata: async ({ route }, c) => c.json({ base: route.base }),
     portal: async ({ route }, c) => c.json({ base: route.base }),
     protectedResource: async ({ route }, c) => c.json({ base: route.base }),
@@ -92,6 +93,29 @@ describe('createOAuthRouteServers (via createPortalOAuthServers) instance gating
     let res = await mount(metadataServer).request('http://test/portal_1');
 
     expect(res.status).toBe(403);
+  });
+
+  it('does not consult outpost access unless authorizeRoute is wired (global-router path)', async () => {
+    isServiceGrantedForInstance.mockResolvedValue(false);
+    let { metadataServer } = createPortalOAuthServers({
+      resolveRoute: async () => ({
+        base: 'https://example.test',
+        host: 'region.example'
+      }),
+      metadata: async ({ route }, c) => c.json({ base: route.base }),
+      portal: async ({ route }, c) => c.json({ base: route.base }),
+      protectedResource: async ({ route }, c) => c.json({ base: route.base }),
+      openIdConfiguration: async ({ route }, c) => c.json({ base: route.base }),
+      register: async ({ route }, c) => c.json({ base: route.base }),
+      authorize: async ({ route }, c) => c.json({ base: route.base }),
+      token: async ({ route }, c) => c.json({ base: route.base }),
+      registration: async ({ route }, c) => c.json({ base: route.base })
+    });
+
+    let res = await mount(metadataServer).request('http://test/portal_1');
+
+    expect(res.status).toBe(200);
+    expect(isServiceGrantedForInstance).not.toHaveBeenCalled();
   });
 
   it('also gates the registration lookup route, which resolves the route outside of withResolvedRoute', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authorization boundaries for OAuth routes: connection portal/plugin paths keep outpost gating, but any skeleton user without `authorizeRoute` no longer gets it—intentional for global router, but worth confirming no other callers relied on implicit gating.
> 
> **Overview**
> Moves **outpost instance gating** out of the shared OAuth skeleton so it no longer runs for every consumer of `createPortalOAuthServers` / `createPluginOAuthServers`.
> 
> The skeleton now supports an optional **`authorizeRoute`** hook invoked from `resolveAuthorizedRoute` after route resolution. Portal and plugin connection handlers wire **`assertOutpostOAuthRouteAccess`** (new helper in `outpost.ts`, same rules as before: require instance scope for outpost-authenticated requests, then call `assertOutpostConnectionAccess`). Routes that only resolve metadata (e.g. global-router style setups without `projectOid`/`instanceOid`) can omit the hook and are not blocked by outpost grants.
> 
> Tests confirm outpost checks still apply when `authorizeRoute` is set, and a new case verifies **`isServiceGrantedForInstance` is not called** when the hook is absent even with outpost auth on the request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd442a0994f8a9b901bea67e1ba9ff4eb25631e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->