### PR TITLE
Bump skill hashes

### DIFF
--- a/src/metorial-frontend/scenes/skills/src/scenes/skillImport.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillImport.tsx
@@ -120,7 +120,7 @@ let CreatePluginFromImportForm = (p: {
       });
       if (!added) return;
 
-      let queue = new PQueue({ concurrency: 10 });
+      let queue = new PQueue({ concurrency: 4 });
       await queue.addAll(
         p.skills.map(
           skill => () =>

--- a/src/metorial/products/core/modules/organization/src/services/instance.ts
+++ b/src/metorial/products/core/modules/organization/src/services/instance.ts
@@ -347,7 +347,7 @@ class InstanceService {
       await addAfterTransactionHook(() =>
         instancePortalSetupQueue.add(
           { instanceId: instance.id, context: d.auditScope.context },
-          { delay: 45_000 }
+          { delay: 5_000 }
         )
       );
 

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/marketplace/index.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/marketplace/index.ts
@@ -50,29 +50,9 @@ export let applyMarketplace = createApplicator(
         }
       }
     });
-    let legacyPluginHashes = plugins
-      .map(plugin =>
-        [
-          1,
-          plugin.oid,
-          plugin.skillPlugin.oid,
-          plugin.updatedAt.getTime(),
-          plugin.skillPlugin.updatedAt.getTime()
-        ].join(':')
-      )
-      .join('|');
-    let legacyHash = await Hash.sha256(
-      [
-        1,
-        input.skillMarketplace.oid,
-        input.skillMarketplace.updatedAt.getTime(),
-        legacyPluginHashes
-      ].join(':')
-    );
-
     let hash = await Hash.sha256(
       canonicalize({
-        serializerVersion: 2,
+        serializerVersion: 3,
         marketplace: {
           slug: input.skillMarketplace.slug,
           name: input.skillMarketplace.name,
@@ -92,8 +72,7 @@ export let applyMarketplace = createApplicator(
     return {
       plugins,
       project,
-      hash,
-      legacyHash
+      hash
     };
   },
   {
@@ -101,12 +80,9 @@ export let applyMarketplace = createApplicator(
 
     getHash: async (_input, { hash }) => hash,
 
-    apply: async (input, context, { plugins, project, hash, legacyHash }) => {
+    apply: async (input, context, { plugins, project, hash }) => {
       if (input.skillMarketplace.versionHash !== hash) {
-        let isHashMigration = input.skillMarketplace.versionHash === legacyHash;
-        let nextVersion = isHashMigration
-          ? input.skillMarketplace.version
-          : semver.inc(input.skillMarketplace.version ?? '0.0.0', 'patch')!;
+        let nextVersion = semver.inc(input.skillMarketplace.version ?? '0.0.0', 'patch')!;
 
         let updated = await db.skillMarketplace.updateMany({
           where: {

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/plugin/index.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/plugin/index.ts
@@ -3,8 +3,8 @@ import { Hash } from '@lowerdeck/hash';
 import { slugify } from '@lowerdeck/slugify';
 import { getConfig } from '@metorial/config';
 import { db } from '@metorial/db';
-import semver from 'semver';
 import { internalImageService } from '@metorial/skills-images';
+import semver from 'semver';
 import { assertSkillPluginSkillLimit } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
 import { getPluginPath, getPluginPruneScope } from '../_lib/paths';
@@ -60,30 +60,9 @@ export let applyPlugin = createApplicator(
     if (image?.type !== 'file' && project.organization.image?.type === 'file') {
       image = project.organization.image;
     }
-    let legacySkillHashes = skills
-      .map(skill =>
-        [
-          1,
-          skill.oid,
-          skill.skill.oid,
-          skill.updatedAt.getTime(),
-          skill.skill.updatedAt.getTime(),
-          skill.skill.store!.lastEditedAt.getTime()
-        ].join(':')
-      )
-      .join('|');
-    let legacyHash = await Hash.sha256(
-      [
-        1,
-        input.skillPlugin.oid,
-        input.skillPlugin.updatedAt.getTime(),
-        legacySkillHashes
-      ].join(':')
-    );
-
     let hash = await Hash.sha256(
       canonicalize({
-        serializerVersion: 2,
+        serializerVersion: 3,
         plugin: {
           slug: input.skillPlugin.slug,
           name: input.skillPlugin.name,
@@ -111,8 +90,7 @@ export let applyPlugin = createApplicator(
       project,
       agents,
       image,
-      hash,
-      legacyHash
+      hash
     };
   },
   {
@@ -120,12 +98,9 @@ export let applyPlugin = createApplicator(
 
     getHash: async (_input, { hash }) => hash,
 
-    apply: async (input, context, { project, agents, image, hash, legacyHash }) => {
+    apply: async (input, context, { project, agents, image, hash }) => {
       if (input.skillPlugin.versionHash !== hash) {
-        let isHashMigration = input.skillPlugin.versionHash === legacyHash;
-        let nextVersion = isHashMigration
-          ? input.skillPlugin.version
-          : semver.inc(input.skillPlugin.version ?? '0.0.0', 'patch')!;
+        let nextVersion = semver.inc(input.skillPlugin.version ?? '0.0.0', 'patch')!;
 
         let updated = await db.skillPlugin.updateMany({
           where: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing hash/version logic will force marketplace and plugin republishes and version bumps for affected records; faster portal setup and lower import concurrency may increase load or race sensitivity during bulk imports.
> 
> **Overview**
> **Bumps skill marketplace and plugin version hashes to `serializerVersion: 3`** and drops the old v1-style `legacyHash` path that could preserve the semver when only the hash algorithm changed.
> 
> When stored `versionHash` no longer matches, both serializers now **always patch-bump** the version on update instead of treating a legacy hash match as a silent migration.
> 
> Operational tweaks bundled with the hash rollout: **skill import** lowers parallel `addPluginSkill` mutations from 10 to 4, and **new instance** portal setup queue delay is cut from 45s to 5s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f4c958cd5aacea586cd5b9044bcf147e01222f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->