### PR TITLE
Add documents slice

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@metorial/oss",

--- a/src/metorial-frontend/packages/config/src/nexus.ts
+++ b/src/metorial-frontend/packages/config/src/nexus.ts
@@ -2,6 +2,7 @@ import { joinPaths } from '@lowerdeck/join-paths';
 
 export type NexusSlices =
   | 'account'
+  | 'documents'
   | 'enterprise'
   | 'index'
   | 'join'

--- a/src/metorial-frontend/packages/config/src/paths.ts
+++ b/src/metorial-frontend/packages/config/src/paths.ts
@@ -1021,6 +1021,19 @@ let SupportPaths = Object.assign(
   }
 );
 
+let DocumentsPaths = Object.assign(
+  (...subPages: SubPages) => getNexusUrl('documents', () => joinPaths(...subPages)),
+  {
+    organization: (
+      organizationId: string | null | undefined,
+      ...subPages: SubPages
+    ) => {
+      if (!organizationId) return '#';
+      return DocumentsPaths(organizationId, 'documents', ...subPages);
+    }
+  }
+);
+
 let EnterprisePaths = Object.assign(
   (accountId: string | null | undefined, ...subPages: SubPages) =>
     getNexusUrl('enterprise', () => {
@@ -1885,6 +1898,7 @@ export let Paths = {
 
   instance: InstancePaths,
   account: AccountPaths,
+  documents: DocumentsPaths,
   support: SupportPaths,
   enterprise: EnterprisePaths,
   organization: OrganizationPaths,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive config and URL helpers only; no runtime behavior until manifest and consumers use the new slice.
> 
> **Overview**
> Introduces a **documents** Nexus slice so the frontend can build URLs for a dedicated documents app/host, consistent with slices like `support` and `enterprise`.
> 
> `NexusSlices` now includes `'documents'`. **`Paths.documents`** adds `DocumentsPaths` via `getNexusUrl('documents', …)`, with **`organization(organizationId, …subPages)`** routing to `{orgId}/documents/…` (or `'#'` when the org id is missing). Call sites can adopt `Paths.documents` once the slice is wired in the Nexus manifest.
> 
> `bun.lock` drops the `configVersion` field (lockfile metadata only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29972e811f05285d88dc820bd69c63e3a8302946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->