### PR TITLE
Fix suppress re-discovery errors

### DIFF
--- a/src/slates/apps/hub/src/lib/invocation/report.test.ts
+++ b/src/slates/apps/hub/src/lib/invocation/report.test.ts
@@ -98,4 +98,28 @@ describe('reportSlateInvocationServerError', () => {
     expect(extra.logs).toHaveLength(50);
     expect(extra.logs[0]).toEqual({ timestamp: 10, message: 'log 10' });
   });
+
+  it('logs but does not report to Sentry when suppressSentry is set', () => {
+    let err = new Error('lambda exploded again');
+
+    reportSlateInvocationServerError({
+      reason: 'invocation_exception',
+      invocationId: 'shiv_3',
+      slateVersionId: 'shvr_1',
+      error: err,
+      suppressSentry: true
+    });
+
+    reportSlateInvocationServerError({
+      reason: 'jsonrpc_server_error',
+      invocationId: 'shiv_4',
+      slateVersionId: 'shvr_1',
+      error: [{ code: -32000, message: 'Internal server error' }],
+      suppressSentry: true
+    });
+
+    expect(mocks.captureException).not.toHaveBeenCalled();
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/slates/apps/hub/src/lib/invocation/report.ts
+++ b/src/slates/apps/hub/src/lib/invocation/report.ts
@@ -54,6 +54,7 @@ export let reportSlateInvocationServerError = (d: {
   error?: unknown;
   logs?: { timestamp: number; message: string }[];
   methods?: string[];
+  suppressSentry?: boolean;
 }) => {
   let extra = {
     reason: d.reason,
@@ -68,6 +69,8 @@ export let reportSlateInvocationServerError = (d: {
   };
 
   console.error('[SlateInvocation] Server error during invocation', extra);
+
+  if (d.suppressSentry) return;
 
   if (d.error instanceof Error) {
     Sentry.captureException(d.error, {

--- a/src/slates/apps/hub/src/lib/invocation/stack.ts
+++ b/src/slates/apps/hub/src/lib/invocation/stack.ts
@@ -51,6 +51,7 @@ export class SlateInvocationStack {
   #tenant?: SlateInvocationBaseParams['tenant'];
   #enclaveId?: string;
   #egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
+  #suppressServerErrorReporting: boolean;
   #productiveMessages: SlatesRequest[] = [];
   #alreadyInvoked = false;
   #runPromise: ReturnType<typeof this.run>;
@@ -63,6 +64,7 @@ export class SlateInvocationStack {
     this.#tenant = d.tenant;
     this.#enclaveId = d.enclaveId;
     this.#egressPolicy = d.egressPolicy;
+    this.#suppressServerErrorReporting = d.suppressServerErrorReporting ?? false;
 
     this.#runPromise = this.run();
   }
@@ -182,7 +184,8 @@ export class SlateInvocationStack {
           providerInvocationId: providerInvocation.id,
           error: providerInvocation.error,
           logs: providerInvocation.logs,
-          methods: messages.map(m => m.method)
+          methods: messages.map(m => m.method),
+          suppressSentry: this.#suppressServerErrorReporting
         });
 
         await storeSlateInvocation({
@@ -237,7 +240,8 @@ export class SlateInvocationStack {
           providerInvocationId: providerInvocation.id,
           error: jsonRpcServerErrors,
           logs: providerInvocation.logs,
-          methods: messages.map(m => m.method)
+          methods: messages.map(m => m.method),
+          suppressSentry: this.#suppressServerErrorReporting
         });
       }
 
@@ -378,7 +382,8 @@ export class SlateInvocationStack {
         slateVersionId: this.#slateVersion.id,
         tenantIdentifier: this.#tenant?.identifier,
         error: err,
-        methods: messages.map(m => m.method)
+        methods: messages.map(m => m.method),
+        suppressSentry: this.#suppressServerErrorReporting
       });
 
       await storeSlateInvocation({
@@ -422,6 +427,7 @@ export class SlateInvocationStack {
         participants: this.#participants,
         enclaveId: this.#enclaveId,
         egressPolicy: this.#egressPolicy,
+        suppressServerErrorReporting: this.#suppressServerErrorReporting,
         initialMessages: this.#initialMessages
       }).invoke(method, params);
     }

--- a/src/slates/apps/hub/src/lib/invocation/types.ts
+++ b/src/slates/apps/hub/src/lib/invocation/types.ts
@@ -30,6 +30,7 @@ export interface SlateInvocationBaseParams {
   participants: SlatesParticipant[];
   enclaveId?: string;
   egressPolicy?: PrismaJson.CompiledEgressNetworkAllowList;
+  suppressServerErrorReporting?: boolean;
 }
 
 export type SlatesRequest = SlatesNotifications | SlatesRequests;

--- a/src/slates/apps/hub/src/queues/discovery/discover.ts
+++ b/src/slates/apps/hub/src/queues/discovery/discover.ts
@@ -266,6 +266,9 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
 
     let slate = version.slate;
 
+    let suppressServerErrorReporting =
+      !stagedDeployment && version.status === 'discovery_failed';
+
     await db.slateEvent.create({
       data: {
         ...getId('slateEvent'),
@@ -282,7 +285,8 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
         deploymentTarget: {
           providerDeploymentInfo: target.providerDeploymentInfo,
           activeDeploymentOid: target.activeDeploymentOid
-        }
+        },
+        suppressServerErrorReporting
       });
 
       let stack = await slateInvocationService.createInvocation({
@@ -291,7 +295,8 @@ export let discoverSlateQueueProcessor = discoverSlateQueue.process(async data =
           providerDeploymentInfo: target.providerDeploymentInfo,
           activeDeploymentOid: target.activeDeploymentOid
         },
-        participants: [] // Only the hub
+        participants: [], // Only the hub
+        suppressServerErrorReporting
       });
 
       let stackResult = await Promise.all([

--- a/src/slates/apps/hub/src/queues/discovery/discoverCapabilities.ts
+++ b/src/slates/apps/hub/src/queues/discovery/discoverCapabilities.ts
@@ -5,12 +5,14 @@ import { slateInvocationService } from '../../services';
 export let discoverSlateCapabilities = async (d: {
   slateVersion: SlateVersion;
   deploymentTarget: SlateInvocationDeploymentTarget;
+  suppressServerErrorReporting?: boolean;
 }): Promise<PrismaJson.SlateCapabilities> => {
   try {
     let stack = await slateInvocationService.createInvocation({
       slateVersion: d.slateVersion,
       deploymentTarget: d.deploymentTarget,
-      participants: [] // Only the hub
+      participants: [], // Only the hub
+      suppressServerErrorReporting: d.suppressServerErrorReporting
     });
 
     let result = await slateInvocationService.getProviderCapabilities({ stack });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change for a narrow discovery retry case; default behavior unchanged and errors remain in logs.
> 
> **Overview**
> **Re-discovery of slate versions already in `discovery_failed` no longer sends invocation server errors to Sentry**, while still logging them to the console. Staged deployment discovery and first-time failures keep normal Sentry reporting.
> 
> A **`suppressSentry` flag** on `reportSlateInvocationServerError` skips `captureException` / `captureMessage` after the existing `console.error`. **`suppressServerErrorReporting`** on invocation stack params threads through all server-error report sites and nested stack creation.
> 
> The discovery queue sets suppression when **`!stagedDeployment && version.status === 'discovery_failed'`**, passing it into capability discovery and the main discovery invocation stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6043d9b22e6e7896673bc89bec909278f7f31308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->