### PR TITLE
Filter by global auth method

### DIFF
--- a/src/metorial/products/integrations/modules/auth/src/services/providerAuthConfig.test.ts
+++ b/src/metorial/products/integrations/modules/auth/src/services/providerAuthConfig.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mocks = vi.hoisted(() => ({
+  providerAuthConfigFindMany: vi.fn(),
+  resolveAuthMethodsGlobal: vi.fn()
+}));
+
+vi.mock('@lowerdeck/service', () => ({
+  Service: {
+    create: vi.fn((_name, factory) => ({
+      build: () => factory()
+    }))
+  }
+}));
+
+vi.mock('@lowerdeck/pagination', () => ({
+  Paginator: {
+    create: vi.fn(factory => ({
+      run: (_query?: object) => factory({ prisma: (fn: (opts: object) => unknown) => fn({}) })
+    })),
+    validate: vi.fn()
+  }
+}));
+
+vi.mock('@metorial-subspace/db', () => ({
+  db: {
+    providerAuthConfig: {
+      findMany: mocks.providerAuthConfigFindMany
+    },
+    providerDeployment: {
+      findFirst: vi.fn()
+    }
+  },
+  withTransaction: vi.fn(),
+  addAfterTransactionHook: vi.fn(),
+  getId: vi.fn()
+}));
+
+vi.mock('@metorial-subspace/list-utils', () => ({
+  assertNoActiveIdentityCredentialAuthConfigLink: vi.fn(),
+  assertNoActiveIntegrationInstanceProviderAuthConfigLink: vi.fn(),
+  checkDeletedEdit: vi.fn(),
+  checkDeletedRelation: vi.fn(),
+  normalizeDateFilter: vi.fn(),
+  normalizeStatusForGet: vi.fn(() => ({ hasParent: {} })),
+  normalizeStatusForList: vi.fn(() => ({ hasParent: {} })),
+  resolveAuthMethodsGlobal: mocks.resolveAuthMethodsGlobal,
+  resolveIdentities: vi.fn(),
+  resolveIdentityActors: vi.fn(),
+  resolveIdentityCredentials: vi.fn(),
+  resolveProviderAuthCredentials: vi.fn(),
+  resolveProviderDeployments: vi.fn(),
+  resolveProviders: vi.fn()
+}));
+
+vi.mock('@metorial-subspace/module-provider-internal', () => ({
+  assertAuthMethodAllowedForTenant: vi.fn(),
+  checkProviderMatch: vi.fn(),
+  normalizeToolFilters: vi.fn()
+}));
+
+vi.mock('@metorial-subspace/module-search', () => ({
+  voyager: { record: { search: vi.fn() } },
+  voyagerIndex: { providerAuthConfig: { id: 'idx' } },
+  voyagerSource: Promise.resolve({ id: 'src' })
+}));
+
+vi.mock('@metorial-subspace/module-tenant', () => ({
+  checkTenant: vi.fn(),
+  getMetorialSolution: vi.fn(async () => ({ oid: 7, id: 'sol_1' })),
+  resolveConsumerActorIds: vi.fn(),
+  resolveMetorialFacing: vi.fn(),
+  resolveMetorialFacingWithOptionalActor: vi.fn(),
+  toProviderEventBase: vi.fn()
+}));
+
+vi.mock('@metorial/fabric', () => ({
+  Fabric: { fire: vi.fn() }
+}));
+
+vi.mock('../queues/lifecycle/providerAuthConfig', () => ({
+  providerAuthConfigArchivedQueue: { add: vi.fn() },
+  providerAuthConfigUpdatedQueue: { add: vi.fn() }
+}));
+
+vi.mock('./providerAuthConfigInternal', () => ({
+  providerAuthConfigInternalService: {}
+}));
+
+vi.mock('./providerAuthCredentials', () => ({
+  providerAuthCredentialsService: {}
+}));
+
+import { providerAuthConfigService } from './providerAuthConfig';
+
+describe('listProviderAuthConfigsInternal auth method filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveAuthMethodsGlobal.mockResolvedValue({
+      oids: [70n],
+      in: { in: [70n] },
+      oidIn: { oid: { in: [70n] } }
+    });
+    mocks.providerAuthConfigFindMany.mockResolvedValue([]);
+  });
+
+  it('matches every concrete auth method in the requested global family', async () => {
+    let paginator = await providerAuthConfigService.listProviderAuthConfigsInternal({
+      tenant: { oid: 10n, id: 'ten_1' } as any,
+      environment: { oid: 30n } as any,
+      providerAuthMethodIds: ['pam_1']
+    });
+
+    await paginator.run({});
+
+    let where = mocks.providerAuthConfigFindMany.mock.calls[0]![0].where;
+
+    expect(where.AND).toContainEqual({
+      authMethod: {
+        globalOid: {
+          in: [70n]
+        }
+      }
+    });
+  });
+});

