### PR TITLE
Add audit logging events for protoguard

### DIFF
--- a/src/metorial/apis/core/src/controllers/instance/monitor/protoGuardConfig.ts
+++ b/src/metorial/apis/core/src/controllers/instance/monitor/protoGuardConfig.ts
@@ -54,6 +54,7 @@ export let protoGuardConfigController = Controller.create(
         if (ctx.body.enabled !== undefined) {
           await protoGuardConfigService.setTenantFilterEnabled({
             instance: ctx.instance,
+            auditScope: ctx.auditScope,
             filterId,
             enabled: ctx.body.enabled
           });
@@ -65,6 +66,7 @@ export let protoGuardConfigController = Controller.create(
         if (ctx.body.alert_confidence_threshold !== undefined) {
           await protoGuardConfigService.setTenantFilterAlertConfidenceThreshold({
             instance: ctx.instance,
+            auditScope: ctx.auditScope,
             filterId,
             threshold: ctx.body.alert_confidence_threshold
           });
@@ -109,6 +111,7 @@ export let protoGuardConfigController = Controller.create(
       .do(async ctx => {
         await protoGuardConfigService.setTenantAlertFilterCountThreshold({
           instance: ctx.instance,
+          auditScope: ctx.auditScope,
           threshold: ctx.body.threshold
         });
 

--- a/src/metorial/packages/fabric/src/types.ts
+++ b/src/metorial/packages/fabric/src/types.ts
@@ -388,6 +388,67 @@ export type AuditSubspaceIdentityDelegationConfig = {
   description: string | null;
 };
 
+export type AuditSubspaceProtoGuardFilterDefinition = {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  issueType: string;
+  severity: string;
+  scoreWeight: number;
+  defaultEnabled: boolean;
+  defaultAlertConfidenceThreshold: number;
+};
+
+export type AuditSubspaceProtoGuardFilterSetting = {
+  filter: AuditSubspaceProtoGuardFilterDefinition;
+  settingId: string | null;
+  enabled: boolean;
+  isUsingDefaultEnabled: boolean;
+  alertConfidenceThreshold: number;
+  isUsingDefaultConfidenceThreshold: boolean;
+};
+
+export type AuditSubspaceProtoGuardAlertThreshold = {
+  settingId: string | null;
+  alertFilterCountThreshold: number;
+  isUsingDefault: boolean;
+  defaultAlertFilterCountThreshold: number;
+};
+
+export type AuditSubspaceProtoGuardAlertMatch = {
+  filter: { key: string; name: string };
+  issueType: string;
+  severity: string;
+  confidence: number;
+  confidenceThreshold: number;
+  scoreWeight: number;
+  path: string;
+  startOffset: number;
+  endOffset: number;
+  description: string | null;
+};
+
+export type AuditSubspaceProtoGuardAlert = {
+  id: string;
+  runId: string;
+  messageId: string;
+  sessionId: string;
+  connectionId: string | null;
+  providerRunId: string | null;
+  issueTypes: string[];
+  score: number;
+  maxScore: number;
+  confidence: number;
+  triggeredFilterCount: number;
+  matchedInstanceCount: number;
+  alertFilterCountThreshold: number;
+  alertByConfidence: boolean;
+  alertByFilterCount: boolean;
+  matches: AuditSubspaceProtoGuardAlertMatch[];
+  createdAt: Date;
+};
+
 export type AuditConsumerProviderDeployment = {
   providerTemplate: { id: string; name: string };
   provider: { id: string; name: string };
@@ -1409,6 +1470,20 @@ export interface FabricEvents {
   };
   'provider.tool_call.created:before': ProviderEventBase;
   'provider.tool_call.created:after': ProviderEventBase & { toolCall: SubspaceToolCall };
+
+  'protoguard.filter_setting.updated:before': ProviderEventBase & { filterId: string };
+  'protoguard.filter_setting.updated:after': ProviderEventBase & {
+    setting: AuditSubspaceProtoGuardFilterSetting;
+    previousSetting: AuditSubspaceProtoGuardFilterSetting;
+  };
+
+  'protoguard.alert_threshold.updated:before': ProviderEventBase;
+  'protoguard.alert_threshold.updated:after': ProviderEventBase & {
+    threshold: AuditSubspaceProtoGuardAlertThreshold;
+    previousThreshold: AuditSubspaceProtoGuardAlertThreshold;
+  };
+
+  'protoguard.alert.created:after': { auditScope: AuditScope; alert: AuditSubspaceProtoGuardAlert };
 
   'provider.custom_provider.created:before': ProviderEventBase;
   'provider.custom_provider.created:after': ProviderEventBase & { customProvider: AuditSubspaceCustomProvider };

--- a/src/metorial/products/auditing/packages/audit-listeners/src/subspace/index.ts
+++ b/src/metorial/products/auditing/packages/audit-listeners/src/subspace/index.ts
@@ -4,5 +4,6 @@ export * from './deployment';
 export * from './identity';
 export * from './integration';
 export * from './network';
+export * from './protoguard';
 export * from './providerListingGroup';
 export * from './session';

--- a/src/metorial/products/auditing/packages/audit-listeners/src/subspace/protoguard.ts
+++ b/src/metorial/products/auditing/packages/audit-listeners/src/subspace/protoguard.ts
@@ -1,0 +1,49 @@
+import { Fabric, type FabricEvents } from '@metorial/fabric';
+import { auditTrackerService } from '@metorial/module-audit-tracker';
+import { getSubspaceAuditScope, recordSubspaceAuditEvent } from './_shared';
+
+export let recordProtoGuardFilterSettingUpdated = async (
+  event: FabricEvents['protoguard.filter_setting.updated:after']
+) => {
+  let scope = getSubspaceAuditScope(event);
+  if (!scope) return;
+
+  await recordSubspaceAuditEvent(() =>
+    auditTrackerService.recordEvent(scope, 'protoguard_filter_setting', 'update', {
+      payload: event.setting,
+      previousPayload: event.previousSetting
+    })
+  );
+};
+
+export let recordProtoGuardAlertThresholdUpdated = async (
+  event: FabricEvents['protoguard.alert_threshold.updated:after']
+) => {
+  let scope = getSubspaceAuditScope(event);
+  if (!scope) return;
+
+  await recordSubspaceAuditEvent(() =>
+    auditTrackerService.recordEvent(scope, 'protoguard_alert_threshold', 'update', {
+      payload: event.threshold,
+      previousPayload: event.previousThreshold
+    })
+  );
+};
+
+export let recordProtoGuardAlertCreated = async (
+  event: FabricEvents['protoguard.alert.created:after']
+) => {
+  await recordSubspaceAuditEvent(() =>
+    auditTrackerService.recordEvent(event.auditScope, 'protoguard_alert', 'create', {
+      payload: event.alert,
+      recordedAt: event.alert.createdAt
+    })
+  );
+};
+
+Fabric.listen('protoguard.filter_setting.updated:after', recordProtoGuardFilterSettingUpdated);
+Fabric.listen(
+  'protoguard.alert_threshold.updated:after',
+  recordProtoGuardAlertThresholdUpdated
+);
+Fabric.listen('protoguard.alert.created:after', recordProtoGuardAlertCreated);

--- a/src/metorial/products/auditing/packages/audit-resources-subspace/src/index.ts
+++ b/src/metorial/products/auditing/packages/audit-resources-subspace/src/index.ts
@@ -41,6 +41,11 @@ import {
   networkPolicyAuditResource
 } from './network';
 import {
+  protoGuardAlertAuditResource,
+  protoGuardAlertThresholdAuditResource,
+  protoGuardFilterSettingAuditResource
+} from './protoguard';
+import {
   providerListingGroupAuditResource,
   providerListingGroupListingAuditResource
 } from './providerListingGroup';
@@ -108,5 +113,9 @@ export let subspaceAuditResources = resourceSet({
   network_policy: networkPolicyAuditResource,
 
   session_connection: sessionConnectionAuditResource,
-  session_message: sessionMessageAuditResource
+  session_message: sessionMessageAuditResource,
+
+  protoguard_filter_setting: protoGuardFilterSettingAuditResource,
+  protoguard_alert_threshold: protoGuardAlertThresholdAuditResource,
+  protoguard_alert: protoGuardAlertAuditResource
 });

--- a/src/metorial/products/auditing/packages/audit-resources-subspace/src/protoguard.ts
+++ b/src/metorial/products/auditing/packages/audit-resources-subspace/src/protoguard.ts
@@ -1,0 +1,82 @@
+import { v } from '@lowerdeck/validation';
+import { resource } from '@metorial/audit-stash';
+
+export type ProtoGuardFilterDefinitionSummary = {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  issueType: string;
+  severity: string;
+  scoreWeight: number;
+  defaultEnabled: boolean;
+  defaultAlertConfidenceThreshold: number;
+};
+
+export let protoGuardFilterSettingAuditResource = resource({
+  name: 'protoguard_filter_setting',
+  payload: v.typedAny<{
+    filter: ProtoGuardFilterDefinitionSummary;
+    settingId: string | null;
+    enabled: boolean;
+    isUsingDefaultEnabled: boolean;
+    alertConfidenceThreshold: number;
+    isUsingDefaultConfidenceThreshold: boolean;
+  }>('protoguard_filter_setting'),
+  presenter: undefined,
+  actions: {
+    update: true
+  }
+});
+
+export let protoGuardAlertThresholdAuditResource = resource({
+  name: 'protoguard_alert_threshold',
+  payload: v.typedAny<{
+    settingId: string | null;
+    alertFilterCountThreshold: number;
+    isUsingDefault: boolean;
+    defaultAlertFilterCountThreshold: number;
+  }>('protoguard_alert_threshold'),
+  presenter: undefined,
+  actions: {
+    update: true
+  }
+});
+
+export let protoGuardAlertAuditResource = resource({
+  name: 'protoguard_alert',
+  payload: v.typedAny<{
+    id: string;
+    runId: string;
+    messageId: string;
+    sessionId: string;
+    connectionId: string | null;
+    providerRunId: string | null;
+    issueTypes: string[];
+    score: number;
+    maxScore: number;
+    confidence: number;
+    triggeredFilterCount: number;
+    matchedInstanceCount: number;
+    alertFilterCountThreshold: number;
+    alertByConfidence: boolean;
+    alertByFilterCount: boolean;
+    matches: {
+      filter: { key: string; name: string };
+      issueType: string;
+      severity: string;
+      confidence: number;
+      confidenceThreshold: number;
+      scoreWeight: number;
+      path: string;
+      startOffset: number;
+      endOffset: number;
+      description: string | null;
+    }[];
+    createdAt: Date;
+  }>('protoguard_alert'),
+  presenter: undefined,
+  actions: {
+    create: true
+  }
+});

--- a/src/metorial/subspace/modules/connection/src/protoguard/createRun.ts
+++ b/src/metorial/subspace/modules/connection/src/protoguard/createRun.ts
@@ -1,6 +1,7 @@
 import { db, getId, withTransaction } from '@metorial-subspace/db';
 import { alertInternalService } from '@metorial-subspace/module-monitor';
 import { evaluateProtoGuardMessage } from './evaluateProtoguard';
+import { recordProtoGuardAlertAuditEvent } from './protoguardAudit';
 
 let truncate = (value: string, maxLength: number) =>
   value.length > maxLength ? value.slice(0, maxLength) : value;
@@ -118,6 +119,17 @@ export let createProtoGuardRunForMessage = async (d: { messageId: string }) => {
     if (createdRun && run.alert) {
       await alertInternalService.createFromProtoGuardAlert({
         protoGuardAlertId: run.alert.id
+      });
+
+      await recordProtoGuardAlertAuditEvent({
+        messageId: message.id,
+        instanceOid: message.instanceOid,
+        projectOid: message.projectOid,
+        alertId: run.alert.id,
+        runId: run.id,
+        alertFilterCountThreshold: evaluation.alertFilterCountThreshold,
+        score,
+        createdAt: run.alert.createdAt
       });
     }
 

--- a/src/metorial/subspace/modules/connection/src/protoguard/index.ts
+++ b/src/metorial/subspace/modules/connection/src/protoguard/index.ts
@@ -2,6 +2,7 @@ export * from './config';
 export * from './createRun';
 export * from './evaluateProtoguard';
 export * from './extractText';
+export * from './protoguardAudit';
 export * from './registry';
 export * from './sampleMarkdown';
 export * from './score';

--- a/src/metorial/subspace/modules/connection/src/protoguard/protoguardAudit.ts
+++ b/src/metorial/subspace/modules/connection/src/protoguard/protoguardAudit.ts
@@ -1,0 +1,74 @@
+import { db } from '@metorial-subspace/db';
+import { getSubspaceSystemAuditScope } from '@metorial-subspace/module-tenant/src/lib/systemAuditScope';
+import { Fabric, type AuditSubspaceProtoGuardAlert } from '@metorial/fabric';
+import type { ProtoGuardScoreResult } from './types';
+
+export let recordProtoGuardAlertAuditEvent = async (d: {
+  messageId: string;
+  instanceOid: bigint | null;
+  projectOid: bigint | null;
+  alertId: string;
+  runId: string;
+  alertFilterCountThreshold: number;
+  score: ProtoGuardScoreResult;
+  createdAt: Date;
+}) => {
+  try {
+    let auditScope = await getSubspaceSystemAuditScope({
+      job: 'subspace/protoguard/evaluateMessage',
+      instanceOid: d.instanceOid,
+      projectOid: d.projectOid,
+      metadata: {
+        protoGuardAlertId: d.alertId,
+        protoGuardRunId: d.runId,
+        messageId: d.messageId
+      }
+    });
+    if (!auditScope) return;
+
+    let links = await db.protoGuardAlert.findUnique({
+      where: { id: d.alertId },
+      select: {
+        session: { select: { id: true } },
+        connection: { select: { id: true } },
+        providerRun: { select: { id: true } }
+      }
+    });
+    if (!links) return;
+
+    let alert: AuditSubspaceProtoGuardAlert = {
+      id: d.alertId,
+      runId: d.runId,
+      messageId: d.messageId,
+      sessionId: links.session.id,
+      connectionId: links.connection?.id ?? null,
+      providerRunId: links.providerRun?.id ?? null,
+      issueTypes: d.score.issueTypes,
+      score: d.score.score,
+      maxScore: d.score.maxScore,
+      confidence: d.score.confidence,
+      triggeredFilterCount: d.score.triggeredFilterCount,
+      matchedInstanceCount: d.score.matchedInstanceCount,
+      alertFilterCountThreshold: d.alertFilterCountThreshold,
+      alertByConfidence: d.score.alertByConfidence,
+      alertByFilterCount: d.score.alertByFilterCount,
+      matches: d.score.matches.map(match => ({
+        filter: { key: match.filterKey, name: match.filterName },
+        issueType: match.issueType,
+        severity: match.severity,
+        confidence: match.confidence,
+        confidenceThreshold: match.alertConfidenceThreshold,
+        scoreWeight: match.scoreWeight,
+        path: match.path,
+        startOffset: match.startOffset,
+        endOffset: match.endOffset,
+        description: match.description ?? null
+      })),
+      createdAt: d.createdAt
+    };
+
+    await Fabric.fire('protoguard.alert.created:after', { auditScope, alert });
+  } catch (error) {
+    console.error('[Audit] Failed to record ProtoGuard alert audit event', error);
+  }
+};

--- a/src/metorial/subspace/modules/monitor/package.json
+++ b/src/metorial/subspace/modules/monitor/package.json
@@ -18,7 +18,8 @@
     "@lowerdeck/validation": "workspace:2.0.0",
     "@metorial-subspace/db": "^1.0.0",
     "@metorial-subspace/list-utils": "^1.0.0",
-    "@metorial-subspace/module-tenant": "^1.0.0"
+    "@metorial-subspace/module-tenant": "^1.0.0",
+    "@metorial/fabric": "^1.0.0"
   },
   "devDependencies": {
     "@metorial-subspace/tsconfig": "^1.0.0",

--- a/src/metorial/subspace/modules/monitor/src/services/protoGuardConfig.ts
+++ b/src/metorial/subspace/modules/monitor/src/services/protoGuardConfig.ts
@@ -1,6 +1,22 @@
 import { Service } from '@lowerdeck/service';
-import { db, getId, type Tenant } from '@metorial-subspace/db';
-import { type MetorialFacing, resolveMetorialFacing } from '@metorial-subspace/module-tenant';
+import {
+  db,
+  getId,
+  type ProtoGuardFilter,
+  type ProtoGuardTenantFilterSetting,
+  type ProtoGuardTenantSetting,
+  type Tenant
+} from '@metorial-subspace/db';
+import {
+  toProviderEventBase,
+  type MetorialFacing,
+  resolveMetorialFacing
+} from '@metorial-subspace/module-tenant';
+import {
+  Fabric,
+  type AuditSubspaceProtoGuardAlertThreshold,
+  type AuditSubspaceProtoGuardFilterSetting
+} from '@metorial/fabric';
 
 export let DEFAULT_PROTO_GUARD_ALERT_FILTER_COUNT_THRESHOLD = 2;
 
@@ -76,6 +92,38 @@ export type SetTenantAlertFilterCountThresholdParams = {
   threshold: number | null;
 };
 
+let toFilterSettingAuditPayload = (
+  filter: ProtoGuardFilter,
+  setting: ProtoGuardTenantFilterSetting | null
+): AuditSubspaceProtoGuardFilterSetting => ({
+  filter: {
+    id: filter.id,
+    key: filter.key,
+    name: filter.name,
+    description: filter.description,
+    issueType: filter.issueType,
+    severity: filter.severity,
+    scoreWeight: filter.scoreWeight,
+    defaultEnabled: filter.defaultEnabled,
+    defaultAlertConfidenceThreshold: filter.alertConfidenceThreshold
+  },
+  settingId: setting?.id ?? null,
+  enabled: setting?.enabled ?? filter.defaultEnabled,
+  isUsingDefaultEnabled: !setting,
+  alertConfidenceThreshold: setting?.alertConfidenceThreshold ?? filter.alertConfidenceThreshold,
+  isUsingDefaultConfidenceThreshold: setting?.alertConfidenceThreshold == null
+});
+
+let toAlertThresholdAuditPayload = (
+  setting: ProtoGuardTenantSetting | null
+): AuditSubspaceProtoGuardAlertThreshold => ({
+  settingId: setting?.id ?? null,
+  alertFilterCountThreshold:
+    setting?.alertFilterCountThreshold ?? DEFAULT_PROTO_GUARD_ALERT_FILTER_COUNT_THRESHOLD,
+  isUsingDefault: !setting,
+  defaultAlertFilterCountThreshold: DEFAULT_PROTO_GUARD_ALERT_FILTER_COUNT_THRESHOLD
+});
+
 class protoGuardConfigServiceImpl {
   async listFilters(d: MetorialFacing<ListProtoGuardFiltersParams>) {
     let { instance, organizationActor, ...rest } = d;
@@ -114,7 +162,29 @@ class protoGuardConfigServiceImpl {
   async setTenantFilterEnabled(d: MetorialFacing<SetTenantFilterEnabledParams>) {
     let { instance, organizationActor, ...rest } = d;
     let { tenant } = await resolveMetorialFacing({ instance, organizationActor });
-    return this.setTenantFilterEnabledInternal({ ...rest, tenant });
+
+    let filter = await db.protoGuardFilter.findFirstOrThrow({
+      where: { OR: [{ id: d.filterId }, { key: d.filterId }] }
+    });
+    let previousSetting = await db.protoGuardTenantFilterSetting.findUnique({
+      where: { tenantOid_filterOid: { tenantOid: tenant.oid, filterOid: filter.oid } }
+    });
+
+    let eventBase = toProviderEventBase(d);
+    await Fabric.fire('protoguard.filter_setting.updated:before', {
+      ...eventBase,
+      filterId: filter.id
+    });
+
+    let setting = await this.setTenantFilterEnabledInternal({ ...rest, tenant });
+
+    await Fabric.fire('protoguard.filter_setting.updated:after', {
+      ...eventBase,
+      setting: toFilterSettingAuditPayload(filter, setting),
+      previousSetting: toFilterSettingAuditPayload(filter, previousSetting)
+    });
+
+    return setting;
   }
 
   async setTenantFilterEnabledInternal(d: SetTenantFilterEnabledParams) {
@@ -148,7 +218,32 @@ class protoGuardConfigServiceImpl {
   ) {
     let { instance, organizationActor, ...rest } = d;
     let { tenant } = await resolveMetorialFacing({ instance, organizationActor });
-    return this.setTenantFilterAlertConfidenceThresholdInternal({ ...rest, tenant });
+
+    let filter = await db.protoGuardFilter.findFirstOrThrow({
+      where: { OR: [{ id: d.filterId }, { key: d.filterId }] }
+    });
+    let previousSetting = await db.protoGuardTenantFilterSetting.findUnique({
+      where: { tenantOid_filterOid: { tenantOid: tenant.oid, filterOid: filter.oid } }
+    });
+
+    let eventBase = toProviderEventBase(d);
+    await Fabric.fire('protoguard.filter_setting.updated:before', {
+      ...eventBase,
+      filterId: filter.id
+    });
+
+    let setting = await this.setTenantFilterAlertConfidenceThresholdInternal({
+      ...rest,
+      tenant
+    });
+
+    await Fabric.fire('protoguard.filter_setting.updated:after', {
+      ...eventBase,
+      setting: toFilterSettingAuditPayload(filter, setting),
+      previousSetting: toFilterSettingAuditPayload(filter, previousSetting)
+    });
+
+    return setting;
   }
 
   async setTenantFilterAlertConfidenceThresholdInternal(
@@ -185,7 +280,23 @@ class protoGuardConfigServiceImpl {
   ) {
     let { instance, organizationActor, ...rest } = d;
     let { tenant } = await resolveMetorialFacing({ instance, organizationActor });
-    return this.setTenantAlertFilterCountThresholdInternal({ ...rest, tenant });
+
+    let previousSetting = await db.protoGuardTenantSetting.findUnique({
+      where: { tenantOid: tenant.oid }
+    });
+
+    let eventBase = toProviderEventBase(d);
+    await Fabric.fire('protoguard.alert_threshold.updated:before', eventBase);
+
+    let setting = await this.setTenantAlertFilterCountThresholdInternal({ ...rest, tenant });
+
+    await Fabric.fire('protoguard.alert_threshold.updated:after', {
+      ...eventBase,
+      threshold: toAlertThresholdAuditPayload(setting),
+      previousThreshold: toAlertThresholdAuditPayload(previousSetting)
+    });
+
+    return setting;
   }
 
   async setTenantAlertFilterCountThresholdInternal(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only additions on existing ProtoGuard paths; failures in alert audit recording are caught and logged without blocking alert creation.
> 
> **Overview**
> Adds **end-to-end audit coverage for ProtoGuard**: tenant filter settings, alert filter-count thresholds, and generated alerts now emit Fabric events and land in the subspace audit log.
> 
> **Config changes (user/API-driven)** pass `ctx.auditScope` from the ProtoGuard config controller into `protoGuardConfigService`. The monitor service fires `protoguard.filter_setting.updated:*` and `protoguard.alert_threshold.updated:*` with before/after payloads (including previous vs new settings). Listeners persist **update** events for `protoguard_filter_setting` and `protoguard_alert_threshold`.
> 
> **Alert creation (system-driven)** runs after a new ProtoGuard alert is created in `createProtoGuardRunForMessage`: it resolves a system audit scope, builds a rich alert payload (scores, matches, session links), and fires `protoguard.alert.created:after`. Listeners record a **create** on `protoguard_alert`.
> 
> Fabric types, audit-stash resources, and subspace resource registration were extended to match these three resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4087ad45e53640f39e2d1a64c2dfba2404cd1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->