### PR TITLE
Auto extend mcp client registrations

### DIFF
--- a/src/ares/service/src/apis/sso/endpoints/delegation.ts
+++ b/src/ares/service/src/apis/sso/endpoints/delegation.ts
@@ -3,7 +3,12 @@ import { v } from '@lowerdeck/validation';
 import { db } from '../../../db';
 import { env } from '../../../env';
 import { getId } from '../../../id';
-import { validateDelegationRedirectUri, allowHttpDelegationRedirect, parseDelegationMetadataRedirectUri } from '../../../lib/ssoDelegationProtocol';
+import {
+  allowHttpDelegationRedirect,
+  DELEGATION_TOKEN_TTL_SECONDS,
+  parseDelegationMetadataRedirectUri,
+  validateDelegationRedirectUri
+} from '../../../lib/ssoDelegationProtocol';
 import { ssoAuthService } from '../../../services/sso/auth';
 import { ssoDelegationService } from '../../../services/sso/delegation';
 
@@ -168,7 +173,7 @@ export let ssoDelegationApp = createHono()
       return c.json({
         access_token: token,
         token_type: 'Bearer',
-        expires_in: 300
+        expires_in: DELEGATION_TOKEN_TTL_SECONDS
       });
     }
 
@@ -187,7 +192,7 @@ export let ssoDelegationApp = createHono()
         return c.json({
           access_token: token,
           token_type: 'Bearer',
-          expires_in: 300
+          expires_in: DELEGATION_TOKEN_TTL_SECONDS
         });
       } catch {
         return c.json({ error: 'invalid_grant' }, 400);

--- a/src/ares/service/src/lib/ssoDelegationProtocol.ts
+++ b/src/ares/service/src/lib/ssoDelegationProtocol.ts
@@ -1,7 +1,13 @@
 import { createHash } from 'crypto';
 
+export let DELEGATION_TOKEN_TTL_SECONDS = 10 * 60;
+export let DELEGATION_TOKEN_EXPIRY_GRACE_MS = 30_000;
+
 export let hashDelegationSecret = (value: string) =>
   createHash('sha256').update(value).digest('hex');
+
+export let isDelegationTokenExpired = (d: { expiresAt: Date; now: Date }) =>
+  d.expiresAt.getTime() + DELEGATION_TOKEN_EXPIRY_GRACE_MS <= d.now.getTime();
 
 export let createDelegationCodeChallenge = (verifier: string) =>
   createHash('sha256').update(verifier).digest('base64url');

--- a/src/ares/service/src/services/sso/delegation.ts
+++ b/src/ares/service/src/services/sso/delegation.ts
@@ -1,7 +1,6 @@
 import { badRequestError, conflictError, notFoundError, ServiceError } from '@lowerdeck/error';
 import { Service } from '@lowerdeck/service';
 import { randomBytes, timingSafeEqual } from 'crypto';
-import { addMinutes } from 'date-fns';
 import { Prisma } from '../../../prisma/generated/client';
 import type {
   App,
@@ -17,8 +16,10 @@ import { env } from '../../env';
 import { getId, ID } from '../../id';
 import {
   assertDelegationAuthorizationGrant,
+  DELEGATION_TOKEN_TTL_SECONDS,
   getExportedDelegationRedirectUri,
   hashDelegationSecret,
+  isDelegationTokenExpired,
   normalizeDelegationAuthorizationEndpoint,
   pickLatestExportedDelegation
 } from '../../lib/ssoDelegationProtocol';
@@ -222,7 +223,7 @@ class SsoDelegationServiceImpl {
         exportedDelegationOid: d.delegation.oid,
         connectionOid: d.connectionOid,
         userProfileOid: d.userProfileOid,
-        expiresAt: addMinutes(new Date(), 5)
+        expiresAt: new Date(Date.now() + DELEGATION_TOKEN_TTL_SECONDS * 1000)
       }
     });
     return token;
