### PR TITLE
Add force sync cache breaker

### DIFF
--- a/src/metorial/db/prisma/schema/skill/marketplace.prisma
+++ b/src/metorial/db/prisma/schema/skill/marketplace.prisma
@@ -24,8 +24,9 @@ model SkillMarketplace {
   /// [SkillMarketplaceClientOverrides]
   providerOverrides Json?
 
-  version     String?
-  versionHash String?
+  version          String?
+  versionHash      String?
+  forceSyncCounter Int     @default(0)
 
   name        String?
   description String?

--- a/src/metorial/products/skills/modules/skill-marketplace/src/lib/destinationSync.test.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/lib/destinationSync.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { db, add } = vi.hoisted(() => ({
+  db: {
+    skillMarketplace: { update: vi.fn() },
+    skillDestination: { update: vi.fn() },
+    skillDestinationSync: { create: vi.fn() }
+  },
+  add: vi.fn()
+}));
+
+vi.mock('@metorial/db', () => ({
+  db,
+  ID: { generateId: vi.fn(async () => 'skillDestinationSync_1') },
+  withTransaction: vi.fn(async (callback: (tx: typeof db) => unknown) => await callback(db))
+}));
+
+vi.mock('../queues/sync/start', () => ({
+  syncStartQueue: { add }
+}));
+
+import { forceSkillDestinationSync } from './destinationSync';
+
+describe('forceSkillDestinationSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.skillDestinationSync.create.mockResolvedValue({ id: 'skillDestinationSync_1' });
+  });
+
+  it('increments the marketplace force counter before enqueueing its sync', async () => {
+    await forceSkillDestinationSync({
+      destination: { oid: 10n },
+      incrementForceSyncCounterFor: { oid: 20n }
+    });
+
+    expect(db.skillMarketplace.update).toHaveBeenCalledWith({
+      where: { oid: 20n },
+      data: { forceSyncCounter: { increment: 1 } }
+    });
+    expect(db.skillDestinationSync.create).toHaveBeenCalledWith({
+      data: {
+        id: 'skillDestinationSync_1',
+        destinationOid: 10n,
+        status: 'pending'
+      }
+    });
+    expect(add).toHaveBeenCalledWith({
+      skillDestinationSyncId: 'skillDestinationSync_1',
+      skillRepositoryId: undefined
+    });
+  });
+});

