### PR TITLE
Improve plugin slug generation

### DIFF
--- a/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.test.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { findFirst, generatePlainId } = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  generatePlainId: vi.fn()
+}));
+
+vi.mock('@lowerdeck/id', () => ({
+  generatePlainId
+}));
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    skillMarketplacePlugin: {
+      findFirst
+    }
+  }
+}));
+
+import {
+  getArchivedMarketplacePluginSlug,
+  getMarketplacePluginSlug,
+  getSkillPluginSlug
+} from './skillMarketplacePluginSlug';
+
+describe('skill plugin slugs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generatePlainId.mockReturnValue('RandomSlugValue123456');
+  });
+
+  it('creates a stable plugin slug from the supplied name', () => {
+    expect(getSkillPluginSlug('My_Skill Plugin')).toBe('my-skill-plugin');
+    expect(generatePlainId).not.toHaveBeenCalled();
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it('uses the nice marketplace slug when it is available', async () => {
+    findFirst.mockResolvedValue(null);
+
+    await expect(
+      getMarketplacePluginSlug(
+        { input: 'My Skill Plugin' },
+        { skillMarketplaceId: 'marketplace_1' }
+      )
+    ).resolves.toBe('my-skill-plugin');
+  });
+
+  it('uses the existing suffix generator for real marketplace conflicts', async () => {
+    findFirst.mockResolvedValueOnce({ id: 'conflict' }).mockResolvedValueOnce(null);
+
+    await expect(
+      getMarketplacePluginSlug(
+        { input: 'My Skill Plugin' },
+        { skillMarketplaceId: 'marketplace_1' }
+      )
+    ).resolves.toBe('my-skill-plugin-2');
+  });
+
+  it('replaces an archived marketplace slug with a random value', async () => {
+    findFirst.mockResolvedValue(null);
+
+    await expect(
+      getArchivedMarketplacePluginSlug({ skillMarketplaceId: 'marketplace_1' })
+    ).resolves.toBe('randomslugvalue123456');
+  });
+});

--- a/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.test.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.test.ts
@@ -35,6 +35,12 @@ describe('skill plugin slugs', () => {
     expect(findFirst).not.toHaveBeenCalled();
   });
 