@@ -311,7 +312,7 @@ class SsoDelegationServiceImpl {
     if (
       !token ||
       token.exportedDelegationOid !== d.delegation.oid ||
-      token.expiresAt <= new Date() ||
+      isDelegationTokenExpired({ expiresAt: token.expiresAt, now: new Date() }) ||
       token.revokedAt ||
       token.exportedDelegation.tenant.status !== 'completed'
     ) {

--- a/src/ares/service/tests/ssoDelegationProtocol.test.ts
+++ b/src/ares/service/tests/ssoDelegationProtocol.test.ts
@@ -4,6 +4,8 @@ import {
   buildIdpInitiatedDelegationRedirect,
   createDelegationCodeChallenge,
   createDelegationMetadataTokenBody,
+  DELEGATION_TOKEN_EXPIRY_GRACE_MS,
+  DELEGATION_TOKEN_TTL_SECONDS,
   FALLBACK_DELEGATION_REDIRECT_URI,
   getDelegationCallbackUri,
   getDelegationResponseMode,
@@ -11,6 +13,7 @@ import {
   getExportedDelegationRedirectUri,
   getIdpInitiatedConsumerLoginRedirect,
   hashDelegationSecret,
+  isDelegationTokenExpired,
   normalizeDelegationAuthorizationEndpoint,
   normalizeDelegationRedirectUri,
   pickLatestExportedDelegation,
@@ -18,6 +21,24 @@ import {
 } from '../src/lib/ssoDelegationProtocol';
 
 describe('SSO delegation protocol', () => {
+  it('allows ten minutes plus a short expiry grace for delegation tokens', () => {
+    expect(DELEGATION_TOKEN_TTL_SECONDS).toBe(600);
+
+    let expiresAt = new Date('2026-09-12T12:00:00.000Z');
+    expect(
+      isDelegationTokenExpired({
+        expiresAt,
+        now: new Date(expiresAt.getTime() + DELEGATION_TOKEN_EXPIRY_GRACE_MS - 1)
+      })
+    ).toBe(false);
+    expect(
+      isDelegationTokenExpired({
+        expiresAt,
+        now: new Date(expiresAt.getTime() + DELEGATION_TOKEN_EXPIRY_GRACE_MS)
+      })
+    ).toBe(true);
+  });
+
   it('creates stable hashes and S256 PKCE challenges', () => {
     expect(hashDelegationSecret('secret')).toHaveLength(64);
     expect(createDelegationCodeChallenge('verifier')).toBe(

--- a/src/lowerdeck/packages/lock/README.md
+++ b/src/lowerdeck/packages/lock/README.md
@@ -64,6 +64,13 @@ await lock.usingLock('resource-key', performWork, {
 });
 ```
 
+Acquisition-budget exhaustion throws `LockAcquisitionError`, allowing callers to handle lock
+contention separately from errors thrown by the critical section:
+
+```typescript
+import { LockAcquisitionError } from '@lowerdeck/lock';
+```
+
 Redis connections are pooled by URL. Long-running services may close the shared pool during
 graceful shutdown:
 

--- a/src/lowerdeck/packages/lock/src/index.test.ts
+++ b/src/lowerdeck/packages/lock/src/index.test.ts
@@ -29,7 +29,7 @@ vi.mock('redlock', () => ({
   }
 }));
 
-import { closeLockPool, createLock } from './index';
+import { closeLockPool, createLock, LockAcquisitionError } from './index';
 
 let createFakeLease = (durationMs: number) => {
   let lease: any = {
@@ -126,9 +126,32 @@ describe('lock pooling and acquisition', () => {
       retryJitter: 0
     });
 
-    let assertion = expect(resultPromise).rejects.toThrow('locked');
+    let assertion = expect(resultPromise).rejects.toMatchObject({
+      name: 'LockAcquisitionError',
+      message: 'locked',
+      cause: expect.objectContaining({ message: 'locked' })
+    });
     await vi.advanceTimersByTimeAsync(2_500);
     await assertion;
     expect(mocks.acquire).toHaveBeenCalledTimes(3);
+  });
+
+  it('exposes acquisition failures separately from critical-section failures', async () => {
+    mocks.acquire.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    let lock = createLock({ name: 'classified', redisUrl: 'redis://localhost:6379/0' });
+    await expect(
+      lock.usingLock('resource', async () => 'never', {
+        acquisitionTimeoutMs: 0
+      })
+    ).rejects.toBeInstanceOf(LockAcquisitionError);
+
+    let criticalSectionError = new Error('critical section failed');
+    mocks.acquire.mockResolvedValueOnce(createFakeLease(10_000));
+    await expect(
+      lock.usingLock('resource', async () => {
+        throw criticalSectionError;
+      })
+    ).rejects.toBe(criticalSectionError);
   });
 });

--- a/src/lowerdeck/packages/lock/src/index.ts
+++ b/src/lowerdeck/packages/lock/src/index.ts
@@ -18,6 +18,15 @@ interface LockPoolState {
   entries: Map<string, LockPoolEntry>;
 }
 
+export class LockAcquisitionError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Failed to acquire distributed lock', {
+      cause
+    });
+    this.name = 'LockAcquisitionError';
+  }
+}
+
 let LOCK_POOL_SYMBOL = Symbol.for('@lowerdeck/lock/pool/v1');
 let globalWithLockPool = globalThis as typeof globalThis & {
   [LOCK_POOL_SYMBOL]?: LockPoolState;
@@ -110,7 +119,7 @@ export let createLock = ({ name, redisUrl }: { name: string; redisUrl: string })
             console.warn(
               `LOCK.acquire.failed name=${name} keyCount=${keyArray.length} attempts=${attempt + 1} elapsedMs=${elapsedMs}`
             );
-            throw error;
+            throw new LockAcquisitionError(error);
           }
 
           let jitter = Math.floor((Math.random() * 2 - 1) * retryJitter);
@@ -119,7 +128,7 @@ export let createLock = ({ name, redisUrl }: { name: string; redisUrl: string })
             console.warn(
               `LOCK.acquire.failed name=${name} keyCount=${keyArray.length} attempts=${attempt + 1} elapsedMs=${elapsedMs}`
             );
-            throw error;
+            throw new LockAcquisitionError(error);
           }
 
           attempt++;

--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.test.ts
@@ -157,4 +157,35 @@ describe('createBullMqQueue', () => {
     expect(mocks.captureException).toHaveBeenCalledOnce();
     expect(mocks.scopeDuringCapture).toEqual(['queue process: failing-queue']);
   });
+
+  it('reports a PostgreSQL deadlock only after queue retries are exhausted', async () => {
+    let deadlock = Object.assign(new Error('deadlock detected'), {
+      name: 'DriverAdapterError',
+      cause: { kind: 'postgres', code: '40P01' }
+    });
+    let handler = await startWorker('deadlocked-queue', async () => {
+      throw deadlock;
+    });
+
+    await expect(
+      handler({
+        id: 'job_1',
+        data: { payload: {} },
+        attemptsMade: 0,
+        opts: { attempts: 25 }
+      })
+    ).rejects.toBe(deadlock);
+    expect(mocks.captureException).not.toHaveBeenCalled();
+
+    await expect(
+      handler({
+        id: 'job_1',
+        data: { payload: {} },
+        attemptsMade: 24,
+        opts: { attempts: 25 }
+      })
+    ).rejects.toBe(deadlock);
+    expect(mocks.captureException).toHaveBeenCalledOnce();
+    expect(mocks.captureException).toHaveBeenCalledWith(deadlock);
+  });
 });

--- a/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
+++ b/src/lowerdeck/packages/queue/src/drivers/bullmq.ts
@@ -113,6 +113,35 @@ let getSerializedExecutionContext = (
 
 let sanitizeJobId = (jobId?: string) => jobId?.replace(/:/g, '_');
 
+let isPostgresDeadlockError = (error: unknown) => {
+  let seen = new Set<object>();
+
+  let inspect = (value: unknown): boolean => {
+    if (!value || typeof value !== 'object' || seen.has(value)) return false;
+    seen.add(value);
+
+    let candidate = value as {
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+      meta?: unknown;
+      driverAdapterError?: unknown;
+    };
+
+    if (candidate.code === '40P01' || candidate.message === 'deadlock detected') {
+      return true;
+    }
+
+    return (
+      inspect(candidate.cause) ||
+      inspect(candidate.meta) ||
+      inspect(candidate.driverAdapterError)
+    );
+  };
+
+  return inspect(error);
+};
+
 export interface BullMqQueueOptions {
   delay?: number;
   id?: string;
@@ -313,6 +342,12 @@ export let createBullMqQueue = <JobData>(
             } catch (e: any) {
               if (e instanceof QueueRetryError) {
                 await delay(1000);
+                throw e;
+              } else if (
+                isPostgresDeadlockError(e) &&
+                job.attemptsMade + 1 < (job.opts.attempts ?? opts.jobOpts?.attempts ?? 25)
+              ) {
+                await delay(1000 + Math.random() * 5000);
                 throw e;
               } else {
                 Sentry.captureException(e);

--- a/src/metorial/products/integrations/provider-backends/provider-shuttle/src/lib/eventProviderInvocation.test.ts
+++ b/src/metorial/products/integrations/provider-backends/provider-shuttle/src/lib/eventProviderInvocation.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let createProviderInvocationId = vi.hoisted(() => vi.fn());
+
+vi.mock('@metorial-subspace/provider-utils', () => ({ createProviderInvocationId }));
+
+import { getEventProviderInvocationId } from './eventProviderInvocation';
+
+describe('getEventProviderInvocationId', () => {
+  beforeEach(() => {
+    createProviderInvocationId.mockImplementation((sourceType, sourceId) =>
+      JSON.stringify([sourceType, sourceId])
+    );
+  });
+
+  it('links connection-scoped events to the Shuttle connection invocation', () => {
+    let id = getEventProviderInvocationId({
+      serverConnectionId: 'server_connection_test'
+    });
+
+    expect(id).toBe('["shuttle.server_connection","server_connection_test"]');
+    expect(createProviderInvocationId).toHaveBeenCalledWith(
+      'shuttle.server_connection',
+      'server_connection_test'
+    );
+  });
+
+  it('prefers the more specific function invocation link', () => {
+    let id = getEventProviderInvocationId({
+      functionInvocationId: 'function_invocation_test',
+      serverConnectionId: 'server_connection_test'
+    });
+
+    expect(id).toBe('["shuttle.function_invocation","function_invocation_test"]');
+  });
+});

--- a/src/metorial/products/integrations/provider-backends/provider-shuttle/src/lib/eventProviderInvocation.ts
+++ b/src/metorial/products/integrations/provider-backends/provider-shuttle/src/lib/eventProviderInvocation.ts
@@ -1,0 +1,19 @@
+import { createProviderInvocationId } from '@metorial-subspace/provider-utils';
+
+export let getEventProviderInvocationId = (event: {
+  functionInvocationId?: string | null;
+  serverConnectionId?: string | null;
+}) => {
+  if (event.functionInvocationId) {
+    return createProviderInvocationId(
+      'shuttle.function_invocation',
+      event.functionInvocationId
+    );
+  }
+
+  if (event.serverConnectionId) {
+    return createProviderInvocationId('shuttle.server_connection', event.serverConnectionId);
+  }
+
+  return null;
+};

--- a/src/metorial/products/integrations/provider-backends/provider-shuttle/src/queues/sync/authConfigEvents.ts
+++ b/src/metorial/products/integrations/provider-backends/provider-shuttle/src/queues/sync/authConfigEvents.ts
@@ -4,7 +4,6 @@ import { createLock } from '@lowerdeck/lock';
 import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db, getId } from '@metorial-subspace/db';
 import {
-  createProviderInvocationId,
   getRetentionPolicy,
   redactJsonShape,
   redactSensitiveKeys
@@ -12,6 +11,7 @@ import {
 import { backend as shuttleBackend } from '../../backend';
 import { shuttle } from '../../client';
 import { env } from '../../env';
+import { getEventProviderInvocationId } from '../../lib/eventProviderInvocation';
 
 type ShuttleAuthConfigEvent = Awaited<
   ReturnType<typeof shuttle.serverAuthConfigEvent.listSync>
@@ -38,11 +38,6 @@ let getErrorInfo = (event: ShuttleAuthConfigEvent) => {
 
 let isErrorEvent = (event: ShuttleAuthConfigEvent) =>
   event.type.endsWith('_failed') || event.type.includes('error');
-
-let getProviderInvocationId = (functionInvocationId: string | null | undefined) =>
-  functionInvocationId
-    ? createProviderInvocationId('shuttle.function_invocation', functionInvocationId)
-    : null;
 
 export let syncAuthConfigEventsQueue = createQueue<{}>({
   name: 'sub/shut/authEvt/many',
@@ -128,7 +123,7 @@ export let syncAuthConfigEventQueueProcessor = syncAuthConfigEventQueue.process(
         type: data.event.type,
         sourceType: 'shuttle.server_auth_config_event',
         sourceId: data.event.id,
-        providerInvocationId: getProviderInvocationId(data.event.functionInvocationId),
+        providerInvocationId: getEventProviderInvocationId(data.event),
         payload: retention.storeErrorPayload ? safePayload : redactJsonShape(safePayload),
         authConfigOid: authConfigVersion.authConfigOid,
         authCredentialsOid:
@@ -169,7 +164,7 @@ export let syncAuthConfigEventQueueProcessor = syncAuthConfigEventQueue.process(
       code,
       message,
       payload: retention.storeErrorPayload ? safePayload : redactJsonShape(safePayload),
-      providerInvocationId: getProviderInvocationId(data.event.functionInvocationId),
+      providerInvocationId: getEventProviderInvocationId(data.event),
       authConfigEventOid: authConfigEvent.oid,
       authConfigOid: authConfigVersion.authConfigOid,
       authCredentialsOid:

--- a/src/metorial/products/integrations/provider-backends/provider-shuttle/src/queues/sync/oauthSetups.ts
+++ b/src/metorial/products/integrations/provider-backends/provider-shuttle/src/queues/sync/oauthSetups.ts
@@ -5,7 +5,6 @@ import { createQueue, QueueRetryError } from '@lowerdeck/queue';
 import { db, getId, type SessionDataRetentionLevel } from '@metorial-subspace/db';
 import { providerOAuthSetupInternalService } from '@metorial-subspace/module-auth';
 import {
-  createProviderInvocationId,
   getRetentionPolicy,
   redactJsonShape,
   redactSensitiveKeys
@@ -13,6 +12,7 @@ import {
 import { backend as shuttleBackend } from '../../backend';
 import { shuttle } from '../../client';
 import { env } from '../../env';
+import { getEventProviderInvocationId } from '../../lib/eventProviderInvocation';
 
 type ShuttleOAuthSetupEvent = Awaited<
   ReturnType<typeof shuttle.serverOAuthSetupEvent.listSync>
@@ -73,11 +73,6 @@ let getErrorInfo = (event: ShuttleOAuthSetupEvent) => {
 let isErrorEvent = (event: ShuttleOAuthSetupEvent) =>
   event.type.endsWith('_failed') || event.type.includes('error');
 
-let getProviderInvocationId = (functionInvocationId: string | null | undefined) =>
-  functionInvocationId
-    ? createProviderInvocationId('shuttle.function_invocation', functionInvocationId)
-    : null;
-
 let ensureProviderAuthConfigEvent = async (d: {
   event: ShuttleOAuthSetupEvent;
   providerOAuthSetup: SyncedProviderOAuthSetup;
@@ -101,7 +96,7 @@ let ensureProviderAuthConfigEvent = async (d: {
         type: d.event.type,
         sourceType: 'shuttle.server_oauth_setup',
         sourceId: d.event.id,
-        providerInvocationId: getProviderInvocationId(d.event.functionInvocationId),
+        providerInvocationId: getEventProviderInvocationId(d.event),
         payload: retention.storeErrorPayload ? safePayload : redactJsonShape(safePayload),
         authConfigOid: d.providerOAuthSetup.authConfigOid,
         authCredentialsOid: d.providerOAuthSetup.authCredentialsOid,
@@ -150,7 +145,7 @@ let createErrorForEvent = async (d: {
       code,
       message,
       payload: retention.storeErrorPayload ? safePayload : redactJsonShape(safePayload),
-      providerInvocationId: getProviderInvocationId(d.event.functionInvocationId),
+      providerInvocationId: getEventProviderInvocationId(d.event),
       authConfigEventOid: d.providerAuthConfigEventOid,
       authConfigOid: d.providerOAuthSetup.authConfigOid,
       authCredentialsOid: d.providerOAuthSetup.authCredentialsOid,

--- a/src/metorial/products/workforce/modules/consumer-oauth/package.json
+++ b/src/metorial/products/workforce/modules/consumer-oauth/package.json
@@ -15,6 +15,7 @@
     "@lowerdeck/service": "workspace:2.0.0",
     "@metorial/audit-scope": "workspace:*",
     "@metorial/config": "1.0.0",
+    "@metorial/cron": "1.0.0",
     "@metorial/consumer-magic-access": "1.0.0",
     "@metorial/consumer-oauth-utils": "1.0.0",
     "@metorial/db": "1.0.0",

--- a/src/metorial/products/workforce/modules/consumer-oauth/src/cron/reconcileConsumerAuthClientExpiration.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/src/cron/reconcileConsumerAuthClientExpiration.ts
@@ -1,0 +1,21 @@
+import { createCron } from '@metorial/cron';
+import { db } from '@metorial/db';
+import { addMonths } from 'date-fns';
+
+export let reconcileConsumerAuthClientExpirationCron = createCron(
+  {
+    name: 'coauth/client/expiration/reconcile',
+    cron: '0 * * * *'
+  },
+  async () => {
+    let now = new Date();
+    await db.consumerAuthClient.updateMany({
+      where: {
+        expiresAt: { gt: now }
+      },
+      data: {
+        expiresAt: addMonths(now, 3)
+      }
+    });
+  }
+);

--- a/src/metorial/products/workforce/modules/consumer-oauth/src/index.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/src/index.ts
@@ -1,5 +1,8 @@
 import { combineQueueProcessors } from '@metorial/queue';
+import { reconcileConsumerAuthClientExpirationCron } from './cron/reconcileConsumerAuthClientExpiration';
 
 export * from './services';
 
-export let consumerOAuthQueueProcessor = combineQueueProcessors([]);
+export let consumerOAuthQueueProcessor = combineQueueProcessors([
+  reconcileConsumerAuthClientExpirationCron
+]);

--- a/src/metorial/products/workforce/modules/consumer-oauth/src/services/_helpers.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/src/services/_helpers.ts
@@ -7,8 +7,14 @@ import {
 } from '@lowerdeck/error';
 import { Hash } from '@lowerdeck/hash';
 import { getConfig } from '@metorial/config';
-import { db, SkillPlugin, type ConsumerAuthAttempt, type ConsumerSurface } from '@metorial/db';
-import { addSeconds } from 'date-fns';
+import {
+  db,
+  SkillPlugin,
+  type ConsumerAuthAttempt,
+  type ConsumerAuthClient,
+  type ConsumerSurface
+} from '@metorial/db';
+import { addDays, addMonths, addSeconds } from 'date-fns';
 import {
   consumerAuthAccessTokenTtlSeconds,
   consumerAuthClientInclude,
@@ -23,6 +29,24 @@ export let getConsumerAuthRefreshTokenExpiry = () =>
 
 export let getConsumerAuthAccessTokenExpiry = () =>
   addSeconds(new Date(), consumerAuthAccessTokenTtlSeconds);
+
+export let slideConsumerAuthClientExpiration = async (d: {
+  consumerAuthClient: Pick<ConsumerAuthClient, 'oid' | 'expiresAt'>;
+}) => {
+  let now = new Date();
+  let renewalThreshold = addDays(now, 7);
+  if (d.consumerAuthClient.expiresAt >= renewalThreshold) return;
+
+  await db.consumerAuthClient.updateMany({
+    where: {
+      oid: d.consumerAuthClient.oid,
+      expiresAt: { lt: renewalThreshold }
+    },
+    data: {
+      expiresAt: addMonths(now, 3)
+    }
+  });
+};
 
 export let consumerAuthClientRegistrationRateLimitError = createError({
   status: 429,

--- a/src/metorial/products/workforce/modules/consumer-oauth/src/services/registration.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/src/services/registration.ts
@@ -10,7 +10,7 @@ import {
   type Instance
 } from '@metorial/db';
 import { type MagicMcpResolvedTarget } from '@metorial/module-magic';
-import { addDays, addMinutes } from 'date-fns';
+import { addDays, addMinutes, addMonths } from 'date-fns';
 import {
   getPortalAllowedRedirectUrlFilters,
   validatePortalRedirectUrisAgainstAllowedFilters,
@@ -94,7 +94,7 @@ class ConsumerOAuthRegistrationService {
           clientId: await ID.generateId('consumerAuthClientId'),
           clientSecret,
           tokenEndpointAuthMethod,
-          expiresAt: addDays(new Date(), 30)
+          expiresAt: addMonths(new Date(), 3)
         }
       });
 
@@ -151,7 +151,7 @@ class ConsumerOAuthRegistrationService {
           clientId: await ID.generateId('consumerAuthClientId'),
           clientSecret,
           tokenEndpointAuthMethod,
-          expiresAt: addDays(new Date(), 30)
+          expiresAt: addMonths(new Date(), 3)
         },
         include: consumerAuthClientInclude
       });

--- a/src/metorial/products/workforce/modules/consumer-oauth/src/services/token.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/src/services/token.ts
@@ -28,7 +28,8 @@ import {
   getConsumerAuthClientPlugin,
   getConsumerAuthClientSurface,
   getConsumerAuthRefreshTokenExpiry,
-  resolveConsumerSurface
+  resolveConsumerSurface,
+  slideConsumerAuthClientExpiration
 } from './_helpers';
 import {
   consumerAuthAttemptInclude,
@@ -38,12 +39,6 @@ import {
   ConsumerSurfaceWithContext
 } from './_types';
 
-/**
- * Token issuance and rotation happen inside the OAuth exchange, which carries no request
- * context of its own -- the client presents a code or refresh token, not a session. The
- * consumer holding the authorization is the actor; where the authorization has no profile
- * yet the exchange is attributed to the flow itself.
- */
 let consumerOAuthAuditScope = (d: {
   consumerSurface: Pick<ConsumerSurface, 'organizationOid' | 'instanceOid'>;
   consumerProfile?: { id: string } | null;
@@ -526,6 +521,7 @@ class ConsumerOAuthTokenService {
         expiresAt
       }
     });
+    await slideConsumerAuthClientExpiration({ consumerAuthClient: d.client });
 
     return {
       accessToken: accessToken.secret,
@@ -589,6 +585,7 @@ class ConsumerOAuthTokenService {
         expiresAt
       }
     });
+    await slideConsumerAuthClientExpiration({ consumerAuthClient: d.client });
 
     return {
       accessToken: rotatedAccessToken.secret,

--- a/src/metorial/products/workforce/modules/consumer-oauth/test/consumerOAuthLinking.test.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/test/consumerOAuthLinking.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addDays, addMonths } from 'date-fns';
 
 vi.mock('@lowerdeck/hash', () => ({
   Hash: {
@@ -140,6 +141,7 @@ import {
   consumerOAuthRegistrationService,
   consumerOAuthTestAuthorizationService
 } from '../src/services';
+import { slideConsumerAuthClientExpiration } from '../src/services/_helpers';
 
 describe('consumer OAuth integration endpoint linking', () => {
   beforeEach(() => {
@@ -153,6 +155,40 @@ describe('consumer OAuth integration endpoint linking', () => {
     vi.mocked(db.consumerClient.create).mockResolvedValue({
       oid: 99n
     } as any);
+  });
+
+  it('slides a client expiry only when it is less than seven days away', async () => {
+    vi.useFakeTimers();
+    let now = new Date('2026-01-15T00:00:00.000Z');
+    vi.setSystemTime(now);
+
+    await slideConsumerAuthClientExpiration({
+      consumerAuthClient: {
+        oid: 10n,
+        expiresAt: new Date(addDays(now, 7).getTime() - 1)
+      }
+    });
+
+    expect(db.consumerAuthClient.updateMany).toHaveBeenCalledWith({
+      where: {
+        oid: 10n,
+        expiresAt: { lt: addDays(now, 7) }
+      },
+      data: {
+        expiresAt: addMonths(now, 3)
+      }
+    });
+
+    vi.mocked(db.consumerAuthClient.updateMany).mockClear();
+    await slideConsumerAuthClientExpiration({
+      consumerAuthClient: {
+        oid: 10n,
+        expiresAt: addDays(now, 7)
+      }
+    });
+
+    expect(db.consumerAuthClient.updateMany).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it('upserts a consumer client during auth client self-registration', async () => {

--- a/src/metorial/products/workforce/modules/consumer-oauth/test/reconcileConsumerAuthClientExpiration.test.ts
+++ b/src/metorial/products/workforce/modules/consumer-oauth/test/reconcileConsumerAuthClientExpiration.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addMonths } from 'date-fns';
+
+let reconcileConsumerAuthClientExpirationHandler: (() => Promise<void>) | undefined;
+
+vi.mock('@metorial/db', () => ({
+  db: {
+    consumerAuthClient: {
+      updateMany: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@metorial/cron', () => ({
+  createCron: vi.fn((_, handler) => {
+    reconcileConsumerAuthClientExpirationHandler = handler;
+    return { handler };
+  })
+}));
+
+let { db } = await import('@metorial/db');
+let { reconcileConsumerAuthClientExpirationCron } = await import(
+  '../src/cron/reconcileConsumerAuthClientExpiration'
+);
+
+describe('reconcile consumer auth client expiration cron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extends every unexpired client by three months', async () => {
+    vi.useFakeTimers();
+    let now = new Date('2026-01-15T00:00:00.000Z');
+    vi.setSystemTime(now);
+
+    expect(reconcileConsumerAuthClientExpirationCron).toBeDefined();
+    await reconcileConsumerAuthClientExpirationHandler!();
+
+    expect(db.consumerAuthClient.updateMany).toHaveBeenCalledWith({
+      where: {
+        expiresAt: { gt: now }
+      },
+      data: {
+        expiresAt: addMonths(now, 3)
+      }
+    });
+    vi.useRealTimers();
+  });
+});

--- a/src/shuttle/service/src/instrument.ts
+++ b/src/shuttle/service/src/instrument.ts
@@ -1,4 +1,4 @@
-import { setSentry } from '@lowerdeck/sentry';
+import { setSentry, shouldIgnoreSentryHttpError } from '@lowerdeck/sentry';
 import { initTelemetry } from '@lowerdeck/telemetry';
 import * as Sentry from '@sentry/bun';
 
@@ -26,7 +26,9 @@ if (
 
     environment: process.env.METORIAL_ENV,
 
-    beforeSend(event) {
+    beforeSend(event, hint) {
+      if (shouldIgnoreSentryHttpError(hint)) return null;
+
       if (!event.tags) event.tags = {};
       event.tags.allocationId = process.env.NOMAD_ALLOC_ID || 'unknown';
       return event;

--- a/src/shuttle/service/src/lib/oauth/oauthRequestError.test.ts
+++ b/src/shuttle/service/src/lib/oauth/oauthRequestError.test.ts
@@ -1,0 +1,88 @@
+import { ServiceError, badRequestError } from '@lowerdeck/error';
+import { describe, expect, it } from 'vitest';
+import {
+  formatOAuthRequestError,
+  getOAuthRequestErrorDetails,
+  isTransientOAuthStatus
+} from './oauthRequestError';
+
+describe('getOAuthRequestErrorDetails', () => {
+  it('extracts safe provider diagnostics without retaining response content', () => {
+    let details = getOAuthRequestErrorDetails({
+      message: 'Request failed for https://private.example/token?secret=value',
+      response: {
+        status: 400,
+        data: {
+          error: 'invalid_grant',
+          error_description: 'refresh_token=very-secret-value'
+        }
+      }
+    });
+
+    expect(details).toEqual({
+      status: 400,
+      oauthCode: 'invalid_grant',
+      isTransient: false,
+      retryAfterMs: null
+    });
+    expect(JSON.stringify(details)).not.toContain('very-secret-value');
+    expect(JSON.stringify(details)).not.toContain('private.example');
+  });
+
+  it('bounds Retry-After and classifies transient responses', () => {
+    let details = getOAuthRequestErrorDetails({
+      response: { status: 429, headers: { 'retry-after': '60' } }
+    });
+
+    expect(details.isTransient).toBe(true);
+    expect(details.retryAfterMs).toBe(5000);
+  });
+
+  it('reads structured service error statuses', () => {
+    let details = getOAuthRequestErrorDetails(
+      new ServiceError(badRequestError({ message: 'Invalid provider response' }))
+    );
+
+    expect(details.status).toBe(400);
+    expect(details.isTransient).toBe(false);
+  });
+
+  it('rejects response text disguised as an OAuth error code', () => {
+    let details = getOAuthRequestErrorDetails({
+      response: {
+        status: 400,
+        data: { error: 'invalid_grant\nrefresh_token=very-secret-value' }
+      }
+    });
+
+    expect(details.oauthCode).toBeNull();
+    expect(JSON.stringify(details)).not.toContain('very-secret-value');
+  });
+});
+
+describe('isTransientOAuthStatus', () => {
+  it('only retries network, throttling and server failures', () => {
+    expect(isTransientOAuthStatus(null)).toBe(true);
+    expect(isTransientOAuthStatus(429)).toBe(true);
+    expect(isTransientOAuthStatus(503)).toBe(true);
+    expect(isTransientOAuthStatus(400)).toBe(false);
+    expect(isTransientOAuthStatus(403)).toBe(false);
+  });
+});
+
+describe('formatOAuthRequestError', () => {
+  it('only includes the safe status and OAuth code', () => {
+    expect(
+      formatOAuthRequestError('Token refresh failed', {
+        status: 400,
+        oauthCode: 'invalid_grant'
+      })
+    ).toBe('Token refresh failed (HTTP 400, OAuth error invalid_grant)');
+  });
+
+  it('uses a safe network fallback', () => {
+    expect(
+      formatOAuthRequestError('Token refresh failed', { status: null, oauthCode: null })
+    ).toBe('Token refresh failed because the OAuth provider could not be reached');
+  });
+});

--- a/src/shuttle/service/src/lib/oauth/oauthRequestError.ts
+++ b/src/shuttle/service/src/lib/oauth/oauthRequestError.ts
@@ -1,0 +1,75 @@
+import { isServiceError } from '@lowerdeck/error';
+
+export type OAuthRequestErrorDetails = {
+  status: number | null;
+  oauthCode: string | null;
+  isTransient: boolean;
+  retryAfterMs: number | null;
+};
+
+let asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+let getStatus = (error: unknown) => {
+  let record = asRecord(error);
+  let response = asRecord(record?.response);
+  let status = response?.status ?? record?.status ?? record?.statusCode;
+
+  if (isServiceError(error)) status = error.data.status;
+
+  return typeof status === 'number' && Number.isInteger(status) ? status : null;
+};
+
+let getOAuthCode = (error: unknown) => {
+  let record = asRecord(error);
+  let response = asRecord(record?.response);
+  let data = asRecord(response?.data);
+  let code = data?.error;
+
+  return typeof code === 'string' && /^[a-z0-9._-]{1,100}$/i.test(code) ? code : null;
+};
+
+let getRetryAfterMs = (error: unknown) => {
+  let record = asRecord(error);
+  let response = asRecord(record?.response);
+  let headers = asRecord(response?.headers);
+  let retryAfter = headers?.['retry-after'];
+
+  if (typeof retryAfter !== 'string' && typeof retryAfter !== 'number') return null;
+
+  let seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) return Math.max(0, Math.min(seconds * 1000, 5000));
+
+  let retryAt = new Date(String(retryAfter)).getTime();
+  if (!Number.isFinite(retryAt)) return null;
+
+  return Math.max(0, Math.min(retryAt - Date.now(), 5000));
+};
+
+export let isTransientOAuthStatus = (status: number | null) =>
+  status === null || status === 408 || status === 425 || status === 429 || status >= 500;
+
+export let getOAuthRequestErrorDetails = (error: unknown): OAuthRequestErrorDetails => {
+  let status = getStatus(error);
+
+  return {
+    status,
+    oauthCode: getOAuthCode(error),
+    isTransient: isTransientOAuthStatus(status),
+    retryAfterMs: getRetryAfterMs(error)
+  };
+};
+
+export let formatOAuthRequestError = (
+  message: string,
+  details: Pick<OAuthRequestErrorDetails, 'status' | 'oauthCode'>
+) => {
+  let diagnostics: string[] = [];
+  if (details.status !== null) diagnostics.push(`HTTP ${details.status}`);
+  if (details.oauthCode) diagnostics.push(`OAuth error ${details.oauthCode}`);
+
+  if (!diagnostics.length) return `${message} because the OAuth provider could not be reached`;
+  return `${message} (${diagnostics.join(', ')})`;
+};

--- a/src/shuttle/service/src/lib/oauth/oauthUtils.test.ts
+++ b/src/shuttle/service/src/lib/oauth/oauthUtils.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let { axiosPost } = vi.hoisted(() => ({ axiosPost: vi.fn() }));
+
+vi.mock('axios', () => ({
+  default: {
+    defaults: { headers: { common: {} } },
+    post: axiosPost,
+    get: vi.fn()
+  }
+}));
+
+vi.mock('../../config', () => ({ oauthCallbackUrl: 'https://metorial.test/callback' }));
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../http/axiosSsrf', () => ({ getAxiosSsrfFilter: () => ({}) }));
+vi.mock('../network/egressPolicy', () => ({
+  assertUrlAllowedByEgressPolicy: vi.fn()
+}));
+
+import { OAuthUtils } from './oauthUtils';
+
+let config = {
+  authorization_endpoint: 'https://provider.test/authorize',
+  token_endpoint: 'https://provider.test/token'
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('OAuthUtils.refreshAccessToken', () => {
+  it('retries one transient failure and returns the successful response', async () => {
+    axiosPost
+      .mockRejectedValueOnce({
+        response: { status: 503, headers: { 'retry-after': '0' } }
+      })
+      .mockResolvedValueOnce({
+        data: { access_token: 'new-token', token_type: 'Bearer' }
+      });
+
+    let result = await OAuthUtils.refreshAccessToken({
+      tokenEndpoint: config.token_endpoint,
+      clientId: 'client-id',
+      refreshToken: 'refresh-token',
+      config
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      response: { access_token: 'new-token', token_type: 'Bearer' }
+    });
+    expect(axiosPost).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry permanent failures or expose provider response content', async () => {
+    axiosPost.mockRejectedValue({
+      message: 'Request failed for https://private.test/token',
+      response: {
+        status: 400,
+        data: {
+          error: 'invalid_grant',
+          error_description: 'refresh_token=secret-value'
+        }
+      }
+    });
+
+    let result = await OAuthUtils.refreshAccessToken({
+      tokenEndpoint: config.token_endpoint,
+      clientId: 'client-id',
+      refreshToken: 'refresh-token',
+      config
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        status: 400,
+        oauthCode: 'invalid_grant',
+        isTransient: false,
+        retryAfterMs: null
+      },
+      message: 'OAuth token refresh failed (HTTP 400, OAuth error invalid_grant)'
+    });
+    expect(JSON.stringify(result)).not.toContain('secret-value');
+    expect(JSON.stringify(result)).not.toContain('private.test');
+    expect(axiosPost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shuttle/service/src/lib/oauth/oauthUtils.ts
+++ b/src/shuttle/service/src/lib/oauth/oauthUtils.ts
@@ -1,7 +1,7 @@
 import { canonicalize } from '@lowerdeck/canonicalize';
+import { delay } from '@lowerdeck/delay';
 import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { Hash } from '@lowerdeck/hash';
-import { getSentry } from '@lowerdeck/sentry';
 import axios from 'axios';
 import { customAlphabet } from 'nanoid';
 import type {
@@ -18,6 +18,11 @@ import { buildClientRegistrationMetadata } from './clientRegistrationMetadata';
 import { normalizeAuthorizationUrl } from './normalizeAuthorizationUrl';
 import { isTransientRegistrationError } from './registrationRetry';
 import {
+  formatOAuthRequestError,
+  getOAuthRequestErrorDetails,
+  type OAuthRequestErrorDetails
+} from './oauthRequestError';
+import {
   type OAuthConfiguration,
   type RegistrationResponse,
   registrationResponseValidator,
@@ -28,8 +33,6 @@ import {
 axios.defaults.headers.common['Accept-Encoding'] = 'gzip';
 
 let id = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz', 21);
-
-let Sentry = getSentry();
 
 export class OAuthUtils {
   static generateState(): string {
@@ -164,19 +167,12 @@ export class OAuthUtils {
 
       return response.data;
     } catch (error: any) {
-      Sentry.captureException(error, {
-        extra: {
-          tokenEndpoint,
-          clientId,
-          redirectUri
-        }
-      });
-
-      let errorMessage = error.response?.data?.error_description || error.message;
+      let details = getOAuthRequestErrorDetails(error);
 
       throw new ServiceError(
         badRequestError({
-          message: `Token exchange failed: ${error.response?.status ?? 'unknown'} ${errorMessage}`
+          code: 'oauth_token_exchange_failed',
+          message: formatOAuthRequestError('OAuth token exchange failed', details)
         })
       );
     }
@@ -194,7 +190,10 @@ export class OAuthUtils {
     clientSecret?: string; // now optional
     refreshToken: string;
     config: OAuthConfiguration;
-  }): Promise<{ ok: true; response: TokenResponse } | { ok: false; message: string }> {
+  }): Promise<
+    | { ok: true; response: TokenResponse }
+    | { ok: false; error: OAuthRequestErrorDetails; message: string }
+  > {
     let body = new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: refreshToken
@@ -225,28 +224,34 @@ export class OAuthUtils {
       }
     }
 
-    try {
-      let response = await axios.post<TokenResponse>(tokenEndpoint, body.toString(), {
-        headers,
-        maxRedirects: 5,
-        timeout: 5000,
-        ...getAxiosSsrfFilter(tokenEndpoint)
-      });
-      return {
-        ok: true,
-        response: response.data
-      };
-    } catch (error: any) {
-      Sentry.captureException(error, {
-        extra: { tokenEndpoint, clientId }
-      });
-      return {
-        ok: false,
-        message:
-          error.response?.data?.error_description ||
-          (error.response?.data ? JSON.stringify(error.response?.data) : error.message)
-      };
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        let response = await axios.post<TokenResponse>(tokenEndpoint, body.toString(), {
+          headers,
+          maxRedirects: 5,
+          timeout: 5000,
+          ...getAxiosSsrfFilter(tokenEndpoint)
+        });
+        return {
+          ok: true,
+          response: response.data
+        };
+      } catch (error) {
+        let details = getOAuthRequestErrorDetails(error);
+        if (details.isTransient && attempt == 0) {
+          await delay(details.retryAfterMs ?? 500);
+          continue;
+        }
+
+        return {
+          ok: false,
+          error: details,
+          message: formatOAuthRequestError('OAuth token refresh failed', details)
+        };
+      }
     }
+
+    throw new Error('OAuth token refresh retry loop completed unexpectedly');
   }
 
   static async getUserProfile({
@@ -284,14 +289,11 @@ export class OAuthUtils {
         email: typeof data.email === 'string' ? data.email : undefined
       };
     } catch (error: any) {
-      Sentry.captureException(error, {
-        extra: { userInfoEndpoint }
-      });
-
-      let errorMessage = error.response?.data?.error_description || error.message;
+      let details = getOAuthRequestErrorDetails(error);
       throw new ServiceError(
         badRequestError({
-          message: `Failed to fetch user profile: ${error.response?.status ?? 'unknown'} ${errorMessage}`
+          code: 'oauth_userinfo_failed',
+          message: formatOAuthRequestError('OAuth user profile lookup failed', details)
         })
       );
     }
@@ -354,8 +356,7 @@ export class OAuthUtils {
   static async registerClient({
     tenant,
     config,
-    owner,
-    captureErrors = true
+    owner
   }: {
     tenant: Tenant;
     config: OAuthConfiguration;
@@ -363,7 +364,6 @@ export class OAuthUtils {
       connection?: RemoteOAuthConnection;
       config?: RemoteOAuthConfig;
     };
-    captureErrors?: boolean;
   }) {
     if (!config.registration_endpoint) return null;
 
@@ -435,7 +435,7 @@ export class OAuthUtils {
         registration: reg
       };
     } catch (error: any) {
-      let status = typeof error?.response?.status == 'number' ? error.response.status : null;
+      let details = getOAuthRequestErrorDetails(error);
 
       let err = await db.remoteOAuthRegistrationError.create({
         data: {
@@ -444,27 +444,17 @@ export class OAuthUtils {
           configOid: owner?.config?.oid || null,
           connectionOid: owner?.connection?.oid || null,
 
-          payload: {
-            error: error?.response?.data || error.message
-          }
+          payload: { error: details }
         }
       });
-
-      if (captureErrors) {
-        Sentry.captureException(error, {
-          extra: {
-            registrationEndpoint: config.registration_endpoint,
-            tenantId: tenant.id,
-            status
-          }
-        });
-      }
 
       return {
         ok: false as const,
         error: err,
-        status,
-        isTransient: isTransientRegistrationError({ status })
+        status: details.status,
+        oauthCode: details.oauthCode,
+        message: formatOAuthRequestError('OAuth client registration failed', details),
+        isTransient: isTransientRegistrationError({ status: details.status })
       };
     }
   }

--- a/src/shuttle/service/src/mcp/function/authManager.ts
+++ b/src/shuttle/service/src/mcp/function/authManager.ts
@@ -1,4 +1,3 @@
-import { getSentry } from '@lowerdeck/sentry';
 import type {
   ServerAuthConfig,
   ServerConfig,
@@ -6,9 +5,8 @@ import type {
   Tenant
 } from '../../../prisma/generated/client';
 import { serverAuthTokenService } from '../../services/oauth/serverAuthToken';
+import { ConnectionError, toConnectionError } from '../utils/connectionError';
 import type { ConnectionLogger } from '../utils/logger';
-
-let Sentry = getSentry();
 
 const EXPIRY_SAFETY_MARGIN_MS = 1000 * 30;
 
@@ -41,7 +39,8 @@ export class FunctionConnectionAuthManager {
         try {
           let res = await serverAuthTokenService.useAuthToken({
             tenant: this.tenant,
-            authConfig: this.connection.serverAuthConfig!
+            authConfig: this.connection.serverAuthConfig!,
+            serverConnectionId: this.connection.id
           });
 
           if (res.didRefresh) {
@@ -68,19 +67,12 @@ export class FunctionConnectionAuthManager {
             tokenType: res.delegatedToken?.tokenType
           };
         } catch (err) {
-          Sentry.captureException(err, {
-            extra: {
-              connectionId: this.connection.id,
-              tenantId: this.tenant.id
-            }
-          });
+          let mapped = toConnectionError(err, 'auth_token_refresh_failed');
+          this.logger.log('debug.error', `Failed to obtain access token: ${mapped.message}`);
 
-          this.logger.log(
-            'debug.error',
-            `Failed to obtain access token: ${(err as Error).message}`
-          );
+          this.#accessTokenPromise = null;
 
-          throw err;
+          throw new ConnectionError(mapped);
         }
       })();
     }

--- a/src/shuttle/service/src/mcp/remote/authManager.ts
+++ b/src/shuttle/service/src/mcp/remote/authManager.ts
@@ -1,4 +1,3 @@
-import { getSentry } from '@lowerdeck/sentry';
 import type {
   ServerAuthConfig,
   ServerConfig,
@@ -9,8 +8,6 @@ import { secretService } from '../../services';
 import { serverAuthTokenService } from '../../services/oauth/serverAuthToken';
 import { ConnectionError, toConnectionError } from '../utils/connectionError';
 import type { ConnectionLogger } from '../utils/logger';
-
-let Sentry = getSentry();
 
 const EXPIRY_SAFETY_MARGIN_MS = 1000 * 30;
 
@@ -94,7 +91,8 @@ export class RemoteConnectionAuthManager {
         try {
           let res = await serverAuthTokenService.useAuthToken({
             tenant: this.tenant,
-            authConfig: this.connection.serverAuthConfig!
+            authConfig: this.connection.serverAuthConfig!,
+            serverConnectionId: this.connection.id
           });
 
           if (res.didRefresh) {
@@ -117,13 +115,6 @@ export class RemoteConnectionAuthManager {
             tokenId: `remote/${res.remoteToken?.id}`
           };
         } catch (err) {
-          Sentry.captureException(err, {
-            extra: {
-              connectionId: this.connection.id,
-              tenantId: this.tenant.id
-            }
-          });
-
           let mapped = toConnectionError(err, 'auth_token_refresh_failed');
           this.logger.log('debug.error', `Failed to obtain access token: ${mapped.message}`);
 

--- a/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.test.ts
+++ b/src/shuttle/service/src/queues/discovery/retryRemoteOAuthConnections.test.ts
@@ -114,4 +114,17 @@ describe('retryRegistrationQueueProcessor', () => {
       retryProcessor()({ oauthConnectionId: 'cso_replacement' })
     ).rejects.toBeInstanceOf(QueueRetryError);
   });
+
+  it('does not retry permanent registration failures', async () => {
+    runAutoRegistration.mockResolvedValue({
+      ok: false,
+      reason: 'failed',
+      isTransient: false
+    });
+    dbMock.serverOAuthCredentials.findFirst.mockResolvedValue(null);
+
+    await expect(
+      retryProcessor()({ oauthConnectionId: 'cso_replacement' })
+    ).resolves.toBeUndefined();
+  });
 });

--- a/src/shuttle/service/src/services/oauth/remote/authToken.test.ts
+++ b/src/shuttle/service/src/services/oauth/remote/authToken.test.ts
@@ -1,0 +1,298 @@
+import { isServiceError } from '@lowerdeck/error';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let {
+  addRemoteErrorCheck,
+  dbMock,
+  lockState,
+  oauthUtilsMock,
+  remoteConnectionServiceMock,
+  secretServiceMock,
+  serverEventServiceMock
+} = vi.hoisted(() => ({
+  addRemoteErrorCheck: vi.fn(),
+  dbMock: {
+    remoteOAuthConnectionAuthToken: {
+      findFirstOrThrow: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn()
+    },
+    remoteOAuthConnectionAuthTokenError: { create: vi.fn() }
+  },
+  lockState: { tail: Promise.resolve() as Promise<unknown> },
+  oauthUtilsMock: { refreshAccessToken: vi.fn() },
+  remoteConnectionServiceMock: { DANGEROUSLY_getCredentials: vi.fn() },
+  secretServiceMock: {
+    DANGEROUSLY_decryptSecret: vi.fn(),
+    DANGEROUSLY_updateSecret: vi.fn()
+  },
+  serverEventServiceMock: { recordServerAuthConfigEvent: vi.fn() }
+}));
+
+vi.mock('@lowerdeck/lock', () => ({
+  createLock: () => ({
+    usingLock: <T>(_key: string, fn: () => Promise<T>) => {
+      let result = lockState.tail.then(fn);
+      lockState.tail = result.then(
+        () => undefined,
+        () => undefined
+      );
+      return result;
+    }
+  })
+}));
+
+vi.mock('../../../db', () => ({ db: dbMock }));
+vi.mock('../../../env', () => ({ env: { service: { REDIS_URL: 'redis://test' } } }));
+vi.mock('../../../id', () => ({ getId: () => ({ oid: 99n, id: 'error_test' }) }));
+vi.mock('../../../lib/oauth/oauthUtils', () => ({ OAuthUtils: oauthUtilsMock }));
+vi.mock('../../../queues/oauth/remoteErrorCheck', () => ({ addRemoteErrorCheck }));
+vi.mock('../../secret', () => ({ secretService: secretServiceMock }));
+vi.mock('../serverEvent', () => ({ serverEventService: serverEventServiceMock }));
+vi.mock('./connection', () => ({
+  remoteOAuthConnectionService: remoteConnectionServiceMock
+}));
+
+import { remoteAuthTokenService } from './authToken';
+
+let tenant = { oid: 1n, id: 'tenant_test' } as any;
+let authConfig = { oid: 2n, id: 'auth_test', tenantOid: 1n } as any;
+let currentSecret: { accessToken: string; refreshToken: string };
+let connection = {
+  oid: 3n,
+  id: 'oauth_connection_test',
+  config: {
+    config: {
+      authorization_endpoint: 'https://provider.test/authorize',
+      token_endpoint: 'https://provider.test/token'
+    }
+  }
+} as any;
+
+let createToken = (overrides: Record<string, unknown> = {}) => ({
+  oid: 4n,
+  id: 'token_test',
+  source: 'oauth',
+  secretOid: 5n,
+  connection,
+  expiresAt: new Date(Date.now() - 60_000),
+  refreshedAt: null,
+  lastUsedAt: new Date(),
+  firstErrorAt: null,
+  lastErrorAt: null,
+  errorDisabledAt: null,
+  errorCount: 0,
+  tokenType: 'Bearer',
+  idToken: null,
+  scope: null,
+  errors: [],
+  ...overrides
+});
+
+let useToken = () =>
+  remoteAuthTokenService.useAuthToken({
+    tenant,
+    remoteOAuthConnectionAuthTokenOid: 4n,
+    serverAuthConfig: authConfig,
+    serverConnectionId: 'server_connection_test'
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lockState.tail = Promise.resolve();
+  currentSecret = {
+    accessToken: 'old-access-token',
+    refreshToken: 'refresh-token'
+  };
+  secretServiceMock.DANGEROUSLY_decryptSecret.mockImplementation(async () => currentSecret);
+  secretServiceMock.DANGEROUSLY_updateSecret.mockImplementation(async ({ secretData }) => {
+    currentSecret = { ...secretData };
+  });
+  remoteConnectionServiceMock.DANGEROUSLY_getCredentials.mockResolvedValue({
+    clientId: 'client-id',
+    clientSecret: 'client-secret'
+  });
+  serverEventServiceMock.recordServerAuthConfigEvent.mockResolvedValue(undefined);
+  addRemoteErrorCheck.mockResolvedValue(undefined);
+});
+
+describe('remoteAuthTokenService', () => {
+  it('stores and permanently suppresses a provider credential rejection', async () => {
+    let token = createToken();
+    dbMock.remoteOAuthConnectionAuthToken.findFirstOrThrow.mockResolvedValue(token);
+    dbMock.remoteOAuthConnectionAuthToken.update.mockResolvedValue(token);
+    dbMock.remoteOAuthConnectionAuthTokenError.create.mockResolvedValue({});
+    oauthUtilsMock.refreshAccessToken.mockResolvedValue({
+      ok: false,
+      error: {
+        status: 400,
+        oauthCode: 'invalid_grant',
+        isTransient: false,
+        retryAfterMs: null
+      },
+      message: 'OAuth token refresh failed (HTTP 400, OAuth error invalid_grant)'
+    });
+
+    let error = await useToken().catch(error => error);
+
+    expect(isServiceError(error)).toBe(true);
+    expect(error.data.code).toBe('auth_token_refresh_failed');
+    expect(error.data.message).toContain('Re-authenticate this connection');
+    expect(dbMock.remoteOAuthConnectionAuthToken.update).toHaveBeenCalledWith({
+      where: { oid: 4n },
+      data: expect.objectContaining({ errorDisabledAt: expect.any(Date) })
+    });
+    expect(dbMock.remoteOAuthConnectionAuthTokenError.create).toHaveBeenCalledTimes(1);
+    expect(serverEventServiceMock.recordServerAuthConfigEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverConnectionId: 'server_connection_test',
+        payload: expect.objectContaining({
+          upstreamStatus: 400,
+          upstreamOAuthCode: 'invalid_grant',
+          retryable: false,
+          replayed: false
+        })
+      })
+    );
+  });
+
+  it('classifies invalid OAuth client credentials separately from an expired grant', async () => {
+    let token = createToken();
+    dbMock.remoteOAuthConnectionAuthToken.findFirstOrThrow.mockResolvedValue(token);
+    dbMock.remoteOAuthConnectionAuthToken.update.mockResolvedValue(token);
+    dbMock.remoteOAuthConnectionAuthTokenError.create.mockResolvedValue({});
+    oauthUtilsMock.refreshAccessToken.mockResolvedValue({
+      ok: false,
+      error: {
+        status: 401,
+        oauthCode: 'invalid_client',
+        isTransient: false,
+        retryAfterMs: null
+      },
+      message: 'OAuth token refresh failed (HTTP 401, OAuth error invalid_client)'
+    });
+
+    let error = await useToken().catch(error => error);
+
+    expect(error.data.code).toBe('invalid_credentials');
+    expect(error.data.message).toContain('Configure valid OAuth client credentials');
+  });
+
+  it('replays a cached permanent failure without contacting the provider again', async () => {
+    let token = createToken({
+      lastErrorAt: new Date(),
+      errorDisabledAt: new Date(),
+      errorCount: 1,
+      errors: [
+        {
+          errorCode: 'auth_token_refresh_failed',
+          errorMessage:
+            'OAuth token refresh failed (HTTP 400, OAuth error invalid_grant). Re-authenticate this connection to continue.'
+        }
+      ]
+    });
+    dbMock.remoteOAuthConnectionAuthToken.findFirstOrThrow.mockResolvedValue(token);
+
+    let error = await useToken().catch(error => error);
+
+    expect(error.data.code).toBe('auth_token_refresh_failed');
+    expect(oauthUtilsMock.refreshAccessToken).not.toHaveBeenCalled();
+    expect(dbMock.remoteOAuthConnectionAuthTokenError.create).not.toHaveBeenCalled();
+    expect(serverEventServiceMock.recordServerAuthConfigEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ replayed: true }) })
+    );
+  });
+
+  it('replays a recent transient failure during the cooldown', async () => {
+    let token = createToken({
+      lastErrorAt: new Date(),
+      errorCount: 1,
+      errors: [
+        {
+          errorCode: 'connection_error',
+          errorMessage: 'OAuth token refresh failed (HTTP 503). Try again shortly.'
+        }
+      ]
+    });
+    dbMock.remoteOAuthConnectionAuthToken.findFirstOrThrow.mockResolvedValue(token);
+
+    let error = await useToken().catch(error => error);
+
+    expect(error.data.code).toBe('connection_error');
+    expect(oauthUtilsMock.refreshAccessToken).not.toHaveBeenCalled();
+    expect(serverEventServiceMock.recordServerAuthConfigEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ retryable: true, replayed: true })
+      })
+    );
+  });
+
+  it('retries after the transient cooldown and clears the failure state', async () => {
+    let token = createToken({
+      firstErrorAt: new Date(Date.now() - 120_000),
+      lastErrorAt: new Date(Date.now() - 61_000),
+      errorCount: 1,
+      errors: [
+        {
+          errorCode: 'connection_error',
+          errorMessage: 'OAuth token refresh failed (HTTP 503). Try again shortly.'
+        }
+      ]
+    });
+    let refreshedToken = createToken({
+      expiresAt: new Date(Date.now() + 3_600_000),
+      refreshedAt: new Date()
+    });
+    dbMock.remoteOAuthConnectionAuthToken.findFirstOrThrow.mockResolvedValue(token);
+    dbMock.remoteOAuthConnectionAuthToken.update.mockResolvedValue(refreshedToken);
+    oauthUtilsMock.refreshAccessToken.mockResolvedValue({
+      ok: true,
+      response: {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600
+      }
+    });
+
+    let result = await useToken();
+
+    expect(result.didRefresh).toBe(true);
+    expect(oauthUtilsMock.refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(dbMock.remoteOAuthConnectionAuthToken.update).toHaveBeenCalledWith({
+      where: { oid: 4n },
+      data: expect.objectContaining({
+        firstErrorAt: null,
+        lastErrorAt: null,
+        errorCount: 0,
+        errorDisabledAt: null
+      })
+    });
+  });
+
+  it('serializes concurrent refreshes and reuses the refreshed token', async () => {
+    let currentToken = createToken();
+    dbMock.remoteOAuthConnectionAuthToken.findFirstOrThrow.mockImplementation(async () => ({
+      ...currentToken
+    }));
+    dbMock.remoteOAuthConnectionAuthToken.update.mockImplementation(async ({ data }) => {
+      currentToken = { ...currentToken, ...data, errors: [] } as any;
+      return currentToken;
+    });
+    oauthUtilsMock.refreshAccessToken.mockResolvedValue({
+      ok: true,
+      response: {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600
+      }
+    });
+
+    let results = await Promise.all([useToken(), useToken()]);
+
+    expect(oauthUtilsMock.refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(results.map(result => result.didRefresh).sort()).toEqual([false, true]);
+    expect(results.every(result => result.accessToken === 'new-access-token')).toBe(true);
+  });
+});

--- a/src/shuttle/service/src/services/oauth/remote/authToken.ts
+++ b/src/shuttle/service/src/services/oauth/remote/authToken.ts
@@ -1,7 +1,7 @@
 import { badRequestError, ServiceError } from '@lowerdeck/error';
-import { getSentry } from '@lowerdeck/sentry';
+import { createLock } from '@lowerdeck/lock';
 import { Service } from '@lowerdeck/service';
-import { addMinutes, differenceInDays, differenceInMinutes } from 'date-fns';
+import { addMinutes, differenceInMinutes } from 'date-fns';
 import type {
   RemoteOAuthConfig,
   RemoteOAuthConnection,
@@ -10,14 +10,40 @@ import type {
   Tenant
 } from '../../../../prisma/generated/client';
 import { db } from '../../../db';
+import { env } from '../../../env';
 import { getId } from '../../../id';
 import { OAuthUtils } from '../../../lib/oauth/oauthUtils';
+import type { OAuthRequestErrorDetails } from '../../../lib/oauth/oauthRequestError';
 import { addRemoteErrorCheck } from '../../../queues/oauth/remoteErrorCheck';
 import { secretService, type SecretOAuthToken } from '../../secret';
 import { serverEventService } from '../serverEvent';
 import { remoteOAuthConnectionService } from './connection';
 
-let Sentry = getSentry();
+let REFRESH_ERROR_COOLDOWN_MS = 60 * 1000;
+
+let refreshLock = createLock({
+  name: 'shuttle/oauth/remote-token/refresh',
+  redisUrl: env.service.REDIS_URL
+});
+
+let getRefreshFailureCode = (error: OAuthRequestErrorDetails) => {
+  if (!error.isTransient) return 'auth_token_refresh_failed';
+  if (error.status == 429) return 'rate_limited';
+  if (error.status == 408) return 'timeout';
+  return 'connection_error';
+};
+
+let isInvalidClientCredentials = (error: OAuthRequestErrorDetails) =>
+  error.oauthCode === 'invalid_client' || error.oauthCode === 'unauthorized_client';
+
+let withRecoveryHint = (message: string, error: OAuthRequestErrorDetails) => {
+  if (error.isTransient) return `${message}. Try again shortly.`;
+  if (isInvalidClientCredentials(error)) {
+    return `${message}. Configure valid OAuth client credentials and re-authenticate this connection.`;
+  }
+
+  return `${message}. Re-authenticate this connection to continue.`;
+};
 
 let refreshToken = async (d: {
   tenant: Tenant;
@@ -25,6 +51,7 @@ let refreshToken = async (d: {
   serverAuthConfig?: ServerAuthConfig;
   connection: RemoteOAuthConnection & { config: RemoteOAuthConfig };
   DANGEROUS_secretData: SecretOAuthToken;
+  serverConnectionId?: string;
 }) => {
   // We start with the old token, but we replace this value later
   let token = d.token;
@@ -64,19 +91,18 @@ let refreshToken = async (d: {
   });
 
   if (!res.ok) {
+    let errorCode = isInvalidClientCredentials(res.error)
+      ? 'invalid_credentials'
+      : getRefreshFailureCode(res.error);
+    let errorMessage = withRecoveryHint(res.message, res.error);
+
     await db.remoteOAuthConnectionAuthToken.update({
       where: { oid: token.oid },
       data: {
         firstErrorAt: token.firstErrorAt ?? new Date(),
         lastErrorAt: new Date(),
         errorCount: { increment: 1 },
-        errorDisabledAt:
-          (token.errorDisabledAt ??
-          (token.firstErrorAt &&
-            Math.abs(differenceInDays(token.firstErrorAt, new Date())) > 1 &&
-            token.errorCount > 5))
-            ? new Date()
-            : null
+        errorDisabledAt: res.error.isTransient ? token.errorDisabledAt : new Date()
       }
     });
 
@@ -84,8 +110,8 @@ let refreshToken = async (d: {
       data: {
         ...getId('remoteOAuthConnectionAuthTokenError'),
         authTokenOid: token.oid,
-        errorCode: 'token_refresh_failed',
-        errorMessage: 'Failed to refresh access token'
+        errorCode,
+        errorMessage
       }
     });
 
@@ -93,10 +119,15 @@ let refreshToken = async (d: {
       await serverEventService.recordServerAuthConfigEvent({
         serverAuthConfig: d.serverAuthConfig,
         type: 'oauth_token_refresh_failed',
-        message: 'Failed to refresh remote OAuth token',
+        message: errorMessage,
         payload: {
-          errorCode: 'token_refresh_failed'
-        }
+          errorCode,
+          upstreamStatus: res.error.status,
+          upstreamOAuthCode: res.error.oauthCode,
+          retryable: res.error.isTransient,
+          replayed: false
+        },
+        serverConnectionId: d.serverConnectionId
       });
     }
 
@@ -104,8 +135,8 @@ let refreshToken = async (d: {
 
     throw new ServiceError(
       badRequestError({
-        code: 'auth_token_refresh_failed',
-        message: 'Failed to refresh the access token for this MCP server'
+        code: errorCode,
+        message: errorMessage
       })
     );
   }
@@ -134,6 +165,11 @@ let refreshToken = async (d: {
       lastUsedAt: new Date(),
       refreshedAt: new Date(),
 
+      firstErrorAt: null,
+      lastErrorAt: null,
+      errorCount: 0,
+      errorDisabledAt: null,
+
       expiresAt: tokenResponse.expires_in
         ? new Date(Date.now() + tokenResponse.expires_in * 1000)
         : null
@@ -146,96 +182,81 @@ let refreshToken = async (d: {
   };
 };
 
+let replayRefreshFailure = async (d: {
+  token: RemoteOAuthConnectionAuthToken & {
+    errors: { errorCode: string; errorMessage: string | null }[];
+  };
+  serverAuthConfig?: ServerAuthConfig;
+  serverConnectionId?: string;
+}) => {
+  let latestError = d.token.errors[0];
+  let isTransient = !d.token.errorDisabledAt;
+  let errorCode = latestError?.errorCode ?? 'auth_token_refresh_failed';
+  let errorMessage =
+    latestError?.errorMessage ??
+    (isTransient
+      ? 'OAuth token refresh failed. Try again shortly.'
+      : 'OAuth token refresh failed. Re-authenticate this connection to continue.');
+
+  if (d.serverAuthConfig) {
+    await serverEventService.recordServerAuthConfigEvent({
+      serverAuthConfig: d.serverAuthConfig,
+      type: 'oauth_token_refresh_failed',
+      message: errorMessage,
+      payload: {
+        errorCode,
+        retryable: isTransient,
+        replayed: true
+      },
+      serverConnectionId: d.serverConnectionId
+    });
+  }
+
+  throw new ServiceError(
+    badRequestError({
+      code: errorCode,
+      message: errorMessage
+    })
+  );
+};
+
+let shouldRefreshToken = (token: RemoteOAuthConnectionAuthToken) => {
+  let lastRefreshAt = token.refreshedAt ?? token.lastUsedAt;
+  let duration = differenceInMinutes(new Date(), lastRefreshAt);
+  let expiryWindow = duration < 10 ? new Date() : addMinutes(new Date(), 10);
+
+  return !!token.expiresAt && token.expiresAt.getTime() < expiryWindow.getTime();
+};
+
 class remoteAuthTokenServiceImpl {
   async useAuthToken(d: {
     tenant: Tenant;
     remoteOAuthConnectionAuthTokenOid: bigint;
     serverAuthConfig?: ServerAuthConfig;
+    serverConnectionId?: string;
   }) {
-    let token = await db.remoteOAuthConnectionAuthToken.findFirstOrThrow({
-      where: { oid: d.remoteOAuthConnectionAuthTokenOid, tenantOid: d.tenant.oid },
-      include: {
-        connection: { include: { config: true } }
-      }
-    });
-
-    if (Math.abs(differenceInMinutes(token.lastUsedAt, new Date())) > 5) {
-      await db.remoteOAuthConnectionAuthToken.updateMany({
-        where: { oid: token.oid },
-        data: { lastUsedAt: new Date() }
+    let getToken = async () =>
+      await db.remoteOAuthConnectionAuthToken.findFirstOrThrow({
+        where: { oid: d.remoteOAuthConnectionAuthTokenOid, tenantOid: d.tenant.oid },
+        include: {
+          connection: { include: { config: true } },
+          errors: { orderBy: { createdAt: 'desc' }, take: 1 }
+        }
       });
-    }
 
-    let DANGEROUS_secretData = await secretService.DANGEROUSLY_decryptSecret({
-      secretOid: token.secretOid!,
-      purpose: 'oauth_token',
-      tenant: d.tenant,
-      note: `roat.use:${token.id}`
-    });
-
-    let didRefresh = false;
-
-    let lastRefreshAt = token.refreshedAt ?? token.lastUsedAt;
-    let duration = differenceInMinutes(new Date(), lastRefreshAt);
-    let expiryWindow = duration < 10 ? new Date() : addMinutes(new Date(), 10);
-
-    if (token.expiresAt && token.expiresAt.getTime() < expiryWindow.getTime()) {
-      if (token.source != 'oauth' || !token.connection) {
-        throw new ServiceError(
-          badRequestError({
-            code: 'auth_token_refresh_failed',
-            message: 'Cannot refresh foreign token from token import',
-            description:
-              'The token you are using is managed externally and cannot be refreshed by Metorial. Please create a new token import to refresh the token.',
-            hint: 'Use the token import flow to refresh the token.'
-          })
-        );
-      }
-
-      let refreshRes = await refreshToken({
-        token,
-        connection: token.connection,
+    let decryptToken = async (token: Awaited<ReturnType<typeof getToken>>) =>
+      await secretService.DANGEROUSLY_decryptSecret({
+        secretOid: token.secretOid,
+        purpose: 'oauth_token',
         tenant: d.tenant,
-        DANGEROUS_secretData,
-        serverAuthConfig: d.serverAuthConfig
+        note: `roat.use:${token.id}`
       });
 
-      DANGEROUS_secretData = refreshRes.DANGEROUS_secretData;
-      token = { ...token, ...refreshRes.token };
-      didRefresh = true;
-
-      if (d.serverAuthConfig) {
-        await serverEventService.recordServerAuthConfigEvent({
-          serverAuthConfig: d.serverAuthConfig,
-          type: 'oauth_token_refresh_succeeded',
-          message: 'Successfully refreshed remote OAuth token',
-          payload: {
-            authTokenId: token.id
-          }
-        });
-      }
-    }
-
-    if (token.errorCount) {
-      (async () => {
-        await db.remoteOAuthConnectionAuthToken.updateMany({
-          where: { oid: token.oid },
-          data: {
-            firstErrorAt: null,
-            lastErrorAt: null,
-            errorCount: 0,
-            errorDisabledAt: null
-          }
-        });
-
-        // await db.remoteOAuthConnectionSetup.updateMany({
-        //   where: { authTokenOid: token.oid },
-        //   data: { associatedTokenErrorDisabledAt: null }
-        // });
-      })().catch(e => Sentry.captureException(e));
-    }
-
-    return {
+    let buildResult = (
+      token: Awaited<ReturnType<typeof getToken>>,
+      DANGEROUS_secretData: SecretOAuthToken,
+      didRefresh: boolean
+    ) => ({
       token,
       didRefresh,
 
@@ -245,7 +266,88 @@ class remoteAuthTokenServiceImpl {
       expiresAt: token.expiresAt,
       idToken: token.idToken,
       scope: token.scope
-    };
+    });
+
+    let token = await getToken();
+
+    if (Math.abs(differenceInMinutes(token.lastUsedAt, new Date())) > 5) {
+      await db.remoteOAuthConnectionAuthToken.updateMany({
+        where: { oid: token.oid },
+        data: { lastUsedAt: new Date() }
+      });
+    }
+
+    if (!shouldRefreshToken(token)) {
+      let DANGEROUS_secretData = await decryptToken(token);
+      return buildResult(token, DANGEROUS_secretData, false);
+    }
+
+    return await refreshLock.usingLock(
+      token.id,
+      async () => {
+        token = await getToken();
+
+        if (!shouldRefreshToken(token)) {
+          let DANGEROUS_secretData = await decryptToken(token);
+          return buildResult(token, DANGEROUS_secretData, false);
+        }
+
+        let isCoolingDown =
+          token.lastErrorAt &&
+          Date.now() - token.lastErrorAt.getTime() < REFRESH_ERROR_COOLDOWN_MS;
+
+        if (token.errorDisabledAt || isCoolingDown) {
+          return await replayRefreshFailure({
+            token,
+            serverAuthConfig: d.serverAuthConfig,
+            serverConnectionId: d.serverConnectionId
+          });
+        }
+
+        if (token.source != 'oauth' || !token.connection) {
+          throw new ServiceError(
+            badRequestError({
+              code: 'auth_token_refresh_failed',
+              message: 'Cannot refresh foreign token from token import',
+              description:
+                'The token you are using is managed externally and cannot be refreshed by Metorial. Please create a new token import to refresh the token.',
+              hint: 'Use the token import flow to refresh the token.'
+            })
+          );
+        }
+
+        let DANGEROUS_secretData = await decryptToken(token);
+        let refreshRes = await refreshToken({
+          token,
+          connection: token.connection,
+          tenant: d.tenant,
+          DANGEROUS_secretData,
+          serverAuthConfig: d.serverAuthConfig,
+          serverConnectionId: d.serverConnectionId
+        });
+
+        DANGEROUS_secretData = refreshRes.DANGEROUS_secretData;
+        token = { ...token, ...refreshRes.token, errors: [] };
+
+        if (d.serverAuthConfig) {
+          await serverEventService.recordServerAuthConfigEvent({
+            serverAuthConfig: d.serverAuthConfig,
+            type: 'oauth_token_refresh_succeeded',
+            message: 'Successfully refreshed remote OAuth token',
+            payload: {
+              authTokenId: token.id
+            },
+            serverConnectionId: d.serverConnectionId
+          });
+        }
+
+        return buildResult(token, DANGEROUS_secretData, true);
+      },
+      {
+        durationMs: 20_000,
+        acquisitionTimeoutMs: 20_000
+      }
+    );
   }
 }
 

--- a/src/shuttle/service/src/services/oauth/remote/authorization.test.ts
+++ b/src/shuttle/service/src/services/oauth/remote/authorization.test.ts
@@ -1,24 +1,41 @@
+import { badRequestError, ServiceError } from '@lowerdeck/error';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-let { defaultRedirectUri, dbMock, oauthUtilsMock, remoteOAuthConnectionServiceMock } =
-  vi.hoisted(() => ({
-    defaultRedirectUri: 'https://shuttle.example.com/shuttle-oauth/callback',
-    dbMock: {
-      remoteOAuthConnection: {
-        findFirstOrThrow: vi.fn()
-      },
-      remoteOAuthConnectionSetup: {
-        create: vi.fn()
-      }
+let {
+  defaultRedirectUri,
+  dbMock,
+  oauthUtilsMock,
+  remoteOAuthConnectionServiceMock,
+  secretServiceMock,
+  serverEventServiceMock
+} = vi.hoisted(() => ({
+  defaultRedirectUri: 'https://shuttle.example.com/shuttle-oauth/callback',
+  dbMock: {
+    remoteOAuthConnection: {
+      findFirstOrThrow: vi.fn()
     },
-    oauthUtilsMock: {
-      generateCodeVerifier: vi.fn(),
-      generateCodeChallenge: vi.fn(),
-      buildAuthorizationUrl: vi.fn()
+    remoteOAuthConnectionSetup: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      updateMany: vi.fn()
     },
-    remoteOAuthConnectionServiceMock: {
-      DANGEROUSLY_getCredentials: vi.fn()
-    }
+    remoteOAuthConnectionProfile: { upsert: vi.fn() },
+    remoteOAuthConnectionAuthToken: { create: vi.fn() },
+    serverAuthConfig: { create: vi.fn() },
+    serverOAuthSetup: { update: vi.fn(), updateMany: vi.fn() }
+  },
+  oauthUtilsMock: {
+    generateCodeVerifier: vi.fn(),
+    generateCodeChallenge: vi.fn(),
+    buildAuthorizationUrl: vi.fn(),
+    exchangeCodeForTokens: vi.fn(),
+    getUserProfile: vi.fn()
+  },
+  remoteOAuthConnectionServiceMock: {
+    DANGEROUSLY_getCredentials: vi.fn()
+  },
+  secretServiceMock: { createSecret: vi.fn() },
+  serverEventServiceMock: { recordServerOAuthSetupEvent: vi.fn() }
 }));
 
 vi.mock('../../../config', () => ({
@@ -38,11 +55,11 @@ vi.mock('../../../lib/oauth/oauthUtils', () => ({
 }));
 
 vi.mock('../../secret', () => ({
-  secretService: {}
+  secretService: secretServiceMock
 }));
 
 vi.mock('../serverEvent', () => ({
-  serverEventService: {}
+  serverEventService: serverEventServiceMock
 }));
 
 vi.mock('./connection', () => ({
@@ -62,6 +79,7 @@ beforeEach(() => {
     clientId: 'test-client-id',
     clientSecret: 'test-client-secret'
   });
+  serverEventServiceMock.recordServerOAuthSetupEvent.mockResolvedValue(undefined);
 });
 
 describe('getRemoteOAuthRedirectUri', () => {
@@ -203,5 +221,85 @@ describe('remoteOauthAuthorizationService.resumeAuthorization', () => {
         serverOAuthSetup: { callbackUrlOverride: null }
       })
     ).rejects.toThrow('OAuth authorization attempt is no longer active');
+  });
+});
+
+describe('remoteOauthAuthorizationService.completeAuthorization', () => {
+  it('completes OAuth and records a sanitized event when user-info is rejected', async () => {
+    let tenant = { oid: 11n };
+    let connection = {
+      oid: 12n,
+      id: 'remote_connection_test',
+      configOid: 14n,
+      serverOid: 15n,
+      tenantOid: tenant.oid,
+      registrationOid: null,
+      config: {
+        config: {
+          authorization_endpoint: 'https://provider.example.com/authorize',
+          token_endpoint: 'https://provider.example.com/token',
+          userinfo_endpoint: 'https://provider.example.com/userinfo'
+        }
+      },
+      serverOAuthCredentials: { oid: 16n }
+    };
+    let serverOAuthSetup = {
+      oid: 17n,
+      id: 'oauth_setup_test',
+      tenantOid: tenant.oid,
+      callbackUrlOverride: null,
+      redirectUri: 'https://app.example.com/oauth/complete',
+      serverInstanceConfiguration: null
+    };
+    let attempt = {
+      oid: 18n,
+      stateIdentifier: 'test-state',
+      codeVerifier: null,
+      connection,
+      tenant,
+      serverOAuthSetup
+    };
+
+    dbMock.remoteOAuthConnectionSetup.findFirst.mockResolvedValue(attempt);
+    dbMock.remoteOAuthConnectionSetup.updateMany.mockResolvedValue({ count: 1 });
+    dbMock.remoteOAuthConnectionAuthToken.create.mockResolvedValue({
+      oid: 19n,
+      id: 'remote_token_test'
+    });
+    dbMock.serverAuthConfig.create.mockResolvedValue({
+      oid: 20n,
+      id: 'auth_config_test'
+    });
+    dbMock.serverOAuthSetup.update.mockResolvedValue(serverOAuthSetup);
+    oauthUtilsMock.exchangeCodeForTokens.mockResolvedValue({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      token_type: 'Bearer',
+      expires_in: 3600
+    });
+    oauthUtilsMock.getUserProfile.mockRejectedValue(
+      new ServiceError(
+        badRequestError({
+          code: 'oauth_userinfo_failed',
+          message: 'OAuth user profile lookup failed (HTTP 401)'
+        })
+      )
+    );
+    secretServiceMock.createSecret.mockResolvedValue({ oid: 21n });
+
+    let result = await remoteOauthAuthorizationService.completeAuthorization({
+      fullUrl: 'https://shuttle.example.com/shuttle-oauth/callback?code=test&state=test-state',
+      response: { code: 'test-code', state: 'test-state' }
+    });
+
+    expect(result.redirectUrl).toContain('metorial_oauth_setup_id=oauth_setup_test');
+    expect(dbMock.remoteOAuthConnectionProfile.upsert).not.toHaveBeenCalled();
+    expect(dbMock.remoteOAuthConnectionAuthToken.create).toHaveBeenCalledTimes(1);
+    expect(serverEventServiceMock.recordServerOAuthSetupEvent).toHaveBeenCalledWith({
+      serverOAuthSetup,
+      type: 'oauth_setup_user_profile_failed',
+      message: 'OAuth user profile lookup failed (HTTP 401)',
+      payload: { errorCode: 'oauth_userinfo_failed' }
+    });
   });
 });

--- a/src/shuttle/service/src/services/oauth/remote/authorization.ts
+++ b/src/shuttle/service/src/services/oauth/remote/authorization.ts
@@ -1,5 +1,5 @@
 import { delay } from '@lowerdeck/delay';
-import { badRequestError, ServiceError } from '@lowerdeck/error';
+import { badRequestError, isServiceError, ServiceError } from '@lowerdeck/error';
 import { generatePlainId } from '@lowerdeck/id';
 import { Service } from '@lowerdeck/service';
 import { subMinutes } from 'date-fns';
@@ -356,7 +356,17 @@ class remoteOauthAuthorizationServiceImpl {
           egressPolicy
         });
       } catch (error) {
-        // Ignore
+        let errorCode = isServiceError(error) ? error.data.code : 'oauth_userinfo_failed';
+        let errorMessage = isServiceError(error)
+          ? error.data.message
+          : 'OAuth user profile lookup failed';
+
+        await serverEventService.recordServerOAuthSetupEvent({
+          serverOAuthSetup: attempt.serverOAuthSetup,
+          type: 'oauth_setup_user_profile_failed',
+          message: errorMessage,
+          payload: { errorCode }
+        });
       }
     }
 

--- a/src/shuttle/service/src/services/oauth/remote/registration.test.ts
+++ b/src/shuttle/service/src/services/oauth/remote/registration.test.ts
@@ -37,7 +37,10 @@ let connection = (partial: Record<string, any> = {}) => ({
   secretOid: null,
   registrationAttemptCount: 0,
   tenant: { oid: 2n, id: 'ten_test', name: 'Test' },
-  config: { oid: 3n, config: { registration_endpoint: 'https://provider.example.com/register' } },
+  config: {
+    oid: 3n,
+    config: { registration_endpoint: 'https://provider.example.com/register' }
+  },
   _count: { remoteOAuthConnectionAuthTokens: 0, serverAuthConfigs: 0 },
   ...partial
 });
@@ -93,8 +96,10 @@ describe('runAutoRegistration', () => {
     dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(connection());
     oauthUtilsMock.registerClient.mockResolvedValue({
       ok: false,
-      error: { payload: { error: { message: 'Validation failed' } } },
       status: 400,
+      oauthCode: 'invalid_client_metadata',
+      message:
+        'OAuth client registration failed (HTTP 400, OAuth error invalid_client_metadata)',
       isTransient: false
     });
 
@@ -108,6 +113,8 @@ describe('runAutoRegistration', () => {
       data: expect.objectContaining({
         discoveryStatus: 'failed',
         errorCode: 'auto_registration_failed',
+        errorMessage:
+          'OAuth client registration failed (HTTP 400, OAuth error invalid_client_metadata). Configure OAuth client credentials manually to continue.',
         registrationAttemptCount: 1
       })
     });
@@ -119,8 +126,9 @@ describe('runAutoRegistration', () => {
     );
     oauthUtilsMock.registerClient.mockResolvedValue({
       ok: false,
-      error: { payload: { error: 'gateway timeout' } },
       status: 504,
+      oauthCode: null,
+      message: 'OAuth client registration failed (HTTP 504)',
       isTransient: true
     });
 
@@ -135,21 +143,22 @@ describe('runAutoRegistration', () => {
     });
   });
 
-  it('only reports the first failure of a connection to Sentry', async () => {
+  it('does not ask the OAuth helper to report provider failures to Sentry', async () => {
     dbMock.remoteOAuthConnection.findFirst.mockResolvedValue(
       connection({ registrationAttemptCount: 2 })
     );
     oauthUtilsMock.registerClient.mockResolvedValue({
       ok: false,
-      error: { payload: { error: 'nope' } },
       status: 400,
+      oauthCode: null,
+      message: 'OAuth client registration failed (HTTP 400)',
       isTransient: false
     });
 
     await remoteOAuthRegistrationService.runAutoRegistration({ connectionId: 'cso_test' });
 
     expect(oauthUtilsMock.registerClient).toHaveBeenCalledWith(
-      expect.objectContaining({ captureErrors: false })
+      expect.not.objectContaining({ captureErrors: expect.anything() })
     );
   });
 

--- a/src/shuttle/service/src/services/oauth/remote/registration.ts
+++ b/src/shuttle/service/src/services/oauth/remote/registration.ts
@@ -53,8 +53,7 @@ class remoteOAuthRegistrationServiceImpl {
       owner: {
         config: connection.config,
         connection
-      },
-      captureErrors: connection.registrationAttemptCount == 0
+      }
     });
 
     if (reg?.ok) {
@@ -85,21 +84,20 @@ class remoteOAuthRegistrationServiceImpl {
       return { ok: true as const, connection, registration: reg.registration };
     }
 
-    let inner = (reg?.error.payload as any)?.error || 'unknown_error';
-
-    let jsonInner = inner;
-    try {
-      jsonInner = JSON.stringify(inner);
-    } catch (e) {}
-
     let isTransient = reg?.isTransient ?? false;
+    let baseErrorMessage =
+      reg?.message ??
+      'OAuth client registration failed because the provider could not be reached';
+    let errorMessage = isTransient
+      ? `${baseErrorMessage}. Try again later.`
+      : `${baseErrorMessage}. Configure OAuth client credentials manually to continue.`;
 
     await db.remoteOAuthConnection.update({
       where: { oid: connection.oid },
       data: {
         discoveryStatus: 'failed',
         errorCode: 'auto_registration_failed',
-        errorMessage: `Failed to auto-register OAuth client for connection: ${jsonInner}`,
+        errorMessage,
         registrationAttemptCount: isTransient ? connection.registrationAttemptCount : attempt
       }
     });
@@ -110,9 +108,11 @@ class remoteOAuthRegistrationServiceImpl {
         connectionOid: connection.oid,
         type: 'auto_registration_failed',
         metadata: {
-          error: inner,
+          errorCode: 'auto_registration_failed',
           attempt,
-          status: reg?.status ?? null
+          status: reg?.status ?? null,
+          oauthCode: reg?.oauthCode ?? null,
+          retryable: isTransient
         }
       }
     });

--- a/src/shuttle/service/src/services/oauth/serverAuthToken.ts
+++ b/src/shuttle/service/src/services/oauth/serverAuthToken.ts
@@ -5,12 +5,17 @@ import { delegatedAuthTokenService } from './delegated';
 import { remoteAuthTokenService } from './remote';
 
 class serverAuthTokenServiceImpl {
-  async useAuthToken(d: { tenant: Tenant; authConfig: ServerAuthConfig }) {
+  async useAuthToken(d: {
+    tenant: Tenant;
+    authConfig: ServerAuthConfig;
+    serverConnectionId?: string;
+  }) {
     if (d.authConfig.type == 'remote' && d.authConfig.remoteOAuthConnectionAuthTokenOid) {
       let token = await remoteAuthTokenService.useAuthToken({
         tenant: d.tenant,
         remoteOAuthConnectionAuthTokenOid: d.authConfig.remoteOAuthConnectionAuthTokenOid,
-        serverAuthConfig: d.authConfig
+        serverAuthConfig: d.authConfig,
+        serverConnectionId: d.serverConnectionId
       });
 
       return {
@@ -30,7 +35,8 @@ class serverAuthTokenServiceImpl {
     ) {
       let token = await delegatedAuthTokenService.useAuthToken({
         tenant: d.tenant,
-        delegatedOAuthConnectionAuthTokenOid: d.authConfig.delegatedOAuthConnectionAuthTokenOid,
+        delegatedOAuthConnectionAuthTokenOid:
+          d.authConfig.delegatedOAuthConnectionAuthTokenOid,
         serverAuthConfig: d.authConfig
       });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes OAuth client expiry semantics, a broad hourly DB update cron, and distributed-lock-gated token refresh paths that affect live MCP connections.
> 
> **Overview**
> **Consumer OAuth (MCP client registrations)** now default to a **3-month** lifetime (was 30 days). On authorization-code and refresh-token exchanges, clients within **7 days** of expiry get **`slideConsumerAuthClientExpiration`**, pushing `expiresAt` out by three months. An **hourly cron** also runs `updateMany` on every still-unexpired `consumerAuthClient`, setting `expiresAt` to three months from the run time.
> 
> **Shuttle remote OAuth** gains sanitized provider error handling (`oauthRequestError`), **one retry** on transient refresh failures, and a **Redis-locked** refresh path with **60s cooldown**, **failure replay**, and clearer codes (`invalid_credentials` vs `auth_token_refresh_failed`). Auth config events can carry **`serverConnectionId`**; provider-shuttle sync links **`providerInvocationId`** via function invocation or server connection.
> 
> **Ares SSO delegation** centralizes a **10-minute** token TTL plus **30s introspection grace** in shared constants used for issuance and `expires_in`.
> 
> **Platform tweaks:** `@lowerdeck/lock` throws **`LockAcquisitionError`** on acquire timeout; BullMQ **suppresses Sentry** for Postgres deadlocks until retries are exhausted; Shuttle **filters HTTP errors** from Sentry and records **userinfo failures** during OAuth setup completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fdc187193b02bb9aa8e5f501b8715d3bc4d0a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->