--- a/src/metorial/products/integrations/modules/auth/src/services/providerAuthConfig.ts
+++ b/src/metorial/products/integrations/modules/auth/src/services/providerAuthConfig.ts
@@ -28,11 +28,11 @@ import {
   normalizeDateFilter,
   normalizeStatusForGet,
   normalizeStatusForList,
+  resolveAuthMethodsGlobal,
   resolveIdentities,
   resolveIdentityActors,
   resolveIdentityCredentials,
   resolveProviderAuthCredentials,
-  resolveProviderAuthMethods,
   resolveProviderDeployments,
   resolveProviders
 } from '@metorial-subspace/list-utils';
@@ -280,7 +280,7 @@ class providerAuthConfigServiceImpl {
         })
       : null;
     let credentials = await resolveProviderAuthCredentials(ts, d.providerAuthCredentialsIds);
-    let authMethods = await resolveProviderAuthMethods(ts, d.providerAuthMethodIds);
+    let authMethodsGlobal = await resolveAuthMethodsGlobal(ts, d.providerAuthMethodIds);
     let actors = await resolveIdentityActors(ts, actorIds);
     let identities = await resolveIdentities(ts, d.identityIds);
     let identityCredentials = await resolveIdentityCredentials(ts, d.identityCredentialIds);
@@ -329,7 +329,9 @@ class providerAuthConfigServiceImpl {
                     }
                   : undefined!,
                 credentials ? { authCredentialsOid: credentials.in } : undefined!,
-                authMethods ? { authMethodOid: authMethods.in } : undefined!,
+                authMethodsGlobal
+                  ? { authMethod: { globalOid: authMethodsGlobal.in } }
+                  : undefined!,
                 actors
                   ? { identityCredentials: { some: { identity: { actor: actors.oidIn } } } }
                   : undefined!,

