### PR TITLE
Set regional apis in outpost creds

### DIFF
--- a/src/metorial/products/core/modules/outpost/src/env.ts
+++ b/src/metorial/products/core/modules/outpost/src/env.ts
@@ -4,5 +4,9 @@ import { v } from '@lowerdeck/validation';
 export let env = createValidatedEnv({
   secrets: {
     OUTPOST_KEY_ENCRYPTION_SECRET: v.string()
+  },
+
+  urls: {
+    OUTPOST_REGIONAL_API_URL: v.optional(v.string())
   }
 });

--- a/src/metorial/products/core/modules/outpost/src/services/outpostCredential.ts
+++ b/src/metorial/products/core/modules/outpost/src/services/outpostCredential.ts
@@ -14,6 +14,7 @@ import {
 import { Fabric } from '@metorial/fabric';
 import { encodeCredentialEnvelope } from '@metorial-outpost/credential-envelope';
 import { base64url, Ed25519 } from '@metorial-outpost/crypto';
+import { env } from '../env';
 import { getEnvelopePreview } from '../lib/envelopePreview';
 
 class OutpostCredentialService {
@@ -45,9 +46,11 @@ class OutpostCredentialService {
     let publicKeyBytes = await Ed25519.exportPublicKey(keyPair.publicKey);
     let privateKeyBytes = await Ed25519.exportPrivateKey(keyPair.privateKey);
 
+    let endpoint = env.urls.OUTPOST_REGIONAL_API_URL ?? getConfig().urls.apiUrl;
+
     let envelope = encodeCredentialEnvelope({
       version: 1,
-      endpoint: `${getConfig().urls.apiUrl}`,
+      endpoint,
       outpost_id: d.outpost.id,
       credential_id: id,
       private_key: base64url.encode(privateKeyBytes)

--- a/src/metorial/products/core/modules/outpost/test/outpostCredential.test.ts
+++ b/src/metorial/products/core/modules/outpost/test/outpostCredential.test.ts
@@ -25,6 +25,8 @@ vi.mock('@metorial/fabric', () => ({
 vi.mock('@metorial/config', () => ({
   getConfig: () => ({ urls: { apiUrl: 'http://api.test' } })
 }));
+const mockEnv = vi.hoisted(() => ({ urls: { OUTPOST_REGIONAL_API_URL: undefined as string | undefined } }));
+vi.mock('../src/env', () => ({ env: mockEnv }));
 vi.mock('@metorial-outpost/server', () => ({ DEFAULT_BASE_PATH: '/outpost' }));
 vi.mock('@metorial-outpost/crypto', () => ({
   Ed25519: {
@@ -51,9 +53,13 @@ let testAuditScope = {
   actor: { type: 'org_actor' as const, id: 'actor_1' }
 } as any;
 
+const decodeEnvelope = (envelope: string) =>
+  JSON.parse(Buffer.from(envelope.replace('metorial_op_', ''), 'base64url').toString());
+
 describe('outpostCredentialService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockEnv.urls.OUTPOST_REGIONAL_API_URL = undefined;
   });
 
   it('creates a credential, returning a one-time envelope while persisting only the public key and preview', async () => {
@@ -78,6 +84,39 @@ describe('outpostCredentialService', () => {
     let createCall = (db.outpostCredential.create as any).mock.calls[0][0];
     expect(createCall.data.publicKey).toBeInstanceOf(Buffer);
     expect(createCall.data).not.toHaveProperty('privateKey');
+  });
+
+  it('falls back to the global API URL when no regional endpoint is configured', async () => {
+    (db.outpostCredential.create as any).mockImplementation(({ data }: any) => ({
+      ...data,
+      oid: 500n
+    }));
+
+    let { envelope } = await outpostCredentialService.createCredential({
+      outpost: baseOutpost,
+      organization: baseOrg,
+      input: { name: 'CI Runner' },
+      auditScope: testAuditScope
+    });
+
+    expect(decodeEnvelope(envelope).endpoint).toBe('http://api.test');
+  });
+
+  it('prefers the regional API endpoint when configured', async () => {
+    mockEnv.urls.OUTPOST_REGIONAL_API_URL = 'https://api-eu1.test';
+    (db.outpostCredential.create as any).mockImplementation(({ data }: any) => ({
+      ...data,
+      oid: 500n
+    }));
+
+    let { envelope } = await outpostCredentialService.createCredential({
+      outpost: baseOutpost,
+      organization: baseOrg,
+      input: { name: 'CI Runner' },
+      auditScope: testAuditScope
+    });
+
+    expect(decodeEnvelope(envelope).endpoint).toBe('https://api-eu1.test');
   });
 
   it('refuses to delete an active credential', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wrong or missing regional URL would send new outpost credentials to the wrong API host, though behavior unchanged when the env var is unset.
> 
> **Overview**
> Outpost credential creation now embeds a **regional API base URL** in the one-time credential envelope when `OUTPOST_REGIONAL_API_URL` is set, instead of always using the global `getConfig().urls.apiUrl`.
> 
> The outpost module env gains an optional `urls.OUTPOST_REGIONAL_API_URL` setting; `createCredential` resolves `endpoint` as regional URL first, then falls back to the global API URL. Tests mock `env` and assert both the fallback and regional preference in the decoded envelope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d564b9d73f2a49a781f75c9e094d4e94c33094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->