### PR TITLE
Fix provider slug redirect

### DIFF
--- a/src/metorial-frontend/apps/dashboard/src/product/pages/provider/_layout.tsx
+++ b/src/metorial-frontend/apps/dashboard/src/product/pages/provider/_layout.tsx
@@ -44,10 +44,12 @@ export let ProviderLayout = () => {
   useEffect(() => {
     if (!provider.data) return;
 
+    if (provider.input?.providerId !== providerId) return;
+
     if (providerId !== provider.data.slug) {
       navigate(pathname.replace(providerId ?? '', provider.data.slug), { replace: true });
     }
-  }, [providerId, provider.data]);
+  }, [providerId, provider.data, provider.input]);
 
   let versions = useProviderVersions(instance.data?.id, provider.data?.id);
   let allVersions: ProviderVersion[] = versions.data?.items ?? [];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small routing guard in the provider layout; no auth, persistence, or API behavior changes.
> 
> **Overview**
> Fixes incorrect **provider slug redirects** when the URL’s `providerId` changes but `useProvider` still has **stale data** from the previous provider.
> 
> The layout effect that rewrites the path to `provider.data.slug` now **bails out** unless `provider.input?.providerId` matches the route param, and **`provider.input`** is included in the effect dependencies so redirect runs only after the fetch input aligns with the current page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097ac7a833cb810566dca43b090ec8d3680969ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->