### PR TITLE
Better plugin names

### DIFF
--- a/src/metorial/apis/connection/src/oauth/skeleton.ts
+++ b/src/metorial/apis/connection/src/oauth/skeleton.ts
@@ -1,6 +1,5 @@
 import { Context } from '@lowerdeck/hono';
 import { createConnectionHono } from '../hono';
-import { assertOutpostConnectionAccess, getOutpostAuth } from '../outpost';
 
 export type PortalOAuthRouteInput = {
   portalId: string;
@@ -40,6 +39,7 @@ export let buildOAuthClientConfig = (base: string) => ({
 type OAuthRouteHandlers<TInput, TRoute> = {
   resolveRoute: (route: TInput, c: Context) => Promise<TRoute>;
   resolveConnectRoute?: (route: TInput, c: Context) => Promise<TRoute>;
+  authorizeRoute?: (c: Context, route: TRoute) => Promise<void>;
   metadata: (d: { route: TRoute }, c: Context) => Promise<Response>;
   portal: (d: { route: TRoute }, c: Context) => Promise<Response>;
   protectedResource: (d: { route: TRoute }, c: Context) => Promise<Response>;
@@ -128,25 +128,12 @@ let createOAuthRouteServers = <TInput, TRoute>(d: {
     return await d.handlers.resolveRoute(input, c);
   };
 
-  // Every connection route resolves to an instance. An outpost-proxied request must be granted
-  // `mcp_connection_proxy` for that specific project and instance -- direct requests are
-  // untouched, see `assertOutpostConnectionAccess`.
   let resolveAuthorizedRoute = async (
     c: Context,
     resolver: (c: Context) => Promise<TRoute>
   ) => {
     let route = await resolver(c);
-    let scope = route as TRoute & { projectOid?: bigint; instanceOid?: bigint };
-    let outpostAuth = getOutpostAuth(c);
-    if (outpostAuth && (scope.projectOid === undefined || scope.instanceOid === undefined)) {
-      throw new Error('Outpost-authenticated OAuth route did not resolve an instance scope');
-    }
-    if (scope.projectOid !== undefined && scope.instanceOid !== undefined) {
-      await assertOutpostConnectionAccess(c, {
-        projectOid: scope.projectOid,
-        instanceOid: scope.instanceOid
-      });
-    }
+    if (d.handlers.authorizeRoute) await d.handlers.authorizeRoute(c, route);
     return route;
   };
 

--- a/src/metorial/apis/connection/src/outpost.ts
+++ b/src/metorial/apis/connection/src/outpost.ts
@@ -147,3 +147,19 @@ export let assertOutpostConnectionAccess = async (
     );
   }
 };
+
+export let assertOutpostOAuthRouteAccess = async (
+  c: Context,
+  route: { projectOid?: bigint; instanceOid?: bigint }
+) => {
+  let outpostAuth = getOutpostAuth(c);
+  if (outpostAuth && (route.projectOid === undefined || route.instanceOid === undefined)) {
+    throw new Error('Outpost-authenticated OAuth route did not resolve an instance scope');
+  }
+  if (route.projectOid !== undefined && route.instanceOid !== undefined) {
+    await assertOutpostConnectionAccess(c, {
+      projectOid: route.projectOid,
+      instanceOid: route.instanceOid
+    });
+  }
+};

--- a/src/metorial/apis/connection/src/portal.ts
+++ b/src/metorial/apis/connection/src/portal.ts
@@ -21,7 +21,12 @@ import {
   createPortalOAuthServers
 } from './oauth/skeleton';
 import { getClientCredentials, getString, parseOAuthBody } from './oauth/utils';
-import { getOutpostAuth, resolveOutpostOrigin, useConnectionRequestContext } from './outpost';
+import {
+  assertOutpostOAuthRouteAccess,
+  getOutpostAuth,
+  resolveOutpostOrigin,
+  useConnectionRequestContext
+} from './outpost';
 
 export { createPluginOAuthServers, createPortalOAuthServers } from './oauth/skeleton';
 
@@ -133,6 +138,7 @@ export let createPortalHandler = (d: {
         originOverride: resolveOutpostOrigin(getOutpostAuth(c))
       });
     },
+    authorizeRoute: assertOutpostOAuthRouteAccess,
 
     metadata: async ({ route }, c) => {
       return c.json(buildOAuthClientConfig(route.base));
@@ -322,6 +328,7 @@ export let createPluginHandler = (d: {
         originOverride: resolveOutpostOrigin(getOutpostAuth(c))
       });
     },
+    authorizeRoute: assertOutpostOAuthRouteAccess,
 
     metadata: async ({ route }, c) => {
       return c.json(buildOAuthClientConfig(route.base));

--- a/src/metorial/apis/connection/test/oauthSkeleton.test.ts
+++ b/src/metorial/apis/connection/test/oauthSkeleton.test.ts
@@ -12,7 +12,7 @@ vi.mock('@metorial/module-outpost', () => ({
 }));
 
 import { createPortalOAuthServers } from '../src/oauth/skeleton';
-import { setOutpostAuth } from '../src/outpost';
+import { assertOutpostOAuthRouteAccess, setOutpostAuth } from '../src/outpost';
 
 let fakeAuth = () =>
   ({
@@ -34,6 +34,7 @@ let buildServers = () =>
       projectOid: 42n,
       instanceOid: 84n
     }),
+    authorizeRoute: assertOutpostOAuthRouteAccess,
     metadata: async ({ route }, c) => c.json({ base: route.base }),
     portal: async ({ route }, c) => c.json({ base: route.base }),
     protectedResource: async ({ route }, c) => c.json({ base: route.base }),
@@ -92,6 +93,29 @@ describe('createOAuthRouteServers (via createPortalOAuthServers) instance gating
     let res = await mount(metadataServer).request('http://test/portal_1');
 
     expect(res.status).toBe(403);
+  });
+
+  it('does not consult outpost access unless authorizeRoute is wired (global-router path)', async () => {
+    isServiceGrantedForInstance.mockResolvedValue(false);
+    let { metadataServer } = createPortalOAuthServers({
+      resolveRoute: async () => ({
+        base: 'https://example.test',
+        host: 'region.example'
+      }),
+      metadata: async ({ route }, c) => c.json({ base: route.base }),
+      portal: async ({ route }, c) => c.json({ base: route.base }),
+      protectedResource: async ({ route }, c) => c.json({ base: route.base }),
+      openIdConfiguration: async ({ route }, c) => c.json({ base: route.base }),
+      register: async ({ route }, c) => c.json({ base: route.base }),
+      authorize: async ({ route }, c) => c.json({ base: route.base }),
+      token: async ({ route }, c) => c.json({ base: route.base }),
+      registration: async ({ route }, c) => c.json({ base: route.base })
+    });
+
+    let res = await mount(metadataServer).request('http://test/portal_1');
+
+    expect(res.status).toBe(200);
+    expect(isServiceGrantedForInstance).not.toHaveBeenCalled();
   });
 
   it('also gates the registration lookup route, which resolves the route outside of withResolvedRoute', async () => {

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/plugin/index.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/plugin/index.ts
@@ -175,13 +175,7 @@ export let applyPlugin = createApplicator(
       await context.setFile(logoIcon, await downloadImage.fetch());
 
       let baseInfo = {
-        name: slugify(
-          (
-            input.skillMarketplacePlugin?.pluginSlug ??
-            input.skillPlugin.name ??
-            input.skillPlugin.id
-          ).replaceAll('_', '-')
-        ),
+        name: slugify((input.skillPlugin.name ?? input.skillPlugin.id).replaceAll('_', '-')),
         description: input.skillPlugin.description,
         version: input.skillPlugin.version,
         author: {

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplacePlugin.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplacePlugin.ts
@@ -1,7 +1,8 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
+import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { createSlugGenerator } from '@lowerdeck/slugify';
+import { slugify } from '@lowerdeck/slugify';
 import type { Instance, Prisma, Project, SkillMarketplacePluginStatus } from '@metorial/db';
 import { db, ID, withTransaction } from '@metorial/db';
 import {
@@ -54,17 +55,37 @@ export type SkillMarketplacePluginRecord = Prisma.SkillMarketplacePluginGetPaylo
 
 export type SkillMarketplacePluginStatusFilter = SkillMarketplacePluginStatus;
 
-let getMarketplacePluginSlug = createSlugGenerator(
-  async (slug, d: { skillMarketplaceId: string }) =>
-    !(await db.skillMarketplacePlugin.findFirst({
-      where: {
-        skillMarketplace: {
-          id: d.skillMarketplaceId
-        },
-        pluginSlug: slug
-      }
-    }))
-);
+let isMarketplacePluginSlugAvailable = async (
+  slug: string,
+  d: { skillMarketplaceId: string }
+) =>
+  !(await db.skillMarketplacePlugin.findFirst({
+    where: {
+      skillMarketplace: {
+        id: d.skillMarketplaceId
+      },
+      pluginSlug: slug
+    }
+  }));
+
+let getMarketplacePluginSlug = async (
+  d: { input: string; current?: string },
+  opts: { skillMarketplaceId: string }
+) => {
+  let baseSlug = slugify(d.input) || generatePlainId(8).toLowerCase();
+
+  if (d.current === baseSlug) return baseSlug;
+  if (await isMarketplacePluginSlugAvailable(baseSlug, opts)) return baseSlug;
+
+  for (let suffix = 2; suffix < 50; suffix++) {
+    let candidate = `${baseSlug}-${suffix}`;
+
+    if (d.current === candidate) return candidate;
+    if (await isMarketplacePluginSlugAvailable(candidate, opts)) return candidate;
+  }
+
+  return `${baseSlug}-${generatePlainId(6).toLowerCase()}`;
+};
 
 class SkillMarketplacePluginServiceImpl {
   private async getSkillMarketplacePluginRecord(d: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> OAuth authorization is refactored behind an optional hook—production handlers still wire it, but any alternate mount that forgets `authorizeRoute` would bypass Outpost gating; marketplace slug logic changes affect published plugin identifiers.
> 
> **Overview**
> **Plugin packaging and marketplace slugs** now favor human-readable skill plugin names over marketplace `pluginSlug` in generated Claude/Cursor/Copilot plugin manifests (`name` comes from `skillPlugin.name` or id). Marketplace `pluginSlug` assignment replaces `createSlugGenerator` with explicit slugify + collision handling (numeric suffixes, then a random suffix).
> 
> **Connection OAuth** stops baking Outpost instance checks into the shared skeleton: routes can supply an optional `authorizeRoute` hook. Portal and plugin handlers wire `assertOutpostOAuthRouteAccess` (moved to `outpost.ts`), so Outpost-authenticated requests still require `mcp_connection_proxy` on the resolved instance; mounts that omit the hook skip that check (covered by a new test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a111cc6b77a74c3f2b2f3fe48d58c330369466c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->