### PR TITLE
Harden member consumer sync

### DIFF
--- a/src/metorial/products/workforce/modules/consumer-core/src/queues/syncOrgMember.ts
+++ b/src/metorial/products/workforce/modules/consumer-core/src/queues/syncOrgMember.ts
@@ -19,17 +19,17 @@ export let syncOrgMemberQueueProcessor = syncOrgMemberQueue.process(async data =
   syncOrgMemberLock.usingLock(data.memberId, async () => {
     let member = await db.organizationMember.findUnique({
       where: {
-        id: data.memberId,
-        actor: { type: 'member' }
+        id: data.memberId
       },
       include: {
         organization: true,
         instanceConsumers: true,
-        user: true
+        user: true,
+        actor: true
       }
     });
     if (!member) throw new QueueRetryError();
-    if (member.user.type === 'system') return;
+    if (member.user.type === 'system' || member.actor.type !== 'member') return;
 
     if (member.instanceConsumers.length) {
       await syncOrgMemberConsumerQueue.addManyWithOps(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small queue-processor change that only affects edge-case org members with non-member actors; normal member sync behavior is unchanged.
> 
> **Overview**
> **Hardens** the `syncOrgMember` queue so it no longer treats non-member organization members as missing records.
> 
> The member lookup now loads by `memberId` only (instead of also requiring `actor.type === 'member'` in the query) and **includes** `actor`. Processing still bails out for system users, and now also returns early when `actor.type !== 'member'`.
> 
> That moves the member-type guard from the DB filter into explicit application logic, so invalid or non-member rows are **skipped** instead of failing the job and triggering **queue retries**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4993ba94e65e1ddb7e08cf43f7a103b5a12cda30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->