### PR TITLE
Update attachments for slates

### DIFF
--- a/src/slates/apps/hub/src/apis/public/integrationAttachment.ts
+++ b/src/slates/apps/hub/src/apis/public/integrationAttachment.ts
@@ -11,7 +11,10 @@ import { PublicUrlPurpose } from 'object-storage-client';
 import { db } from '../../db';
 import { env } from '../../env';
 import { verifyAttachmentSignature } from '../../lib/attachmentSignature';
-import { AuthConfigSecretSerializer } from '../../lib/secretSerializer';
+import {
+  AuthConfigSecretSerializer,
+  containsSecretPlaceholder
+} from '../../lib/secretSerializer';
 import {
   refreshableAttachmentInclude,
   slateAttachmentRefreshService,
@@ -193,7 +196,10 @@ export let integrationAttachmentApp = createHono().get(
       let needsHeaderOrQueryProxy =
         Object.keys(headers).length > 0 || Object.keys(query).length > 0;
 
-      if (attachment.authConfigOid) {
+      if (
+        attachment.authConfigOid &&
+        (containsSecretPlaceholder(headers) || containsSecretPlaceholder(query))
+      ) {
         let freshAuth = await slateAuthHandlerService.getSlateInstanceAuth({
           tenant: attachment.tenant!,
           authConfigId: attachment.authConfig!.id,

--- a/src/slates/apps/hub/src/lib/secretSerializer.test.ts
+++ b/src/slates/apps/hub/src/lib/secretSerializer.test.ts
@@ -13,8 +13,97 @@ describe('AuthConfigSecretSerializer', () => {
         query: { key: 'also_secret' }
       })
     ).toEqual({
-      headers: { Authorization: 'Bearer 123SECRET' }, // whole-value match only, not substring
+      headers: { Authorization: 'Bearer $$MT$secret$authConfig$token$$' },
       query: { key: '$$MT$secret$authConfig$nested.token2' }
+    });
+  });
+
+  it.each([
+    ['Bearer 123SECRET', 'Bearer $$MT$secret$authConfig$token$$'],
+    ['123SECRET suffix', '$$MT$secret$authConfig$token$$ suffix'],
+    ['prefix 123SECRET suffix', 'prefix $$MT$secret$authConfig$token$$ suffix'],
+    ['123SECRET/123SECRET', '$$MT$secret$authConfig$token$$/$$MT$secret$authConfig$token$$']
+  ])('round-trips embedded secrets in %s', (value, expected) => {
+    let serializer = new AuthConfigSecretSerializer(authConfig);
+    expect(serializer.serialize(value)).toBe(expected);
+    expect(serializer.deserialize(expected)).toBe(value);
+  });
+
+  it('prefers longer overlapping secrets and treats regex characters literally', () => {
+    let serializer = new AuthConfigSecretSerializer({
+      token: 'ABC',
+      token2: 'ABCDE',
+      special: 'a.*+?^${}()|[]\\z'
+    });
+    let value = 'ABCDE/ABC/a.*+?^${}()|[]\\z';
+    let expected =
+      '$$MT$secret$authConfig$token2$$/$$MT$secret$authConfig$token$$/$$MT$secret$authConfig$special$$';
+
+    expect(serializer.serialize(value)).toBe(expected);
+    expect(serializer.deserialize(expected)).toBe(value);
+    expect(serializer.serialize('ABCx/aZZz')).toBe('$$MT$secret$authConfig$token$$x/aZZz');
+  });
+
+  it('does not rescan inserted placeholders during serialization', () => {
+    let serializer = new AuthConfigSecretSerializer({ token: 'ABC', other: 'authConfig' });
+    expect(serializer.serialize('Bearer ABC')).toBe('Bearer $$MT$secret$authConfig$token$$');
+  });
+
+  it('distinguishes a secret suffix from a longer auth path', () => {
+    let serializer = new AuthConfigSecretSerializer({ token: 'ABC', token2: 'XYZ' });
+    expect(serializer.serialize('ABC2')).toBe('$$MT$secret$authConfig$token$$2');
+    expect(serializer.deserialize('$$MT$secret$authConfig$token$$2')).toBe('ABC2');
+    expect(serializer.deserialize('$$MT$secret$authConfig$token2')).toBe('XYZ');
+    expect(serializer.deserialize('Bearer $$MT$secret$authConfig$token2$$')).toBe(
+      'Bearer XYZ'
+    );
+  });
+
+  it.each([
+    '$$MT$secret$authConfig$token2',
+    '$$MT$secret$authConfig$token2$$',
+    'Bearer $$MT$secret$authConfig$token2$$',
+    'Bearer $$MT$secret$authConfig$token',
+    'Bearer $$MT$secret$authConfig$missing$$'
+  ])('does not partially resolve unknown or unterminated placeholders: %s', value => {
+    let serializer = new AuthConfigSecretSerializer({ token: 'ABC' });
+    expect(serializer.deserialize(value)).toBe(value);
+  });
+
+  it('does not rescan resolved secrets containing another placeholder', () => {
+    let nestedPlaceholder = '$$MT$secret$authConfig$token2$$';
+    let serializer = new AuthConfigSecretSerializer({
+      token: nestedPlaceholder,
+      token2: 'OTHER_SECRET'
+    });
+    expect(serializer.deserialize('$$MT$secret$authConfig$token')).toBe(nestedPlaceholder);
+    expect(serializer.deserialize('Bearer $$MT$secret$authConfig$token$$')).toBe(
+      `Bearer ${nestedPlaceholder}`
+    );
+  });
+
+  it('escapes special characters in auth paths when deserializing', () => {
+    let serializer = new AuthConfigSecretSerializer({ 'token[0]+': 'ABC' });
+    expect(serializer.deserialize('Bearer $$MT$secret$authConfig$token[0]+$$')).toBe(
+      'Bearer ABC'
+    );
+    expect(serializer.deserialize('Bearer $$MT$secret$authConfig$token0$$')).toBe(
+      'Bearer $$MT$secret$authConfig$token0$$'
+    );
+  });
+
+  it('resolves embedded header and query secrets against rotated auth', () => {
+    let serialized = new AuthConfigSecretSerializer(authConfig).serialize({
+      headers: { Authorization: 'Bearer 123SECRET' },
+      query: { signature: 'prefix-also_secret-suffix' }
+    });
+    let rotated = new AuthConfigSecretSerializer({
+      token: 'NEW_TOKEN',
+      nested: { token2: 'NEW_KEY' }
+    });
+    expect(rotated.deserialize(serialized)).toEqual({
+      headers: { Authorization: 'Bearer NEW_TOKEN' },
+      query: { signature: 'prefix-NEW_KEY-suffix' }
     });
   });
 
@@ -66,10 +155,14 @@ describe('containsSecretPlaceholder', () => {
     expect(containsSecretPlaceholder('$$MT$secret$authConfig$token')).toBe(true);
   });
 
+  it('detects a placeholder embedded in a larger string', () => {
+    expect(containsSecretPlaceholder('Bearer $$MT$secret$authConfig$token$$')).toBe(true);
+  });
+
   it('detects a placeholder nested in an object', () => {
-    expect(containsSecretPlaceholder({ headers: { Authorization: '$$MT$secret$authConfig$token' } })).toBe(
-      true
-    );
+    expect(
+      containsSecretPlaceholder({ headers: { Authorization: '$$MT$secret$authConfig$token' } })
+    ).toBe(true);
   });
 
   it('detects a placeholder nested in an array', () => {
@@ -77,9 +170,9 @@ describe('containsSecretPlaceholder', () => {
   });
 
   it('returns false when there is no placeholder', () => {
-    expect(containsSecretPlaceholder({ headers: { Authorization: 'Bearer plain-value' } })).toBe(
-      false
-    );
+    expect(
+      containsSecretPlaceholder({ headers: { Authorization: 'Bearer plain-value' } })
+    ).toBe(false);
   });
 
   it('returns false for undefined/null', () => {

--- a/src/slates/apps/hub/src/lib/secretSerializer.ts
+++ b/src/slates/apps/hub/src/lib/secretSerializer.ts
@@ -1,30 +1,65 @@
 let PLACEHOLDER_PREFIX = '$$MT$secret$authConfig$';
 
 export let containsSecretPlaceholder = (value: unknown): boolean => {
-  if (typeof value === 'string') return value.startsWith(PLACEHOLDER_PREFIX);
+  if (typeof value === 'string') return value.includes(PLACEHOLDER_PREFIX);
   if (Array.isArray(value)) return value.some(containsSecretPlaceholder);
-  if (value && typeof value === 'object') return Object.values(value).some(containsSecretPlaceholder);
+  if (value && typeof value === 'object')
+    return Object.values(value).some(containsSecretPlaceholder);
   return false;
 };
 
 export class AuthConfigSecretSerializer {
   private readonly secretToPlaceholder = new Map<string, string>();
   private readonly placeholderToSecret = new Map<string, string>();
+  private readonly secretPattern: RegExp | undefined;
+  private readonly placeholderPattern: RegExp | undefined;
 
   public constructor(authConfig: Record<string, unknown>) {
     this.buildSecretMap(authConfig);
+    this.secretPattern = this.buildPattern([...this.secretToPlaceholder.keys()]);
+    this.placeholderPattern = this.buildPattern(
+      [...this.placeholderToSecret.keys()].map(placeholder => `${placeholder}$$`)
+    );
   }
 
   public serialize<T>(value: T): T {
     return this.transform(value, stringValue => {
-      return this.secretToPlaceholder.get(stringValue) ?? stringValue;
+      let exact = this.secretToPlaceholder.get(stringValue);
+      if (exact !== undefined) return exact;
+      if (!this.secretPattern) return stringValue;
+
+      return stringValue.replace(
+        this.secretPattern,
+        secret => `${this.secretToPlaceholder.get(secret)}$$`
+      );
     });
   }
 
   public deserialize<T>(value: T): T {
     return this.transform(value, stringValue => {
-      return this.placeholderToSecret.get(stringValue) ?? stringValue;
+      let exact = this.placeholderToSecret.get(stringValue);
+      if (exact !== undefined) return exact;
+      if (!this.placeholderPattern) return stringValue;
+
+      return stringValue.replace(
+        this.placeholderPattern,
+        // Remove the two-character "$$" terminator before looking up the legacy key.
+        placeholder => this.placeholderToSecret.get(placeholder.slice(0, -2)) ?? placeholder
+      );
     });
+  }
+
+  private buildPattern(values: string[]): RegExp | undefined {
+    if (!values.length) return undefined;
+
+    return new RegExp(
+      values
+        .sort((a, b) => b.length - a.length)
+        // Escape regex metacharacters so values match literally; $& inserts the matched character.
+        .map(value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('|'),
+      'g'
+    );
   }
 
   private buildSecretMap(value: unknown, path: string[] = []): void {

--- a/src/slates/apps/hub/src/services/slateSessionToolCall.ts
+++ b/src/slates/apps/hub/src/services/slateSessionToolCall.ts
@@ -425,7 +425,10 @@ class slateSessionToolCallServiceImpl {
       data: {
         ...getId('slateAttachment'),
         tenantOid: d.tenant.oid,
-        authConfigOid: needsAuthConfig ? d.authConfig!.authConfig.oid : null,
+        authConfigOid:
+          needsAuthConfig || d.content.refreshReference !== undefined
+            ? (d.authConfig?.authConfig.oid ?? null)
+            : null,
         slateInstanceOid:
           d.content.refreshReference !== undefined ? d.slateInstance.oid : null,
         targetUrl: d.content.url,


### PR DESCRIPTION
Update attachments for slates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auth secrets are substituted in proxied attachment requests and when live auth is loaded; mistakes could leak credentials or break authorized fetches.
> 
> **Overview**
> **Extends auth secret placeholders** so tokens can be redacted and resolved when they appear inside header/query strings (e.g. `Bearer …`), not only when a value is the entire secret.
> 
> `AuthConfigSecretSerializer` now scans strings with length-prioritized, regex-escaped patterns, writes embedded placeholders with a `$$` terminator, and deserializes only well-formed placeholders without partial or double-expansion. `containsSecretPlaceholder` uses substring detection so values like `Bearer $$MT$…$$` count as needing resolution.
> 
> The **integration attachment proxy** fetches fresh auth and deserializes headers/query only when an `authConfigOid` is set **and** those fields actually contain placeholders, avoiding unnecessary auth lookups.
> 
> **Refreshable proxied attachments** persist `authConfigOid` when a `refreshReference` is present (even without placeholders), so refresh flows can still tie back to the auth config used for the attachment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5461875b03fa04f5f6947cc03eb38b0074051758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->