--- a/src/metorial/products/integrations/modules/auth/src/services/providerAuthCredentials.test.ts
+++ b/src/metorial/products/integrations/modules/auth/src/services/providerAuthCredentials.test.ts
@@ -2,12 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mocks = vi.hoisted(() => ({
   providerAuthCredentialsCreate: vi.fn(),
+  providerAuthCredentialsFindMany: vi.fn(),
   providerAuthCredentialsUpdate: vi.fn(),
   providerAuthCredentialsUpdateMany: vi.fn(),
   addAfterTransactionHook: vi.fn(),
   queueAdd: vi.fn(),
   backendCreateProviderAuthCredentials: vi.fn(),
-  backendGetScopes: vi.fn()
+  backendGetScopes: vi.fn(),
+  resolveAuthMethodsGlobal: vi.fn(),
+  resolveProviders: vi.fn()
 }));
 
 vi.mock('@lowerdeck/service', () => ({
@@ -23,7 +26,12 @@ vi.mock('@lowerdeck/lock', () => ({
 }));
 
 vi.mock('@lowerdeck/pagination', () => ({
-  Paginator: { create: vi.fn(), validate: vi.fn() }
+  Paginator: {
+    create: vi.fn(factory => ({
+      run: (_query?: object) => factory({ prisma: (fn: (opts: object) => unknown) => fn({}) })
+    })),
+    validate: vi.fn()
+  }
 }));
 
 vi.mock('@metorial-subspace/db', () => {
@@ -33,7 +41,7 @@ vi.mock('@metorial-subspace/db', () => {
       update: mocks.providerAuthCredentialsUpdate,
       updateMany: mocks.providerAuthCredentialsUpdateMany,
       findFirst: vi.fn(),
-      findMany: vi.fn(),
+      findMany: mocks.providerAuthCredentialsFindMany,
       findUniqueOrThrow: vi.fn()
     },
     managedProviderAuthCredentials: { findFirstOrThrow: vi.fn() },
@@ -55,8 +63,8 @@ vi.mock('@metorial-subspace/list-utils', () => ({
   normalizeDateFilter: vi.fn(),
   normalizeStatusForGet: vi.fn(() => ({ noParent: {} })),
   normalizeStatusForList: vi.fn(() => ({ noParent: {} })),
-  resolveAuthMethodsGlobal: vi.fn(),
-  resolveProviders: vi.fn()
+  resolveAuthMethodsGlobal: mocks.resolveAuthMethodsGlobal,
+  resolveProviders: mocks.resolveProviders
 }));
 
 vi.mock('@metorial-subspace/module-search', () => ({
@@ -189,5 +197,47 @@ describe('createProviderAuthCredentialsInternal double writes', () => {
     expect(where).toMatchObject({ tenantOid: 10n, environmentOid: 30n });
     expect(where).not.toHaveProperty('projectOid');
     expect(where).not.toHaveProperty('instanceOid');
+  });
+});
+
+describe('listProviderAuthCredentialsInternal auth method filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveProviders.mockResolvedValue(undefined);
+    mocks.resolveAuthMethodsGlobal.mockResolvedValue({
+      oids: [70n],
+      in: { in: [70n] },
+      oidIn: { oid: { in: [70n] } }
+    });
+    mocks.providerAuthCredentialsFindMany.mockResolvedValue([]);
+  });
+
+  it('matches managed credentials through their global family, including legacy rows', async () => {
+    let paginator = await providerAuthCredentialsService.listProviderAuthCredentialsInternal({
+      tenant: { oid: 10n, id: 'ten_1' } as any,
+      environment: { oid: 30n } as any,
+      providerAuthMethodIds: ['pam_1']
+    });
+
+    await paginator.run({});
+
+    let where = mocks.providerAuthCredentialsFindMany.mock.calls[0]![0].where;
+    let managedBackingFilter = where.AND.at(-1).OR[1];
+
+    expect(managedBackingFilter.managedCredentialsBacking.is.managedCredentials.OR).toEqual([
+      {
+        providerAuthMethodGlobalOid: {
+          in: [70n]
+        }
+      },
+      {
+        providerAuthMethodGlobalOid: null,
+        initialProviderAuthMethod: {
+          globalOid: {
+            in: [70n]
+          }
+        }
+      }
+    ]);
   });
 });

--- a/src/metorial/products/integrations/modules/auth/src/services/providerAuthCredentials.ts
+++ b/src/metorial/products/integrations/modules/auth/src/services/providerAuthCredentials.ts
@@ -29,15 +29,15 @@ import {
 } from '@metorial-subspace/list-utils';
 import { voyager, voyagerIndex, voyagerSource } from '@metorial-subspace/module-search';
 import {
-  getMetorialSolution,
   checkTenant,
+  getMetorialSolution,
   type MetorialFacing,
   resolveMetorialFacing,
   resolveMetorialFacingWithOptionalActor,
   toProviderEventBase
 } from '@metorial-subspace/module-tenant';
-import { Fabric, type AuditSubspaceProviderAuthCredentials } from '@metorial/fabric';
 import { getBackend } from '@metorial-subspace/provider';
+import { type AuditSubspaceProviderAuthCredentials, Fabric } from '@metorial/fabric';
 import { env } from '../env';
 import { normalizeManagedOAuthScopeIds } from '../lib/managedOAuthScopes';
 import {
@@ -148,9 +148,21 @@ let getManagedBackingWhereForTenantList = (d: {
         managedCredentialsBacking: {
           is: {
             managedCredentials: {
-              providerAuthMethodGlobalOid: {
-                in: d.providerAuthMethodGlobalOids
-              }
+              OR: [
+                {
+                  providerAuthMethodGlobalOid: {
+                    in: d.providerAuthMethodGlobalOids
+                  }
+                },
+                {
+                  providerAuthMethodGlobalOid: null,
+                  initialProviderAuthMethod: {
+                    globalOid: {
+                      in: d.providerAuthMethodGlobalOids
+                    }
+                  }
+                }
+              ]
             }
           }
         }
@@ -173,13 +185,12 @@ export type UpdateProviderAuthCredentialsParams = {
   };
 };
 
-/**
- * The public entry point takes the record with its relations already loaded -- every
- * caller has just read it through this service's `include` -- so the audit event can
- * carry a previous payload without reading the row a second time.
- */
-export type UpdateProviderAuthCredentialsFacingParams = Omit<UpdateProviderAuthCredentialsParams, 'providerAuthCredentials'> & {
-  providerAuthCredentials: UpdateProviderAuthCredentialsParams['providerAuthCredentials'] & AuditSubspaceProviderAuthCredentials;
+export type UpdateProviderAuthCredentialsFacingParams = Omit<
+  UpdateProviderAuthCredentialsParams,
+  'providerAuthCredentials'
+> & {
+  providerAuthCredentials: UpdateProviderAuthCredentialsParams['providerAuthCredentials'] &
+    AuditSubspaceProviderAuthCredentials;
 };
 
 export type ArchiveProviderAuthCredentialsParams = {
@@ -251,7 +262,9 @@ class providerAuthCredentialsServiceImpl {
     return authCredentials;
   }
 
-  async updateProviderAuthCredentials(d: MetorialFacing<UpdateProviderAuthCredentialsFacingParams>) {
+  async updateProviderAuthCredentials(
+    d: MetorialFacing<UpdateProviderAuthCredentialsFacingParams>
+  ) {
     let { instance, organizationActor, ...rest } = d;
     let scope = await resolveMetorialFacingWithOptionalActor(d);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes list-query semantics for auth configs and managed credentials when filtering by auth method IDs; broader result sets and legacy OR logic could surprise API consumers but stays within tenant-scoped list paths.
> 
> **Overview**
> **Provider auth config and credentials lists now filter by global auth method family** when callers pass `providerAuthMethodIds`, instead of matching only a single concrete method OID.
> 
> For **provider auth configs**, listing resolves IDs through `resolveAuthMethodsGlobal` and applies `authMethod.globalOid` in the Prisma `where` clause, so any instance in the same global family is included.
> 
> For **managed backing credentials**, the managed-credentials filter adds an **OR** branch for legacy rows where `providerAuthMethodGlobalOid` is null but `initialProviderAuthMethod.globalOid` still matches the requested family.
> 
> Vitest coverage asserts the generated `where` clauses for both `listProviderAuthConfigsInternal` and `listProviderAuthCredentialsInternal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 247f65aacd8a1e1a838ea140ee8b7a8a86e543ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->