### PR TITLE
Use correct skill values for skill linked plugins

### DIFF
--- a/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
+++ b/src/metorial-frontend/scenes/skills/src/scenes/skillMarketplacePlugins.tsx
@@ -1160,8 +1160,8 @@ export let SkillMarketplacePluginsScene = (p: {
         let [plugin] = await createPlugin.mutate({
           instanceId: p.instanceId!,
           skillMarketplaceId: p.skillMarketplaceId!,
-          name: skill.name,
-          description: skill.description ?? undefined
+          name: skill.clientName || skill.name,
+          description: skill.clientDescription ?? undefined
         });
         if (!plugin) return false;
         let [membership] = await addPluginSkill.mutate({
@@ -1204,8 +1204,8 @@ export let SkillMarketplacePluginsScene = (p: {
     let [plugin] = await createPlugin.mutate({
       instanceId: p.instanceId,
       skillMarketplaceId: p.skillMarketplaceId,
-      name: p2.skill.skill.name,
-      description: p2.skill.skill.description ?? undefined
+      name: p2.skill.skill.clientName || p2.skill.skill.name,
+      description: p2.skill.skill.clientDescription ?? undefined
     });
     if (!plugin) return;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small display/metadata fix for plugin creation flows; no auth, data migration, or API contract changes.
> 
> **Overview**
> When a marketplace **adds a skill as its own plugin** or **drags a skill out to create a standalone plugin**, the new plugin’s name and description now use the skill’s **client-facing** fields (`clientName`, `clientDescription`) with fallbacks to the internal `name`/`description`, instead of always using the internal values.
> 
> This matches how plugin skill membership is already populated via `getNewSkillInput`, so standalone plugins show the same labels customers see elsewhere in the marketplace UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db12a293d95c4e490f13d69baa38279eca8b2390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->