### PR TITLE
Improve lock errors

### DIFF
--- a/src/lowerdeck/packages/lock/README.md
+++ b/src/lowerdeck/packages/lock/README.md
@@ -64,6 +64,13 @@ await lock.usingLock('resource-key', performWork, {
 });
 ```
 
+Acquisition-budget exhaustion throws `LockAcquisitionError`, allowing callers to handle lock
+contention separately from errors thrown by the critical section:
+
+```typescript
+import { LockAcquisitionError } from '@lowerdeck/lock';
+```
+
 Redis connections are pooled by URL. Long-running services may close the shared pool during
 graceful shutdown:
 

--- a/src/lowerdeck/packages/lock/src/index.test.ts
+++ b/src/lowerdeck/packages/lock/src/index.test.ts
@@ -29,7 +29,7 @@ vi.mock('redlock', () => ({
   }
 }));
 
-import { closeLockPool, createLock } from './index';
+import { closeLockPool, createLock, LockAcquisitionError } from './index';
 
 let createFakeLease = (durationMs: number) => {
   let lease: any = {
@@ -126,9 +126,32 @@ describe('lock pooling and acquisition', () => {
       retryJitter: 0
     });
 
-    let assertion = expect(resultPromise).rejects.toThrow('locked');
+    let assertion = expect(resultPromise).rejects.toMatchObject({
+      name: 'LockAcquisitionError',
+      message: 'locked',
+      cause: expect.objectContaining({ message: 'locked' })
+    });
     await vi.advanceTimersByTimeAsync(2_500);
     await assertion;
     expect(mocks.acquire).toHaveBeenCalledTimes(3);
+  });
+
+  it('exposes acquisition failures separately from critical-section failures', async () => {
+    mocks.acquire.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    let lock = createLock({ name: 'classified', redisUrl: 'redis://localhost:6379/0' });
+    await expect(
+      lock.usingLock('resource', async () => 'never', {
+        acquisitionTimeoutMs: 0
+      })
+    ).rejects.toBeInstanceOf(LockAcquisitionError);
+
+    let criticalSectionError = new Error('critical section failed');
+    mocks.acquire.mockResolvedValueOnce(createFakeLease(10_000));
+    await expect(
+      lock.usingLock('resource', async () => {
+        throw criticalSectionError;
+      })
+    ).rejects.toBe(criticalSectionError);
   });
 });

--- a/src/lowerdeck/packages/lock/src/index.ts
+++ b/src/lowerdeck/packages/lock/src/index.ts
@@ -18,6 +18,15 @@ interface LockPoolState {
   entries: Map<string, LockPoolEntry>;
 }
 
+export class LockAcquisitionError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Failed to acquire distributed lock', {
+      cause
+    });
+    this.name = 'LockAcquisitionError';
+  }
+}
+
 let LOCK_POOL_SYMBOL = Symbol.for('@lowerdeck/lock/pool/v1');
 let globalWithLockPool = globalThis as typeof globalThis & {
   [LOCK_POOL_SYMBOL]?: LockPoolState;
@@ -110,7 +119,7 @@ export let createLock = ({ name, redisUrl }: { name: string; redisUrl: string })
             console.warn(
               `LOCK.acquire.failed name=${name} keyCount=${keyArray.length} attempts=${attempt + 1} elapsedMs=${elapsedMs}`
             );
-            throw error;
+            throw new LockAcquisitionError(error);
           }
 
           let jitter = Math.floor((Math.random() * 2 - 1) * retryJitter);
@@ -119,7 +128,7 @@ export let createLock = ({ name, redisUrl }: { name: string; redisUrl: string })
             console.warn(
               `LOCK.acquire.failed name=${name} keyCount=${keyArray.length} attempts=${attempt + 1} elapsedMs=${elapsedMs}`
             );
-            throw error;
+            throw new LockAcquisitionError(error);
           }
 
           attempt++;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized API change in the lock package; acquisition failures are wrapped but messages are preserved via `cause`, while critical-section errors are unchanged.
> 
> **Overview**
> **`@lowerdeck/lock` now throws a dedicated `LockAcquisitionError` when lock acquisition fails** (timeout, retries exhausted, or Redis/Redlock errors), instead of rethrowing the underlying error directly.
> 
> The new error preserves the original failure as `cause` and uses the underlying message when available, so callers can branch on acquisition/contention separately from failures inside the critical section—which still propagate unchanged.
> 
> Tests assert bounded-acquisition behavior via `LockAcquisitionError`, and the README documents importing it from the package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adad468695e3b73df4bdc680e90cf333161b3040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->