+  it('uses a random plugin slug when the name has no slug characters', () => {
+    expect(getSkillPluginSlug('!!!')).toBe('randomslugvalue123456');
+    expect(generatePlainId).toHaveBeenCalledWith(8);
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
   it('uses the nice marketplace slug when it is available', async () => {
     findFirst.mockResolvedValue(null);
 

--- a/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.ts
@@ -1,0 +1,43 @@
+import { generatePlainId } from '@lowerdeck/id';
+import { slugify } from '@lowerdeck/slugify';
+import { db } from '@metorial/db';
+
+export let getSkillPluginSlug = (input: string) => slugify(input.replaceAll('_', '-'));
+
+let isMarketplacePluginSlugAvailable = async (
+  slug: string,
+  d: { skillMarketplaceId: string }
+) =>
+  !(await db.skillMarketplacePlugin.findFirst({
+    where: {
+      skillMarketplace: {
+        id: d.skillMarketplaceId
+      },
+      pluginSlug: slug
+    }
+  }));
+
+export let getMarketplacePluginSlug = async (
+  d: { input: string; current?: string },
+  opts: { skillMarketplaceId: string }
+) => {
+  let baseSlug = slugify(d.input) || generatePlainId(8).toLowerCase();
+
+  if (d.current === baseSlug) return baseSlug;
+  if (await isMarketplacePluginSlugAvailable(baseSlug, opts)) return baseSlug;
+
+  for (let suffix = 2; suffix < 50; suffix++) {
+    let candidate = `${baseSlug}-${suffix}`;
+
+    if (d.current === candidate) return candidate;
+    if (await isMarketplacePluginSlugAvailable(candidate, opts)) return candidate;
+  }
+
+  return `${baseSlug}-${generatePlainId(6).toLowerCase()}`;
+};
+
+export let getArchivedMarketplacePluginSlug = async (d: { skillMarketplaceId: string }) =>
+  await getMarketplacePluginSlug(
+    { input: generatePlainId(20).toLowerCase() },
+    { skillMarketplaceId: d.skillMarketplaceId }
+  );

--- a/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/lib/skillMarketplacePluginSlug.ts
@@ -2,7 +2,8 @@ import { generatePlainId } from '@lowerdeck/id';
 import { slugify } from '@lowerdeck/slugify';
 import { db } from '@metorial/db';
 
-export let getSkillPluginSlug = (input: string) => slugify(input.replaceAll('_', '-'));
+export let getSkillPluginSlug = (input: string) =>
+  slugify(input.replaceAll('_', '-')) || generatePlainId(8).toLowerCase();
 
 let isMarketplacePluginSlugAvailable = async (
   slug: string,

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplacePlugin.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplacePlugin.ts
@@ -1,8 +1,6 @@
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
-import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { slugify } from '@lowerdeck/slugify';
 import type { Instance, Prisma, Project, SkillMarketplacePluginStatus } from '@metorial/db';
 import { db, ID, withTransaction } from '@metorial/db';
 import {
@@ -24,6 +22,10 @@ import {
   assertSkillMarketplaceWriteAccess,
   type SkillMarketplaceAccessInput
 } from '../lib/skillMarketplaceAccess';
+import {
+  getArchivedMarketplacePluginSlug,
+  getMarketplacePluginSlug
+} from '../lib/skillMarketplacePluginSlug';
 import { enqueueSkillMarketplacePluginLifecycle } from '../queues/lifecycle';
 import type { SkillMarketplaceRecord } from './skillMarketplace';
 import {
@@ -54,38 +56,6 @@ export type SkillMarketplacePluginRecord = Prisma.SkillMarketplacePluginGetPaylo
 }>;
 
 export type SkillMarketplacePluginStatusFilter = SkillMarketplacePluginStatus;
-
-let isMarketplacePluginSlugAvailable = async (
-  slug: string,
-  d: { skillMarketplaceId: string }
-) =>
-  !(await db.skillMarketplacePlugin.findFirst({
-    where: {
-      skillMarketplace: {
-        id: d.skillMarketplaceId
-      },
-      pluginSlug: slug
-    }
-  }));
-
-let getMarketplacePluginSlug = async (
-  d: { input: string; current?: string },
-  opts: { skillMarketplaceId: string }
-) => {
-  let baseSlug = slugify(d.input) || generatePlainId(8).toLowerCase();
-
-  if (d.current === baseSlug) return baseSlug;
-  if (await isMarketplacePluginSlugAvailable(baseSlug, opts)) return baseSlug;
-
-  for (let suffix = 2; suffix < 50; suffix++) {
-    let candidate = `${baseSlug}-${suffix}`;
-
-    if (d.current === candidate) return candidate;
-    if (await isMarketplacePluginSlugAvailable(candidate, opts)) return candidate;
-  }
-
-  return `${baseSlug}-${generatePlainId(6).toLowerCase()}`;
-};
 
 class SkillMarketplacePluginServiceImpl {
   private async getSkillMarketplacePluginRecord(d: {
@@ -211,13 +181,17 @@ class SkillMarketplacePluginServiceImpl {
         skillPluginOid: skillPlugin.oid
       },
       select: {
-        pluginSlug: true
+        pluginSlug: true,
+        status: true
       }
     });
     let pluginSlug = await getMarketplacePluginSlug(
       {
         input: d.input.pluginSlug ?? skillPlugin.name ?? skillPlugin.slug ?? skillPlugin.id,
-        current: existingSkillMarketplacePlugin?.pluginSlug
+        current:
+          existingSkillMarketplacePlugin?.status === 'active'
+            ? existingSkillMarketplacePlugin.pluginSlug
+            : undefined
       },
       { skillMarketplaceId: d.skillMarketplace.id }
     );
@@ -278,7 +252,10 @@ class SkillMarketplacePluginServiceImpl {
       }
 
       if (skillMarketplacePlugin) {
-        if (skillMarketplacePlugin.pluginSlug !== pluginSlug) {
+        if (
+          skillMarketplacePlugin.status === 'active' &&
+          skillMarketplacePlugin.pluginSlug !== pluginSlug
+        ) {
           throw new ServiceError(
             badRequestError({
               message: 'Marketplace plugin slug cannot be changed'
@@ -292,6 +269,7 @@ class SkillMarketplacePluginServiceImpl {
           },
           data: {
             status: 'active',
+            pluginSlug,
             skillPluginOid: skillPlugin.oid,
             skillConfigurationOid
           },
@@ -333,12 +311,17 @@ class SkillMarketplacePluginServiceImpl {
     });
     assertPluginIsNotManaged(d.skillMarketplacePlugin.skillPlugin);
 
+    let pluginSlug = await getArchivedMarketplacePluginSlug({
+      skillMarketplaceId: d.skillMarketplacePlugin.skillMarketplace.id
+    });
+
     let skillMarketplacePlugin = await db.skillMarketplacePlugin.update({
       where: {
         id: d.skillMarketplacePlugin.id
       },
       data: {
         status: 'archived',
+        pluginSlug,
         skillConfigurationOid: null
       },
       include: skillMarketplacePluginInclude

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillPlugin.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillPlugin.ts
@@ -1,9 +1,7 @@
 import { canonicalize } from '@lowerdeck/canonicalize';
 import { badRequestError, notFoundError, ServiceError } from '@lowerdeck/error';
-import { generatePlainId } from '@lowerdeck/id';
 import { Paginator } from '@lowerdeck/pagination';
 import { Service } from '@lowerdeck/service';
-import { slugify } from '@lowerdeck/slugify';
 import type {
   EntityImage,
   Instance,
@@ -37,6 +35,11 @@ import {
   CargoSkillLimitError,
   toCargoSkillLimitServiceError
 } from '../lib/limits';
+import {
+  getArchivedMarketplacePluginSlug,
+  getMarketplacePluginSlug,
+  getSkillPluginSlug
+} from '../lib/skillMarketplacePluginSlug';
 import {
   assertSkillMarketplaceWriteAccess,
   assertSkillPluginArchiveAccess,
@@ -394,6 +397,12 @@ class SkillPluginServiceImpl {
       organizationOid: d.instance.organizationOid,
       instance: d.instance
     });
+    let marketplacePluginSlug = skillMarketplace
+      ? await getMarketplacePluginSlug(
+          { input: d.input.slug ?? d.input.name },
+          { skillMarketplaceId: skillMarketplace.id }
+        )
+      : undefined;
 
     return await withTransaction(async db => {
       await Fabric.fire('skill.plugin.created:before', {
@@ -412,7 +421,7 @@ class SkillPluginServiceImpl {
           description: d.input.description,
           longDescription: d.input.longDescription,
           category: d.input.category,
-          slug: `${slugify((d.input.slug ?? d.input.name).replaceAll('_', '-'))}-${generatePlainId(6)}`.toLowerCase(),
+          slug: getSkillPluginSlug(d.input.slug ?? d.input.name),
           projectOid: d.project.oid,
           instanceOid: d.instance.oid,
           organizationOid: d.project.organizationOid,
@@ -455,7 +464,7 @@ class SkillPluginServiceImpl {
           data: {
             id: await ID.generateId('skillMarketplacePlugin'),
             status: 'active',
-            pluginSlug: skillPlugin.slug!,
+            pluginSlug: marketplacePluginSlug!,
             skillMarketplaceOid: skillMarketplace.oid,
             skillPluginOid: skillPlugin.oid
           }
@@ -599,16 +608,36 @@ class SkillPluginServiceImpl {
         }
       });
 
-      await db.skillMarketplacePlugin.updateMany({
+      let activeMarketplacePlugins = await db.skillMarketplacePlugin.findMany({
         where: {
           skillPluginOid: d.skillPlugin.oid,
           status: 'active'
         },
-        data: {
-          status: 'archived',
-          skillConfigurationOid: null
+        select: {
+          id: true,
+          skillMarketplace: {
+            select: {
+              id: true
+            }
+          }
         }
       });
+      for (let marketplacePlugin of activeMarketplacePlugins) {
+        let pluginSlug = await getArchivedMarketplacePluginSlug({
+          skillMarketplaceId: marketplacePlugin.skillMarketplace.id
+        });
+
+        await db.skillMarketplacePlugin.update({
+          where: {
+            id: marketplacePlugin.id
+          },
+          data: {
+            status: 'archived',
+            pluginSlug,
+            skillConfigurationOid: null
+          }
+        });
+      }
 
       await db.skillPlugin.update({
         where: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes identifier assignment for create, archive, and re-activate flows; marketplace URLs and uniqueness depend on `pluginSlug`, though behavior is covered by new unit tests.
> 
> **Overview**
> Centralizes skill and marketplace **plugin slug** logic in `skillMarketplacePluginSlug` and changes how slugs are assigned over the plugin lifecycle.
> 
> **Skill plugins** now get a **stable** slug from the name (underscores normalized, random ID only when the name cannot slugify), instead of always appending a random suffix. **Marketplace listings** get their own slug via marketplace uniqueness rules (`-2`, etc.), not by copying the skill plugin slug.
> 
> **Archive / re-activate** behavior changes: archiving a marketplace plugin **replaces** `pluginSlug` with a random value so the human-readable slug can be reused; re-adding or reactivating only treats the previous slug as locked when the row is **active**, allows updating `pluginSlug` when coming back from archived, and still blocks slug changes for active plugins. Archiving a skill plugin now archives each active marketplace row with a fresh archived slug (per marketplace) instead of a single `updateMany` without slug rotation.
> 
> Adds **Vitest** coverage for slug helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cce3c09da8669c40486c4886c694e10726118b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->