### PR TITLE
Logic fixes for attachment urls

### DIFF
--- a/src/metorial/products/integrations/db/src/utils/toolCallAttachment.ts
+++ b/src/metorial/products/integrations/db/src/utils/toolCallAttachment.ts
@@ -31,7 +31,7 @@ export let getToolCallAttachmentPublicUrl = async (urlKey: string, tokenExpiresA
 };
 
 export let getToolCallAttachmentUrlKey = () => {
-  let random = generateCustomId('tca_link_', 50);
+  let random = generateCustomId('tca_link_', 20);
   let region = process.env.METORIAL_REGION;
   return region ? `${random}_${region}` : random;
 };

--- a/src/slates/apps/hub/src/presenters/slateAttachment.test.ts
+++ b/src/slates/apps/hub/src/presenters/slateAttachment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 let mocks = vi.hoisted(() => ({
+  ATTACHMENT_SIGNATURE_MAX_AGE_MS: 5 * 60_000,
   signedIntegrationAttachmentUrl: vi.fn(
     async (attachmentId: string) =>
       `https://slates.example.com/integration-attachment/${attachmentId}?ts=1&sig=2`
@@ -9,6 +10,7 @@ let mocks = vi.hoisted(() => ({
 
 vi.mock('../db', () => ({ db: {} }));
 vi.mock('../lib/attachmentSignature', () => ({
+  ATTACHMENT_SIGNATURE_MAX_AGE_MS: mocks.ATTACHMENT_SIGNATURE_MAX_AGE_MS,
   signedIntegrationAttachmentUrl: mocks.signedIntegrationAttachmentUrl
 }));
 
@@ -29,7 +31,7 @@ describe('slateStoredAttachmentPresenter', () => {
       type: 'url',
       attachmentId: 'shsa_123',
       url: 'https://slates.example.com/integration-attachment/shsa_123?ts=1&sig=2',
-      urlExpiresAt: expiresAt
+      urlExpiresAt: new Date(1 + mocks.ATTACHMENT_SIGNATURE_MAX_AGE_MS)
     });
   });
 

--- a/src/slates/apps/hub/src/presenters/slateAttachment.ts
+++ b/src/slates/apps/hub/src/presenters/slateAttachment.ts
@@ -1,6 +1,9 @@
 import type { SlateAttachment, SlateInvocation } from '../../prisma/generated/client';
 import { db } from '../db';
-import { signedIntegrationAttachmentUrl } from '../lib/attachmentSignature';
+import {
+  ATTACHMENT_SIGNATURE_MAX_AGE_MS,
+  signedIntegrationAttachmentUrl
+} from '../lib/attachmentSignature';
 
 type InvocationWithStoredAttachments = SlateInvocation & {
   slateInvocationAttachment?: { attachments: SlateAttachment }[];
@@ -31,11 +34,14 @@ export let slateStoredAttachmentPresenter = async (attachment: SlateAttachment) 
     throw new Error(`Attachment ${attachment.id} has no stored object`);
   }
 
+  let url = await signedIntegrationAttachmentUrl(attachment.id);
+  let ts = Number(new URL(url).searchParams.get('ts'));
+
   return {
     type: 'url' as const,
     attachmentId: attachment.id,
-    url: await signedIntegrationAttachmentUrl(attachment.id),
-    urlExpiresAt: attachment.expiresAt
+    url,
+    urlExpiresAt: new Date(ts + ATTACHMENT_SIGNATURE_MAX_AGE_MS)
   };
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: corrects client-facing expiry for signed Slate URLs and shortens new tool-call URL keys without changing signing or auth logic.
> 
> **Overview**
> Fixes attachment URL metadata so clients see accurate expiry and slightly shorter tool-call link IDs.
> 
> **Slate integration attachments:** `slateStoredAttachmentPresenter` now sets `urlExpiresAt` from the signed URL’s `ts` query param plus `ATTACHMENT_SIGNATURE_MAX_AGE_MS`, instead of the attachment record’s `expiresAt`. That aligns reported expiry with when the signature actually stops working.
> 
> **Tool-call attachments:** `getToolCallAttachmentUrlKey` generates shorter random segments (`generateCustomId` length **50 → 20**), producing more compact `tca_link_` keys (region suffix unchanged).
> 
> Tests mock `ATTACHMENT_SIGNATURE_MAX_AGE_MS` and assert the new `urlExpiresAt` calculation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 675feba92b00fb31295598beaaf2437b1fc04466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->