--- a/src/metorial/products/skills/modules/skill-marketplace/src/lib/destinationSync.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/lib/destinationSync.ts
@@ -1,12 +1,20 @@
-import type { SkillDestination, SkillRepository } from '@metorial/db';
+import type { SkillDestination, SkillMarketplace, SkillRepository } from '@metorial/db';
 import { db, ID, withTransaction } from '@metorial/db';
 import { syncStartQueue } from '../queues/sync/start';
 
 export let forceSkillDestinationSync = async (d: {
   destination: Pick<SkillDestination, 'oid'>;
   repository?: Pick<SkillRepository, 'id'>;
+  incrementForceSyncCounterFor?: Pick<SkillMarketplace, 'oid'>;
 }) => {
   let sync = await withTransaction(async db => {
+    if (d.incrementForceSyncCounterFor) {
+      await db.skillMarketplace.update({
+        where: { oid: d.incrementForceSyncCounterFor.oid },
+        data: { forceSyncCounter: { increment: 1 } }
+      });
+    }
+
     await db.skillDestination.update({
       where: {
         oid: d.destination.oid

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/_lib/forceSync.test.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/_lib/forceSync.test.ts
@@ -1,0 +1,23 @@
+import { canonicalize } from '@lowerdeck/canonicalize';
+import { describe, expect, it } from 'vitest';
+import { getMarketplaceForceSyncHashInput } from './forceSync';
+
+describe('marketplace force sync hash input', () => {
+  it('does not change existing hashes before a marketplace is force synced', () => {
+    expect(getMarketplaceForceSyncHashInput()).toEqual({});
+    expect(getMarketplaceForceSyncHashInput({ forceSyncCounter: 0 })).toEqual({});
+  });
+
+  it('changes the canonical hash input every time the counter is incremented', () => {
+    let first = canonicalize({
+      content: 'unchanged',
+      ...getMarketplaceForceSyncHashInput({ forceSyncCounter: 1 })
+    });
+    let second = canonicalize({
+      content: 'unchanged',
+      ...getMarketplaceForceSyncHashInput({ forceSyncCounter: 2 })
+    });
+
+    expect(first).not.toBe(second);
+  });
+});

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/_lib/forceSync.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/_lib/forceSync.ts
@@ -1,0 +1,8 @@
+import type { SkillMarketplace } from '@metorial/db';
+
+export let getMarketplaceForceSyncHashInput = (
+  skillMarketplace?: Pick<SkillMarketplace, 'forceSyncCounter'>
+) =>
+  skillMarketplace && skillMarketplace.forceSyncCounter > 0
+    ? { marketplaceForceSyncCounter: skillMarketplace.forceSyncCounter }
+    : {};

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/marketplace/index.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/marketplace/index.ts
@@ -4,6 +4,7 @@ import { db } from '@metorial/db';
 import semver from 'semver';
 import { assertSkillMarketplaceLimits } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
+import { getMarketplaceForceSyncHashInput } from '../_lib/forceSync';
 import { getMarketplacePruneScope } from '../_lib/paths';
 
 let json = (data: any) => JSON.stringify(data, null, 2);
@@ -53,6 +54,7 @@ export let applyMarketplace = createApplicator(
     let hash = await Hash.sha256(
       canonicalize({
         serializerVersion: 3,
+        ...getMarketplaceForceSyncHashInput(input.skillMarketplace),
         marketplace: {
           slug: input.skillMarketplace.slug,
           name: input.skillMarketplace.name,

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/plugin/index.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/plugin/index.ts
@@ -7,6 +7,7 @@ import { internalImageService } from '@metorial/skills-images';
 import semver from 'semver';
 import { assertSkillPluginSkillLimit } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
+import { getMarketplaceForceSyncHashInput } from '../_lib/forceSync';
 import { getPluginPath, getPluginPruneScope } from '../_lib/paths';
 
 export { getPluginPath };
@@ -63,6 +64,7 @@ export let applyPlugin = createApplicator(
     let hash = await Hash.sha256(
       canonicalize({
         serializerVersion: 3,
+        ...getMarketplaceForceSyncHashInput(input.skillMarketplace),
         plugin: {
           slug: input.skillPlugin.slug,
           name: input.skillPlugin.name,

--- a/src/metorial/products/skills/modules/skill-marketplace/src/serializers/skill/index.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/serializers/skill/index.ts
@@ -9,6 +9,7 @@ import { stringify } from 'yaml';
 import { combineConfigs } from '../../lib/combineConfigs';
 import { assertSkillStoreByteLimit, assertSkillStoreFileLimit } from '../../lib/limits';
 import { createApplicator } from '../_lib/apply';
+import { getMarketplaceForceSyncHashInput } from '../_lib/forceSync';
 import { getSkillPath, getSkillPruneScope } from '../_lib/paths';
 import type { SkillSerializerInput } from '../_lib/types';
 import {
@@ -135,6 +136,7 @@ export let applySkill = createApplicator(
       return await Hash.sha256(
         canonicalize({
           serializerVersion: 4,
+          ...getMarketplaceForceSyncHashInput(input.skillMarketplace),
           path: getSkillPath(input),
           skill: {
             name: input.skill.name,

--- a/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplace.ts
+++ b/src/metorial/products/skills/modules/skill-marketplace/src/services/skillMarketplace.ts
@@ -458,7 +458,8 @@ class SkillMarketplaceServiceImpl {
     skillMarketplace: SkillMarketplaceRecord;
   }) {
     await forceSkillDestinationSync({
-      destination: d.skillMarketplace.destination!
+      destination: d.skillMarketplace.destination!,
+      incrementForceSyncCounterFor: d.skillMarketplace
     });
 
     return await this.getSkillMarketplaceRecord({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes destination sync transactions and content/version hashing for marketplace exports; incorrect counter or hash wiring could skip or over-trigger re-syncs.
> 
> **Overview**
> Adds a **`forceSyncCounter`** on skill marketplaces so a manual **force marketplace sync** can bust serializer/content hashes when underlying data has not changed.
> 
> When `forceSkillMarketplaceSync` runs, it now passes the marketplace into `forceSkillDestinationSync`, which **increments `forceSyncCounter` in the same transaction** before creating the destination sync job. Marketplace, plugin, and skill serializer hashes include **`marketplaceForceSyncCounter`** only after the counter is above zero, so **existing hashes stay stable** until the first force sync, then change on each subsequent force sync.
> 
> Tests cover the DB increment + queue enqueue path and the hash-input helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb1a0991422cbb017ef13fe432eeef10d713e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->