### PR TITLE
Remove slates name references

### DIFF
--- a/src/slates/apps/hub/src/internal/slateWebhookEventServiceInternal.ts
+++ b/src/slates/apps/hub/src/internal/slateWebhookEventServiceInternal.ts
@@ -38,7 +38,7 @@ class slateWebhookEventServiceInternalImpl {
 
   async getById(d: { id: string }) {
     let event = await db.slateWebhookEvent.findUnique({ where: { id: d.id }, include });
-    if (!event) throw new ServiceError(notFoundError('slate.webhook_event'));
+    if (!event) throw new ServiceError(notFoundError('webhook_event'));
     return event;
   }
 

--- a/src/slates/apps/hub/src/presenters/adminWebhookTrigger.ts
+++ b/src/slates/apps/hub/src/presenters/adminWebhookTrigger.ts
@@ -17,7 +17,7 @@ export let adminWebhookTriggerPresenter = (
     triggerWebhookTarget: TriggerWebhookTarget | null;
   }
 ) => ({
-  object: 'slate.webhook_trigger',
+  object: 'webhook_trigger',
 
   id: registration.id,
   type: registration.type,

--- a/src/slates/apps/hub/src/presenters/slateWebhookEvent.ts
+++ b/src/slates/apps/hub/src/presenters/slateWebhookEvent.ts
@@ -20,7 +20,7 @@ export let slateWebhookEventPresenter = async (
   }
 
   return {
-    object: 'slate.webhook_event',
+    object: 'webhook_event',
 
     id: event.id,
     status: event.status,

--- a/src/slates/apps/hub/src/presenters/slateWebhookRegistration.ts
+++ b/src/slates/apps/hub/src/presenters/slateWebhookRegistration.ts
@@ -19,7 +19,7 @@ export let slateWebhookRegistrationPresenter = (
     })[];
   }
 ) => ({
-  object: 'slate.webhook_registration',
+  object: 'webhook_registration',
 
   id: registration.id,
   type: registration.type,

--- a/src/slates/apps/hub/src/services/slateWebhookEvent.ts
+++ b/src/slates/apps/hub/src/services/slateWebhookEvent.ts
@@ -43,7 +43,7 @@ class slateWebhookEventServiceImpl {
       where: { id: d.id, ...visibleTo(d.tenant) },
       include
     });
-    if (!event) throw new ServiceError(notFoundError('slate.webhook_event'));
+    if (!event) throw new ServiceError(notFoundError('webhook_event'));
     return event;
   }
 

--- a/src/slates/apps/hub/src/services/slateWebhookRegistration.ts
+++ b/src/slates/apps/hub/src/services/slateWebhookRegistration.ts
@@ -74,7 +74,7 @@ class slateWebhookRegistrationServiceImpl {
       },
       include
     });
-    if (!registration) throw new ServiceError(notFoundError('slate.webhook_registration'));
+    if (!registration) throw new ServiceError(notFoundError('webhook_registration'));
     return registration;
   }
 
@@ -83,7 +83,7 @@ class slateWebhookRegistrationServiceImpl {
       where: { urlKey: d.urlKey },
       include
     });
-    if (!registration) throw new ServiceError(notFoundError('slate.webhook_registration'));
+    if (!registration) throw new ServiceError(notFoundError('webhook_registration'));
     return registration;
   }
 
@@ -320,7 +320,7 @@ class slateWebhookRegistrationServiceImpl {
       where: { id: d.id, owner: 'global', status: { not: 'deleted' } },
       include
     });
-    if (!registration) throw new ServiceError(notFoundError('slate.webhook_registration'));
+    if (!registration) throw new ServiceError(notFoundError('webhook_registration'));
     return registration;
   }
 
@@ -381,7 +381,7 @@ class slateWebhookRegistrationServiceImpl {
     };
   }) {
     if (d.registration.tenantOid !== d.tenant.oid) {
-      throw new ServiceError(notFoundError('slate.webhook_registration'));
+      throw new ServiceError(notFoundError('webhook_registration'));
     }
 
     return db.slateWebhookRegistration.update({
@@ -400,7 +400,7 @@ class slateWebhookRegistrationServiceImpl {
     registration: { oid: bigint; tenantOid: bigint | null };
   }) {
     if (d.registration.tenantOid !== d.tenant.oid) {
-      throw new ServiceError(notFoundError('slate.webhook_registration'));
+      throw new ServiceError(notFoundError('webhook_registration'));
     }
 
     await db.slateWebhookRegistration.update({
@@ -414,7 +414,7 @@ class slateWebhookRegistrationServiceImpl {
       where: { id: d.id, status: { not: 'deleted' } },
       include: adminInclude
     });
-    if (!registration) throw new ServiceError(notFoundError('slate.webhook_registration'));
+    if (!registration) throw new ServiceError(notFoundError('webhook_registration'));
     return registration;
   }
 
@@ -637,7 +637,7 @@ class slateWebhookRegistrationServiceImpl {
     let userConfig = validateJsonSchema({
       schema: registrationSpec.userConfigSchema,
       data: d.userConfig,
-      entity: 'slate.webhook_registration.user_config',
+      entity: 'webhook_registration.user_config',
       message: 'Invalid webhook setup configuration.'
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking change for API clients that branch on `object` values or error entity codes; runtime logic is otherwise unchanged.
> 
> **Overview**
> Removes the **`slate.`** prefix from webhook-related **public API `object` types** and from **error/validation entity identifiers** across the hub.
> 
> API responses now use `webhook_trigger`, `webhook_event`, and `webhook_registration` instead of `slate.webhook_*`. **Not-found** paths and **JSON schema validation** for manual setup use the same unprefixed names (`webhook_event`, `webhook_registration`, `webhook_registration.user_config`). Behavior and routes are unchanged; only the string identifiers exposed to clients and in structured errors change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80e1c5d311f0ed7167e436950f28baa141c50f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->