### PR TITLE
Harden queue races

### DIFF
--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
@@ -157,4 +157,35 @@ describe('createBullMqQueue', () => {
     expect(mocks.captureException).toHaveBeenCalledOnce();
     expect(mocks.scopeDuringCapture).toEqual(['queue process: failing-queue']);
   });
+
+  it('reports a PostgreSQL deadlock only after queue retries are exhausted', async () => {
+    let deadlock = Object.assign(new Error('deadlock detected'), {
+      name: 'DriverAdapterError',
+      cause: { kind: 'postgres', code: '40P01' }
+    });
+    let handler = await startWorker('deadlocked-queue', async () => {
+      throw deadlock;
+    });
+
+    await expect(
+      handler({
+        id: 'job_1',
+        data: { payload: {} },
+        attemptsMade: 0,
+        opts: { attempts: 25 }
+      })
+    ).rejects.toBe(deadlock);
+    expect(mocks.captureException).not.toHaveBeenCalled();
+
+    await expect(
+      handler({
+        id: 'job_1',
+        data: { payload: {} },
+        attemptsMade: 24,
+        opts: { attempts: 25 }
+      })
+    ).rejects.toBe(deadlock);
+    expect(mocks.captureException).toHaveBeenCalledOnce();
+    expect(mocks.captureException).toHaveBeenCalledWith(deadlock);
+  });
 });

--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
@@ -113,6 +113,35 @@ let getSerializedExecutionContext = (
 
 let sanitizeJobId = (jobId?: string) => jobId?.replace(/:/g, '_');
 
+let isPostgresDeadlockError = (error: unknown) => {
+  let seen = new Set<object>();
+
+  let inspect = (value: unknown): boolean => {
+    if (!value || typeof value !== 'object' || seen.has(value)) return false;
+    seen.add(value);
+
+    let candidate = value as {
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+      meta?: unknown;
+      driverAdapterError?: unknown;
+    };
+
+    if (candidate.code === '40P01' || candidate.message === 'deadlock detected') {
+      return true;
+    }
+
+    return (
+      inspect(candidate.cause) ||
+      inspect(candidate.meta) ||
+      inspect(candidate.driverAdapterError)
+    );
+  };
+
+  return inspect(error);
+};
+
 export interface BullMqQueueOptions {
   delay?: number;
   id?: string;
@@ -313,6 +342,12 @@ export let createBullMqQueue = <JobData>(
             } catch (e: any) {
               if (e instanceof QueueRetryError) {
                 await delay(1000);
+                throw e;
+              } else if (
+                isPostgresDeadlockError(e) &&
+                job.attemptsMade + 1 < (job.opts.attempts ?? opts.jobOpts?.attempts ?? 25)
+              ) {
+                await delay(1000 + Math.random() * 5000);
                 throw e;
               } else {
                 Sentry.captureException(e);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes failure-handling in the shared BullMQ worker path; misclassification could hide real errors or spam Sentry, but scope is limited to deadlock-shaped errors with retries remaining.
> 
> **Overview**
> BullMQ job processing now treats **PostgreSQL deadlocks** like transient failures: while BullMQ still has retry attempts left, the worker **does not** report the error to Sentry and instead waits **1–6 seconds** (jitter) before rethrowing so the job can retry.
> 
> Deadlocks are detected via a new **`isPostgresDeadlockError`** helper that walks nested `cause` / `meta` / `driverAdapterError` shapes for code **`40P01`** or message **`deadlock detected`**. Sentry capture and logging only run when retries are exhausted or the error is not a deadlock—matching the existing **`QueueRetryError`** pattern. A unit test asserts **`captureException`** is skipped on early attempts and fires on the final attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af8c59077aac18f544404cbf5ffbfd9b3256461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->