### PR TITLE
Add slate capability discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5615,7 +5615,7 @@
         "@remixicon/react": "^4.0.0",
         "@sentry/bun": "^10.36.0",
         "@sentry/cli": "^3.2.0",
-        "@slates/proto": "1.0.0-rc.13",
+        "@slates/proto": "1.0.0-rc.17",
         "@types/semver": "^7.7.1",
         "@types/unzipper": "^0.10.11",
         "date-fns": "^4.1.0",
@@ -7784,7 +7784,7 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
-    "@slates/proto": ["@slates/proto@1.0.0-rc.13", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-LpXwx2UnG6X6JlzKINdGNLFfSFt8F737dIbVvO31Kmv+i2egpBxm6g2mbmclke+Qe2WCBDnv3pMt0B+43PErOQ=="],
+    "@slates/proto": ["@slates/proto@1.0.0-rc.17", "", { "dependencies": { "@lowerdeck/emitter": "^1.0.4", "@lowerdeck/error": "^1.1.0", "@toon-format/toon": "^2.1.0", "axios": "^1.13.2", "zod": "^4.2.1" } }, "sha512-VIkLw2O9Fx+CbvdspsCQUNBbZ0wieRUDIk3NnucvTHb/FXWB0wjO+MyuHPGES8IbGsjbSb8B5DTAmAe6qKgP3g=="],
 
     "@smithy/core": ["@smithy/core@3.26.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 minimumReleaseAge = 604800
-minimumReleaseAgeExcludes = ["@codemirror/view", "resend"]
+minimumReleaseAgeExcludes = ["@codemirror/view", "resend", "@slates/proto", "@slates/provider-handler"]
 linker = "hoisted"

--- a/src/slates/apps/hub/package.json
+++ b/src/slates/apps/hub/package.json
@@ -99,7 +99,7 @@
     "@remixicon/react": "^4.0.0",
     "@sentry/bun": "^10.36.0",
     "@sentry/cli": "^3.2.0",
-    "@slates/proto": "1.0.0-rc.13",
+    "@slates/proto": "1.0.0-rc.17",
     "@types/semver": "^7.7.1",
     "@types/unzipper": "^0.10.11",
     "date-fns": "^4.1.0",

--- a/src/slates/apps/hub/prisma/schema/slate.prisma
+++ b/src/slates/apps/hub/prisma/schema/slate.prisma
@@ -80,6 +80,9 @@ model SlateVersion {
   /// [SlateDeploymentProviderDeploymentInfo]
   providerDeploymentInfo Json @default("null")
 
+  /// [SlateCapabilities]
+  capabilities Json @default("{}")
+
   slateOid BigInt
   slate    Slate  @relation(fields: [slateOid], references: [oid])
 
@@ -280,6 +283,9 @@ model SlateSpecification {
 
   /// [SlateActions]
   actions Json
+
+  /// [SlateCapabilities]
+  capabilities Json @default("{}")
 
   slateOid BigInt
   slate    Slate  @relation(fields: [slateOid], references: [oid])

--- a/src/slates/apps/hub/src/db.ts
+++ b/src/slates/apps/hub/src/db.ts
@@ -89,6 +89,15 @@ declare global {
 
     type SlateProviderInfo = SlatesMessageProviderIdentifyResponse['result']['provider'];
 
+    type SlateCapabilities = {
+      hub?: {
+        // Understands slates/hub.capabilities.set
+        capabilitiesNotification?: boolean;
+        // Understands slates/hub.live_invocation.set
+        liveInvocation?: boolean;
+      };
+    };
+
     type AuthProfile = {
       id?: string;
       email?: string;

--- a/src/slates/apps/hub/src/lib/invocation/stack.ts
+++ b/src/slates/apps/hub/src/lib/invocation/stack.ts
@@ -84,9 +84,14 @@ export class SlateInvocationStack {
 
     let invocationId = await ID.generateId('slateInvocation');
 
-    let liveInvocationToken = this.#tenant
-      ? await mintLiveInvocationToken({ invocationId, tenantOid: this.#tenant.oid })
-      : null;
+    let capabilities = this.#slateVersion.capabilities?.hub;
+    let supportsHubCapabilities = !!capabilities?.capabilitiesNotification;
+    let supportsLiveInvocation = !!capabilities?.liveInvocation;
+
+    let liveInvocationToken =
+      this.#tenant && supportsLiveInvocation
+        ? await mintLiveInvocationToken({ invocationId, tenantOid: this.#tenant.oid })
+        : null;
 
     let messages: SlatesRequest[] = [
       { jsonrpc: '2.0', method: 'slates/hello', params: { protocol: 'slates@2026-01-01' } },
@@ -100,11 +105,11 @@ export class SlateInvocationStack {
           ]
         }
       },
-      ...(liveInvocationToken
-        ? ([
+      ...(supportsHubCapabilities
+        ? [
             {
-              jsonrpc: '2.0',
-              method: 'slates/hub.capabilities.set',
+              jsonrpc: '2.0' as const,
+              method: 'slates/hub.capabilities.set' as const,
               params: {
                 capabilities: {
                   attachments: {
@@ -117,17 +122,20 @@ export class SlateInvocationStack {
                   }
                 }
               }
-            },
+            }
+          ]
+        : []),
+      ...(liveInvocationToken
+        ? [
             {
-              jsonrpc: '2.0',
-              method: 'slates/hub.live_invocation.set',
+              jsonrpc: '2.0' as const,
+              method: 'slates/hub.live_invocation.set' as const,
               params: {
                 token: liveInvocationToken.token,
                 baseUrl: env.service.SERVICE_PUBLIC_URL
               }
             }
-            // TODO: slates proto update
-          ] as unknown as SlatesRequest[])
+          ]
         : []),
 
       ...this.#initialMessages,

--- a/src/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/slates/apps/hub/src/queues/discovery/discover.ts
@@ -15,6 +15,7 @@ import {
   dedupeDiscoveredItems
 } from '../../lib/specificationHash';
 import { slateInvocationService } from '../../services';
+import { discoverSlateCapabilities } from './discoverCapabilities';
 
 let Sentry = getSentry();
 
@@ -276,6 +277,14 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
     });
 
     try {
+      let capabilities = await discoverSlateCapabilities({
+        slateVersion: version,
+        deploymentTarget: {
+          providerDeploymentInfo: target.providerDeploymentInfo,
+          activeDeploymentOid: target.activeDeploymentOid
+        }
+      });
+
       let stack = await slateInvocationService.createInvocation({
         slateVersion: version,
         deploymentTarget: {
@@ -358,7 +367,8 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         configSchema: configSchema.schema,
         configSchemaDocs,
         authMethods: discoveredAuthMethods,
-        actions: discoveredActions
+        actions: discoveredActions,
+        capabilities
       };
       let specification = await db.slateSpecification.upsert({
         where: {
@@ -479,6 +489,7 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         status: 'active' as const,
         specificationOid: specification.oid,
         lastDiscoveredAt: new Date(),
+        capabilities,
         ...(stagedDeployment
           ? {
               providerDeploymentInfo: target.providerDeploymentInfo,

--- a/src/slates/apps/hub/src/queues/discovery/discoverCapabilities.ts
+++ b/src/slates/apps/hub/src/queues/discovery/discoverCapabilities.ts
@@ -1,0 +1,24 @@
+import type { SlateVersion } from '../../../prisma/generated/client';
+import type { SlateInvocationDeploymentTarget } from '../../lib/invocation/types';
+import { slateInvocationService } from '../../services';
+
+export let discoverSlateCapabilities = async (d: {
+  slateVersion: SlateVersion;
+  deploymentTarget: SlateInvocationDeploymentTarget;
+}): Promise<PrismaJson.SlateCapabilities> => {
+  try {
+    let stack = await slateInvocationService.createInvocation({
+      slateVersion: d.slateVersion,
+      deploymentTarget: d.deploymentTarget,
+      participants: [] // Only the hub
+    });
+
+    let result = await slateInvocationService.getProviderCapabilities({ stack });
+    if (result.status === 'error') return {};
+
+    return result.data.capabilities ?? {};
+  } catch (e) {
+    console.error('Error discovering slate capabilities:', e);
+    return {};
+  }
+};

--- a/src/slates/apps/hub/src/services/slateInvocation.ts
+++ b/src/slates/apps/hub/src/services/slateInvocation.ts
@@ -85,6 +85,10 @@ class slateInvocationServiceImpl {
     return await d.stack.invoke('slates/provider.identify', {});
   }
 
+  async getProviderCapabilities(d: { stack: SlateInvocationStack }) {
+    return await d.stack.invoke('slates/provider.capabilities.get', {});
+  }
+
   async listAuthMethods(d: { stack: SlateInvocationStack }) {
     return await d.stack.invoke('slates/auth.methods.list', {});
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes discovery and every invocation handshake based on persisted capability flags; schema adds JSON columns and requires migration, with backward-compatible defaults when discovery returns empty capabilities.
> 
> **Overview**
> Adds **slate capability discovery** so the hub learns what each provider supports and negotiates hub features only when advertised.
> 
> Discovery now calls `slates/provider.capabilities.get` (via `discoverSlateCapabilities`) before the main discovery pass, and persists the result on **`SlateVersion`** and **`SlateSpecification`** as JSON `capabilities`. Invocation startup reads `capabilities.hub` to **conditionally** send `slates/hub.capabilities.set` and `slates/hub.live_invocation.set`, and only mints live-invocation tokens when `liveInvocation` is true.
> 
> Bumps **`@slates/proto`** to `1.0.0-rc.17` and exempts `@slates/proto` / `@slates/provider-handler` from Bun’s `minimumReleaseAge` in `bunfig.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0c9839bec62b80aecd3126a0cdd27f55eddcf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->